### PR TITLE
Fixed typo

### DIFF
--- a/D&D_4E/D&D_4E.html
+++ b/D&D_4E/D&D_4E.html
@@ -1370,7 +1370,7 @@
 							<div class="sheet-item sheet-med">
 								<select name="attr_mba-def">
 									<option value="AC" selected="selected">AC</option>
-									<option value="Fort">Ref</option>
+									<option value="Fort">Fort</option>
 									<option value="Ref">Ref</option>
 									<option value="Will">Will</option>
 								</select>


### PR DESCRIPTION
attribute defence had 'Ref' listed twice, change one to fort to match it's value
