### PR TITLE
V2.03

### DIFF
--- a/AD&D_2E/2ESheet.html
+++ b/AD&D_2E/2ESheet.html
@@ -1,4 +1,5 @@
-<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" checked="checked" /><span></span>Character Sheet|Monster Sheet&nbsp;&nbsp;<input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2"/><span></span>
+
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" checked="checked" /><span></span>Character Sheet | Monster Sheet&nbsp;&nbsp;<input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2"/><span></span>
 <br><br>
 
 
@@ -14,14 +15,14 @@
     <tr><td><b>Race:</b><br><input type="text" name="attr_race"/></td>
     <td><b>Alignment:</b><br><input type="text" name="attr_alignment"/></td></tr>
     <tr><td><hr></td><td><hr></td></tr>
-    <tr><td><b>HP:<input type="text" name="attr_HP" class="sheet-short" value="@{HP}"/>/<input type="number" name="attr_HP_max" class="sheet-short" /></b></td>
+    <tr><td><b>HP:<input type="text" name="attr_HP" class="sheet-short" value="@{HP}"/>/<input type="text" name="attr_HP_max" class="sheet-short" /></b></td>
     <td><b>AC:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_AC" class="sheet-short" /></b>   <br>
     <b>AC Surprised:&nbsp;<input type="text" name="attr_ACsurprise" class="sheet-short" /></b>   <br>
     <b>AC Shieldless:<input type="text" name="attr_ACshieldless" class="sheet-short" /></b></td></tr></table>
     <b>Armor Type:</b><br><textarea name="attr_armtype" width="20"></textarea><table>
     <tr><td><hr></td><td><hr></td></tr>
     <tr></tr><td><b>Height: <input type="text" name="attr_Height" class="sheet-short" /></b>   <br>
-    <b>Weight:<input type="number" name="attr_Weight" class="sheet-short" /></b></td>
+    <b>Weight:<input type="text" name="attr_Weight" class="sheet-short" /></b></td>
     <td><b>Age:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <input type="number" name="attr_Age" class="sheet-short" /></b>   <br>
     <b>Max age:&nbsp;<input type="number" name="attr_Agemax" class="sheet-short" /></b></td></tr>
     <tr><td><br><b>Handedness:<input type="text" name="attr_Handedness"/></b></td></tr>
@@ -319,7 +320,7 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="text" name="attr_intlang" class="sheet-short" value="0"/></td>
             <td><input type="text" name="attr_intlvl" class="sheet-short" value="0"/></td>
             <td><input type="text" name="attr_intchance" class="sheet-short" value="0"/>%</td>
-            <td><input type="text" name="attr_intmax" class="sheet-short" value="+0"/></td>
+            <td><input type="text" name="attr_intmax" class="sheet-short" value="0"/></td>
             <td> </td>
             <td><input type="text" name="attr_intimm"></td>
             <td><input type="text" name="attr_intnotes"></td>
@@ -340,7 +341,7 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="text" name="attr_Wisdom" class="short" value="@{Wisdom}"/></td>
             <td><input type="text" name="attr_wisdef" class="sheet-short" value="+0"/></td>
             <td><input type="text" name="attr_wisbonus" class="sheet-short"/></td>
-            <td><input type="text" name="attr_wisfail" class="sheet-short" value="0"/></td>
+            <td><input type="text" name="attr_wisfail" class="sheet-short" value="0"/>%</td>
             <td> </td>
             <td> </td>
             <td><input type="text" name="attr_wisimm"/></td>
@@ -457,7 +458,7 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="number" class="short" disabled="true"><br><input type="text" name="attr_intlang" class="sheet-short" value="0"/></td>
             <td><input type="text" name="attr_intlvl" class="sheet-short" value="0"/><br><input type="number" class="short" disabled="true"></td>
             <td><input type="number" class="short" disabled="true"><br><input type="text" name="attr_intchance" class="sheet-short" value="0"/>%</td>
-            <td><input type="text" name="attr_intmax" class="sheet-short" value="+0"/><br><input type="number" class="short" disabled="true"></td>
+            <td><input type="text" name="attr_intmax" class="sheet-short" value="0"/><br><input type="number" class="short" disabled="true"></td>
             <td> </td>
             <td><input type="text" name="attr_intimm"><br><input type="text" class="" disabled="true"></td>
             <td><input type="text" name="attr_intnotes"></td>
@@ -532,9 +533,9 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="test" name="attr_attacknum" class="sheet-short"></td>
             <td><input type="text" name="attr_attackadj" class="sheet-short" value="+0"></td>
             <td><input type="text" name="attr_damadj" class="sheet-short" value="+0"></td>
-            <td><input type="text" name="attr_ThAC0" class="sheet-short" value="20"><button type="roll" name="roll_hit1" value="/em hits an AC of [[@{ThAC0}-(1d20+(@{attackadj})+(?{Strength bonus. Do not modify this field|@{strengthhit}}*@{strbonus})+(?{Dexterity bonus. Do not modify this field|@{dexmissile}}*@{dexbonus})+(?{Misc. bonus|+0}))]]">Hit</button></td>
-            <td><input type="text" name="attr_damsm" class="sheet-short"><button type="roll" name="roll_test1" value="/em rolls [[@{damsm}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage!"></button></td>
-            <td><input type="text" name="attr_daml" class="sheet-short"><button type="roll" name="roll_test2" value="/em rolls [[@{daml}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage!"></button></td>
+            <td><input type="text" name="attr_ThAC0" class="sheet-short" value="20"><button type="roll" name="roll_hit1" value="/em hits an AC of [[@{ThAC0}-(1d20+(@{attackadj})+(?{Strength bonus. Do not modify this field|@{strengthhit}}*@{strbonus})+(?{Dexterity bonus. Do not modify this field|@{dexmissile}}*@{dexbonus})+(?{Misc. bonus|+0}))]] using his/her @{weaponname}">Hit</button></td>
+            <td><input type="text" name="attr_damsm" class="sheet-short"><button type="roll" name="roll_test1" value="/em rolls [[@{damsm}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage using his/her @{weaponname}!"></button></td>
+            <td><input type="text" name="attr_daml" class="sheet-short"><button type="roll" name="roll_test2" value="/em rolls [[@{daml}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage using his/her @{weaponname}!"></button></td>
             <td><input type="text" name="attr_range" class="sheet-short"></td>
             <td><input type="number" name="attr_weapweight" class="sheet-short"></td>
             <td><input type="text" name="attr_weapsize" class="sheet-short"></td>
@@ -548,9 +549,9 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="test" name="attr_attacknum" class="sheet-short"></td>
             <td><input type="text" name="attr_attackadj" class="sheet-short" value="+0"></td>
             <td><input type="text" name="attr_damadj" class="sheet-short" value="+0"></td>
-            <td><input type="text" name="attr_ThAC0" class="sheet-short" value="20"><button type="roll" name="roll_hit1" value="/em hits an AC of [[@{ThAC0}-(1d20+(@{attackadj})+(?{Strength bonus. Do not modify this field|@{strengthhit}}*@{strbonus})+(?{Dexterity bonus. Do not modify this field|@{dexmissile}}*@{dexbonus})+(?{Misc. bonus|+0}))]]">Hit</button></td>
-            <td><input type="text" name="attr_damsm" class="sheet-short"><button type="roll" name="roll_test1" value="/em rolls [[@{damsm}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage!"></button></td>
-            <td><input type="text" name="attr_daml" class="sheet-short"><button type="roll" name="roll_test2" value="/em rolls [[@{daml}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage!"></button></td>
+            <td><input type="text" name="attr_ThAC0" class="sheet-short" value="20"><button type="roll" name="roll_hit1" value="/em hits an AC of [[@{ThAC0}-(1d20+(@{attackadj})+(?{Strength bonus. Do not modify this field|@{strengthhit}}*@{strbonus})+(?{Dexterity bonus. Do not modify this field|@{dexmissile}}*@{dexbonus})+(?{Misc. bonus|+0}))]] using his/her @{weaponname}">Hit</button></td>
+            <td><input type="text" name="attr_damsm" class="sheet-short"><button type="roll" name="roll_test1" value="/em rolls [[@{damsm}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage using his/her @{weaponname}!"></button></td>
+            <td><input type="text" name="attr_daml" class="sheet-short"><button type="roll" name="roll_test2" value="/em rolls [[@{daml}+(@{damadj})+(?{Strength bonus. Do not modify this field|@{strengthdmg}}*@{strbonus})+(?{Misc. bonus (please include + or -)|+0})]] damage using his/her @{weaponname}!"></button></td>
             <td><input type="text" name="attr_range" class="sheet-short"></td>
             <td><input type="number" name="attr_weapweight" class="sheet-short"></td>
             <td><input type="text" name="attr_weapsize" class="sheet-short"></td>
@@ -564,7 +565,12 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
 
 
 <h4>Special Abilities and Attacks</h4><br><textarea name="attr_abilitiesnotes"></textarea><br>
-<h4>Rogue Skills</h4>
+
+    <h4>Rogue Skills</h4><div><input type="checkbox" class="arrow" /><span></span>Hide
+    
+    <div class="body">
+
+    
 <strong>Backstab Multiplier:</strong><input type="text" name="attr_backstabmultiplier" class="tiny">
 <table style='border-collapse: collapse; border-spacing: 0;'>
     <tr>
@@ -693,7 +699,8 @@ Current weight:<input type="number" name="attr_movweighttotal" value="@{gearweig
             <td><input type="text" name="attr_ebl" value="+0" class="sheet-short"/>%</td>
             <td><input type="text" name="attr_ebt" value="@{ebb}@{ebr}@{ebd}@{eba}@{ebl}" disabled="true" class="sheet-short"/>%<button type="roll" name="roll_eb" value="/gmroll {1d100+[[?{Misc. modifier|+0}]]}<[[@{ebt}]] [Escape Bonds*]"></button><button type="roll" name="roll_ebnoarmor" value="/gmroll {1d100+[[?{Misc. modifier|+0}]]}<[[@{ebb}@{ebr}@{ebd}@{ebl}]] [Escape Bonds* (no armor)]">No armor</button></td>
     </tr>
-</table>Skills with an asterisk (*) are from Skills & Powers, and may be ignored for campaigns using core rules.<br><hr>
+</table>Skills with an asterisk (*) are from Skills & Powers, and may be ignored for campaigns using core rules.</div>
+</div><br><hr>
 
 
 <div class="sheet-2colrow">


### PR DESCRIPTION
Changed the "weight" and "max HP" character information fields to text fields.
Adjusted the spelling for the character sheet selection.
Added weapon name to attack and damage rolls.
Turned rogue skills into a collapsible section.
