### PR TITLE
Removed obsolete rolls

### DIFF
--- a/AD&D_2E/2ESheet.html
+++ b/AD&D_2E/2ESheet.html
@@ -575,34 +575,3 @@ Current weight:<input type="number" name="attr_gearweighttotal" class="sheet-nob
     </tr>
 </table>
 </fieldset><br><ul><b>Notes</b><textarea name="attr_henchnotes"></textarea></ul><hr>
-
-
-
-
-
-<h3>Rolls</h3><br>
-<h4>Hit roll</h4>
-<br>Weapon slot:               
-          <button type="roll" name="roll_hit1" value="/em hits an AC of [[@{ThAC0}-(1d20@{attackadj})]]">1</button>
-          <button type="roll" name="roll_hit2" value="/em hits an AC of [[@{repeating_weapons_0_ThAC0}-(1d20@{repeating_weapons_0_attackadj})]]"!>2</button>
-          <button type="roll" name="roll_hit3" value="/em hits an AC of [[@{repeating_weapons_1_ThAC0}-(1d20@{repeating_weapons_1_attackadj})]]"!>3</button>
-          <button type="roll" name="roll_hit4" value="/em hits an AC of [[@{repeating_weapons_2_ThAC0}-(1d20@{repeating_weapons_2_attackadj})]]!">4</button>
-          <button type="roll" name="roll_hit5" value="/em hits an AC of [[@{repeating_weapons_3_ThAC0}-(1d20@{repeating_weapons_3_attackadj})]]!">5</button>
-          <button type="roll" name="roll_hit6" value="/em hits an AC of [[@{repeating_weapons_4_ThAC0}-(1d20@{repeating_weapons_4_attackadj})]]!">6</button>
-          <button type="roll" name="roll_hit7" value="/em hits an AC of [[@{repeating_weapons_5_ThAC0}-(1d20@{repeating_weapons_5_attackadj})]]!">7</button>
-          <button type="roll" name="roll_hit8" value="/em hits an AC of [[@{repeating_weapons_6_ThAC0}-(1d20@{repeating_weapons_6_attackadj})]!">8</button>
-          <button type="roll" name="roll_hit9" value="/em hits an AC of [[@{repeating_weapons_7_ThAC0}-(1d20@{repeating_weapons_7_attackadj})]]!">9</button>
-          <button type="roll" name="roll_hit10" value="/em hits an AC of [[@{repeating_weapons_8_ThAC0}-(1d20@{repeating_weapons_8_attackadj})]]!">10</button>
-      
-<br><h4>Damage roll</h4>
-<br>Weapon slot:              
-          <button type="roll" name="roll_test1" value="/em rolls [[@{damsm}@{damadj}]] vs small/medium, [[@{daml}@{damadj}]] vs large!">1</button>
-          <button type="roll" name="roll_test2" value="/em rolls [[@1{repeating_weapons_0_damsm}@{repeating_weapons_0_damadj}]] vs small/medium, [[@{repeating_weapons_0_daml}@{repeating_weapons_0_damadj}]] vs large!">2</button>
-          <button type="roll" name="roll_test3" value="/em rolls [[@{repeating_weapons_1_damsm}@{repeating_weapons_1_damadj}]] vs small/medium, [[@{repeating_weapons_1_daml}@{repeating_weapons_1_damadj}]] vs large!">3</button>
-          <button type="roll" name="roll_test4" value="/em rolls [[@{repeating_weapons_2_damsm}@{repeating_weapons_2_damadj}]] vs small/medium, [[@{repeating_weapons_2_daml}@{repeating_weapons_2_damadj}]] vs large!">4</button>
-          <button type="roll" name="roll_test5" value="/em rolls [[@{repeating_weapons_3_damsm}@{repeating_weapons_3_damadj}]] vs small/medium, [[@{repeating_weapons_3_daml}@{repeating_weapons_3_damadj}]] vs large!">5</button>
-          <button type="roll" name="roll_test6" value="/em rolls [[@{repeating_weapons_4_damsm}@{repeating_weapons_4_damadj}]] vs small/medium, [[@{repeating_weapons_4_daml}@{repeating_weapons_4_damadj}]] vs large!">6</button>
-          <button type="roll" name="roll_test7" value="/em rolls [[@{repeating_weapons_5_damsm}@{repeating_weapons_5_damadj}]] vs small/medium, [[@{repeating_weapons_5_daml}@{repeating_weapons_5_damadj}]] vs large!">7</button>
-          <button type="roll" name="roll_test8" value="/em rolls [[@{repeating_weapons_6_damsm}@{repeating_weapons_6_damadj}]] vs small/medium, [[@{repeating_weapons_6_daml}@{repeating_weapons_6_damadj}]] vs large!">8</button>
-		  <button type="roll" name="roll_test9" value="/em rolls [[@{repeating_weapons_7_damsm}@{repeating_weapons_7_damadj}]] vs small/medium, [[@{repeating_weapons_7_daml}@{repeating_weapons_7_damadj}]] vs large!">9</button>
-			  <button type="roll" name="roll_test10" value="/em rolls [[@{repeating_weapons_8_damsm}@{repeating_weapons_8_damadj}]] vs small/medium, [[@{rep>


### PR DESCRIPTION
The rolls area at the bottom of the sheet was no longer functional, and had been replaced by the button in the repeating weapons section.
