### PR TITLE
Fix Expertise and make Proficiency calc readable

### DIFF
--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -155,7 +155,7 @@
 				<h4 class="sheet-center">Level, Experience and Inspiration <span class="sheet-pictos-three">d</span></h4>
 				<div class="sheet-row">
 					<div class="sheet-col-1-2 sheet-small-label sheet-center" title="This is automatically calculated from your individual class levels listed in the class section"><input class="sheet-underlined" type="number" name="attr_level" value="@{barbarian_level} + @{bard_level} + @{cleric_level} + @{druid_level} + @{fighter_level} + @{monk_level} + @{paladin_level} + @{ranger_level} + @{rogue_level} + @{wizard_level}" disabled="disabled"><br/>Overall Level</div>
-					<div class="sheet-col-1-2 sheet-small-label sheet-center" title="This is a bonus for you being proficient in a given task.  This bonus automatically increases as you level up and is used automatically in various rolls"><input class="sheet-underlined" type="number" name="attr_PB" value="ceil((@{level})/1e10) + ceil((@{level})/4)" disabled="disabled"  ><br/>Prof Bonus</div>
+					<div class="sheet-col-1-2 sheet-small-label sheet-center" title="This is a bonus for you being proficient in a given task.  This bonus automatically increases as you level up and is used automatically in various rolls"><input class="sheet-underlined" type="number" name="attr_PB" value="1 + ceil((@{level})/4)" disabled="disabled"  ><br/>Prof Bonus</div>
 				</div>
 				
 				<div class="sheet-row">
@@ -237,7 +237,7 @@
 						<select name="attr_acrobatics_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_acrobatics_bonus" value="0" step="1"/></div>
@@ -251,7 +251,7 @@
 						<select name="attr_animalhandling_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_animalhandling_bonus" value="0" step="1"/></div>
@@ -265,7 +265,7 @@
 						<select name="attr_arcana_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_arcana_bonus" value="0" step="1"/></div>
@@ -279,7 +279,7 @@
 						<select name="attr_athletics_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_athletics_bonus" value="0" step="1"/></div>
@@ -293,7 +293,7 @@
 						<select name="attr_deception_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_deception_bonus" value="0" step="1"/></div>
@@ -307,7 +307,7 @@
 						<select name="attr_history_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_history_bonus" value="0" step="1"/></div>
@@ -321,7 +321,7 @@
 						<select name="attr_insight_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_insight_bonus" value="0" step="1"/></div>
@@ -335,7 +335,7 @@
 						<select name="attr_intimidation_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_intimidation_bonus" value="0" step="1"/></div>
@@ -349,7 +349,7 @@
 						<select name="attr_investigation_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_investigation_bonus" value="0" step="1"/></div>
@@ -377,7 +377,7 @@
 						<select name="attr_medicine_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_medicine_bonus" value="0" step="1"/></div>
@@ -391,7 +391,7 @@
 						<select name="attr_nature_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_nature_bonus" value="0" step="1"/></div>
@@ -405,7 +405,7 @@
 						<select name="attr_perception_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_perception_bonus" value="0" step="1"/></div>
@@ -419,7 +419,7 @@
 						<select name="attr_performance_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_performance_bonus" value="0" step="1"/></div>
@@ -433,7 +433,7 @@
 						<select name="attr_persuasion_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_persuasion_bonus" value="0" step="1"/></div>
@@ -447,7 +447,7 @@
 						<select name="attr_religion_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_religion_bonus" value="0" step="1"/></div>
@@ -461,7 +461,7 @@
 						<select name="attr_sleightofhand_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_sleightofhand_bonus" value="0" step="1"/></div>
@@ -475,7 +475,7 @@
 						<select name="attr_stealth_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_stealth_bonus" value="0" step="1"/></div>
@@ -489,7 +489,7 @@
 						<select name="attr_survival_prof_exp">
 							<option value="0">Untrained</option>
 							<option value="@{PB}">Trained</option>
-							<option value="2*@{PB}">Expert</option>
+							<option value="2*(@{PB})">Expert</option>
 						</select>
 					</div>
 					<div class="sheet-col-1-7"><input type="number" name="attr_survival_bonus" value="0" step="1"/></div>


### PR DESCRIPTION
Not sure why Proficiency was calculated with "ceil((@{level})/1e10)" instead of "1" because they are functionally the same thing (PC will never reach a level over 1e10).

Added brackets to the Expertise calculation because it was only multiplying the 1, making Expertise's bonus a +1 instead of +Proficiency.

Realised after editing that adding the brackets to the Proficiency calculations might have been the way to go as it would fix similar problems in other situations at the same time.
