### PR TITLE
Fixed Hidden Attribute Roll Fields

### DIFF
--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
@@ -1199,7 +1199,7 @@
 							<option value="12">d12</option>
 						 </select>+<input type="number" name="attr_agMod" value="0" />&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_agrollMod" value="0" />
 						<button type='roll' name='roll_Agility' value='/em @{character_name} attempts to be agile and rolls [[1d@{agility}![Agility]+@{agMod}[Agility Modifier]+ @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-						<input type='hidden' name=attr_rollAgility value='/em @{character_name} attempts to be agile and rolls [[1d@{agility}![Agility]+@{agMod}[Agility Modifier]+ @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+						<input type='hidden' name=attr_rollmAgility value='/em @{character_name} attempts to be agile and rolls [[1d@{agility}![Agility]+@{agMod}[Agility Modifier]+ @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
 					<label style='width:60px;'>Smarts:</label>
 						<select name="attr_smarts" class="dtype" value="4" style='width:55px;'>
 							<option value="4">d4</option>
@@ -1210,7 +1210,7 @@
 						</select>+<input type="number" name="attr_smMod" value="0" />&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_smrollMod" value="0" />
 						 <input type="hidden" name="attr_fullsmarts" value="d@{smarts}" />
 						<button type='roll' name='roll_Smarts' value='/em @{character_name} attempts to be smart and rolls [[1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier]+ @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-						<input type='hidden' name='attr_rollSmarts' value='/em @{character_name} attempts to be smart and rolls [[1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier]+ @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+						<input type='hidden' name='attr_rollmSmarts' value='/em @{character_name} attempts to be smart and rolls [[1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier]+ @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
 					<label style='width:60px;'>Spirit:</label>
 						<select name="attr_spirit" class="dtype" value="4" style='width:55px;'>
 							<option value="4">d4</option>
@@ -1220,7 +1220,7 @@
 							<option value="12">d12</option>
 						 </select>+<input type="number" name="attr_spMod" value="0" />&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_sprollMod" value="0" />
 						<button type='roll' name='roll_Spirit' value='/em @{character_name} attempts to be spirited and rolls [[1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier]+ @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-						<input type='hidden' name='attr_rollSpirit' value='/em @{character_name} attempts to be spirited and rolls [[1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier]+ @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+						<input type='hidden' name='attr_rollmSpirit' value='/em @{character_name} attempts to be spirited and rolls [[1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier]+ @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
 					<label style='width:60px;'>Strength:</label>
 						<select name="attr_strength" class="dtype" value="4" style='width:55px;'>
 							<option value="4">d4</option>
@@ -1230,7 +1230,7 @@
 							<option value="12">d12</option>
 						 </select>+<input type="number" name="attr_stMod" value="0" />&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_strollMod" value="0" />
 						<button type='roll' name='roll_Strength' value='/em @{character_name} attempts to be strong and rolls [[1d@{strength}![Strength]+@{stMod}[Strength Modifier]+ @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + (@{encumbrance})[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-						<input type='hidden' name='attr_rollStrength' value='/em @{character_name} attempts to be strong and rolls [[1d@{strength}![Strength]+@{stMod}[Strength Modifier]+ @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+						<input type='hidden' name='attr_rollmStrength' value='/em @{character_name} attempts to be strong and rolls [[1d@{strength}![Strength]+@{stMod}[Strength Modifier]+ @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
 					<label style='width:60px;'>Vigor:</label>
 						<select name="attr_vigor" class="dtype" value="4" style='width:55px;'>
 							<option value="4">d4</option>
@@ -1240,7 +1240,7 @@
 							<option value="12">d12</option>
 						 </select>+<input type="number" name="attr_viMod" value="0" />&nbsp;&nbsp;&nbsp;&nbsp;<input type="number" name="attr_virollMod" value="0" />
 						<button type='roll' name='roll_Vigor' value='/em @{character_name} attempts to be healthy and rolls [[1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier]+@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-						<input type='hidden' name='attr_rollVigor' value='/em @{character_name} attempts to be healthy and rolls [[1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier]+@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+						<input type='hidden' name='attr_rollmVigor' value='/em @{character_name} attempts to be healthy and rolls [[1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier]+@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
 				</div> <!-- End Attributes Column -->
 				<div class='sheet-col' style='width:540px;'>
 					<div class='sheet-col' style='width:157px; border-bottom-style:dashed; border-width:1px;'>


### PR DESCRIPTION
The hidden attribute roll fields for the Mooks were overriding the Wild
Card rolls, so when using @{rollSmarts} in a macro, the Wild Die was
not being rolled. Fixed the name of the fields on the Mook sheet.
