### PR TITLE
Added name attributes to textarea tags

### DIFF
--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
@@ -548,7 +548,7 @@
     <div class='sheet-col'>
         <h4 class="section-head">Gear and Posessions</h4>
         <div class="sheet-section">
-            <textarea style="width:97%;height:180px"></textarea>
+            <textarea name="attr_gear_and_posessions" style="width:97%;height:180px"></textarea>
         </div>
     </div>
     <div class='sheet-col'>
@@ -578,27 +578,27 @@
     <div class="sheet-section">
         <div class='sheet-col'>
             Personal Description
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_personal_description" class="backstory-box"></textarea>
             Ideaology/Beliefs
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_ideaology_beliefs" class="backstory-box"></textarea>
             Significant People
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_significant_people" class="backstory-box"></textarea>
             Meaningful Locations
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_meaningful_locations" class="backstory-box"></textarea>
             Treasured Possessions
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_treasured_posessions" class="backstory-box"></textarea>
         </div>
         <div class='sheet-col'>
             Traits
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_traits" class="backstory-box"></textarea>
             Injuries & Scars
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_injuries_scars" class="backstory-box"></textarea>
             Phobias/Manias
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_phobias_manias" class="backstory-box"></textarea>
             Tomes, Spells and Artifacts
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_tomes_spells_artifacts" class="backstory-box"></textarea>
             Encounters with Strange Entities
-            <textarea class="backstory-box"></textarea>
+            <textarea name="attr_encounters_with_strange_entities" class="backstory-box"></textarea>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The textarea tags did not have a name attribute defined.  Text that was
input into these sections was not being retained.
