### PR TITLE
Missing parentheses on JumpHorizontal

### DIFF
--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -754,7 +754,7 @@
         <div>Jump (vertical): <input type="number" name="attr_JumpVertical" value="@{Strength}+@{Athletics}*(1-@{Athletics|max})" disabled="true" /></div>
         <div>
             Jump (horizontal):
-            <input type="number" name="attr_JumpHorizontal" value="(@{Strength}+@{Athletics}*(1-@{Athletics|max})*2" disabled="true" />
+            <input type="number" name="attr_JumpHorizontal" value="(@{Strength}+@{Athletics}*(1-@{Athletics|max}))*2" disabled="true" />
             <p class="disclaimer">Speed 5, DV -1 miscellaneous action; used up to once per flurry, may combine with move</p>
         </div>
     </div>


### PR DESCRIPTION
A simple typo on one of the calculated statistics. This is past the due date for the contest, but it does make one of the fields blank, and need to be merged at some point. :)
