### PR TITLE
Fix the Dark Heresy sheets

### DIFF
--- a/Dark_Heresy/DarkHeresy.html
+++ b/Dark_Heresy/DarkHeresy.html
@@ -1,704 +1,979 @@
 <div class="sheet-wrapper">
+	<!-- Logo Header -->
 
-<!-- Logo Header -->
-<div class="sheet-1colrow">
-    <div class="sheet-col" style="margin-bottom:-30px;">
-        <img src="https://i.imgur.com/IO1zs3a.png" style="max-height: 100px; margin-left:21%;"/>
-    </div>
-</div>
+	<div class="sheet-1colrow sheet-col" style="margin-bottom:-30px;"><img src="https://i.imgur.com/IO1zs3a.png" style="max-height: 100px; margin-left:21%;"></div><!-- Base Character Information -->
 
-<!-- Base Character Information -->
-<div class="sheet-1colrow">
-    <div class="sheet-col">
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:13.2%"><label>Character Name</label></div>
-            <div class="sheet-item sheet-large"><input type="text" name="attr_character_name" /></div>
-            <div class="sheet-item sheet-tiny"><label>Player Name</label></div>
-            <div class="sheet-item sheet-large"><input type="text" name="attr_playername" /></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item sheet-little"><label>Home World</label></div>
-            <div class="sheet-item sheet-med"><input type="text" name="attr_homeworld" /></div>
-            <div class="sheet-item sheet-little"><label>Career Path</label></div>
-            <div class="sheet-item sheet-small"><input type="text" name="attr_careerpath" /></div>
-            <div class="sheet-item sheet-puny"><label>Rank</label></div>
-            <div class="sheet-item sheet-small"><input type="text" name="attr_rank" /></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item sheet-little"><label>Divination</label></div>
-            <div class="sheet-item sheet-large"><input type="text" name="attr_divination"/></div>
-            <div class="sheet-item sheet-puny"></div>
-            <div class="sheet-item sheet-puny"><label>Quirk</label></div>
-            <div class="sheet-item sheet-large"><input type="text" name="attr_quirk"/></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item sheet-puny"><label>Gender</label></div>
-            <div class="sheet-item sheet-small"><input type="text" name="attr_gender" /></div>
-            <div class="sheet-item sheet-puny"><label>Build</label></div>
-            <div class="sheet-item sheet-small"><input type="text" name="attr_build" /></div>
-            <div class="sheet-item sheet-puny"><label>Height</label></div>
-            <div class="sheet-item sheet-small"><input type="text" name="attr_height" /></div>
-            <div class="sheet-item sheet-puny"><label>Weight</label></div>
-            <div class="sheet-item sheet-tiny"><input type="text" name="attr_weight" /></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-row">
-                <div class="sheet-item sheet-little"><label>Skin Colour</label></div>
-                <div class="sheet-item sheet-tiny"><input type="text" name="attr_skincolour" /></div>
-                <div class="sheet-item sheet-little"><label>Hair Colour</label></div>
-                <div class="sheet-item sheet-tiny"><input type="text" name="attr_haircolour" /></div>
-                <div class="sheet-item sheet-puny"></div>
-                <div class="sheet-item sheet-little"><label>Eye Colour</label></div>
-                <div class="sheet-item sheet-tiny"><input type="text" name="attr_eyecolour" /></div>
-                <div class="sheet-item sheet-puny"><label>Age</label></div>
-                <div class="sheet-item sheet-tiny"><input type="text" name="attr_age" /></div>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- Main Sheet First Tier -->
-<div class="sheet-3colrow">
-
-    <!-- Left Column -->
-    <div class="sheet-col sheet-skills">
-    <hr>
-        <h3>Basic Skills</h3>
-        <table>
-            <tr>
-                <th>Skill Name</th>
-                <th></th>
-                <th>10</th>
-                <th>20</th>
-                <th>Roll</th>
-            </tr>
-            <tr>
-                <td>Awareness (Per)</td>
-                <td><input type="checkbox" name="attr_awareness1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_awareness2" value="10" /></td>
-                <td><input type="checkbox" name="attr_awareness3" value="10" /></td>
-                <td><button type="roll" name="roll_awareness" value="/em rolls Awareness with [[(@{awareness}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_awareness" value="floor((@{awareness1}+0.5)*@{per}+@{awareness2}+@{awareness3})" disabled="true"/>
-                </button></td>
-            </tr>
-            <tr>
-                <td>Barter (Fel)</td>
-                <td><input type="checkbox" name="attr_barter1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_barter2" value="10" /></td>
-                <td><input type="checkbox" name="attr_barter3" value="10" /></td>
-                <td><button type="roll" name="roll_Barter" value="/em rolls Barter with [[(@{Barter}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Barter" value="floor((@{Barter1}+0.5)*@{fel}+@{Barter2}+@{Barter3})" disabled="true"/>
-                </button></td>
-            </tr>
-            <tr>
-                <td>Carouse (T)</td>
-                <td><input type="checkbox" name="attr_Carouse1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Carouse2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Carouse3" value="10" /></td>
-                <td><button type="roll" name="roll_Carouse" value="/em rolls Carouse with [[(@{Carouse}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Carouse" value="floor((@{Carouse1}+0.5)*@{toughness}+@{Carouse2}+@{Carouse3})" disabled="true"/>
-                </button></td>
-            </tr>
-            <tr>
-                <td>Charm (Fel)</td>
-                <td><input type="checkbox" name="attr_charm1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_charm2" value="10" /></td>
-                <td><input type="checkbox" name="attr_charm3" value="10" /></td>
-                <td><button type="roll" name="roll_Charm" value="/em rolls Charm with [[(@{Charm}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Charm" value="floor((@{Charm1}+0.5)*@{fel}+@{Charm2}+@{Charm3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Climb (S)</td>
-                <td><input type="checkbox" name="attr_Climb1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Climb2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Climb3" value="10" /></td>
-                <td><button type="roll" name="roll_Climb" value="/em rolls Climb with [[(@{Climb}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Climb" value="floor((@{Climb1}+0.5)*@{strength}+@{Climb2}+@{Climb3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Concealment (Ag)</td>
-                <td><input type="checkbox" name="attr_Concealment1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Concealment2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Concealment3" value="10" /></td>
-                <td><button type="roll" name="roll_Concealment" value="/em rolls Concealment with [[(@{Concealment}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Concealment" value="floor((@{Concealment1}+0.5)*@{ag}+@{Concealment2}+@{Concealment3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Contortionist (Ag)</td>
-                <td><input type="checkbox" name="attr_Contortionist1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Contortionist2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Contortionist3" value="10" /></td>
-                <td><button type="roll" name="roll_Contortionist" value="/em rolls Contortionist with [[(@{Contortionist}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Contortionist" value="floor((@{Contortionist1}+0.5)*@{ag}+@{Contortionist2}+@{Contortionist3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Deceive (Fel)</td>
-                <td><input type="checkbox" name="attr_Deceive1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Deceive2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Deceive3" value="10" /></td>
-                <td><button type="roll" name="roll_Deceive" value="/em rolls Deceive with [[(@{Deceive}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Deceive" value="floor((@{Deceive1}+0.5)*@{fel}+@{Deceive2}+@{Deceive3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Disguise (Fel)</td>
-                <td><input type="checkbox" name="attr_Disguise1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Disguise2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Disguise3" value="10" /></td>
-                <td><button type="roll" name="roll_Disguise" value="/em rolls Disguise with [[(@{Disguise}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Disguise" value="floor((@{Disguise1}+0.5)*@{fel}+@{Disguise2}+@{Disguise3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Dodge (Ag)</td>
-                <td><input type="checkbox" name="attr_Dodge1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Dodge2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Dodge3" value="10" /></td>
-                <td><button type="roll" name="roll_Dodge" value="/em rolls Dodge with [[(@{Dodge}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Dodge" value="floor((@{Dodge1}+0.5)*@{ag}+@{Dodge2}+@{Dodge3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Evaluate (Int)</td>
-                <td><input type="checkbox" name="attr_Evaluate1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Evaluate2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Evaluate3" value="10" /></td>
-                <td><button type="roll" name="roll_Evaluate" value="/em rolls Evaluate with [[(@{Evaluate}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Evaluate" value="floor((@{Evaluate1}+0.5)*@{int}+@{Evaluate2}+@{Evaluate3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Gamble (Int)</td>
-                <td><input type="checkbox" name="attr_Gamble1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Gamble2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Gamble3" value="10" /></td>
-                <td><button type="roll" name="roll_Gamble" value="/em rolls Gamble with [[(@{Gamble}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Gamble" value="floor((@{Gamble1}+0.5)*@{int}+@{Gamble2}+@{Gamble3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Inquiry (Fel)</td>
-                <td><input type="checkbox" name="attr_Inquiry1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Inquiry2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Inquiry3" value="10" /></td>
-                <td><button type="roll" name="roll_Inquiry" value="/em rolls Inquiry with [[(@{Inquiry}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Inquiry" value="floor((@{Inquiry1}+0.5)*@{fel}+@{Inquiry2}+@{Inquiry3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Intimidate (S)</td>
-                <td><input type="checkbox" name="attr_Intimidate1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Intimidate2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Intimidate3" value="10" /></td>
-                <td><button type="roll" name="roll_Intimidate" value="/em rolls Intimidate with [[(@{Intimidate}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Intimidate" value="floor((@{Intimidate1}+0.5)*@{strength}+@{Intimidate2}+@{Intimidate3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Logic (Int)</td>
-                <td><input type="checkbox" name="attr_Logic1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Logic2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Logic3" value="10" /></td>
-                <td><button type="roll" name="roll_Logic" value="/em rolls Logic with [[(@{Logic}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Logic" value="floor((@{Logic1}+0.5)*@{int}+@{Logic2}+@{Logic3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Scrutiny (Per)</td>
-                <td><input type="checkbox" name="attr_Scrutiny1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Scrutiny2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Scrutiny3" value="10" /></td>
-                <td><button type="roll" name="roll_Scrutiny" value="/em rolls Scrutiny with [[(@{Scrutiny}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Scrutiny" value="floor((@{Scrutiny1}+0.5)*@{per}+@{Scrutiny2}+@{Scrutiny3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Search (Per)</td>
-                <td><input type="checkbox" name="attr_Search1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Search2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Search3" value="10" /></td>
-                <td><button type="roll" name="roll_Search" value="/em rolls Search with [[(@{Search}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Search" value="floor((@{Search1}+0.5)*@{per}+@{Search2}+@{Search3})" disabled="true"/>
-                </button></td>             </tr>
-            <tr>
-                <td>Silent Move (Ag)</td>
-                <td><input type="checkbox" name="attr_SilentMove1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_SilentMove2" value="10" /></td>
-                <td><input type="checkbox" name="attr_SilentMove3" value="10" /></td>
-                <td><button type="roll" name="roll_SilentMove" value="/em rolls Silent Move with [[(@{SilentMove}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_SilentMove" value="floor((@{SilentMove1}+0.5)*@{ag}+@{SilentMove2}+@{SilentMove3})" disabled="true"/>
-                </button></td>             </tr>
-
-            <tr>
-                <td>Swim (S)</td>
-                <td><input type="checkbox" name="attr_Swim1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_Swim2" value="10" /></td>
-                <td><input type="checkbox" name="attr_Swim3" value="10" /></td>
-                <td><button type="roll" name="roll_Swim" value="/em rolls Swim with [[(@{Swim}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_Swim" value="floor((@{Swim1}+0.5)*@{strength}+@{Swim2}+@{Swim3})" disabled="true"/>
-                </button></td>             </tr>
-        </table>
-
-        <fieldset class="repeating_basicskills">
-            <table><tr>
-                <td>
-                    <div class="sheet-row">
-                        <div class="sheet-item sheet-bigger">
-                            <input class="sheet-baseinfo" type="text" name="attr_basicskillname"/>
-                        </div>
-                        <div class="sheet-item sheet-med">
-                            <select name="attr_basicskillcharacteristic" class="charaselect">
-                                <option value="@{ws}">(WS)</option>
-                                <option value="@{bs}">(BS)</option>
-                                <option value="@{strength}">(S)</option>
-                                <option value="@{toughness}">(T)</option>
-                                <option value="@{ag}">(Ag)</option>
-                                <option value="@{int}">(Int)</option>
-                                <option value="@{per}">(Per)</option>
-                                <option value="@{wp}">(Wp)</option>
-                                <option value="@{fel}">(Fel)</option>
-                            </select>
-                        </div>
-                    </div>
-                </td>
-                <td><input type="checkbox" name="attr_basicskillbox1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_basicskillbox2" value="10" /></td>
-                <td><input type="checkbox" name="attr_basicskillbox3" value="10" /></td>
-                <td><button type="roll" name="roll_basicskill" value="/em rolls @{basicskillname} with [[(@{basicskill}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_basicskill" value="floor((@{basicskillbox1}+0.5)*@{basicskillcharacteristic}+@{basicskillbox2}+@{basicskillbox3})" disabled="true"/>
-                </button></td>             </table></tr>
-        </fieldset>
-
-        <h3>Talents & Traits</h3>
-        <div class="sheet-row">
-            <div class="sheet-item sheet-tiny" style="width:16%;"><input type="text" name="attr_weapontrainingclass"/></div>
-            <div class="sheet-item sheet-large"><label> Weapon Training </label></div>
-            <div class="sheet-item sheet-big sheet-brackets"><input type="text" name="attr_weapontraining"/></div>
-        </div>
-
-        <fieldset class="repeating_weapontalents">
-            <div class="sheet-row">
-                <div class="sheet-item sheet-tiny"  style="width:16%;"><input type="text" name="attr_weapontrainingclass"/></div>
-                <div class="sheet-item sheet-large"><label> Weapon Training </label></div>
-                <div class="sheet-item sheet-big sheet-brackets"><input type="text" name="attr_weapontraining"/></div>
-            </div>
-        </fieldset>
-
-        <input type="text" name="attr_fixtalent" />
-        <fieldset class="repeating_talents">
-            <input type="text" name="attr_reptalent" />
-        </fieldset>
-
-    </div>
-
-    <!-- Mid Column / Characteristics -->
-    <div class="sheet-col sheet-characteristics">
-        <h3>Characteristics</h3>
-        <button type="roll" name="roll_ws" value="/me rolls a Weapon Skill check with [[(@{WS}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Weapon Skill (WS)</label></button><br>
-               <input type="text" name="attr_ws" value="0" />
-        <button type="roll" name="roll_bs" value="/me rolls a Ballistic Skill check with [[(@{BS}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Ballistic Skill (BS)</label></button><br>
-               <input type="text" name="attr_bs" value="0" />
-        <button type="roll" name="roll_strength" value="/me rolls a Strength check with [[(@{Strength}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Strength (S)</label></button><br>
-               <input type="text" name="attr_strength" value="0" />
-        <button type="roll" name="roll_toughness" value="/me rolls a Toughness check with [[(@{Toughness}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Toughness (T)</label></button><br>
-               <input type="text" name="attr_toughness" value="0" />
-        <button type="roll" name="roll_ag" value="/me rolls an Agility check with [[(@{Ag}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Agility (Ag)</label></button><br>
-               <input type="text" name="attr_ag" value="0" />
-        <button type="roll" name="roll_int" value="/me rolls an Intelligence check with [[(@{Int}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Intelligence (Int)</label></button><br>
-           	<input type="text" name="attr_int" value="0" />
-        <button type="roll" name="roll_Per" value="/me rolls a Perception check with [[(@{Per}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Perception (Per)</label></button><br>
-           	<input type="text" name="attr_per" value="0" />
-        <button type="roll" name="roll_Wp" value="/me rolls a Willpower check with [[(@{Wp}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Willpower (Wp)</label></button><br>
-           	<input type="text" name="attr_wp" value="0" />
-        <button type="roll" name="roll_Fel" value="/me rolls a Fellowship check with [[(@{Fel}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Fellowship (Fel)</label></button><br>
-           	<input type="text" name="attr_fel" value="0" />
-    </div>
-
-    <!-- Right Column -->
-	<div class="sheet-col sheet-skills">
-    <hr>
-        <h3>Advanced Skills</h3>
-    	<table>
-    		<tr>
-                <th>Skill Name</th>
-                <th></th>
-                <th>10</th>
-                <th>20</th>
-                <th>Roll</th>
-            </tr>
-        	<tr>
-                <td>Speak Language (Low Gothic)</td>
-                <td><input type="checkbox" name="attr_speaklow1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_speaklow2" value="10" /></td>
-                <td><input type="checkbox" name="attr_speaklow3" value="10" /></td>
-                <td><button type="roll" name="roll_speaklow" value="/em rolls Speak Language (Low Gothic) with [[(@{speaklow}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_speaklow" value="floor((@{speaklow1}+0.5)*@{int}+@{speaklow2}+@{speaklow3})" disabled="true"/>
-                </button></td>
-            </tr>
-        </table>
-        <fieldset class="repeating_advancedskills">
-            <table><tr>
-                <td>
-                    <div class="sheet-row">
-                        <div class="sheet-item sheet-bigger">
-                            <input class="sheet-baseinfo" type="text" name="attr_advancedskillname"/>
-                        </div>
-                        <div class="sheet-item sheet-med">
-                            <select name="attr_advancedskillcharacteristic" class="charaselect">
-                                <option value="@{ws}">(WS)</option>
-                                <option value="@{bs}">(BS)</option>
-                                <option value="@{strength}">(S)</option>
-                                <option value="@{toughness}">(T)</option>
-                                <option value="@{ag}">(Ag)</option>
-                                <option value="@{int}">(Int)</option>
-                                <option value="@{per}">(Per)</option>
-                                <option value="@{wp}">(Wp)</option>
-                                <option value="@{fel}">(Fel)</option>
-                            </select>
-                        </div>
-                    </div>
-                </td>
-                <td><input type="checkbox" name="attr_advancedskillbox1" value="0.5" /></td>
-                <td><input type="checkbox" name="attr_advancedskillbox2" value="10" /></td>
-                <td><input type="checkbox" name="attr_advancedskillbox3" value="10" /></td>
-                <td><button type="roll" name="roll_advancedskill" value="/em rolls @{advancedskillname} with [[(@{advancedskill}+?{Modifier|0}-1d100)/10]] degree(s) of success!">
-                    <input type="number" name="attr_advancedskill" value="floor((@{advancedskillbox1}+0.5)*@{advancedskillcharacteristic}+@{advancedskillbox2}+@{advancedskillbox3})" disabled="true"/>
-                </button></td>             </table></tr>
-        </fieldset>
-
-        <hr>
-
-        <!-- ATTENTION PSYKERS AHEAD! -->
-
-        <h3>Psychic Powers</h3>
-        	<div class="sheet-row">
-            	<div class="sheet-item" style="width:37.5%"><label>Psychic Discipline</label></div>
-                <div class="sheet-item sheet-morebig"><input type="text" name="attr_psychicdiscipline" /></div>
-                <div class="sheet-item sheet-puny">
-                	<button type="roll" name="roll_psycicpower" value="/me draws on the power of the Warp!\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})">
-                    	<label>Psy</label>
-                    </button>
-                </div>
-            </div>
-            <fieldset class="repeating_psychicdiscipline">
-            	<div class="sheet-row">
-                    <div class="sheet-item" style="width:37.5%"><label>Psychic Discipline</label></div>
-                    <div class="sheet-item sheet-morebig"><input type="text" name="attr_reppsychicdiscipline" /></div>
-                    <div class="sheet-item sheet-puny">
-                        <button type="roll" name="roll_reppsycicpower" value="/me draws on the power of the Warp!\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})">
-                            <label>Psy</label>
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <!-- Minor Powers -->
-            <fieldset class="repeating_minorpsychicpowers">
-            	<div class="sheet-row">
-                	<div class="sheet-item sheet-large"><label>Minor Power</label></div>
-                    <div class="sheet-item sheet-morebig sheet-brackets"><input type="text" name="attr_repminorpsychicpower" /></div>
-                    <div class="sheet-item sheet-puny">
-                        <button type="roll" name="roll_repminorpower" value="/me draws on the power of the Warp and casts @{repminorpsychicpower}! (Threshold: [[?{Threshold|7}]])\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})">
-                            <label>Psy</label>
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-            <!-- Discipline Powers -->
-            <fieldset class="repeating_disciplinepsychicpowers">
-                <div class="sheet-row">
-                	<div class="sheet-item sheet-large"><label>Discipline Power</label></div>
-                    <div class="sheet-item sheet-morebig sheet-brackets"><input type="text" name="attr_repdisciplinepsychicpower" /></div>
-                    <div class="sheet-item sheet-puny">
-                        <button type="roll" name="roll_repdisciplinepower" value="/me draws on the power of the Warp and casts @{repdisciplinepsychicpower}! (Threshold: [[?{Threshold|7}]])\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})">
-                            <label>Psy</label>
-                        </button>
-                    </div>
-                </div>
-            </fieldset>
-
-        <!-- Mutations anyone? -->
-        <h3>Mutation</h3>
-            <textarea name="attr_mutations" style="width:95%; margin:auto; height:75px;"></textarea>
-
-        <h3>Talents & Traits</h3>
-        	<input type="text" name="attr_fixtalent2" />
-        <fieldset class="repeating_talents2">
-		<input type="text" name="attr_reptalent2" />
-	</fieldset>
-
-
-    </div>
-</div>
-<div class="sheet-2colrow">
-	<div class="sheet-col">
-		<h3>Melee Weapons</h3>
-        <fieldset class="repeating_meleeweapons">
-        	<div class="sheet-quickborder">
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-tiny">
-                       <button type="roll" name="roll_meleeattack"
-                                value="/me uses their @{meleeweaponname} to try and hit and achieves [[(@{ws}+?{Modifier|0}-1d100)/10]] degree(s) of success! (Pen: [[@{meleeweaponpen}]])">
-                            <label>Name:</label>
-                        </button></div>
-                    <div class="sheet-item sheet-big"><input type="text" name="attr_meleeweaponname" /></div>
-                    <div class="sheet-item sheet-puny"></div>
-                    <div class="sheet-item sheet-tiny"><label>Class:</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_meleeweaponclass" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-small">
-                       <button type="roll" name="roll_meleedamage"
-                                value="/me does [[{@{meleeweapondamage}+(floor(@{strength}/10)), (@{meleeweapontearing}*(@{meleeweapondamage}+(floor(@{strength}/10))))}kh1]] @{meleeweapontype} damage!">
-                            <label>Damage:</label>
-                        </button></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_meleeweapondamage" /></div>
-                    <div class="sheet-item sheet-little"><label style="font-size:0.9em;">Tearing</label></div>
-                    <div class="sheet-item sheet-puny"><input type="checkbox" name="attr_meleeweapontearing" value="1" /></div>
-                    <div class="sheet-item sheet-little"><label>Type:</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_meleeweapontype" /></div>
-                    <div class="sheet-item sheet-puny"><label>Pen:</label></div>
-                    <div class="sheet-item sheet-puny"><input type="text" name="attr_meleeweaponpen" value="0" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-large"><label>Special Rules:</label></div>
-                    <div class="sheet-item sheet-morebig"><input type="text" name="attr_meleeweaponspecial" /></div>
-                    <div class="sheet-item sheet-puny">
-                       <button type="roll" name="roll_meleeattackcomp"
-                                value="/me uses their @{meleeweaponname} to try and hit and achieves [[(@{ws}+?{Modifier|0}-1d100)/10]] degree(s) of success! (Pen: [[@{meleeweaponpen}]])\n/me does [[{@{meleeweapondamage}+(floor(@{strength}/10)), (@{meleeweapontearing}*(@{meleeweapondamage}+(floor(@{strength}/10))))}kh1]] @{meleeweapontype} damage!">
-                            <label>R</label>
-                        </button>
-                    </div>
-                </div>
+	<div class="sheet-1colrow sheet-col">
+		<div class="sheet-row">
+			<div class="sheet-item" style="width:13.2%">
+				<label>Character Name</label>
 			</div>
-        </fieldset>
 
-        <div class="sheet-row">
-        	<div class="sheet-item sheet-med"><label>Handedness:</label></div>
-            <div class="sheet-item sheet-bigger"><input type="text" name="attr_handedness" /></div>
-        </div>
-           			<br />
-        <!-- Armor! -->
-        <h3>Armour</h3>
-        <div class="sheet-armourblock">
-
-        </div>
-       	<div class="sheet-quickborder sheet-armourblock">
-           	<label>Head</label>
-			<input type="text" name="attr_headarmourvalue" />
-            <label>(1-10) Type</label>
-            <input type="text" name="attr_headarmourtype" />
-	    </div><br />
-        <div class="sheet-quickborder sheet-armourblock">
-           	<label>Left Arm</label>
-			<input type="text" name="attr_leftarmarmourvalue" />
-            <label>(11-20) Type</label>
-            <input type="text" name="attr_leftarmarmourtype" />
-        </div>
-       	<div class="sheet-quickborder sheet-armourblock">
-           	<label>Body</label>
-
-			<input type="text" name="attr_bodyarmourvalue" />
-            <label>(31-70) Type</label>
-            <input type="text" name="attr_bodyarmourtype" />
-	    </div>
-        <div class="sheet-quickborder sheet-armourblock">
-           	<label>Right Arm</label>
-			<input type="text" name="attr_rightarmarmourvalue" />
-            <label>(31-30) Type</label>
-            <input type="text" name="attr_rightarmarmourtype" />
-        </div>
-        <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-           	<label>Left Leg</label>
-			<input type="text" name="attr_leftlegarmourvalue" />
-            <label>(71-85) Type</label>
-            <input type="text" name="attr_leftlegarmourtype" />
-        </div>
-        <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-           	<label>Right Leg</label>
-			<input type="text" name="attr_rightlegarmourvalue" />
-            <label>(86-00) Type</label>
-            <input type="text" name="attr_rightlegarmourtype" />
-        </div>
-    </div>
-
-    <!-- Right Side -->
-
-    <div class="sheet-col">
-		<h3>Ranged Weapons</h3>
-        <fieldset class="repeating_rangedweapons">
-        	<div class="sheet-quickborder">
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-tiny">
-                       <button type="roll" name="roll_rangedattack"
-                                value="/me uses their @{rangedweaponname} to try and shoot and achieves [[(@{bs}+?{Modifier|0}-1d100)/10]] degree(s) of success! (RoF: @{rangedweaponrof} | Clip: [[@{rangedweaponclip}]] | Pen: [[@{rangedweaponpen}]])">
-                            <label>Name:</label>
-                        </button></div>
-                    <div class="sheet-item sheet-big"><input type="text" name="attr_rangedweaponname" /></div>
-                    <div class="sheet-item sheet-puny"></div>
-                    <div class="sheet-item sheet-tiny"><label>Class:</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_rangedweaponclass" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-small">
-                       <button type="roll" name="roll_rangeddamage"
-                                value="/me does [[{@{rangedweapondamage}, (@{rangedweapontearing}*@{rangedweapondamage})}kh1]] @{rangedweapontype} damage!">
-                            <label>Damage:</label>
-                        </button></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_rangedweapondamage" /></div>
-                    <div class="sheet-item sheet-little"><label style="font-size:0.9em;">Tearing</label></div>
-                    <div class="sheet-item sheet-puny"><input type="checkbox" name="attr_rangedweapontearing" value="1" /></div>
-                    <div class="sheet-item sheet-little"><label>Type:</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_rangedweapontype" /></div>
-                    <div class="sheet-item sheet-puny"><label>Pen:</label></div>
-                    <div class="sheet-item sheet-puny"><input type="text" name="attr_rangedweaponpen" value="0" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-tiny"><label>Range:</label></div>
-                    <div class="sheet-item sheet-tiny"><input type="text" name="attr_rangedweaponrange" /></div>
-                    <div class="sheet-item sheet-puny"><label>RoF:</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_rangedweaponrof" /></div>
-                    <div class="sheet-item sheet-puny"><label>Clip:</label></div>
-                    <div class="sheet-item sheet-tiny"><input type="text" name="attr_rangedweaponclip" value="0" /></div>
-                    <div class="sheet-item sheet-tiny"><label>Reload:</label></div>
-                    <div class="sheet-item sheet-tiny"><input type="text" name="attr_rangedweaponreload" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-large"><label>Special Rules:</label></div>
-                    <div class="sheet-item sheet-morebig"><input type="text" name="attr_rangedweaponspecial" /></div>
-                    <div class="sheet-item sheet-puny">
-                       <button type="roll" name="roll_rangedattackcomp"
-                                value="/me uses their @{rangedweaponname} to try and shoot and achieves [[(@{bs}+?{Modifier|0}-1d100)/10]] degree(s) of success! (RoF: @{rangedweaponrof} | Clip: [[@{rangedweaponclip}]] | Pen: [[@{rangedweaponpen}]])\n/me does [[{@{rangedweapondamage}, (@{rangedweapontearing}*@{rangedweapondamage})}kh1]] @{rangedweapontype} damage!">
-                            <label>R</label>
-                        </button>
-                    </div>
-                </div>
+			<div class="sheet-item sheet-large">
+				<input name="attr_character_name" type="text">
 			</div>
-        </fieldset>
 
-        <h3>Gear</h3>
+			<div class="sheet-item sheet-tiny">
+				<label>Player Name</label>
+			</div>
 
-        <textarea name="attr_gear"></textarea><br /><br />
+			<div class="sheet-item sheet-large">
+				<input name="attr_playername" type="text">
+			</div>
+		</div>
 
-        <div class="sheet-row">
-        <!-- Movement -->
-        	<div class="sheet-item sheet-big">
-            	<div class="sheet-row">
-                	<div class="sheet-item sheet-med"></div>
-                	<div class="sheet-item sheet-med"><label>Walk</label></div>
-                    <div class="sheet-item sheet-med"><input type="number" name="attr_walkspeed" value="floor(@{ag}/10)" disabled="true" /></div>
+		<div class="sheet-row">
+			<div class="sheet-item sheet-little">
+				<label>Home World</label>
+			</div>
+
+			<div class="sheet-item sheet-med">
+				<input name="attr_homeworld" type="text">
+			</div>
+
+			<div class="sheet-item sheet-little">
+				<label>Career Path</label>
+			</div>
+
+			<div class="sheet-item sheet-small">
+				<input name="attr_careerpath" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Rank</label>
+			</div>
+
+			<div class="sheet-item sheet-small">
+				<input name="attr_rank" type="text">
+			</div>
+		</div>
+
+		<div class="sheet-row">
+			<div class="sheet-item sheet-little">
+				<label>Divination</label>
+			</div>
+
+			<div class="sheet-item sheet-large">
+				<input name="attr_divination" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny"></div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Quirk</label>
+			</div>
+
+			<div class="sheet-item sheet-large">
+				<input name="attr_quirk" type="text">
+			</div>
+		</div>
+
+		<div class="sheet-row">
+			<div class="sheet-item sheet-puny">
+				<label>Gender</label>
+			</div>
+
+			<div class="sheet-item sheet-small">
+				<input name="attr_gender" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Build</label>
+			</div>
+
+			<div class="sheet-item sheet-small">
+				<input name="attr_build" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Height</label>
+			</div>
+
+			<div class="sheet-item sheet-small">
+				<input name="attr_height" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Weight</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny">
+				<input name="attr_weight" type="text">
+			</div>
+		</div>
+
+		<div class="sheet-row sheet-row">
+			<div class="sheet-item sheet-little">
+				<label>Skin Colour</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny">
+				<input name="attr_skincolour" type="text">
+			</div>
+
+			<div class="sheet-item sheet-little">
+				<label>Hair Colour</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny">
+				<input name="attr_haircolour" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny"></div>
+
+			<div class="sheet-item sheet-little">
+				<label>Eye Colour</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny">
+				<input name="attr_eyecolour" type="text">
+			</div>
+
+			<div class="sheet-item sheet-puny">
+				<label>Age</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny">
+				<input name="attr_age" type="text">
+			</div>
+		</div>
+	</div><!-- Main Sheet First Tier -->
+
+	<div class="sheet-3colrow">
+		<!-- Left Column -->
+
+		<div class="sheet-col sheet-skills">
+			<hr>
+
+			<h3>Basic Skills</h3>
+
+			<table>
+				<tr>
+					<th>Skill Name</th>
+
+					<th></th>
+
+					<th>10</th>
+
+					<th>20</th>
+
+					<th>Roll</th>
+				</tr>
+
+				<tr>
+					<td>Awareness (Per)</td>
+					<td><input name="attr_awareness1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_awareness2" type="checkbox" value="10"></td>
+					<td><input name="attr_awareness3" type="checkbox" value="10"></td>
+					<td><button name="roll_awareness" type="roll" value="/em rolls Awareness with [[(@{awareness}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_awareness" type="number" value="floor((@{awareness1}+0.5)*@{per}+@{awareness2}+@{awareness3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Barter (Fel)</td>
+					<td><input name="attr_barter1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_barter2" type="checkbox" value="10"></td>
+					<td><input name="attr_barter3" type="checkbox" value="10"></td>
+					<td><button name="roll_Barter" type="roll" value="/em rolls Barter with [[(@{Barter}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Barter" type="number" value="floor((@{Barter1}+0.5)*@{fel}+@{Barter2}+@{Barter3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Carouse (T)</td>
+					<td><input name="attr_Carouse1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Carouse2" type="checkbox" value="10"></td>
+					<td><input name="attr_Carouse3" type="checkbox" value="10"></td>
+					<td><button name="roll_Carouse" type="roll" value="/em rolls Carouse with [[(@{Carouse}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Carouse" type="number" value="floor((@{Carouse1}+0.5)*@{toughness}+@{Carouse2}+@{Carouse3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Charm (Fel)</td>
+					<td><input name="attr_charm1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_charm2" type="checkbox" value="10"></td>
+					<td><input name="attr_charm3" type="checkbox" value="10"></td>
+					<td><button name="roll_Charm" type="roll" value="/em rolls Charm with [[(@{Charm}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Charm" type="number" value="floor((@{Charm1}+0.5)*@{fel}+@{Charm2}+@{Charm3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Climb (S)</td>
+					<td><input name="attr_Climb1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Climb2" type="checkbox" value="10"></td>
+					<td><input name="attr_Climb3" type="checkbox" value="10"></td>
+					<td><button name="roll_Climb" type="roll" value="/em rolls Climb with [[(@{Climb}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Climb" type="number" value="floor((@{Climb1}+0.5)*@{strength}+@{Climb2}+@{Climb3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Concealment (Ag)</td>
+					<td><input name="attr_Concealment1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Concealment2" type="checkbox" value="10"></td>
+					<td><input name="attr_Concealment3" type="checkbox" value="10"></td>
+					<td><button name="roll_Concealment" type="roll" value="/em rolls Concealment with [[(@{Concealment}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Concealment" type="number" value="floor((@{Concealment1}+0.5)*@{ag}+@{Concealment2}+@{Concealment3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Contortionist (Ag)</td>
+					<td><input name="attr_Contortionist1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Contortionist2" type="checkbox" value="10"></td>
+					<td><input name="attr_Contortionist3" type="checkbox" value="10"></td>
+					<td><button name="roll_Contortionist" type="roll" value="/em rolls Contortionist with [[(@{Contortionist}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Contortionist" type="number" value="floor((@{Contortionist1}+0.5)*@{ag}+@{Contortionist2}+@{Contortionist3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Deceive (Fel)</td>
+					<td><input name="attr_Deceive1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Deceive2" type="checkbox" value="10"></td>
+					<td><input name="attr_Deceive3" type="checkbox" value="10"></td>
+					<td><button name="roll_Deceive" type="roll" value="/em rolls Deceive with [[(@{Deceive}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Deceive" type="number" value="floor((@{Deceive1}+0.5)*@{fel}+@{Deceive2}+@{Deceive3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Disguise (Fel)</td>
+					<td><input name="attr_Disguise1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Disguise2" type="checkbox" value="10"></td>
+					<td><input name="attr_Disguise3" type="checkbox" value="10"></td>
+					<td><button name="roll_Disguise" type="roll" value="/em rolls Disguise with [[(@{Disguise}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Disguise" type="number" value="floor((@{Disguise1}+0.5)*@{fel}+@{Disguise2}+@{Disguise3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Dodge (Ag)</td>
+					<td><input name="attr_Dodge1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Dodge2" type="checkbox" value="10"></td>
+					<td><input name="attr_Dodge3" type="checkbox" value="10"></td>
+					<td><button name="roll_Dodge" type="roll" value="/em rolls Dodge with [[(@{Dodge}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Dodge" type="number" value="floor((@{Dodge1}+0.5)*@{ag}+@{Dodge2}+@{Dodge3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Evaluate (Int)</td>
+					<td><input name="attr_Evaluate1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Evaluate2" type="checkbox" value="10"></td>
+					<td><input name="attr_Evaluate3" type="checkbox" value="10"></td>
+					<td><button name="roll_Evaluate" type="roll" value="/em rolls Evaluate with [[(@{Evaluate}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Evaluate" type="number" value="floor((@{Evaluate1}+0.5)*@{int}+@{Evaluate2}+@{Evaluate3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Gamble (Int)</td>
+					<td><input name="attr_Gamble1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Gamble2" type="checkbox" value="10"></td>
+					<td><input name="attr_Gamble3" type="checkbox" value="10"></td>
+					<td><button name="roll_Gamble" type="roll" value="/em rolls Gamble with [[(@{Gamble}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Gamble" type="number" value="floor((@{Gamble1}+0.5)*@{int}+@{Gamble2}+@{Gamble3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Inquiry (Fel)</td>
+					<td><input name="attr_Inquiry1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Inquiry2" type="checkbox" value="10"></td>
+					<td><input name="attr_Inquiry3" type="checkbox" value="10"></td>
+					<td><button name="roll_Inquiry" type="roll" value="/em rolls Inquiry with [[(@{Inquiry}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Inquiry" type="number" value="floor((@{Inquiry1}+0.5)*@{fel}+@{Inquiry2}+@{Inquiry3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Intimidate (S)</td>
+					<td><input name="attr_Intimidate1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Intimidate2" type="checkbox" value="10"></td>
+					<td><input name="attr_Intimidate3" type="checkbox" value="10"></td>
+					<td><button name="roll_Intimidate" type="roll" value="/em rolls Intimidate with [[(@{Intimidate}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Intimidate" type="number" value="floor((@{Intimidate1}+0.5)*@{strength}+@{Intimidate2}+@{Intimidate3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Logic (Int)</td>
+					<td><input name="attr_Logic1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Logic2" type="checkbox" value="10"></td>
+					<td><input name="attr_Logic3" type="checkbox" value="10"></td>
+					<td><button name="roll_Logic" type="roll" value="/em rolls Logic with [[(@{Logic}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Logic" type="number" value="floor((@{Logic1}+0.5)*@{int}+@{Logic2}+@{Logic3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Scrutiny (Per)</td>
+					<td><input name="attr_Scrutiny1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Scrutiny2" type="checkbox" value="10"></td>
+					<td><input name="attr_Scrutiny3" type="checkbox" value="10"></td>
+					<td><button name="roll_Scrutiny" type="roll" value="/em rolls Scrutiny with [[(@{Scrutiny}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Scrutiny" type="number" value="floor((@{Scrutiny1}+0.5)*@{per}+@{Scrutiny2}+@{Scrutiny3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Search (Per)</td>
+					<td><input name="attr_Search1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Search2" type="checkbox" value="10"></td>
+					<td><input name="attr_Search3" type="checkbox" value="10"></td>
+					<td><button name="roll_Search" type="roll" value="/em rolls Search with [[(@{Search}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Search" type="number" value="floor((@{Search1}+0.5)*@{per}+@{Search2}+@{Search3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Silent Move (Ag)</td>
+					<td><input name="attr_SilentMove1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_SilentMove2" type="checkbox" value="10"></td>
+					<td><input name="attr_SilentMove3" type="checkbox" value="10"></td>
+					<td><button name="roll_SilentMove" type="roll" value="/em rolls Silent Move with [[(@{SilentMove}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_SilentMove" type="number" value="floor((@{SilentMove1}+0.5)*@{ag}+@{SilentMove2}+@{SilentMove3})"></button></td>
+				</tr>
+
+				<tr>
+					<td>Swim (S)</td>
+					<td><input name="attr_Swim1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_Swim2" type="checkbox" value="10"></td>
+					<td><input name="attr_Swim3" type="checkbox" value="10"></td>
+					<td><button name="roll_Swim" type="roll" value="/em rolls Swim with [[(@{Swim}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_Swim" type="number" value="floor((@{Swim1}+0.5)*@{strength}+@{Swim2}+@{Swim3})"></button></td>
+				</tr>
+			</table>
+
+			<fieldset class="repeating_basicskills">
+				<table>
+					<tr>
+						<td>
+							<div class="sheet-row">
+								<div class="sheet-item sheet-bigger">
+									<input class="sheet-baseinfo" name="attr_basicskillname" type="text">
+								</div>
+
+								<div class="sheet-item sheet-med">
+									<select class="charaselect" name="attr_basicskillcharacteristic">
+										<option value="@{ws}">(WS)</option>
+										<option value="@{bs}">(BS)</option>
+										<option value="@{strength}">(S)</option>
+										<option value="@{toughness}">(T)</option>
+										<option value="@{ag}">(Ag)</option>
+										<option value="@{int}">(Int)</option>
+										<option value="@{per}">(Per)</option>
+										<option value="@{wp}">(Wp)</option>
+										<option value="@{fel}">(Fel)</option>
+									</select>
+								</div>
+							</div>
+						</td>
+
+						<td><input name="attr_basicskillbox1" type="checkbox" value="0.5"></td>
+
+						<td><input name="attr_basicskillbox2" type="checkbox" value="10"></td>
+
+						<td><input name="attr_basicskillbox3" type="checkbox" value="10"></td>
+
+						<td><button name="roll_basicskill" type="roll" value="/em rolls @{basicskillname} with [[(@{basicskill}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_basicskill" type="number" value="floor((@{basicskillbox1}+0.5)*@{basicskillcharacteristic}+@{basicskillbox2}+@{basicskillbox3})"></button></td>
+					</tr>
+				</table>
+			</fieldset>
+
+			<h3>Talents & Traits</h3>
+
+			<div class="sheet-row">
+				<div class="sheet-item sheet-tiny" style="width:16%;">
+					<input name="attr_weapontrainingclass" type="text">
 				</div>
-                <div class="sheet-row">
-                	<div class="sheet-item sheet-med"></div>
-                    <div class="sheet-item sheet-med"><label>Walk</label></div>
-                    <div class="sheet-item sheet-med"><input type="number" name="attr_walkspeed" value="2*(floor(@{ag}/10))" disabled="true" /></div>
-                </div>
-                <div class="sheet-row">
-                	<div class="sheet-item sheet-med"></div>
-                	<div class="sheet-item sheet-med"><label>Charge</label></div>
-                    <div class="sheet-item sheet-med"><input type="number" name="attr_walkspeed" value="3*(floor(@{ag}/10))" disabled="true" /></div>
-                </div>
-                <div class="sheet-row">
-                	<div class="sheet-item sheet-med"></div>
-                    <div class="sheet-item sheet-med"><label>Run</label></div>
-                    <div class="sheet-item sheet-med"><input type="number" name="attr_walkspeed" value="6*(floor(@{ag}/10))" disabled="true" /></div>
-                </div>
-            </div>
-        <!-- Wealth -->
-        	<div class="sheet-item sheet-big sheet-uppercase sheet-armourblock">
-            	<label>Throne Gelt:</label>
-                <input type="number" name="attr_thronegelt" />
-                <label>Monthly: </label>
-                <input type="number" name="attr_monthlyincome" />
-            </div>
-        </div>
-    </div>
-</div>
 
-<hr />
-<!-- Footer Stuff -->
-    <div class="1colrow sheet-tablecontainer">
-            <div class="sheet-footer sheet-mainleft sheet-tablecell">
-                <h3>Wounds</h3>
-                <div class="sheet-innerfooter sheet-armourblock">
-                    <p>Total</p> <input type="text" name="attr_wounds_max" />
-                </div>
-                <div class="sheet-innerfooter  sheet-armourblock">
-                    <p style="text-transform:uppercase;">Critical Damage</p> <input type="text" name="attr_woundscritical" />
-                </div>
-                <div class="sheet-innerfooter  sheet-armourblock">
-                    <p>Current</p> <input type="text" name="attr_wounds" />
-                </div>
-                <div class="sheet-innerfooter  sheet-armourblock">
-                    <p style="text-transform:uppercase;">Fatigue (Max = TB)</p> <input type="text" name="attr_woundsfatigue" />
-                </div>
-            </div>
-            <div class="sheet-footer sheet-tablecell" style="width:18%;">
-                <h3>Fate Points</h3>
-                <div class="sheet-innerfooter" style="width:95%;">
-                    <p>Total: </p> <br> <input type="text" name="attr_fatetotal" />
-                </div>
-                <div class="sheet-innerfooter" style="width:95%;">
-                    <p>Current: </p> <br> <input type="text" name="attr_fatecurrent" />
-                </div>
-            </div>
-            <div class="sheet-footer sheet-mainright sheet-tablecell">
-                <div style="float:left; width:49%;">
-                <h3>Insanity</h3>
-                <table><tr>
-                    <td style="width:70%;">
-                    	<p>Insanity Points: </p>
-                    </td>
-                    <td style="width:70%;">
-                    	<input type="number" name="attr_insanitypoints" />
-                    </td></tr>
-                    <tr><td>
-                    	<p>Degree of M: </p>
-                    </td>
-                    <td>
-                    	<input type="number" name="attr_degreeofinsanity" />
-                    </td></tr>
-                </table>
-                    <textarea name="attr_disorders" placeholder="Disorders" style="width:90%; margin:auto; height:50px;"></textarea>
-                </div>
-                <div style="float:left; width:49%;">
-                <h3>Corruption</h3>
-                <table><tr>
-                    <td style="width:70%;">
-                    	<p>Corruption Points: </p>
-                    </td>
-                    <td>
-                    	<input type="number" name="attr_corruptionpoints" />
-                    </td></tr>
-                    <tr><td style="width:70%;">
-                    	<p>Degree of C: </p>
-                    </td>
-                    <td>
-                   		<input type="number" name="attr_degreeofcorruption" />
-                    </td></tr>
-                </table>
-                    <textarea name="attr_malignancies" placeholder="Malignancies" style="width:90%; margin:auto; height:50px;"></textarea>
-                </div>
-            </div>
-    </div>
-<hr />
-    <!-- XP -->
-<div class="1colrow">
-    <div class="colrow">
-        <h3>Experience Points</h3>
-            <div class="sheet-row">
-            	<div class="sheet-item sheet-tiny"><label>XP to spend </label></div>
-                <div class="sheet-item sheet-tiny sheet-armourblock"><input type="number" name="attr_xptospent" /></div>
-                <div class="sheet-item sheet-big"></div>
-                <div class="sheet-item sheet-tiny"><label>Total XP spent </label></div>
-                <div class="sheet-item sheet-tiny sheet-armourblock"><input type="number" name="attr_totalxpspent" /></div>
-            </div>
-            <label>Advancements Taken:</label>
-            <fieldset class="repeating_advancements">
-            	<div class="sheet-row">
-                	<div class="sheet-item" style="width:26%;"><input type="text" name="attr_advancement1" /></div>
-                    <div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock"><input type="text" name="attr_advancement1xp" /></div>
-                    <div class="sheet-item" style="width:26%;"><input type="text" name="attr_advancement2" /></div>
-                    <div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock"><input type="text" name="attr_advancement2xp" /></div>
-                    <div class="sheet-item" style="width:26%;"><input type="text" name="attr_advancement3" /></div>
-                    <div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock"><input type="text" name="attr_advancement3xp" /></div>
-                </div>
-            </fieldset>
-        <hr>
-        <h3>Other Notes:</h3>
-        <textarea name="attr_othernotes"></textarea>
-    </div>
-</div>
+				<div class="sheet-item sheet-large">
+					<label>Weapon Training</label>
+				</div>
 
-<!-- Charsheet End -->
+				<div class="sheet-item sheet-big sheet-brackets">
+					<input name="attr_weapontraining" type="text">
+				</div>
+			</div>
+
+			<fieldset class="repeating_weapontalents">
+				<div class="sheet-row">
+					<div class="sheet-item sheet-tiny" style="width:16%;">
+						<input name="attr_weapontrainingclass" type="text">
+					</div>
+
+					<div class="sheet-item sheet-large">
+						<label>Weapon Training</label>
+					</div>
+
+					<div class="sheet-item sheet-big sheet-brackets">
+						<input name="attr_weapontraining" type="text">
+					</div>
+				</div>
+			</fieldset><input name="attr_fixtalent" type="text">
+
+			<fieldset class="repeating_talents">
+				<input name="attr_reptalent" type="text">
+			</fieldset>
+		</div><!-- Mid Column / Characteristics -->
+
+		<div class="sheet-col sheet-characteristics">
+			<h3>Characteristics</h3><button name="roll_ws" type="roll" value="/me rolls a Weapon Skill check with [[(@{WS}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Weapon Skill (WS)</label></button><br>
+			<input name="attr_ws" type="text" value="0"> <button name="roll_bs" type="roll" value="/me rolls a Ballistic Skill check with [[(@{BS}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Ballistic Skill (BS)</label></button><br>
+			<input name="attr_bs" type="text" value="0"> <button name="roll_strength" type="roll" value="/me rolls a Strength check with [[(@{Strength}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Strength (S)</label></button><br>
+			<input name="attr_strength" type="text" value="0"> <button name="roll_toughness" type="roll" value="/me rolls a Toughness check with [[(@{Toughness}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Toughness (T)</label></button><br>
+			<input name="attr_toughness" type="text" value="0"> <button name="roll_ag" type="roll" value="/me rolls an Agility check with [[(@{Ag}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Agility (Ag)</label></button><br>
+			<input name="attr_ag" type="text" value="0"> <button name="roll_int" type="roll" value="/me rolls an Intelligence check with [[(@{Int}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Intelligence (Int)</label></button><br>
+			<input name="attr_int" type="text" value="0"> <button name="roll_Per" type="roll" value="/me rolls a Perception check with [[(@{Per}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Perception (Per)</label></button><br>
+			<input name="attr_per" type="text" value="0"> <button name="roll_Wp" type="roll" value="/me rolls a Willpower check with [[(@{Wp}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Willpower (Wp)</label></button><br>
+			<input name="attr_wp" type="text" value="0"> <button name="roll_Fel" type="roll" value="/me rolls a Fellowship check with [[(@{Fel}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><label>Fellowship (Fel)</label></button><br>
+			<input name="attr_fel" type="text" value="0">
+		</div><!-- Right Column -->
+
+		<div class="sheet-col sheet-skills">
+			<hr>
+
+			<h3>Advanced Skills</h3>
+
+			<table>
+				<tr>
+					<th>Skill Name</th>
+
+					<th></th>
+
+					<th>10</th>
+
+					<th>20</th>
+
+					<th>Roll</th>
+				</tr>
+
+				<tr>
+					<td>Speak Language (Low Gothic)</td>
+					<td><input name="attr_speaklow1" type="checkbox" value="0.5"></td>
+					<td><input name="attr_speaklow2" type="checkbox" value="10"></td>
+					<td><input name="attr_speaklow3" type="checkbox" value="10"></td>
+					<td><button name="roll_speaklow" type="roll" value="/em rolls Speak Language (Low Gothic) with [[(@{speaklow}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_speaklow" type="number" value="floor((@{speaklow1}+0.5)*@{int}+@{speaklow2}+@{speaklow3})"></button></td>
+				</tr>
+			</table>
+
+			<fieldset class="repeating_advancedskills">
+				<table>
+					<tr>
+						<td>
+							<div class="sheet-row">
+								<div class="sheet-item sheet-bigger">
+									<input class="sheet-baseinfo" name="attr_advancedskillname" type="text">
+								</div>
+
+								<div class="sheet-item sheet-med">
+									<select class="charaselect" name="attr_advancedskillcharacteristic">
+										<option value="@{ws}">(WS)</option>
+										<option value="@{bs}">(BS)</option>
+										<option value="@{strength}">(S)</option>
+										<option value="@{toughness}">(T)</option>
+										<option value="@{ag}">(Ag)</option>
+										<option value="@{int}">(Int)</option>
+										<option value="@{per}">(Per)</option>
+										<option value="@{wp}">(Wp)</option>
+										<option value="@{fel}">(Fel)</option>
+									</select>
+								</div>
+							</div>
+						</td>
+
+						<td><input name="attr_advancedskillbox1" type="checkbox" value="0.5"></td>
+
+						<td><input name="attr_advancedskillbox2" type="checkbox" value="10"></td>
+
+						<td><input name="attr_advancedskillbox3" type="checkbox" value="10"></td>
+
+						<td><button name="roll_advancedskill" type="roll" value="/em rolls @{advancedskillname} with [[(@{advancedskill}+?{Modifier|0}-1d100)/10]] degree(s) of success!"><input disabled="true" name="attr_advancedskill" type="number" value="floor((@{advancedskillbox1}+0.5)*@{advancedskillcharacteristic}+@{advancedskillbox2}+@{advancedskillbox3})"></button></td>
+					</tr>
+				</table>
+			</fieldset>
+			<hr>
+			<!-- ATTENTION PSYKERS AHEAD! -->
+
+			<h3>Psychic Powers</h3>
+
+			<div class="sheet-row">
+				<div class="sheet-item" style="width:37.5%">
+					<label>Psychic Discipline</label>
+				</div>
+
+				<div class="sheet-item sheet-morebig">
+					<input name="attr_psychicdiscipline" type="text">
+				</div>
+
+				<div class="sheet-item sheet-puny">
+					<button name="roll_psycicpower" type="roll" value="/me draws on the power of the Warp!\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})"><label>Psy</label></button>
+				</div>
+			</div>
+
+			<fieldset class="repeating_psychicdiscipline">
+				<div class="sheet-row">
+					<div class="sheet-item" style="width:37.5%">
+						<label>Psychic Discipline</label>
+					</div>
+
+					<div class="sheet-item sheet-morebig">
+						<input name="attr_reppsychicdiscipline" type="text">
+					</div>
+
+					<div class="sheet-item sheet-puny">
+						<button name="roll_reppsycicpower" type="roll" value="/me draws on the power of the Warp!\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})"><label>Psy</label></button>
+					</div>
+				</div>
+			</fieldset><!-- Minor Powers -->
+
+			<fieldset class="repeating_minorpsychicpowers">
+				<div class="sheet-row">
+					<div class="sheet-item sheet-large">
+						<label>Minor Power</label>
+					</div>
+
+					<div class="sheet-item sheet-morebig sheet-brackets">
+						<input name="attr_repminorpsychicpower" type="text">
+					</div>
+
+					<div class="sheet-item sheet-puny">
+						<button name="roll_repminorpower" type="roll" value="/me draws on the power of the Warp and casts @{repminorpsychicpower}! (Threshold: [[?{Threshold|7}]])\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})"><label>Psy</label></button>
+					</div>
+				</div>
+			</fieldset><!-- Discipline Powers -->
+
+			<fieldset class="repeating_disciplinepsychicpowers">
+				<div class="sheet-row">
+					<div class="sheet-item sheet-large">
+						<label>Discipline Power</label>
+					</div>
+
+					<div class="sheet-item sheet-morebig sheet-brackets">
+						<input name="attr_repdisciplinepsychicpower" type="text">
+					</div>
+
+					<div class="sheet-item sheet-puny">
+						<button name="roll_repdisciplinepower" type="roll" value="/me draws on the power of the Warp and casts @{repdisciplinepsychicpower}! (Threshold: [[?{Threshold|7}]])\n/r ((?{Psy Rating|1}d10)+[[floor(@{wp}/10)]]+?{Modifier|0})"><label>Psy</label></button>
+					</div>
+				</div>
+			</fieldset><!-- Mutations anyone? -->
+
+			<h3>Mutation</h3>
+			<textarea name="attr_mutations" style="width:95%; margin:auto; height:75px;">
+</textarea>
+
+			<h3>Talents & Traits</h3><input name="attr_fixtalent2" type="text">
+
+			<fieldset class="repeating_talents2">
+				<input name="attr_reptalent2" type="text">
+			</fieldset>
+		</div>
+	</div>
+
+	<div class="sheet-2colrow">
+		<div class="sheet-col">
+			<h3>Melee Weapons</h3>
+
+			<fieldset class="repeating_meleeweapons">
+				<div class="sheet-quickborder">
+					<div class="sheet-row">
+						<div class="sheet-item sheet-tiny">
+							<button name="roll_meleeattack" type="roll" value="/me uses their @{meleeweaponname} to try and hit and achieves [[(@{ws}+?{Modifier|0}-1d100)/10]] degree(s) of success! (Pen: [[@{meleeweaponpen}]])"><label>Name:</label></button>
+						</div>
+
+						<div class="sheet-item sheet-big">
+							<input name="attr_meleeweaponname" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny"></div>
+
+						<div class="sheet-item sheet-tiny">
+							<label>Class:</label>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_meleeweaponclass" type="text">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-small">
+							<button name="roll_meleedamage" type="roll" value="/me does [[{@{meleeweapondamage}+(floor(@{strength}/10)), (@{meleeweapontearing}*(@{meleeweapondamage}+(floor(@{strength}/10))))}kh1]] @{meleeweapontype} damage!"><label>Damage:</label></button>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_meleeweapondamage" type="text">
+						</div>
+
+						<div class="sheet-item sheet-little">
+							<label style="font-size:0.9em;">Tearing</label>
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<input name="attr_meleeweapontearing" type="checkbox" value="1">
+						</div>
+
+						<div class="sheet-item sheet-little">
+							<label>Type:</label>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_meleeweapontype" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<label>Pen:</label>
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<input name="attr_meleeweaponpen" type="text" value="0">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-large">
+							<label>Special Rules:</label>
+						</div>
+
+						<div class="sheet-item sheet-morebig">
+							<input name="attr_meleeweaponspecial" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<button name="roll_meleeattackcomp" type="roll" value="/me uses their @{meleeweaponname} to try and hit and achieves [[(@{ws}+?{Modifier|0}-1d100)/10]] degree(s) of success! (Pen: [[@{meleeweaponpen}]])\n/me does [[{@{meleeweapondamage}+(floor(@{strength}/10)), (@{meleeweapontearing}*(@{meleeweapondamage}+(floor(@{strength}/10))))}kh1]] @{meleeweapontype} damage!"><label>R</label></button>
+						</div>
+					</div>
+				</div>
+			</fieldset>
+
+			<div class="sheet-row">
+				<div class="sheet-item sheet-med">
+					<label>Handedness:</label>
+				</div>
+
+				<div class="sheet-item sheet-bigger">
+					<input name="attr_handedness" type="text">
+				</div>
+			</div><br>
+			<!-- Armor! -->
+
+			<h3>Armour</h3>
+
+			<div class="sheet-armourblock"></div>
+
+			<div class="sheet-quickborder sheet-armourblock">
+				<label>Head</label> <input name="attr_headarmourvalue" type="text"> <label>(1-10) Type</label> <input name="attr_headarmourtype" type="text">
+			</div><br>
+
+			<div class="sheet-quickborder sheet-armourblock">
+				<label>Left Arm</label> <input name="attr_leftarmarmourvalue" type="text"> <label>(11-20) Type</label> <input name="attr_leftarmarmourtype" type="text">
+			</div>
+
+			<div class="sheet-quickborder sheet-armourblock">
+				<label>Body</label> <input name="attr_bodyarmourvalue" type="text"> <label>(31-70) Type</label> <input name="attr_bodyarmourtype" type="text">
+			</div>
+
+			<div class="sheet-quickborder sheet-armourblock">
+				<label>Right Arm</label> <input name="attr_rightarmarmourvalue" type="text"> <label>(31-30) Type</label> <input name="attr_rightarmarmourtype" type="text">
+			</div>
+
+			<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
+				<label>Left Leg</label> <input name="attr_leftlegarmourvalue" type="text"> <label>(71-85) Type</label> <input name="attr_leftlegarmourtype" type="text">
+			</div>
+
+			<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
+				<label>Right Leg</label> <input name="attr_rightlegarmourvalue" type="text"> <label>(86-00) Type</label> <input name="attr_rightlegarmourtype" type="text">
+			</div>
+		</div><!-- Right Side -->
+
+		<div class="sheet-col">
+			<h3>Ranged Weapons</h3>
+
+			<fieldset class="repeating_rangedweapons">
+				<div class="sheet-quickborder">
+					<div class="sheet-row">
+						<div class="sheet-item sheet-tiny">
+							<button name="roll_rangedattack" type="roll" value="/me uses their @{rangedweaponname} to try and shoot and achieves [[(@{bs}+?{Modifier|0}-1d100)/10]] degree(s) of success! (RoF: @{rangedweaponrof} | Clip: [[@{rangedweaponclip}]] | Pen: [[@{rangedweaponpen}]])"><label>Name:</label></button>
+						</div>
+
+						<div class="sheet-item sheet-big">
+							<input name="attr_rangedweaponname" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny"></div>
+
+						<div class="sheet-item sheet-tiny">
+							<label>Class:</label>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_rangedweaponclass" type="text">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-small">
+							<button name="roll_rangeddamage" type="roll" value="/me does [[{@{rangedweapondamage}, (@{rangedweapontearing}*@{rangedweapondamage})}kh1]] @{rangedweapontype} damage!"><label>Damage:</label></button>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_rangedweapondamage" type="text">
+						</div>
+
+						<div class="sheet-item sheet-little">
+							<label style="font-size:0.9em;">Tearing</label>
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<input name="attr_rangedweapontearing" type="checkbox" value="1">
+						</div>
+
+						<div class="sheet-item sheet-little">
+							<label>Type:</label>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_rangedweapontype" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<label>Pen:</label>
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<input name="attr_rangedweaponpen" type="text" value="0">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-tiny">
+							<label>Range:</label>
+						</div>
+
+						<div class="sheet-item sheet-tiny">
+							<input name="attr_rangedweaponrange" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<label>RoF:</label>
+						</div>
+
+						<div class="sheet-item sheet-small">
+							<input name="attr_rangedweaponrof" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<label>Clip:</label>
+						</div>
+
+						<div class="sheet-item sheet-tiny">
+							<input name="attr_rangedweaponclip" type="text" value="0">
+						</div>
+
+						<div class="sheet-item sheet-tiny">
+							<label>Reload:</label>
+						</div>
+
+						<div class="sheet-item sheet-tiny">
+							<input name="attr_rangedweaponreload" type="text">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-large">
+							<label>Special Rules:</label>
+						</div>
+
+						<div class="sheet-item sheet-morebig">
+							<input name="attr_rangedweaponspecial" type="text">
+						</div>
+
+						<div class="sheet-item sheet-puny">
+							<button name="roll_rangedattackcomp" type="roll" value="/me uses their @{rangedweaponname} to try and shoot and achieves [[(@{bs}+?{Modifier|0}-1d100)/10]] degree(s) of success! (RoF: @{rangedweaponrof} | Clip: [[@{rangedweaponclip}]] | Pen: [[@{rangedweaponpen}]])\n/me does [[{@{rangedweapondamage}, (@{rangedweapontearing}*@{rangedweapondamage})}kh1]] @{rangedweapontype} damage!"><label>R</label></button>
+						</div>
+					</div>
+				</div>
+			</fieldset>
+
+			<h3>Gear</h3>
+			<textarea name="attr_gear">
+</textarea><br>
+			<br>
+
+			<div class="sheet-row">
+				<!-- Movement -->
+
+				<div class="sheet-item sheet-big">
+					<div class="sheet-row">
+						<div class="sheet-item sheet-med"></div>
+
+						<div class="sheet-item sheet-med">
+							<label>Walk</label>
+						</div>
+
+						<div class="sheet-item sheet-med">
+							<input disabled="true" name="attr_walkspeed" type="number" value="floor(@{ag}/10)">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-med"></div>
+
+						<div class="sheet-item sheet-med">
+							<label>Walk</label>
+						</div>
+
+						<div class="sheet-item sheet-med">
+							<input disabled="true" name="attr_walkspeed" type="number" value="2*(floor(@{ag}/10))">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-med"></div>
+
+						<div class="sheet-item sheet-med">
+							<label>Charge</label>
+						</div>
+
+						<div class="sheet-item sheet-med">
+							<input disabled="true" name="attr_walkspeed" type="number" value="3*(floor(@{ag}/10))">
+						</div>
+					</div>
+
+					<div class="sheet-row">
+						<div class="sheet-item sheet-med"></div>
+
+						<div class="sheet-item sheet-med">
+							<label>Run</label>
+						</div>
+
+						<div class="sheet-item sheet-med">
+							<input disabled="true" name="attr_walkspeed" type="number" value="6*(floor(@{ag}/10))">
+						</div>
+					</div>
+				</div><!-- Wealth -->
+
+				<div class="sheet-item sheet-big sheet-uppercase sheet-armourblock">
+					<label>Throne Gelt:</label> <input name="attr_thronegelt" type="number"> <label>Monthly:</label> <input name="attr_monthlyincome" type="number">
+				</div>
+			</div>
+		</div>
+	</div>
+	<hr>
+	<!-- Footer Stuff -->
+
+	<div class="1colrow sheet-tablecontainer">
+		<div class="sheet-footer sheet-mainleft sheet-tablecell">
+			<h3>Wounds</h3>
+
+			<div class="sheet-innerfooter sheet-armourblock">
+				<p>Total</p><input name="attr_wounds_max" type="text">
+			</div>
+
+			<div class="sheet-innerfooter sheet-armourblock">
+				<p style="text-transform:uppercase;">Critical Damage</p><input name="attr_woundscritical" type="text">
+			</div>
+
+			<div class="sheet-innerfooter sheet-armourblock">
+				<p>Current</p><input name="attr_wounds" type="text">
+			</div>
+
+			<div class="sheet-innerfooter sheet-armourblock">
+				<p style="text-transform:uppercase;">Fatigue (Max = TB)</p><input name="attr_woundsfatigue" type="text">
+			</div>
+		</div>
+
+		<div class="sheet-footer sheet-tablecell" style="width:18%;">
+			<h3>Fate Points</h3>
+
+			<div class="sheet-innerfooter" style="width:95%;">
+				<p>Total:</p><br>
+				<input name="attr_fatetotal" type="text">
+			</div>
+
+			<div class="sheet-innerfooter" style="width:95%;">
+				<p>Current:</p><br>
+				<input name="attr_fatecurrent" type="text">
+			</div>
+		</div>
+
+		<div class="sheet-footer sheet-mainright sheet-tablecell">
+			<div style="float:left; width:49%;">
+				<h3>Insanity</h3>
+
+				<table>
+					<tr>
+						<td style="width:70%;">
+							<p>Insanity Points:</p>
+						</td>
+
+						<td style="width:70%;"><input name="attr_insanitypoints" type="number"></td>
+					</tr>
+
+					<tr>
+						<td>
+							<p>Degree of M:</p>
+						</td>
+
+						<td><input name="attr_degreeofinsanity" type="number"></td>
+					</tr>
+				</table>
+				<textarea name="attr_disorders" placeholder="Disorders" style="width:90%; margin:auto; height:50px;">
+</textarea>
+			</div>
+
+			<div style="float:left; width:49%;">
+				<h3>Corruption</h3>
+
+				<table>
+					<tr>
+						<td style="width:70%;">
+							<p>Corruption Points:</p>
+						</td>
+
+						<td><input name="attr_corruptionpoints" type="number"></td>
+					</tr>
+
+					<tr>
+						<td style="width:70%;">
+							<p>Degree of C:</p>
+						</td>
+
+						<td><input name="attr_degreeofcorruption" type="number"></td>
+					</tr>
+				</table>
+				<textarea name="attr_malignancies" placeholder="Malignancies" style="width:90%; margin:auto; height:50px;">
+</textarea>
+			</div>
+		</div>
+	</div>
+	<hr>
+	<!-- XP -->
+
+	<div class="1colrow colrow">
+		<h3>Experience Points</h3>
+
+		<div class="sheet-row">
+			<div class="sheet-item sheet-tiny">
+				<label>XP to spend</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny sheet-armourblock">
+				<input name="attr_xptospent" type="number">
+			</div>
+
+			<div class="sheet-item sheet-big"></div>
+
+			<div class="sheet-item sheet-tiny">
+				<label>Total XP spent</label>
+			</div>
+
+			<div class="sheet-item sheet-tiny sheet-armourblock">
+				<input name="attr_totalxpspent" type="number">
+			</div>
+		</div><label>Advancements Taken:</label>
+
+		<fieldset class="repeating_advancements">
+			<div class="sheet-row">
+				<div class="sheet-item" style="width:26%;">
+					<input name="attr_advancement1" type="text">
+				</div>
+
+				<div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock">
+					<input name="attr_advancement1xp" type="text">
+				</div>
+
+				<div class="sheet-item" style="width:26%;">
+					<input name="attr_advancement2" type="text">
+				</div>
+
+				<div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock">
+					<input name="attr_advancement2xp" type="text">
+				</div>
+
+				<div class="sheet-item" style="width:26%;">
+					<input name="attr_advancement3" type="text">
+				</div>
+
+				<div class="sheet-item sheet-puny sheet-center sheet-brackets sheet-armourblock">
+					<input name="attr_advancement3xp" type="text">
+				</div>
+			</div>
+		</fieldset>
+		<hr>
+
+		<h3>Other Notes:</h3>
+		<textarea name="attr_othernotes">
+</textarea>
+	</div><!-- Charsheet End -->
 </div>


### PR DESCRIPTION
This includes multiple fixes and cleanups for the Dark Heresy character sheets, such as:
- Cleans up whitespace (and adds a blank line at the end of the file)
- Tidies up the HTML, especially indentation.
- Fixes the 'R' button for melee weapons (#338)
- Fixes the duplication of the first talent between the two talent groups.
