### PR TITLE
Fixing CSS typo

### DIFF
--- a/DnDNext/D&DNext.css
+++ b/DnDNext/D&DNext.css
@@ -165,5 +165,5 @@ select.sheet-dtype {
     background-color: #000000;
     color: #ffffff;
 
-{
+}
 


### PR DESCRIPTION
Typo in DnD Next CSS file, last bracket should have been } and not {
