### PR TITLE
Fixed & Updated

### DIFF
--- a/GURPS_Mutonized/GURPS.css
+++ b/GURPS_Mutonized/GURPS.css
@@ -65,8 +65,6 @@ input[type=text]{
 .sheet-input-centeraligned{text-align:center!important;}
 .sheet-input-topaligned{vertical-align:top!important;}
 .sheet-input-medaligned{vertical-align:med!important;}
-.sheet-colored-white{background-color:#FFFFFF;}
-/*.sheet-colored-white{background-color:#F4A460;}*/
 .sheet-colored-green{background-color:#FDFCDC!important;}
 .sheet-colored-gray{background-color:#C9C9C9!important;}
 .charsheet .sheet-fluid-textarea {height: 100%;}
@@ -121,6 +119,8 @@ input[type=checkbox]{
 }
 
 select{
+	-webkit-appearance: none;
+	background-color: #CDC8B1!important;
 	font-size:10px;
 	text-align: center;
 	border: 0px!important;
@@ -291,9 +291,9 @@ textarea{
 
 .charsheet .sheet-attributebox-fourth-panel{width: 100%;height:100px;vertical-align:top;text-align:center;background-color:#A2CD5A;}
 .charsheet .sheet-attributebox-fourth-main-col{width: 32%;text-align:center;font-weight:bold;vertical-align:top;}
-.charsheet .sheet-attributebox-fourth-parry-button{width: 32%;text-align:center;font-size:8px;}
-.charsheet .sheet-attributebox-fourth-parry-left{width: 32%;text-align:center;font-size:8px;}
-.charsheet .sheet-attributebox-fourth-parry-right{width: 32%;text-align:center}
+.charsheet .sheet-attributebox-fourth-parry-button{width: 42%;text-align:center;font-size:8px;}
+.charsheet .sheet-attributebox-fourth-parry-left{width: 40%;text-align:center;font-size:8px;}
+.charsheet .sheet-attributebox-fourth-parry-right{width: 14%;text-align:center}
 .charsheet .sheet-attributebox-fourth-block-button{width: 50%;text-align:center;font-size:8px;}
 .charsheet .sheet-attributebox-fourth-block-left{width: 50%;text-align:center;}
 .charsheet .sheet-attributebox-fourth-block-right{width: 48%;text-align:center;}
@@ -330,7 +330,7 @@ textarea{
 .charsheet .sheet-meleeweapons-parry{width: 10%;font-size:10px;text-align:center;vertical-align:middle;}
 .charsheet .sheet-meleeweapons-reach{width: 10%;font-size:10px;text-align:center;vertical-align:middle;}
 .charsheet .sheet-meleeweapons-type{width: 5%;font-size:10px;text-align:center;vertical-align:middle;}
-.charsheet .sheet-meleeweapons-damage{width: 20%;font-size:10px;text-align:center;vertical-align:middle;}
+.charsheet .sheet-meleeweapons-damage{width: 16%;font-size:10px;text-align:center;vertical-align:middle;}
 
 .charsheet .sheet-rangedweapons-button{width: 5%;font-size:12px;text-align:center;vertical-align:middle;}
 .charsheet .sheet-rangedweapons-name{width: 20%;font-size:12px;text-align:left;vertical-align:middle;}
@@ -342,7 +342,7 @@ textarea{
 .charsheet .sheet-rangedweapons-bulk{width: 5%;font-size:10px;text-align:center;vertical-align:middle;}
 .charsheet .sheet-rangedweapons-recoil{width: 5%;font-size:10px;text-align:center;vertical-align:middle;}
 .charsheet .sheet-rangedweapons-type{width: 5%;font-size:10px;text-align:center;vertical-align:middle;}
-.charsheet .sheet-rangedweapons-damage{width: 20%;font-size:10px;text-align:center;vertical-align:middle;}
+.charsheet .sheet-rangedweapons-damage{width: 16%;font-size:10px;text-align:center;vertical-align:middle;}
 
 
 /* SKILL PAGE SETUP */
@@ -426,9 +426,9 @@ textarea{
 /* INVENTORY PAGE ATTRIBUTE BOX */
 .charsheet .sheet-inventorypanel-top{width: 100%;vertical-align:top;}
 .charsheet .sheet-inventorypanel-bottom{width: 100%;vertical-align:top;}
-.charsheet .sheet-inventorypanel-coin{width: 600px;vertical-align:top}
+.charsheet .sheet-inventorypanel-coin{width: 650px;vertical-align:top}
 
-.charsheet .sheet-coin-name{width: 50px;vertical-align:top}
+.charsheet .sheet-coin-name{width: 60px;vertical-align:top}
 .charsheet .sheet-coin-amount{width: 50px;vertical-align:top}
 
 .charsheet .sheet-inventory-title{width: 10%;font-size:12px;text-align:left;vertical-align:top;}
@@ -489,6 +489,7 @@ textarea{
 .charsheet .sheet-cpoint-amount,
 .charsheet .sheet-desc-label,
 .charsheet .sheet-desc-field,
+.charsheet .sheet-desc-fieldlarge,
 .charsheet .sheet-appear-label,
 .charsheet .sheet-appear-selectfield,
 .charsheet .sheet-appear-textfield,
@@ -517,6 +518,7 @@ textarea{
 
 .charsheet .sheet-desc-label{width: 10%;font-size:12px;text-align:left;vertical-align:top;}
 .charsheet .sheet-desc-field{width: 10%;font-size:12px;text-align:left;vertical-align:top;}
+.charsheet .sheet-desc-fieldlarge{width: 15%;font-size:12px;text-align:left;vertical-align:top;}
 
 .charsheet .sheet-appear-label{width: 10%;font-size:12px;text-align:left;vertical-align:top;}
 .charsheet .sheet-appear-selectfield{width: 20%;font-size:12px;text-align:left;vertical-align:top;}
@@ -607,15 +609,17 @@ div.sheet-tab-content
 
 .sheet-popup:hover + .sheet-tooltip {
     width: auto;
+	height: auto;
     display: inline;
     position: absolute;
-	top:25px;
-	right:0px;
+	top:75px;right:0px;
 	width:250px;	
     color: #111;
-    border: 1px solid #DCA;
+    border: 1px solid black;
+	border-radius:5px;
     background: #fffAF0;
     line-height: 1.5em;
+	font-size: 10px;
 }
 
 .sheet-popup + .sheet-tooltip {
@@ -630,7 +634,7 @@ div.sheet-tab-content
 .sheet-tooltip table {
     float: left;
     line-height: 2em;
-    font-size: 11px;
+    font-size: 10px;
     border-collapse: collapse;
     text-align: center;
 }

--- a/GURPS_Mutonized/GURPS.html
+++ b/GURPS_Mutonized/GURPS.html
@@ -2,7 +2,7 @@
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Skills"/>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Traits"/>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="4" title="Inventory"/>
-<input type="radio" name="attr_tab" class="sheet-tab sheet-tab5" value="5" title="Spells"/>
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab5" value="5" title="Powers"/>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab6" value="6" title="Various"/>
 
 <div class="sheet-tab-content sheet-tab1">
@@ -11,84 +11,92 @@
     	<div class="sheet-row-panel sheet-input-rightaligned">        
 			<div class="sheet-attributebox-attributes-panel">			
 				<div class="sheet-row">
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_ST' value='/ooc Check(ST) [[3d6]] vs [[@{ST}]]'>ST</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_ST' value='/ooc Check(ST) [[3d6]] vs [[@{ST}]]'>ST</button></div>
 					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_ST"/></div>
-					<div class="sheet-attributebox-button"><button type='roll' name='' value=''>HP</button></div>
-					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_HP_max"/></div>
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Vision' value='/ooc Check(Vision) [[3d6]] vs @{Vision}'>Vision</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_Will' value='/ooc Check(Will) [[3d6]] vs @{Will}'>Will</button></div>
+					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_Will"/></div>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Vision' value='/ooc Check(Vision) [[3d6]] vs @{Vision}'>Vision</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Vision"/></div>					
 				</div>			
 				<div class="sheet-row">
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_DX' value='/ooc Check(DX) [[3d6]] vs @{DX}'>DX</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_DX' value='/ooc Check(DX) [[3d6]] vs @{DX}'>DX</button></div>
 					<div class="attributebox-input"><input type="text" value="10" name="attr_DX"/></div>
-					<div class="sheet-attributebox-button"><button type='roll' name='' value=''>FP</button></div>
-					<div class="attributebox-input"><input type="text" value="10" name="attr_FP_max"/></div>
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Hearing' value='/ooc Check(Hearing) [[3d6]] vs @{Hearing}'>Hearing</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_Per' value='/ooc Check(Per) [[3d6]] vs @{Per}'>Per</button></div>
+					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_Per"/></div>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Hearing' value='/ooc Check(Hearing) [[3d6]] vs @{Hearing}'>Hearing</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Hearing"/></div>					
 				</div>			
 				<div class="sheet-row">
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_IQ' value='/ooc Check(IQ) [[3d6]] vs @{IQ}'>IQ</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_IQ' value='/ooc Check(IQ) [[3d6]] vs @{IQ}'>IQ</button></div>
 					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_IQ"/></div>
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_Will' value='/ooc Check(Will) [[3d6]] vs @{Will}'>Will</button></div>
-					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_Will"/></div>
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Touch' value='/ooc Check(Touch) [[3d6]] vs @{Touch}'>Touch</button></div>
+					<div class="sheet-attributebox-button">MAX HP</div>
+					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_HP_max"/></div>					
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Touch' value='/ooc Check(Touch) [[3d6]] vs @{Touch}'>Touch</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Touch"/></div>						
 				</div>							
 				<div class="sheet-row">
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_HT' value='/ooc Check(HT) [[3d6]] vs @{HT}'>HT</button></div>
+					<div class="sheet-attributebox-button"><button tabindex=500 type='roll' name='roll_check_HT' value='/ooc Check(HT) [[3d6]] vs @{HT}'>HT</button></div>
 					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_HT"/></div>
-					<div class="sheet-attributebox-button"><button type='roll' name='roll_check_Per' value='/ooc Check(Per) [[3d6]] vs @{Per}'>Per</button></div>
-					<div class="sheet-attributebox-input"><input type="text" value="10" name="attr_Per"/></div>
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Smell' value='/ooc Check(Smell) [[3d6]] vs @{Smell}'>Smell</button></div>
+					<div class="sheet-attributebox-button">MAX FP</div>
+					<div class="attributebox-input"><input type="text" value="10" name="attr_FP_max"/></div>					
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Smell' value='/ooc Check(Smell) [[3d6]] vs @{Smell}'>Smell</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Smell"/></div>						
 				</div>				
 				<div class="sheet-row">
 					<div class="sheet-attributebox-doublelabel sheet-input-rightaligned">Basic MOVE</div>
 					<div class="sheet-attributebox-doubleinput"><input type="text" value="5" name="attr_Move"/></div>						
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Fear' value='/ooc Check(Fear) [[3d6]] vs @{Fear}'>Fear</button></div>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Fear' value='/ooc Check(Fear) [[3d6]] vs @{Fear}'>Fear</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Fear"/></div>						
 				</div>				
 				<div class="sheet-row">
-					<div class="sheet-attributebox-doublelabel">Combat MOVE</div>
-					<div class="sheet-attributebox-doubleinput"><input type="text" value="@{Move}+@{CurrLoad}" disabled="true" name="attr_Move_max"/></div>										
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_KO' value='/ooc Check(KO) [[3d6]] vs @{KO}'>KO</button></div>
+					<div class="sheet-attributebox-doublelabel sheet-input-rightaligned">Combat MOVE</div>
+					<div class="sheet-attributebox-doubleinput sheet-popup"><input type="text" value="@{Move}+@{CurrLoad}" disabled="true" name="attr_Move_max"/></div>	
+						<span class="sheet-tooltip">
+							This is your Basic MOVE, modified by the effects of Encumbrance according to what you selected for your COMBAT LOAD-OUT.<br/>
+							Usually, this is the value you'll use to move your token during combat.
+						</span>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_KO' value='/ooc Check(KO) [[3d6]] vs @{KO}'>KO</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_KO"/></div>						
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-attributebox-doublelabel"><button type='roll' name='roll_check_HT' value='/w gm @{selected|token_name} - Initiative: [[@{selected|Speed} &{tracker}]] (DX: @{selected|DX} / roll: [[3d6]])'>Basic SPEED</button></div>
-					<div class="sheet-attributebox-doubleinput"><input type="text" value="5" name="attr_Speed"/></div>	
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_check_Death' value='/ooc Check(Death) [[3d6]] vs @{Death}'>Death</button></div>
+					<div class="sheet-attributebox-doublelabel"><button tabindex=500 type='roll' name='roll_initiative' value='/w gm @{selected|token_name} - Initiative: [[@{selected|Speed} &{tracker}]] (DX: @{selected|DX} / roll: [[3d6]])'>Basic SPEED</button></div>					
+					<div class="sheet-attributebox-doubleinput sheet-popup"><input type="text" value="5" name="attr_Speed"/></div>	
+						<span class="sheet-tooltip">
+							The button on the left doubles as your INITIATIVE macro.<br/>
+							Select your token and press the button to add it automatically to the Initiative Tracker.
+						</span>	
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_check_Death' value='/ooc Check(Death) [[3d6]] vs @{Death}'>Death</button></div>
 					<div class="sheet-attributebox-smallinput"><input class="sheet-colored-gray" type="text" value="10" name="attr_Death"/></div>						
 				</div>
 				<hr/>
 				<div class="sheet-row">
 					<div class="sheet-attributebox-doublelabel sheet-input-rightaligned">Current FP</div>
 					<div class="sheet-attributebox-doubleinput"><input class="sheet-colored-green" type="text" value="0" name="attr_FP"/></div>
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_DMG_Swing' value='/ooc Base damage(swing): [[@{DMG_base}]]'>Swing</button></div>
-					<div class="sheet-attributebox-smallinput"><input type="text" value="d6" name="attr_DMG_base"/></div>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_DMG_Swing' value='/ooc Base damage(swing): [[@{DMG_base}]]'>Swing</button></div>
+					<div class="sheet-attributebox-smallinput"><input class="sheet-input-text-small" type="text" value="d6" name="attr_DMG_base"/></div>
 				</div>
 				<div class="sheet-row">					
 					<div class="sheet-attributebox-doublelabel sheet-input-rightaligned">Current ER</div>
 					<div class="sheet-attributebox-doubleinput"><input class="sheet-colored-green" type="text" value="0" name="attr_ER"/></div>	
-					<div class="sheet-attributebox-smallbutton"><button type='roll' name='roll_DMG_Thrust' value='/ooc Base damage(thrust): [[@{DMG_base|max}]]'>Thrust</button></div>
-					<div class="sheet-attributebox-smallinput"><input type="text" value="d6" name="attr_DMG_base_max"/></div>
+					<div class="sheet-attributebox-smallbutton"><button tabindex=500 type='roll' name='roll_DMG_Thrust' value='/ooc Base damage(thrust): [[@{DMG_base|max}]]'>Thrust</button></div>
+					<div class="sheet-attributebox-smallinput"><input class="sheet-input-text-small" type="text" value="d6" name="attr_DMG_base_max"/></div>
 				</div>				
 				<div class="sheet-row">
 					<div class="sheet-attributebox-doublelabel sheet-input-rightaligned">Current HP</div>
 					<div class="sheet-attributebox-doubleinput"><input class="sheet-colored-green" type="text" value="0" name="attr_HP"/></div>					
-					<div class="sheet-attributebox-smallinput"><input type="text" value="@{HP}/2" disabled="true" name="attr_info_HP"/></div>
-					<div class="sheet-attributebox-button sheet-input-leftaligned">Limb</div>					
+					<div class="sheet-attributebox-smallinput"><input type="text" value="ceil(@{HP|max}/2)" disabled="true" name="attr_info_HP"/></div>
+					<div class="sheet-attributebox-button sheet-input-leftaligned">1/2 HP</div>					
 				</div>
 				<div class="sheet-row">
 					<div class="sheet-attributebox-doublelabel">&nbsp;</div>
 					<div class="sheet-attributebox-doubleinput">&nbsp;</div>
-					<div class="sheet-attributebox-smallinput"><input type="text" value="@{HP}/3" disabled="true" name="attr_info_HP_max"/></div>															
-					<div class="sheet-attributebox-button sheet-input-leftaligned">1/3</div>					
+					<div class="sheet-attributebox-smallinput"><input type="text" value="ceil(@{HP|max}/3)" disabled="true" name="attr_info_HP_max"/></div>															
+					<div class="sheet-attributebox-button sheet-input-leftaligned">1/3 HP</div>					
 				</div>					
 			</div>
 			<div class="sheet-attributebox-right-block">
 				<div class="sheet-row-panel">
-					<div class="sheet-attributebox-second-panel sheet-colored-white">
+					<div class="sheet-attributebox-second-panel">
 						<div class="sheet-row">
 							<div class="sheet-attributebox-second-left">&nbsp;</div>
 							<div class="sheet-attributebox-second-col">NONE</div>
@@ -99,7 +107,10 @@
 						</div>
 						<div class="sheet-row">
 							<div class="sheet-attributebox-second-left">LOAD</div>
-							<div class="sheet-attributebox-second-input"><input class="sheet-colored-green" type="text" value="0" name="attr_BL"/></div>
+							<div class="sheet-attributebox-second-input sheet-popup"><input class="sheet-colored-green" type="text" value="0" name="attr_BL"/></div>
+								<span class="sheet-tooltip">
+									Put in your effective BL (Basic Lift) value here, modified by Advantages and whatnot.
+								</span>	
 							<div class="sheet-attributebox-second-input"><input type="text" name="attr_Load02" value="(@{BL}*2)" disabled="true"/></div>
 							<div class="sheet-attributebox-second-input"><input type="text" name="attr_Load03" value="(@{BL}*4)" disabled="true"/></div>
 							<div class="sheet-attributebox-second-input"><input type="text" name="attr_Load04" value="(@{BL}*8)" disabled="true"/></div>
@@ -113,31 +124,31 @@
 							<div class="sheet-attributebox-second-col">-3</div>
 							<div class="sheet-attributebox-second-col">-4</div>
 						</div>
-						<div class="sheet-row">
+						<div class="sheet-row sheet-input-leftaligned">
 							<div class="sheet-attributebox-second-title sheet-popup">LOAD-OUTS</div>
 								<span class="sheet-tooltip">
-									Select the appropriate Encumberance level for your Combat and Hiking Load-Outs.<br/>
+									Select the appropriate Encumberance level for your Combat and Full Load Load-Outs.<br/>
 									This will be used for things like Dodge macros and whatnot.
 								</span>	
 						</div>
 						<div class="sheet-row">
 							<div class="sheet-attributebox-second-left">Combat</div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='0' name='attr_CurrLoad' checked='true'/></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-1' name='attr_CurrLoad' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-2' name='attr_CurrLoad' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-3' name='attr_CurrLoad' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-4' name='attr_CurrLoad' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='0' name='attr_CurrLoad' checked='true'/></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-1' name='attr_CurrLoad' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-2' name='attr_CurrLoad' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-3' name='attr_CurrLoad' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-4' name='attr_CurrLoad' /></div>
 						</div>
 						<div class="sheet-row">
-							<div class="sheet-attributebox-second-left">Hiking</div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='0' name='attr_CurrLoad_max' checked='true' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-1' name='attr_CurrLoad_max' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-2' name='attr_CurrLoad_max' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-3' name='attr_CurrLoad_max' /></div>
-							<div class="sheet-attributebox-second-col"><input type='radio' value='-4' name='attr_CurrLoad_max' /></div>
+							<div class="sheet-attributebox-second-left">Full Load</div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='0' name='attr_CurrLoad_max' checked='true' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-1' name='attr_CurrLoad_max' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-2' name='attr_CurrLoad_max' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-3' name='attr_CurrLoad_max' /></div>
+							<div class="sheet-attributebox-second-col"><input type='radio' tabindex=500 value='-4' name='attr_CurrLoad_max' /></div>
 						</div>
 					</div>
-					<div class="sheet-attributebox-third-panel sheet-colored-white">
+					<div class="sheet-attributebox-third-panel">
 						<div class="sheet-row">
 							<div class="sheet-attributebox-third-title">MAX LIFTING</div>					
 						</div>
@@ -165,7 +176,11 @@
 				</div>
 				<hr/>				
 				<div class="sheet-row sheet-input-rightaligned">
-					<div class="sheet-attributebox-fourth-main-col">ACTIVE DEFENSE OPTION: </div>
+					<div class="sheet-attributebox-fourth-main-col sheet-popup">ACTIVE DEFENSE OPTION: </div>
+						<span class="sheet-tooltip">
+							ACTIVE DEFENSE OPTION<br/>
+							It'll then be displayed automatically when you use the Active Defense macros below.
+						</span>	
 					<div class="sheet-attributebox-fourth-main-col">
 						<select name="attr_AD_option">
 							<option value="n/a" selected="selected">n/a</option>
@@ -180,24 +195,24 @@
 							<div class="sheet-attributebox-fourth-main-col sheet-popup">PARRY								
 								<br/>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-parry-button"><button type='roll' name='roll_check_Parry01' value='/em tries to parry with @{Parry01|max}.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry01}]](+DB:@{DB})'>PARRY</button></div>
+									<div class="sheet-attributebox-fourth-parry-button"><button tabindex=500 type='roll' name='roll_check_Parry01' value='/em ?{Defense Emote|tries to parry with @{Parry01|max}}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry01}]](+DB:@{DB})'>PARRY</button></div>
 									<div class="sheet-attributebox-fourth-parry-left"><input class="input-text-small" type="text" value="" name="attr_Parry01_max"/></div>
 									<div class="sheet-attributebox-fourth-parry-right"><input class="sheet-colored-green" type="text" value="0" name="attr_Parry01"/></div>
 								</div>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-parry-button"><button type='roll' name='roll_check_Parry02' value='/em tries to parry with @{Parry02|max}.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry02}]](+DB:@{DB})'>PARRY</button></div>
+									<div class="sheet-attributebox-fourth-parry-button"><button tabindex=500 type='roll' name='roll_check_Parry02' value='/em ?{Defense Emote|tries to parry with @{Parry02|max}}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry02}]](+DB:@{DB})'>PARRY</button></div>
 									<div class="sheet-attributebox-fourth-parry-left"><input class="input-text-small" type="text" value="" name="attr_Parry02_max"/></div>
 									<div class="sheet-attributebox-fourth-parry-right"><input class="sheet-colored-green" type="text" value="0" name="attr_Parry02"/></div>
 								</div>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-parry-button"><button type='roll' name='roll_check_Parry02' value='/em tries to parry with @{Parry03|max}.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry03}]](+DB:@{DB})'>PARRY</button></div>
+									<div class="sheet-attributebox-fourth-parry-button"><button tabindex=500 type='roll' name='roll_check_Parry02' value='/em ?{Defense Emote|tries to parry with @{Parry03|max}}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Parry) [[3d6]] vs [[@{Parry03}]](+DB:@{DB})'>PARRY</button></div>
 									<div class="sheet-attributebox-fourth-parry-left"><input class="sheet-input-text-small" type="text" value="" name="attr_Parry03_max"/></div>
 									<div class="sheet-attributebox-fourth-parry-right"><input class="sheet-colored-green" type="text" value="0" name="attr_Parry03"/></div>
 								</div>
 							</div>							
 							<div class="sheet-attributebox-fourth-main-col">BLOCK<br/>
 								<div class="sheet-row-panel">
-									<div class="sheet-attributebox-fourth-block-button"><button class="sheet-button-double-height" type='roll' name='roll_check_Block01' value='/em tries to block.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Block) [[3d6]] vs [[@{Block01}]](+DB:@{DB})'>BLOCK</button></div>									
+									<div class="sheet-attributebox-fourth-block-button"><button tabindex=500 class="sheet-button-double-height" type='roll' name='roll_check_Block01' value='/em ?{Defense Emote|tries to block}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Block) [[3d6]] vs [[@{Block01}]](+DB:@{DB})'>BLOCK</button></div>									
 									<div class="sheet-attributebox-fourth-block-right"><input class="sheet-button-double-height sheet-colored-green" type="text" value="0" name="attr_Block01"/></div>									
 								</div>
 								<div class="sheet-row">
@@ -207,15 +222,15 @@
 							</div>
 							<div class="sheet-attributebox-fourth-main-col">DODGE<br/>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-dodge-button"><button type='roll' name='roll_check_Dodge01' value='/em tries to dodge.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge01}]](+DB:@{DB})'>Base</button></div>									
+									<div class="sheet-attributebox-fourth-dodge-button"><button tabindex=500 type='roll' name='roll_check_Dodge01' value='/em ?{Defense Emote|tries to dodge}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge01}]](+DB:@{DB})'>Base</button></div>									
 									<div class="sheet-attributebox-fourth-dodge-right"><input class="sheet-colored-green" type="text" value="0" name="attr_Dodge01"/></div>									
 								</div>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-dodge-button"><button type='roll' name='roll_check_Dodge02' value='/em tries to dodge.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge02}]](+DB:@{DB})'>Combat</button></div>									
+									<div class="sheet-attributebox-fourth-dodge-button"><button tabindex=500 type='roll' name='roll_check_Dodge02' value='/em ?{Defense Emote|tries to dodge}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge02}]](+DB:@{DB})'>Combat</button></div>									
 									<div class="sheet-attributebox-fourth-dodge-right"><input type="text"value="(@{Dodge01}+@{CurrLoad})" disabled="true" name="attr_Dodge02"/></div>									
 								</div>
 								<div class="sheet-row">
-									<div class="sheet-attributebox-fourth-dodge-button"><button type='roll' name='roll_check_Dodge03' value='/em tries to dodge.\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge03}]](+DB:@{DB})'>Hiking</button></div>									
+									<div class="sheet-attributebox-fourth-dodge-button"><button tabindex=500 type='roll' name='roll_check_Dodge03' value='/em ?{Defense Emote|tries to dodge}\n/ooc Option: @{AD_option} | @{ATK_option01}\n/ooc Check(Dodge) [[3d6]] vs [[@{Dodge03}]](+DB:@{DB})'>Full Load</button></div>									
 									<div class="sheet-attributebox-fourth-dodge-right"><input type="text" value="(@{Dodge01}+@{CurrLoad|max})" disabled="true" name="attr_Dodge03"/></div>									
 								</div>
 							</div>
@@ -309,12 +324,12 @@
 				</div>
 				<hr/>
 				<div class="sheet-row-panel">
-					<div class="sheet-mainlower-injurypanel sheet-colored-white">
+					<div class="sheet-mainlower-injurypanel sheet-popup">
 						<div class="sheet-row">
-							<div class="sheet-armorpanel-calcdamage">DMG</div>						
+							<div class="sheet-armorpanel-calcdamage">DMG</div>
 							<div class="sheet-armorpanel-calcDR">DR</div>
 							<div class="sheet-armorpanel-calclocation">LOC</div>
-							<div class="sheet-armorpanel-calctype">TYP</div>
+							<div class="sheet-armorpanel-calctype">TYPE</div>
 							<div class="sheet-armorpanel-calcbutton">&nbsp;</div>
 						</div>				
 						<div class="sheet-row">
@@ -322,29 +337,35 @@
 							<div class="sheet-armorpanel-calcDR"><input type="text" value="" name="attr_calc_dr"/></div>
 							<div class="sheet-armorpanel-calclocation">
 								<select name="attr_calc_location">
-									<option value="1" selected="selected">other</option>
-									<option value="3">vitals</option>
-									<option value="1.5">neck</option>							
+									<option value="1" selected="selected">other (1x)</option>
+									<option value="3">vitals (imp, pi) (3x)</option>
+									<option value="2">vitals (tight beam) (2x)</option>
+									<option value="1.5">neck (cru, corr) (1.5x)</option>							
+									<option value="2">neck (cut) (2x)</option>							
+									<option value="1.5">face (corr) (1.5x)</option>									
 								</select>
 							</div>
 							<div class="sheet-armorpanel-calctype">
 								<select name="attr_calc_type">
-									<option value="1" selected="selected">other</option>
-									<option value="1.5">cut</option>							
-									<option value="2">imp</option>							
-									<option value="0.5">pie-</option>							
-									<option value="1.5">pie+</option>							
-									<option value="2">pie++</option>							
+									<option value="1" selected="selected">other (1x)</option>
+									<option value="0.5">pie- (0.5x)</option>																
+									<option value="1.5">cut,pie+ (1.5x)</option>							
+									<option value="2">imp, pie++ (2x)</option>													
+									<option value="1">limb (1x) (imp, pi+, pi++)</option>							
 								</select>
 							</div>
-							<div class="sheet-armorpanel-calcbutton"><button type='roll' name='roll_calc_damage' value='/w @{character_name} DMG taken: [[floor((@{calc_damage}-@{calc_dr})*@{calc_location}*@{calc_type})]]'>*</button></div>
+							<div class="sheet-armorpanel-calcbutton"><button tabindex=500 type='roll' name='roll_calc_damage' value='/w @{character_name} DMG taken: [[floor((@{calc_damage}-@{calc_dr})*@{calc_location}*@{calc_type})]]'>*</button></div>
 						</div>
 						<hr/>
 					</div>
+					<span class="sheet-tooltip">
+						DAMAGE TAKEN CALCULATOR<br/>
+						When taking a hit, just fill this up accordingly and press the macro button on the right to get the actual amount of damage taken.
+					</span>	
 				</div>
 				<hr/>
 				<div class="sheet-row-panel">
-					<div class="sheet-mainlower-injurypanel sheet-colored-white">
+					<div class="sheet-mainlower-injurypanel">
 						<div class="sheet-row">			
 							<div class="sheet-injury-name"><b>Injury</b></div>
 							<div class="sheet-injury-desc"><b>Description</b></div>									
@@ -357,13 +378,16 @@
 					</div>
 				</div>
 			</div>	
-			<div class="sheet-mainlower-rightpanel sheet-colored-white sheet-input-rightaligned">
+			<div class="sheet-mainlower-rightpanel sheet-input-rightaligned">
 				<div class="sheet-row-panel">
-					<div class="sheet-rightpanel-attackstyle">	
+					<div class="sheet-rightpanel-attackstyle">						
 						<div class="sheet-row">
-							<div class="sheet-attackpanel-atk">
-								<button type='roll' name='roll_atk_mweapon' value='/ooc MANEUVER DECLARATION: [ @{character_name} ]\n/ooc - @{ATK_option01}'>Maneuver</button>
-							</div>
+							<div class="sheet-attackpanel-atk sheet-popup"><button tabindex=500 type='roll' name='roll_atk_mweapon' value='/ooc MANEUVER DECLARATION: [ @{character_name} ]\n/ooc - @{ATK_option01} @{ATK_option01|max}'>Maneuver</button></div>
+								<span class="sheet-tooltip">
+									TURN MANEUVER DECLARATION<br/>
+									Select your maneuver for the turn below, then press this button to declare it.<br/>
+									If you choose Ready, Concentrate or Wait, you can use the Text Box below to input the specifics of it. Otherwise, leave it blank.
+								</span>	
 							<div class="sheet-attackpanel-atk">Option</div>
 							<div class="sheet-attackpanel-atk">Option</div>
 							<div class="sheet-attackpanel-atk">Location</div>
@@ -387,84 +411,128 @@
 									<option value="AO(Determined)">AO(Determined)</option>
 									<option value="AO(Double)">AO(Double)</option>
 									<option value="AO(Feint)">AO(Feint)</option>
-									<option value="AO(Strong)">AO(Strong)</option>
+									<option value="AO(Strong)">AO(Strong)</option>									
 									<option value="n/a">----</option>
 									<option value="AD(Double)">AD(Double)</option>
 									<option value="AD(Parry)">AD(Parry)</option>
 									<option value="AD(Dodge)">AD(Dodge)</option>
 									<option value="AD(Block)">AD(Block)</option>											
-								</select>
+									<option value="n/a">----</option>
+									<option value="other">other</option>
+								</select>	
 							</div>
 							<div class="sheet-attackpanel-atk">
 								<select name="attr_ATK_option02">
 									<option value="n/a" selected="selected">n/a</option>
-									<option value="Telegraphic">Telegraphic</option>
 									<option value="Deceptive">Deceptive</option>
-									<option value="Rapid Strike">Rapid Strike</option>
-									<option value="Dual Weapon">Dual Weapon</option>									
-									<option value="Off-hand">Off-hand</option>
-									<option value="Feint">Feint</option>
 									<option value="Disarm">Disarm</option>
+									<option value="Dual Weapon">Dual Weapon</option>									
+									<option value="Feint">Feint</option>
+									<option value="Off-hand">Off-hand</option>
+									<option value="Rapid Strike">Rapid Strike</option>
+									<option value="Telegraphic">Telegraphic</option>
+									<option value="n/a">----</option>
+									<option value="other">other</option>
 								</select>
 							</div>
 							<div class="sheet-attackpanel-atk">
 								<select name="attr_ATK_option03">
 									<option value="n/a" selected="selected">n/a</option>
-									<option value="Telegraphic">Telegraphic</option>
 									<option value="Deceptive">Deceptive</option>
-									<option value="Rapid Strike">Rapid Strike</option>
-									<option value="Dual Weapon">Dual Weapon</option>									
-									<option value="Off-hand">Off-hand</option>
-									<option value="Feint">Feint</option>
 									<option value="Disarm">Disarm</option>
+									<option value="Dual Weapon">Dual Weapon</option>									
+									<option value="Feint">Feint</option>
+									<option value="Off-hand">Off-hand</option>
+									<option value="Rapid Strike">Rapid Strike</option>
+									<option value="Telegraphic">Telegraphic</option>
+									<option value="n/a">----</option>
+									<option value="other">other</option>
 								</select>
 							</div>
 							<div class="sheet-attackpanel-atk">
 								<select name="attr_ATK_option04">
 									<option value="Torso (0)" selected="selected">Torso (0)</option>
 									<option value="Wild Swing">Wild Swing</option>
-									<option value="Eyes (-9)">Eyes (-9)</option>
-									<option value="Neck (-5)">Neck (-5)</option>
+									<option value="">----</option>
+									<option value="Vitals (-3)">Vitals (-3)</option>
 									<option value="Skull (-7)">Skull (-7)</option>
 									<option value="Face (-5)">Face (-5)</option>							
+									<option value="Eyes (-9)">Eyes (-9)</option>
+									<option value="Neck (-5)">Neck (-5)</option>									
 									<option value="Groin (-3)">Groin (-3)</option>
-									<option value="Arms (-2)">Arms (-2)</option>
-									<option value="Hands (-4)">Hands (-4)</option>
-									<option value="Legs (-2)">Legs (-2)</option>
-									<option value="Feet (-4)">Feet (-4)></option>
+									<option value="">----</option>
+									<option value="right Arm (-2)">Arm, right (-2)</option>
+									<option value="left Arm (-2)">Arm, left (-2)</option>
+									<option value="right Hand (-4)">Hand, right (-4)</option>
+									<option value="left Hand (-4)">Hand, left (-4)</option>
+									<option value="right Leg (-2)">Leg, right (-2)</option>
+									<option value="left Leg (-2)">Leg, left (-2)</option>
+									<option value="right Foot (-4)">Foot, right (-4)</option>
+									<option value="left Foot (-4)">Foot, left(-4)</option>
+									<option value="">----</option>
+									<option value="Tail (-3)">Tail (-3)</option>
+									<option value="Wing (-2)">Wing (-2)</option>
+									<option value="">----</option>
+									<option value="other (-x)">other (-x)</option>
 								</select>
 							</div>
-							<div class="sheet-attackpanel-atk"><input type="text" value="n/a"name="attr_ATK_option05"/></div>
+							<div class="sheet-attackpanel-atk"><input class="sheet-input-text-small" type="text" value="n/a"name="attr_ATK_option05"/></div>
+						</div>
+						<div class="sheet-row">
+							<div class="sheet-attackpanel-atk"><input class="sheet-input-text-small" type="text" value=""name="attr_ATK_option01_max"/></div>
+							<div class="sheet-attackpanel-atk">&nbsp;</div>
+							<div class="sheet-attackpanel-atk">&nbsp;</div>
+							<div class="sheet-attackpanel-atk">&nbsp;</div>
+							<div class="sheet-attackpanel-atk">&nbsp;</div>
 						</div>
 					</div>
 					<hr/>
 					<div class="sheet-rightpanel-meleeweapons">	
-						<div class="sheet-row">
-							<div class="sheet-meleeweapons-button">&nbsp;</div>
+						<div class="sheet-row">							
 							<div class="sheet-meleeweapons-name">melee attacks</div>					
 							<div class="sheet-meleeweapons-parry">parry</div>
 							<div class="sheet-meleeweapons-reach">reach</div>
 							<div class="sheet-meleeweapons-skill">skill</div>
+							<div class="sheet-meleeweapons-button">&nbsp;</div>
 							<div class="sheet-meleeweapons-type">type</div>
 							<div class="sheet-meleeweapons-damage">damage</div>
+							<div class="sheet-meleeweapons-button">&nbsp;</div>
 						</div>
-						<fieldset class="repeating_mweapon">										
-							<div class="sheet-meleeweapons-button">
-								<button type='roll' name='roll_atk_mweapon' value='/em attacks with @{name}\n/ooc @{ATK_option01} | @{ATK_option04}\n/ooc - ATK: [[3d6]] vs @{skill} | DMG: [[@{damage}]] @{type}\n/ooc - Specials: @{ATK_option02}, @{ATK_option03}, @{ATK_option05}'>*</button>
-							</div>
+						<fieldset class="repeating_mweapon">
 							<div class="sheet-meleeweapons-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>						
 							<div class="sheet-meleeweapons-parry"><input class="sheet-input-uppercase" type="text" value="" name="attr_parry"/></div>
 							<div class="sheet-meleeweapons-reach"><input class="sheet-input-uppercase" type="text" value="" name="attr_reach"/></div>
 							<div class="sheet-meleeweapons-skill"><input class="sheet-colored-green" type="text" value=""name="attr_skill"/></div>
-							<div class="sheet-meleeweapons-type"><input class="sheet-input-text-small" type="text" value=""name="attr_type"/></div>
+							<div class="sheet-meleeweapons-button">
+								<button tabindex=500 type='roll' name='roll_atk_mweapon' value='/em ?{Attack Emote|attacks with @{name}}\n/ooc @{ATK_option01} | @{ATK_option04}\n/ooc - ATK: [[3d6]] vs @{skill} (@{name})\n/ooc - Specials: @{ATK_option02}, @{ATK_option03}, @{ATK_option05}'>A</button>
+							</div>	
+							<div class="sheet-meleeweapons-type">
+								<select name="attr_type" class="sheet-input-text-small">																		
+									<option value="spec" selected="selected">spec</option>									
+									<option value="cr">cr</option>									
+									<option value="cut">cut</option>									
+									<option value="imp">imp</option>									
+									<option value="pi-">pi-</option>									
+									<option value="pi">pi</option>									
+									<option value="pi+">pi+</option>									
+									<option value="pi++">pi++</option>									
+									<option value="aff">aff</option>									
+									<option value="burn">burn</option>									
+									<option value="cor">cor</option>																		
+									<option value="fat">fat</option>																		
+									<option value="tox">tox</option>									
+								</select>
+							</div>
 							<div class="sheet-meleeweapons-damage"><input type="text" value=""name="attr_damage"/></div>													
+							<div class="sheet-meleeweapons-button">
+								<button tabindex=500 type='roll' name='roll_dm_mweapon' value='/ooc DMG: [[@{damage}]] @{type}, @{ATK_option04}, @{name}'>D</button>
+							</div>
 						</fieldset>
 						<hr/>
 					</div>
 					<hr/>
 					<div class="sheet-rightpanel-rangedweapons">	
-						<div class="sheet-row">
-							<div class="sheet-rangedweapons-button">&nbsp;</div>
+						<div class="sheet-row">							
 							<div class="sheet-rangedweapons-name">ranged attacks</div>					
 							<div class="sheet-rangedweapons-acc">acc</div>	
 							<div class="sheet-rangedweapons-range">range</div>	
@@ -473,11 +541,12 @@
 							<div class="sheet-rangedweapons-bulk">bulk</div>	
 							<div class="sheet-rangedweapons-recoil">recoil</div>
 							<div class="sheet-rangedweapons-skill">skill</div>
+							<div class="sheet-rangedweapons-button">&nbsp;</div>
 							<div class="sheet-rangedweapons-type">type</div>	
 							<div class="sheet-rangedweapons-damage">damage</div>						
+							<div class="sheet-rangedweapons-button">&nbsp;</div>
 						</div>	
-						<fieldset class="repeating_rweapon">							
-							<div class="sheet-rangedweapons-button"><button type='roll' name='roll_atk_rweapon' value='/em attacks with @{name}\n/ooc @{ATK_option01} | @{ATK_option04}\n/ooc - ATK: [[3d6]] vs @{skill} | DMG: [[@{damage}]] @{type}\n/ooc - Specials: @{ATK_option02}, @{ATK_option03}, @{ATK_option05}'>*</button></div>
+						<fieldset class="repeating_rweapon">														
 							<div class="sheet-rangedweapons-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>						
 							<div class="sheet-rangedweapons-acc"><input class="sheet-input-uppercase" type="text" value="" name="attr_acc"/></div>
 							<div class="sheet-rangedweapons-range"><input class="sheet-input-uppercase" type="text" value="" name="attr_range"/></div>
@@ -486,8 +555,26 @@
 							<div class="sheet-rangedweapons-bulk"><input class="sheet-input-uppercase" type="text" value="" name="attr_bulk"/></div>
 							<div class="sheet-rangedweapons-recoil"><input class="sheet-input-uppercase" type="text" value="" name="attr_recoil"/></div>
 							<div class="sheet-rangedweapons-skill"><input class="sheet-colored-green" type="text" value=""name="attr_skill"/></div>
-							<div class="sheet-rangedweapons-type"><input class="sheet-input-text-small" type="text" value=""name="attr_type"/></div>
+							<div class="sheet-rangedweapons-button"><button tabindex=500 type='roll' name='roll_atk_rweapon' value='/em ?{Attack Emote|attacks with @{name}}\n/ooc @{ATK_option01} | @{ATK_option04}\n/ooc - ATK: [[3d6]] vs @{skill} (@{name})\n/ooc - Specials: @{ATK_option02}, @{ATK_option03}, @{ATK_option05}'>A</button></div>
+							<div class="sheet-rangedweapons-type">
+								<select name="attr_type" class="sheet-input-text-small">																		
+									<option value="spec" selected="selected">spec</option>									
+									<option value="cr">cr</option>									
+									<option value="cut">cut</option>									
+									<option value="imp">imp</option>									
+									<option value="pi-">pi-</option>									
+									<option value="pi">pi</option>									
+									<option value="pi+">pi+</option>									
+									<option value="pi++">pi++</option>									
+									<option value="aff">aff</option>									
+									<option value="burn">burn</option>									
+									<option value="cor">cor</option>																		
+									<option value="fat">fat</option>																		
+									<option value="tox">tox</option>									
+								</select>
+							</div>
 							<div class="sheet-rangedweapons-damage"><input type="text" value=""name="attr_damage"/></div>					
+							<div class="sheet-rangedweapons-button"><button tabindex=500 type='roll' name='roll_atk_rweapon' value='/ooc DMG [[@{damage}]] @{type}, @{ATK_option04}, @{name}'>D</button></div>
 						</fieldset>				
 						<hr/>
 					</div>
@@ -500,7 +587,7 @@
 	<h3>Skills</h3>
 	<div class="sheet-tabbed-panel">
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-skillpanel-top sheet-colored-white">
+			<div class="charsheet sheet-skillpanel-top">
 				<div class="sheet-row">
 					<div class="sheet-skill-button">&nbsp;</div>
 					<div class="sheet-skill-name">Name</div>
@@ -510,15 +597,15 @@
 					<div class="sheet-skill-stat sheet-popup">Stat</div>
 						<span class="sheet-tooltip">STAT linked to the Skill.</span>						
 					<div class="sheet-skill-level sheet-popup">Level</div>
-						<span class="sheet-tooltip">Level in the Skill (this will add to the STAT to determine Base Skill).</span>						
+						<span class="sheet-tooltip">Level in the Skill<br/>This will be added to the STAT to determine your Base Skill.</span>						
 					<div class="sheet-skill-base sheet-popup">Base</div>
-						<span class="sheet-tooltip">Doesn't work currently due to roll20, but the button macro uses flat values (STAT + LEVEL) and works proper so just ignore for now.</span>						
+						<span class="sheet-tooltip">Base Skill<br>Automatically calculated based on STAT + LEVEL.</span>						
 					<div class="sheet-skill-trained sheet-popup">CP</div>
-						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a training in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
+						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a CP in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
 				</div>
 				<fieldset class="repeating_skill">
 					<div class="sheet-row">
-						<div class="sheet-skill-button"><button type='roll' name='roll_baseskill' value='/ooc Check(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]'>*</button></div>
+						<div class="sheet-skill-button"><button tabindex=500 type='roll' name='roll_baseskill' value='/ooc Check(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]'>*</button></div>
 						<div class="sheet-skill-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>
 						<div class="sheet-skill-note"><input class="sheet-input-leftaligned sheet-input-text-small" type="text" value="" name="attr_desc"/></div>
 						<div class="sheet-skill-ref"><input class="sheet-input-text-small sheet-colored-gray" type="text" value="" name="attr_ref"/></div>						
@@ -545,7 +632,7 @@
 	<h3>Techniques</h3>
 	<div class="sheet-tabbed-panel">
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-skillpanel-bottom sheet-colored-white">
+			<div class="charsheet sheet-skillpanel-bottom">
 				<div class="sheet-row">
 					<div class="sheet-skill-button">&nbsp;</div>
 					<div class="sheet-skill-name">Name</div>						
@@ -555,15 +642,15 @@
 					<div class="sheet-skill-stat sheet-popup">Stat</div>
 						<span class="sheet-tooltip">STAT linked to the Skill.</span>						
 					<div class="sheet-skill-level sheet-popup">Level</div>
-						<span class="sheet-tooltip">Level in the Skill (this will add to the STAT to determine Base Skill).</span>						
+						<span class="sheet-tooltip">Level in the Skill<br/>This will be added to the STAT to determine your Base Skill.</span>						
 					<div class="sheet-skill-base sheet-popup">Base</div>
-						<span class="sheet-tooltip">Doesn't work currently due to roll20, but the button macro uses flat values (STAT + LEVEL) and works proper so just ignore for now.</span>						
+						<span class="sheet-tooltip">Base Skill<br>Automatically calculated based on STAT + LEVEL.</span>						
 					<div class="sheet-skill-trained sheet-popup">CP</div>
-						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a training in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
+						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a CP in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
 				</div>
 				<fieldset class="repeating_technique">
 					<div class="sheet-row">
-						<div class="sheet-skill-button"><button type='roll' name='roll_baseskill' value='/ooc Check(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]'>*</button></div>
+						<div class="sheet-skill-button"><button tabindex=500 type='roll' name='roll_baseskill' value='/ooc Check(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]'>*</button></div>
 						<div class="sheet-skill-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>
 						<div class="sheet-skill-note"><input class="sheet-input-leftaligned sheet-input-text-small" type="text" value="" name="attr_desc"/></div>
 						<div class="sheet-skill-ref"><input class="sheet-input-text-small sheet-colored-gray" type="text" value="" name="attr_ref"/></div>						
@@ -592,7 +679,7 @@
     <h3>Advantages & Perks</h3>
 	<div class="sheet-tabbed-panel">
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-traitpanel-top sheet-colored-white">
+			<div class="charsheet sheet-traitpanel-top">
 				<div class="sheet-row">					
 					<div class="sheet-trait-name">Name</div>
 					<div class="sheet-trait-note">Notes</div>					
@@ -613,7 +700,7 @@
 	<h3>Disadvantages & Quirks</h3>
 	<div class="sheet-tabbed-panel">
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-traitpanel-top sheet-colored-white">
+			<div class="charsheet sheet-traitpanel-top">
 				<div class="sheet-row">					
 					<div class="sheet-trait-name">Name</div>
 					<div class="sheet-trait-note">Notes</div>					
@@ -641,9 +728,9 @@
 					<div class="sheet-coin-amount sheet-input-text-small"><input class="sheet-input-text-small" type="text" value="0" name="attr_cash01"/></div>
 					<div class="sheet-coin-name sheet-input-text-small">Gold</div>
 					<div class="sheet-coin-amount sheet-input-text-small"><input class="sheet-input-text-small" type="text" value="0" name="attr_cash01_max"/></div>
-					<div class="sheet-coin-name sheet-input-text-small sheet-popup">Silver</div>
-						<span class="sheet-tooltip sheet-input-text-small">Usually this is the default GURPS silver Dollar ($).</span>
-					<div class="sheet-coin-amount sheet-input-text-small"><input class="sheet-input-text-small" type="text" value="0" name="attr_cash02"/></div>
+					<div class="sheet-coin-name sheet-input-text-small sheet-popup">Silver ($)</div>
+						<span class="sheet-tooltip sheet-input-text-small">Default GURPS Dollar ($).</span>
+					<div class="sheet-coin-amount sheet-input-text-small"><input class="sheet-input-text-small sheet-colored-green" type="text" value="0" name="attr_cash02"/></div>
 					<div class="sheet-coin-name sheet-input-text-small">Copper</div>
 					<div class="sheet-coin-amount sheet-input-text-small"><input class="sheet-input-text-small" type="text" value="0" name="attr_cash02_max"/></div>
 				</div>
@@ -652,7 +739,7 @@
 	</h3>		
 	<div class="sheet-tabbed-panel">
 		<div class="sheet-row-panel sheet-input-centeraligned">
-			<div class="charsheet sheet-inventorypanel-top sheet-colored-white">
+			<div class="charsheet sheet-inventorypanel-top">
 				<div class="sheet-row-panel">					
 					<div class="sheet-inventory-title sheet-popup">Quick inventory</div>
 						<span class="sheet-tooltip">Use this to make quick and dirty notes during a session, for quest items like special papers, or whatever you want.</span>
@@ -662,39 +749,26 @@
 		</div>
 		<hr/>
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-inventorypanel-bottom sheet-colored-white">
+			<div class="charsheet sheet-inventorypanel-bottom">
 				<div class="sheet-row">					
 					<div class="sheet-inventory-carried">&nbsp;</div>
-					<div class="sheet-inventory-name">Consumables</div>						
+					<div class="sheet-inventory-name">Consumables & Ammo</div>						
 					<div class="sheet-inventory-ref sheet-popup">Ref</div>
 						<span class="sheet-tooltip">Page & Book reference.</span>						
 					<div class="sheet-inventory-note">Macro Effect</div>												
-					<div class="sheet-inventory-location">Location</div>																
+					<div class="sheet-inventory-location">Held in</div>																
 					<div class="sheet-inventory-WT">WT</div>																
 					<div class="sheet-inventory-QT">QT</div>																					
 					<div class="sheet-inventory-totalWT sheet-popup">#WT</div>
-						<span class="sheet-tooltip">Quantity * Weight total.<br/>Doesn't work currently due to roll20, so just ignore for now.</span>
+						<span class="sheet-tooltip">Quantity * Weight<br/>No global weight calculation for now, only item by item.</span>
 				</div>
 				<fieldset class="repeating_consumable">
 					<div class="sheet-row">					
-						<div class="sheet-inventory-carried"><button type='roll' name='roll_baseskill' value='/em uses @{name}\n/ooc @{desc}'>*</button></div>
+						<div class="sheet-inventory-carried"><button tabindex=500 type='roll' name='roll_baseskill' value='/em ?{Use Emote|uses @{name}}\n/ooc (@{name}) @{desc}'>*</button></div>
 						<div class="sheet-inventory-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>						
 						<div class="sheet-inventory-ref"><input class="sheet-input-text-small sheet-colored-gray" type="text" value="" name="attr_ref"/></div>											
 						<div class="sheet-inventory-note"><input class="sheet-input-leftaligned sheet-input-text-small" type="text" value="" name="attr_desc"/></div>												
-						<div class="sheet-inventory-location">
-							<select name="attr_location">
-								<option value="0">right hand</option>
-								<option value="1">left hand</option>
-								<option value="2">right arm</option>
-								<option value="3">left arm</option>
-								<option value="4">backpack</option>
-								<option value="5">potion belt</option>
-								<option value="6">bandolier</option>
-								<option value="7">pouches</option>
-								<option value="8">other</option>								
-								<option value="9" selected="selected">n/a</option>
-							</select>
-						</div>							
+						<div class="sheet-inventory-location"><input class="sheet-input-text-small" type="text" value="" name="attr_location"/></div>						
 						<div class="sheet-inventory-WT"><input type="text" value="0" name="attr_wt"/></div>																
 						<div class="sheet-inventory-QT"><input class="sheet-colored-green" type="text" value="0" name="attr_qt"/></div>																					
 						<div class="sheet-inventory-totalWT"><input type="text" value="(@{wt}*@{qt})" disabled="true" name="attr_totalwt"/></div>						
@@ -704,18 +778,18 @@
 			</div>
 		</div>
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-inventorypanel-bottom sheet-colored-white">
+			<div class="charsheet sheet-inventorypanel-bottom">
 				<div class="sheet-row">					
 					<div class="sheet-inventory-carried">&nbsp;</div>
 					<div class="sheet-inventory-name">Other Items</div>						
 					<div class="sheet-inventory-ref sheet-popup">Ref</div>
 						<span class="sheet-tooltip">Page & Book reference.</span>						
 					<div class="sheet-inventory-note">Notes</div>												
-					<div class="sheet-inventory-location">Location</div>																
+					<div class="sheet-inventory-location">Held in</div>																
 					<div class="sheet-inventory-WT">WT</div>																
 					<div class="sheet-inventory-QT">QT</div>																					
 					<div class="sheet-inventory-totalWT sheet-popup">#WT</div>
-						<span class="sheet-tooltip">Quantity * Weight total.<br/>Doesn't work currently due to roll20, so just ignore for now.</span>
+						<span class="sheet-tooltip">Quantity * Weight<br/>No global weight calculation for now, only item by item.</span>
 				</div>
 				<fieldset class="repeating_inventory">
 					<div class="sheet-row">					
@@ -723,20 +797,7 @@
 						<div class="sheet-inventory-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>						
 						<div class="sheet-inventory-ref"><input class="sheet-input-text-small sheet-colored-gray" type="text" value="" name="attr_ref"/></div>											
 						<div class="sheet-inventory-note"><input class="sheet-input-leftaligned sheet-input-text-small" type="text" value="" name="attr_desc"/></div>												
-						<div class="sheet-inventory-location">
-							<select name="attr_location">
-								<option value="0">right hand</option>
-								<option value="1">left hand</option>
-								<option value="2">right arm</option>
-								<option value="3">left arm</option>
-								<option value="4">backpack</option>
-								<option value="5">potion belt</option>
-								<option value="6">bandolier</option>
-								<option value="7">pouches</option>
-								<option value="8">other</option>								
-								<option value="9" selected="selected">n/a</option>
-							</select>
-						</div>							
+						<div class="sheet-inventory-location"><input class="sheet-input-text-small" type="text" value="" name="attr_location"/></div>												
 						<div class="sheet-inventory-WT"><input type="text" value="0" name="attr_wt"/></div>																
 						<div class="sheet-inventory-QT"><input class="sheet-colored-green" type="text" value="0" name="attr_qt"/></div>																					
 						<div class="sheet-inventory-totalWT"><input type="text" value="(@{wt}*@{qt})" disabled="true" name="attr_totalwt"/></div>						
@@ -748,31 +809,31 @@
 	</div>
 </div>
 <div class="sheet-tab-content sheet-tab5">
-    <h3>Spells</h3>
+    <h3>Spells, PSI & Powers</h3>
 	<div class="sheet-tabbed-panel">
     	<div class="sheet-row-panel">
-			<div class="charsheet sheet-spellpanel-top sheet-colored-white">
+			<div class="charsheet sheet-spellpanel-top">
 				<div class="sheet-row">					
 					<div class="sheet-spell-button">&nbsp;</div>
 					<div class="sheet-spell-name">Name</div>						
 					<div class="sheet-spell-ref sheet-popup">Ref</div>
 						<span class="sheet-tooltip">Page & Book reference.</span>						
-					<div class="sheet-spell-duration">Duration</div>												
+					<div class="sheet-spell-duration">Dur</div>												
 					<div class="sheet-spell-cost">Cost</div>																
 					<div class="sheet-spell-emote">Macro Emote</div>																
 					<div class="sheet-spell-effect">Macro Effect</div>																
 					<div class="sheet-spell-stat sheet-popup">Stat</div>
 						<span class="sheet-tooltip">STAT linked to the Skill.</span>						
 					<div class="sheet-spell-level sheet-popup">Level</div>
-						<span class="sheet-tooltip">Level in the Skill (this will add to the STAT to determine Base Skill).</span>						
+						<span class="sheet-tooltip">Level in the Skill<br/>This will be added to the STAT to determine your Base Skill.</span>						
 					<div class="sheet-spell-base sheet-popup">Base</div>
-						<span class="sheet-tooltip">Doesn't work currently due to roll20, but the button macro uses flat values (STAT + LEVEL) and works proper so just ignore for now.</span>						
+						<span class="sheet-tooltip">Base Skill<br>Automatically calculated based on STAT + LEVEL.</span>						
 					<div class="sheet-spell-trained sheet-popup">CP</div>
-						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a training in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
+						<span class="sheet-tooltip">Check the box during a session to indicate that you've gained a CP in this Skill. <br/>Once you sort the CPs and whatnot after the session, just untick the box.</span>						
 				</div>
 				<fieldset class="repeating_spell">
 					<div class="sheet-row">	
-						<div class="sheet-spell-button"><button type='roll' name='roll_basespelll' value='/em @{emote}\n/ooc Spell(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]\n/ooc Effect: @{effect}'>*</button></div>
+						<div class="sheet-spell-button"><button tabindex=500 type='roll' name='roll_basespelll' value='/em ?{Casting Emote|@{emote}}\n/ooc Spell(@{name}) [[3d6]] vs [[(@{statscore}+@{level})]]\n/ooc Effect: @{effect}'>*</button></div>
 						<div class="sheet-spell-name"><input class="sheet-input-leftaligned" type="text" value="" name="attr_name"/></div>						
 						<div class="sheet-spell-ref"><input class="sheet-input-text-small sheet-colored-gray" type="text" value="" name="attr_ref"/></div>						
 						<div class="sheet-spell-duration"><input class="sheet-input-text-small" type="text" value="" name="attr_duration"/></div>												
@@ -819,7 +880,7 @@
 				<hr/>
 				<div class="sheet-row">					
 					<div class="sheet-desc-label sheet-input-centeraligned">NAME</div>						
-					<div class="sheet-desc-field"><input class="sheet-input-text-small" type="text" name="attr_character_name"/></div>					
+					<div class="sheet-desc-fieldlarge"><input class="sheet-input-text-small sheet-input-leftaligned" type="text" name="attr_character_name"/></div>					
 					<div class="sheet-desc-label sheet-input-centeraligned">RACE</div>						
 					<div class="sheet-desc-field"><input type="text" name="attr_charinfo01"/></div>					
 					<div class="sheet-desc-label sheet-input-centeraligned">GENDER</div>						
@@ -829,7 +890,7 @@
 				</div>
 				<div class="sheet-row">					
 					<div class="sheet-desc-label sheet-input-centeraligned">TITLE</div>						
-					<div class="sheet-desc-field"><input class="sheet-input-text-small" type="text" name="attr_character_name_name"/></div>					
+					<div class="sheet-desc-fieldlarge"><input class="sheet-input-text-small sheet-input-leftaligned" type="text" name="attr_character_name_name"/></div>					
 					<div class="sheet-desc-label sheet-input-centeraligned">AGE</div>						
 					<div class="sheet-desc-field"><input type="text" name="attr_charinfo02_max"/></div>					
 					<div class="sheet-desc-label sheet-input-centeraligned">SM</div>						
@@ -844,7 +905,7 @@
 	</div>
 	<div class="sheet-tabbed-panel">
 		<div class="sheet-row-panel sheet-input-centeraligned">			
-			<div class="charsheet sheet-variouspanel-appear sheet-colored-white sheet-input-leftaligned">
+			<div class="charsheet sheet-variouspanel-appear sheet-input-leftaligned">
 				<hr/>
 				<div class="sheet-row">					
 					<div class="sheet-appear-label sheet-input-rightaligned">Appearance</div>											
@@ -876,7 +937,7 @@
 	</div>
 	<div class="sheet-tabbed-panel">
 		<div class="sheet-row-panel sheet-input-centeraligned">
-			<div class="charsheet sheet-quicknotes-appear sheet-colored-white sheet-input-leftaligned">
+			<div class="charsheet sheet-quicknotes-appear sheet-input-leftaligned">
 				<div class="sheet-row-panel">					
 					<div class="sheet-appear-label sheet-input-rightaligned">Quick Notes</div>						
 					<div class="sheet-appear-textfield"><textarea class="sheet-fluid-textarea charsheet sheet-button-triple-height" name="attr_variousnotes"></textarea></div>					
@@ -887,7 +948,7 @@
 	</div>
 	<div class="sheet-tabbed-panel">
 		<div class="sheet-row-panel sheet-input-centeraligned">
-			<div class="charsheet sheet-contacts-appear sheet-colored-white sheet-input-leftaligned">
+			<div class="charsheet sheet-contacts-appear sheet-input-leftaligned">
 				<div class="sheet-row-panel">					
 					<div class="sheet-contacts-name">Contacts</div>																
 					<div class="sheet-contacts-location">Location</div>

--- a/GURPS_Mutonized/ReadMe.md
+++ b/GURPS_Mutonized/ReadMe.md
@@ -7,6 +7,18 @@ There is no CP calculation, this sheet is purely for actual play and focuses on:
 
 Otherwise, sheet is pretty much done and as far as I could tell, works perfectly fine.
 
-minor TODO:
-- Add field for maneuvers asking for it such as Ready, Change Posture, etc
-- Polish macros with custom inputs to allow for user defined emotes.
+CHANGELOG
+06/05/2014:
+- Fixed 1/2 and 1/3 HP calculation so that it's based off Max HP instead of Current HP.
+- Split the Attack macro into an Attack (A) and a Damage (D) macros.
+- Added an input text field below the Maneuver Declaration button. This is meant to be used to specify what you actually do when choosing Maneuvers like Ready, Concentrate, Wait and Change Posture. For other Maneuvers, just leave it blank.
+- Changed "location" in inventory to a text field for wider compatibility.
+- Changed TABINDEX across the board so that it'll ignore buttons and macros. You can now press TAB for quick data input usually.
+- Fixed a couple Wounding Modifiers errors in the Damage Taken Calculator (below Armor DR panel)
+- Changed weapon "type" to use a select list instead of text for ease of use and consistant formatting.
+- Re-organised and Added entries for many select lists to offer more options and clarity.
+- Added custom emote prompt for Active Defenses, Attacks, Consumables and Spell macros. For each of these, there will be an auto-filled in Default value as well (so you can just accept it and it stills looks ok).
+- Slight improvement in layout in many places.
+- Added and updated many tooltips (should appear at the top right corner of the sheet usually.)
+- Known Issues: 
+	- If you scroll down, tooltips can go off-screen.

--- a/GURPS_Mutonized/sheet.json
+++ b/GURPS_Mutonized/sheet.json
@@ -1,7 +1,7 @@
 {
 	"html": "GURPS.html",
 	"css": "GURPS.css",
-	"authors": "by MutonZ, based on the sheet design by David L. Hawkins (@The Story Teller)& Aaron C. Meadows",
+	"authors": "by MutonZ, based on the sheet design by David L. Hawkins (@The Story Teller)& Aaron C. Meadows and others",
 	"preview": "gurps.jpg",
 	"instructions": "#GURPS Character Sheet\r Designed for efficiency during play and screen space saving, using tabs"
 }


### PR DESCRIPTION
Hey, 
This is update to GURPS Style 2 sheet after some user feedback and comment.
Thanks again.

CHANGELOG
06/05/2014:
- Fixed 1/2 and 1/3 HP calculation so that it's based off Max HP instead of Current HP.
- Split the Attack macro into an Attack (A) and a Damage (D) macros.
- Added an input text field below the Maneuver Declaration button. This is meant to be used to specify what you actually do when choosing Maneuvers like Ready, Concentrate, Wait and Change Posture. For other Maneuvers, just leave it blank.
- Changed "location" in inventory to a text field for wider compatibility.
- Changed TABINDEX across the board so that it'll ignore buttons and macros. You can now press TAB for quick data input usually.
- Fixed a couple Wounding Modifiers errors in the Damage Taken Calculator (below Armor DR panel)
- Changed weapon "type" to use a select list instead of text for ease of use and consistant formatting.
- Re-organised and Added entries for many select lists to offer more options and clarity.
- Added custom emote prompt for Active Defenses, Attacks, Consumables and Spell macros. For each of these, there will be an auto-filled in Default value as well (so you can just accept it and it stills looks ok).
- Slight improvement in layout in many places.
- Added and updated many tooltips (should appear at the top right corner of the sheet usually.)
- Known Issues: 
  - If you scroll down, tooltips can go off-screen.
