### PR TITLE
Multiple Fixes

### DIFF
--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
@@ -187,6 +187,10 @@ input[type=radio].sheet-tab6:checked ~ div.sheet-tab6 {
     display:none;
 }
 
+.sheet-arrow:checked + *.sheet-hindrance{
+	display:none;
+}
+
 /*  Trying to hide NPC Sections without Tabs */
 
 .sheet-HideAtts,

--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
@@ -1183,11 +1183,18 @@
 					<h2>Edges & Hindrances</h2><!-- Attributes Row -->
 				</div>
 			<div class='sheet-row' style='width:830px;'>
-				<div class='sheet-row' style='width:260px;'> <!-- Head Row for Attributes -->
+				<div class='sheet-row' style='width:830px;'> <!-- Head Row for Attributes -->
     					<div class='sheet-col' style='width:60px;'>&nbsp;</div>
     					<div class='sheet-col' style='width:68px;'>&nbsp;</div>
     					<div class='sheet-col' style='width:60px;'>Attribute Modifier</div>
     					<div class='sheet-col' style='width:60px;'>Roll Modifier</div>
+    					<div class='sheet-col' style='width:16px;'>&nbsp;</div>
+    					<div class='sheet-col' style='width:157px; border-bottom-style:dashed; border-width:1px;'>
+						<h3>Edge / Hindrance</h3>
+					</div>
+					<div class='sheet-col' style='width:370px; border-bottom-style:dashed; border-width:1px;'>
+						<h3>Notes</h3>
+					</div>
     			</div>
     			<div class='sheet-col' style='width:280px;'>
     				<label style='width:60px;'>Agility:</label>
@@ -1243,13 +1250,8 @@
 						<input type='hidden' name='attr_rollmVigor' value='/em @{character_name} attempts to be healthy and rolls [[1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier]+@{virollMod}[Vigor Roll Modifier]+ @{mttmod}[Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]' />
 				</div> <!-- End Attributes Column -->
 				<div class='sheet-col' style='width:540px;'>
-					<div class='sheet-col' style='width:157px; border-bottom-style:dashed; border-width:1px;'>
-						<h3>Edge / Hindrance</h3>
-					</div>
-					<div class='sheet-col' style='width:370px; border-bottom-style:dashed; border-width:1px;'>
-						<h3>Notes</h3>
-					</div>
-					<div class='sheet-row'> <br />
+					<input type='checkbox' name='attr_mSkillsFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Edges & Hindrances
+					<div class='sheet-row sheet-hindrance'> <br />
 						<fieldset class="repeating_mhindrances">
 							<div class='sheet-col' style='width:157px;'>
 								<input type="text" name="attr_mhindrance" style='width:152px;'/>


### PR DESCRIPTION
Fixed the Fighting Skill button on the Character Sheet to remove some odd formatting for carriage returns and new lines. 

Fixed the Mook Section for a couple of problems: The Ability Roll Buttons had the same name as the Wild Card Ability roll buttons, which could cause a problem with Wild Dice rolling (or not) for the appropriate character type.

Fixed the problem with the Skills (and all other fields) on the Mook section, so that their field names are completely unique.  This should resolve the problem of Wild Card skills suddenly resetting to d4 and losing all the appropriate data.

Added a version number so it's easier to identify when a new version of the sheet has been pushed out.
