### PR TITLE
Corrected Fort display name

### DIFF
--- a/D&D_4E/D&D_4E.html
+++ b/D&D_4E/D&D_4E.html
@@ -1324,7 +1324,7 @@
 						<div class="sheet-item sheet-small">
 							<select name="attr_power-def">
 								<option value="AC">AC</option>
-								<option value="Fort">Ref</option>
+								<option value="Fort">Fort</option>
 								<option value="Ref">Ref</option>
 								<option value="Will" selected="selected">Will</option>
 							</select>
@@ -1428,7 +1428,7 @@
 							<div class="sheet-item sheet-med">
 								<select name="attr_mba-def">
 									<option value="AC">AC</option>
-									<option value="Fort">Ref</option>
+									<option value="Fort">Fort</option>
 									<option value="Ref">Ref</option>
 									<option value="Will">Will</option>
 								</select>
@@ -1442,7 +1442,7 @@
 							<div class="sheet-item sheet-med">
 								<select name="attr_rba-def">
 									<option value="AC">AC</option>
-									<option value="Fort">Ref</option>
+									<option value="Fort">Fort</option>
 									<option value="Ref">Ref</option>
 									<option value="Will">Will</option>
 								</select>
@@ -1456,7 +1456,7 @@
 							<div class="sheet-item sheet-med">
 								<select name="attr_iba-def">
 									<option value="AC">AC</option>
-									<option value="Fort">Ref</option>
+									<option value="Fort">Fort</option>
 									<option value="Ref">Ref</option>
 									<option value="Will" selected="selected">Will</option>
 								</select>


### PR DESCRIPTION
In the powers section, the drop down list for defense type mistakenly labeled Fortitude as Reflex. Corrected.
