### PR TITLE
Revert "Update Proficiency bonus calculation for Basic D&D"

### DIFF
--- a/DnDNext_Actoba/DnDNext.html
+++ b/DnDNext_Actoba/DnDNext.html
@@ -62,7 +62,7 @@
 						<div class="sheet-col-1-3 sheet-center"><input class="sheet-underlined" type="number" name="attr_speed" ><br/>Speed</div>
 					</div>
 					<div class="sheet-row">
-						<div class="sheet-col-1-3 sheet-center" title="This is a bonus for you being proficient in a given task.  This bonus automatically increases as you level up and is used automatically in various rolls"><input class="sheet-underlined" type="number" name="attr_PB" value="ceil(@{Level}/4)+1" disabled="disabled"  ><br/>Prof Bonus</div>
+						<div class="sheet-col-1-3 sheet-center" title="This is a bonus for you being proficient in a given task.  This bonus automatically increases as you level up and is used automatically in various rolls"><input class="sheet-underlined" type="number" name="attr_PB" value="floor((@{Level}+5)/4)" disabled="disabled"  ><br/>Prof Bonus</div>
 						<div class="sheet-col-1-3 sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button"><input class="sheet-underlined" type="number" name="attr_initiative" value="0"><br/>Init Bonus</div>
 						<div class="sheet-col-1-3 sheet-center"><button type='roll' name='roll_Initiative' value='@{selected|token_name} rolls a [[1d20 + @{selected|dexterity_mod} [Dexterity Mod] + @{selected|initiative} [Initiative Bonus] &{tracker}]] for initiative!'>Initiative</button></div>
 					</div>


### PR DESCRIPTION
Only just seen this.  The Next playtest sheet is designed for use with the playtest ruleset and therefore should not have been updated to the 5e "Basic D&D" rules.  As such this commit should be reverted to ensure anyone still using the playtest documents to play with has a working sheet (though i doubt many are by now.....)
