### PR TITLE
Additional Setting Support and CSS Cleanup

### DIFF
--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
@@ -7,12 +7,14 @@ semi-trans75.png = 75% opacity
 semi-trans-grayish.png = 75% opacity
 
 */
+
+/*----------- Font Information -----------*/
 @font-face {
     font-family: 'cinzelregular';
     src: url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.eot');
     src: url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.woff') format('woff'),
-         url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.ttf') format('truetype'),
+         url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.woff') format('woff');
+    src: url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.ttf') format('truetype'),
          url('http://www.geeksville.us/fonts/Cinzel-Regular-webfont.svg#cinzelregular') format('svg');
     font-weight: normal;
     font-style: normal;
@@ -99,27 +101,182 @@ semi-trans-grayish.png = 75% opacity
 
 }*/
 
-.charsheet .sheet-maindiv{
-	width: 830px;
-}
-.charsheet .sheet-background {
-	width: 840px;
-}
-
-.sheet-imagespacer{
-	width: 830px;
-	padding-left: 5px;
-	padding-right: 15px;
+/*Font Drop Down Menu*/
+.sheet-fontDropdown {
+    /* fixed widths work best;*/
+    width: 100px;
+    /*border: dotted 1px;*/
+    display: inline-block;
 }
 
-.charsheet .sheet-cdiv {
-    width:810px;
-    /*border: 1px dotted;*/
-    padding-right: 15px;
-    padding-left: 15px;
+.sheet-fontlist {
+	display: inline-block;
 }
 
-/* Set up the Background Settings */
+.sheet-fontlist {
+    vertical-align: middle;
+    width: 100px;
+    height: 20px;
+    /*border: solid 1px;*/
+}
+.sheet-fontlist input,
+.sheet-fontlist input + span {
+    display:none;
+    z-index: 1;
+    /*width: 150px;*/
+}
+
+.sheet-fontlist:hover {
+    background: silver;
+    /*position:absolute;*/
+    position: relative;
+    top: -10px;
+    width: 130px;
+    height: auto;
+    z-index: 1;
+    padding: 5px;
+}
+
+.sheet-fontlist:hover input ,
+.sheet-fontlist:hover input + span {
+    display:inline-block;
+}
+
+/*Margin placeholder*/
+.sheet-fontlist:hover input + span {
+    /*push the margin to the right
+    just to get the radio and label 
+    to be on their own line*/
+   margin-right: 50%;
+}
+
+.sheet-fontlist:hover span {
+    display: inline-block;
+}
+
+.sheet-font1,
+.sheet-font2,
+.sheet-font3,
+.sheet-font4,
+.sheet-font5,
+.sheet-font6,
+.sheet-font7,
+.sheet-font8,
+.sheet-font9,
+.sheet-font10 {
+    width: 100px;
+    height: 20px;
+    background-image: url("https://www.geeksville.us/roll20/semi-trans.png");
+    background-color: transparent;
+    /*display: inline-block;*/
+    color: black;
+    line-height: 20px;
+    text-align: left;
+    display: inline-block;
+    display: none;
+}
+.sheet-font2 {
+    font-family: "Handwriting";
+    font-size: 200%;
+}
+
+.sheet-font3 {
+    font-family: "Glitch";
+    font-size: 1.8em;
+}
+.sheet-font4 {
+    font-family: "CuttyFruty";
+    font-size: 15px;
+}
+.sheet-font5 {
+    font-family: "Saucy";
+    font-size: 15px;
+    /*font-size: 175%;*/
+}
+.sheet-font6 {
+    font-family: "Rujis";
+    font-size: 15px;
+}
+.sheet-font7 {
+    font-family: "Dashley";
+    font-size: 25px;
+}
+.sheet-font8 {
+    font-family: "Graziano";
+    font-size: 25px;
+}
+/*.sheet-font9 {
+    font-family: "BlackletterHand";
+    font-size: 25px;
+}*/
+.sheet-font10 {
+    font-family: "Architect";
+    font-size: 15px;
+}
+
+.sheet-fontlist:not(:hover) input[value="1"]:checked ~ .sheet-font1,
+.sheet-fontlist:not(:hover) input[value="2"]:checked ~ .sheet-font2,
+.sheet-fontlist:not(:hover) input[value="3"]:checked ~ .sheet-font3,
+.sheet-fontlist:not(:hover) input[value="4"]:checked ~ .sheet-font4,
+.sheet-fontlist:not(:hover) input[value="5"]:checked ~ .sheet-font5,
+.sheet-fontlist:not(:hover) input[value="6"]:checked ~ .sheet-font6,
+.sheet-fontlist:not(:hover) input[value="7"]:checked ~ .sheet-font7,
+.sheet-fontlist:not(:hover) input[value="8"]:checked ~ .sheet-font8,
+.sheet-fontlist:not(:hover) input[value="9"]:checked ~ .sheet-font9,
+.sheet-fontlist:not(:hover) input[value="10"]:checked ~ .sheet-font10 {
+    display: block;
+}
+
+.sheet-useFont2:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont2:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Handwriting"; 
+	font-size: 200%;
+}
+
+.sheet-useFont3:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont3:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Glitch"; 
+	font-size: 175%;
+}
+.sheet-useFont4:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont4:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "CuttyFruty"; 
+	font-size: 125%;
+}
+.sheet-useFont5:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont5:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Saucy";
+	font-size: 150%;
+}
+.sheet-useFont6:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont6:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Rujis";
+}
+.sheet-useFont7:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont7:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Dashley"; 
+	font-size: 175%;
+}
+.sheet-useFont8:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont8:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Graziano"; 
+	font-size: 130%;
+}
+.sheet-useFont9:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont9:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "BlackletterHand"; 
+	font-size: 130%;
+}
+.sheet-useFont10:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
+.sheet-useFont10:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
+	font-family: "Architect"; 
+	font-size: 75%;
+}
+/*End Font Drop Down Menu*/
+
+/*----------- End Font Information -----------*/
+
+/*----------- Background Info -----------*/
 
 .sheet-useBackground input[value="1"]:checked ~ *.sheet-background {
 	background-image: none;
@@ -150,15 +307,62 @@ semi-trans-grayish.png = 75% opacity
     background-origin: content-box;
 }
 
-/* End Background Settings */
+.sheet-useBackground input[value="4"]:checked ~ *.sheet-background {
+	/*background-image: url("http://www.geeksville.us/roll20/NYC-Night_2.jpg");*/
+	/*background-image: url("http://www.geeksville.us/roll20/noir3.jpg");*/
+	background-image: url("http://www.geeksville.us/roll20/NewNoir2.jpg");
+	background-size: 850px 920px;
+    /*background-repeat: no-repeat;*/
+    /*background-attachment: fixed;*/
+    background-position: center; 
+    background-origin: content-box;
+}
 
-/*Character Sheet Logo*/
+.sheet-useBackground input[value="5"]:checked ~ *.sheet-background {
+	background-image: url("http://www.geeksville.us/roll20/LastParsec-Background.jpg");
+	background-size: 840px 1060px;
+    /*background-repeat: no-repeat;*/
+    /*background-attachment: fixed;*/
+    background-position: center; 
+    background-origin: content-box;
+    -webkit-border-image:url("http://www.geeksville.us/roll20/LastParsec-Border.png"); /*  Safari 3.1-5 */
+    -o-border-image:url("http://www.geeksville.us/roll20/LastParsec-Border.png"); /*round; Opera 11-12.1 */
+    -moz-border-image:url("http://www.geeksville.us/roll20/LastParsec-Border.png");
+    border-image:url("http://www.geeksville.us/roll20/LastParsec-Border.png") 100 50;
+    border-image-width: 20px;
+}
+
+.sheet-useBackground input[value="6"]:checked ~ *.sheet-background {
+	background-image: url("http://www.geeksville.us/roll20/supers.jpg");
+	background-size: 840px 564px;
+    /*background-repeat: no-repeat;*/
+    /*background-attachment: fixed;*/
+    background-position: center; 
+    background-origin: content-box;
+}
+
+.sheet-useBackground input[value="7"]:checked ~ *.sheet-background {
+	background-image: url("http://www.geeksville.us/roll20/cyberpunk2.jpg");
+	background-size: 840px 840px;
+    /*background-repeat: no-repeat;*/
+    /*background-attachment: fixed;*/
+    background-position: center; 
+    background-origin: content-box;
+}
+
+/*----------- End Background Info -----------*/
+
+/*----------- Logo Configuration Info -----------*/
+
 .sheet-SWD,
 .sheet-PotSM,
 .sheet-TLP,
 .sheet-Zombie,
 .sheet-NecessaryEvil,
-.sheet-Deadlands {
+.sheet-Deadlands,
+.sheet-DeadlandsNoir,
+.sheet-DeadlandsHoE,
+.sheet-InterfaceZero {
 	max-width: 250px;
 	/*max-height: 100px;*/
 	margin-left: auto;
@@ -190,41 +394,98 @@ semi-trans-grayish.png = 75% opacity
 	display: block;
 }
 
-/*End Character Sheet Logo*/
+.sheet-ShowLogo input[value="7"]:checked ~ .sheet-DeadlandsNoir{
+	display: block;
+}
+.sheet-ShowLogo input[value="8"]:checked ~ .sheet-DeadlandsHoE{
+	display: block;
+}
 
-/* Disclaimer Information */
+.sheet-ShowLogo input[value="9"]:checked ~ .sheet-InterfaceZero{
+	display: block;
+}
+
+/*----------- End Logo Configuration Info -----------*/
+
+/*----------- Disclaimer Info Setup -----------*/
+
+.sheet-disclaimer{
+	font-size: 10px;
+	text-align: center;
+}
+
 .sheet-playDisclaimer input[value="1"]:checked + span.sheet-disclaimer::before,
 .sheet-playDisclaimer input[value="4"]:checked + span.sheet-disclaimer::before {
-	text-align: center;
 	content: "The Savage Worlds logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
 	/*display: inline-block;*/
 }
 
 .sheet-playDisclaimer input[value="3"]:checked + span.sheet-disclaimer::before {
-	text-align: center;
 	content: "The Last Parsec logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
 	/*display: inline-block;*/
 }
 
 .sheet-playDisclaimer input[value="2"]:checked + span.sheet-disclaimer::before {
-	text-align: center;
 	content: "The Pirates of the Spanish Main logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
 	/*display: inline-block;*/
 }
 
 .sheet-playDisclaimer input[value="5"]:checked + span.sheet-disclaimer::before {
-	text-align: center;
 	content: "The Necessary Evil logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
 	/*display: inline-block;*/
 }
 
 .sheet-playDisclaimer input[value="6"]:checked + span.sheet-disclaimer::before {
-	text-align: center;
 	content: "The Deadlands logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
 	/*display: inline-block;*/
 }
 
-/* End Disclaimer Information */
+.sheet-playDisclaimer input[value="7"]:checked + span.sheet-disclaimer::before {
+	content: "The Deadlands: Noir logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
+	/*display: inline-block;*/
+}
+
+.sheet-playDisclaimer input[value="8"]:checked + span.sheet-disclaimer::before {
+	content: "The Deadlands: Hell on Earth logo is a trademark of Pinnacle Entertainment Group. Used with permission.";
+	/*display: inline-block;*/
+}
+
+.sheet-playDisclaimer input[value="9"]:checked + span.sheet-disclaimer::before {
+	content: "The Interface Zero 2.0 logo is a trademark of Gun Metal Games. Used with permission.";
+	/*display: inline-block;*/
+}
+
+/*--- Web Site Info For Disclaimer ---*/
+
+.sheet-CoURL {
+	font-size: 10px;
+	text-align: center;
+}
+
+.sheet-playDisclaimer input[value="1"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="2"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="3"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="4"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="5"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="6"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="7"]:checked ~ span.sheet-CoURL::after,
+.sheet-playDisclaimer input[value="8"]:checked ~ span.sheet-CoURL::after {
+	content: "http://www.peginc.com/";
+}
+
+.sheet-playDisclaimer input[value="9"]:checked ~ span.sheet-CoURL::after {
+	content: "http://www.gunmetalgames.com/";
+}
+
+/*----------- End Disclaimer Info Setup -----------*/
+
+/*----------- Configuration Specific Items Setup -----------*/
+
+.sheet-hideArcanum:checked + input.sheet-tab5,
+.sheet-hideArcanum:checked ~ span.sheet-tab5,
+.sheet-hideArcanum:checked + div.sheet-section-arcanum {
+	display: none;
+}
 
 .sheet-useCodeName:checked + label.sheet-characterName::before {
 	content: "Code Name:";
@@ -264,216 +525,9 @@ semi-trans-grayish.png = 75% opacity
 	content: "Clams:";
 }
 
-/*.sheet-usePieces:not(:checked) + label.sheet-Money::before {
-	content: "Money";
-}*/
+/*----------- End Configuration Specific Items Setup -----------*/
 
-h2.sheet-sectionHeader {
-    text-align: center; 
-	color: #755b27; 
-    background-color: #dbc792;
-	border-radius: 15px;
-	font-family: "cinzelregular";
-}
-
-.sheet-subsectionHeader {
-	text-align:center; 
-	background-color: black; 
-	color: #c7c3b0; 
-	border-radius: 5px;
-}
-
-.sheet-repeatingHeader {
-	/*text-align: left; */
-	background-color: black; 
-	color: #c7c3b0; 
-	border-radius: 5px;
-	padding-left: 5px;
-	margin-right: 0px;
-	margin-left: 0px;
-}
-
-.sheet-WCSkillsRow {
-	width: 785px; 
-	padding: 5px; 
-	margin-bottom: 5px; 
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-}
-
-/*.charsheet input {
-    display: inline-block;
-    width: 165px;
-    margin-bottom: 1px;
-}*/
-
-button[type=roll].sheet-GM-button::before { 
-    background-image: none;
-    /*background-color: #f2f5d3;*/
-    /*background-color: white;*/
-    font-size: 13px;
-    font-family: sans-serif;
-    content: "gm";
-}
-
-button[type=roll].sheet-GM-button {
-    background-image: none;
-    background-color: #f2f5d3;
-}
-
-input[type=number] {
-    -moz-appearance: textfield;
-}
-input[type=number]::-webkit-outer-spin-button,
-input[type=number]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-}
-
-.sheet-standardtext {
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-	font-weight: bold;
-}
-
-.charsheet input[type=text].sheet-standard {
-	width: 140px;
-	border-top: none;
-	border-right: none;
-	border-left: none;
-	border-bottom: solid 1px;
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-	font-weight: bold;
-}
-
-input.sheet-standardQuest {
-	width: 140px;
-	border-top: none;
-	border-right: none;
-	border-left: none;
-	border-bottom: solid 1px;
-	/*color: transparent;*/
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-}
-
-textarea.sheet-Questtextarea {
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-}
-
-input.sheet-standardNum {
-	width: 37px;
-	border-top: none;
-	border-right: none;
-	border-left: none;
-	border-bottom: solid 1px;
-	text-align: center;
-	/*color: transparent;*/
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-	font-weight: bold;
-}
-
-input.sheet-derivedStat {
-	width: 37px;
-	text-align: center;
-	/*background-color: white;*/
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-	font-weight: bold;
-}
-
-input.sheet-modifier {
-	width: 35px;
-	text-align: center;
-	background-color: transparent;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
-	color: black;
-	font-weight: bold;
-}
-
-.charsheet select {
-	-webkit-appearance: none;
-	vertical-align: top;
-	padding-top: 0px;
-}
-
-label.sheet-nameRankXp,
-label.sheet-AttributeLabel
-span.sheet-nameRankXp {
-    width:80px;
-    font-weight: bold;
-    font-size: 12px;
-    padding-left: 5px;
-    padding-right: 5px;
-    /*background-color: #c7c3b0;*/
-    color: black;
-    background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");
-    border-radius: 8px;
-}
-
-.sheet-MooknameRankXp{
-    width:75px;
-}
-
-.sheet-weight {
-	color: black;
-    background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");
-    border-radius: 8px;
-    padding: 5px;
-}
-
-label.sheet-AttributeLabel {
-	width: 60px;
-}
-
-.sheet-AttBorder {
-	border: solid 1px;
-	/*width: 88px;*/
-	width: auto;
-	height: 28px;
-	margin: 0px;
-	padding: 2px;
-	margin-right: 0px;
-	margin-left: -3px;
-	margin-top: -3px;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans.png");
-}
-
-.sheet-AttBorder > input.sheet-NewDieType:checked{
-	height: auto;
-	/*margin-top: -2px;*/
-}
-
-.sheet-AttMod {
-	padding: 0px; 
-	width: auto; 
-	margin: 0px; 
-	margin-right: -3px;
-}
-
-.sheet-numSpan {
-	width: 50px;
-	font-size: 12px;
-	font-weight: bold;
-	text-align: center;
-	background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png"); 
-	color: black;
-	display: inline-block;
-}
-
-.sheet-additionalrules{
-    width:46%;
-    margin-left:10px;
-    margin-right:10px;
-}
-/* -----------Section for NPC--------------*/
+/*----------- Character Sheet Type setup --------------*/
 
 .charsheet div.sheet-player, 
 .charsheet div.sheet-npc {     
@@ -485,7 +539,7 @@ label.sheet-AttributeLabel {
 }
 
 .charsheet input.sheet-is-npc:checked ~ div.sheet-npc,
-.charsheet input.sheet-is-npc:not(:checked )~ div.sheet-player,
+.charsheet input.sheet-is-npc:not(:checked )~ div.sheet-player
 {
 	max-height: 999999px;
 	visibility: visible;
@@ -504,7 +558,7 @@ label.sheet-AttributeLabel {
 }
 
 .charsheet span.sheet-is-npc-tab::before {
-    content: "Wild Card";
+    content: "Switch to Ally / Mook";
 }
 
 .charsheet span.sheet-is-npc-tab {
@@ -529,17 +583,14 @@ label.sheet-AttributeLabel {
 }
 
 .charsheet input.sheet-is-npc:checked + span.sheet-is-npc-tab::before {
-	content: "Ally / Mook"
+	content: "Switch to Wild Card"
 }
 
-/* -----------NPC Section End--------------*/
+/*----------- Character Sheet Type setup End -------------*/
 
-
-/* -----------Section for Tabs-------------*/
+/*----------- Tabs Setup -------------*/
 
 div.sheet-core-content { display: none; width:840px;}
-
-/*-----------Actoba's way----------------- */
 
 .charsheet div[class^="sheet-section"] { 	
 	visibility: hidden;
@@ -592,7 +643,6 @@ div.sheet-core-content { display: none; width:840px;}
     cursor: pointer;	
 	position: relative;
 	vertical-align: middle;
-	align-content: center;
 	margin-left: -101px;/*originally 91px*/
 }
 
@@ -611,6 +661,30 @@ div.sheet-core-content { display: none; width:840px;}
 	border-radius: 4px;
 }
 
+/*----------- End Tab Setup -----------*/
+
+/*----------- Main Setup -----------*/
+
+.charsheet .sheet-maindiv{
+	width: 830px;
+}
+.charsheet .sheet-background {
+	width: 840px;
+}
+
+.charsheet .sheet-cdiv {
+    width:810px;
+    /*border: 1px dotted;*/
+    padding-right: 15px;
+    padding-left: 15px;
+}
+
+.sheet-imagespacer{
+	width: 830px;
+	padding-left: 5px;
+	padding-right: 15px;
+}
+
 .charsheet span.sheet-spacer {
 	display: block;
 	margin-top: 5px;
@@ -626,361 +700,76 @@ div.sheet-core-content { display: none; width:840px;}
 	margin-left: 10px;
 }
 
-.sheet-formula{
-    display:inline-block;
+h1.sheet-sheetHeaderWC {
+	text-align: center; 
+	color: #dbc792; 
+    background-color: #755b27;
+	border-radius: 15px;
+	font-family: "cinzelregular";
 }
 
-.sheet-arrow:checked + *.sheet-formula{
-    display:none;
+h1.sheet-sheetHeaderM {
+	text-align: center; 
+	color: black; 
+    background-color: #c7c3b0;
+	border-radius: 15px;
+	font-family: "cinzelregular";
 }
 
-.sheet-arrow:checked + *.sheet-hindrance{
-	display:none;
+h2.sheet-sectionHeader {
+    text-align: center; 
+	color: #755b27; 
+    background-color: #dbc792;
+	border-radius: 15px;
+	font-family: "cinzelregular";
 }
 
-.sheet-staticBoating,
-.sheet-staticClimbing,
-.sheet-staticDriving,
-.sheet-staticGambling,
-.sheet-staticHealing,
-.sheet-staticIntimidation,
-.sheet-staticInvestigation,
-.sheet-staticLockpicking,
-.sheet-staticNotice,
-.sheet-staticPersuasion,
-.sheet-staticPiloting,
-.sheet-staticRepair,
-.sheet-staticRiding,
-.sheet-staticShooting,
-.sheet-staticStealth,
-.sheet-staticStreetwise,
-.sheet-staticSurvival,
-.sheet-staticSwimming,
-.sheet-staticTaunt,
-.sheet-staticThrowing,
-.sheet-staticTracking,
-.sheet-Fame,
-.sheet-Homeworld,
-.sheet-Species,
-.sheet-Occupation,
-.sheet-ShipName,
-.sheet-Sanity,
-.sheet-civilian,
-.sheet-Grit,
-.sheet-WorstNightmare {
-	display:none;
+.sheet-subsectionHeader {
+	text-align:center; 
+	background-color: black; 
+	color: #c7c3b0; 
+	border-radius: 5px;
 }
 
-.sheet-StaticSkill:checked + *.sheet-staticBoating,
-.sheet-StaticSkill:checked + *.sheet-staticClimbing,
-.sheet-StaticSkill:checked + *.sheet-staticDriving,
-.sheet-StaticSkill:checked + *.sheet-staticGambling,
-.sheet-StaticSkill:checked + *.sheet-staticHealing,
-.sheet-StaticSkill:checked + *.sheet-staticIntimidation,
-.sheet-StaticSkill:checked + *.sheet-staticInvestigation,
-.sheet-StaticSkill:checked + *.sheet-staticLockpicking,
-.sheet-StaticSkill:checked + *.sheet-staticNotice,
-.sheet-StaticSkill:checked + *.sheet-staticPersuasion,
-.sheet-StaticSkill:checked + *.sheet-staticPiloting,
-.sheet-StaticSkill:checked + *.sheet-staticRepair,
-.sheet-StaticSkill:checked + *.sheet-staticRiding,
-.sheet-StaticSkill:checked + *.sheet-staticShooting,
-.sheet-StaticSkill:checked + *.sheet-staticStealth,
-.sheet-StaticSkill:checked + *.sheet-staticStreetwise,
-.sheet-StaticSkill:checked + *.sheet-staticSurvival,
-.sheet-StaticSkill:checked + *.sheet-staticSwimming,
-.sheet-StaticSkill:checked + *.sheet-staticTaunt,
-.sheet-StaticSkill:checked + *.sheet-staticThrowing,
-.sheet-StaticSkill:checked + *.sheet-staticTracking,
-.sheet-useFame:checked + *.sheet-Fame,
-.sheet-useHomeworld:checked + *.sheet-Homeworld,
-.sheet-useSpecies:checked + *.sheet-Species,
-.sheet-useOccupation:checked + *.sheet-Occupation,
-.sheet-useShipName:checked + *.sheet-ShipName,
-.sheet-useSanity:checked + *.sheet-Sanity,
-.sheet-useCodeName:checked ~ .sheet-civilian,
-.sheet-useGrit:checked + *.sheet-Grit,
-.sheet-useWorstNightmare:checked + *.sheet-WorstNightmare {
-	display:inline-block;
+input[type=number] {
+    -moz-appearance: textfield;
+    -webkit-appearance: textfield;
+}
+input[type=number]::-webkit-outer-spin-button,
+input[type=number]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    -webkit-appearance: textfield;
 }
 
-.sheet-useSpecies:checked ~ *.sheet-Race {
-	display: none;
-}
-
-.sheet-NewDieType:checked + *.sheet-dtypedropdown,
-.sheet-NewDieType:checked ~ [data-groupname=repeating_skills] > .repitem .sheet-dtypedropdown,
-.sheet-WDNewDieType:checked + *.sheet-dtypedropdown,
-.sheet-WDNewDieType:checked ~ [data-groupname=repeating_skills] > .repitem .sheet-dtypedropdown {
-	display:inline-block;
-	/*display: none;*/
-}
-
-/*  Trying to hide NPC Sections without Tabs */
-
-.sheet-HideHindrance,
-.sheet-HideEdges,
-.sheet-HideArmor,
-.sheet-HideMelee,
-.sheet-HideRanged,
-.sheet-HideGear,
-.sheet-HideSpellsd,
-.sheet-HideSpellsn,
-.sheet-HideAtts,
-.sheet-HideSkills,
-.sheet-HideMWeapons,
-.sheet-HideRWeapons,
-.sheet-HideArcanum,
-.sheet-HideNotes,
-.sheet-HideConfig,
-.sheet-HideWCSkills,
-.sheet-HidemSkills,
-.sheet-HideUITweaks,
-.sheet-HideGameSettings {
-    width: 20%;
-    height: 16px;
-    cursor: pointer;	
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
-}
-
-.sheet-HideHindrance:checked ~ *.sheet-hindrance,
-.sheet-HideEdges:checked ~ *.sheet-edge,
-.sheet-HideArmor:checked ~ *.sheet-armor,
-.sheet-HideMelee:checked ~ *.sheet-melee,
-.sheet-HideRanged:checked ~ *.sheet-ranged,
-.sheet-HideGear:checked ~ *.sheet-gear,
-.sheet-HideSpellsd:checked ~ *.sheet-spellsd,
-.sheet-HideSpellsn:checked ~ *.sheet-spellsn,
-.sheet-HideAtts:checked ~ *.sheet-atts,
-.sheet-HideSkills:checked ~ *.sheet-mskills,
-.sheet-HideMWeapons:checked ~ *.sheet-mweapons,
-.sheet-HideRWeapons:checked ~ *.sheet-rweapons,
-.sheet-HideArcanum:checked ~ *.sheet-arcanum,
-.sheet-HideNotes:checked ~ *.sheet-notes,
-.sheet-HideConfig:checked ~ *.sheet-config,
-.sheet-HideWCSkills:checked ~ *.sheet-wcSkills,
-.sheet-HidemSkills:checked ~ *.sheet-mSkills,
-.sheet-HideUITweaks:checked ~ *.sheet-UITweaks,
-.sheet-HideGameSettings:checked ~ *.sheet-GameSettings {
-    display:none;
-    
-}
-
-.sheet-hindrance,
-.sheet-edge,
-.sheet-armor,
-.sheet-melee,
-.sheet-ranged,
-.sheet-gear,
-.sheet-spellsd,
-.sheet-spellsn,
-.sheet-atts,
-.sheet-mskills,
-.sheet-mweapons,
-.sheet-rweapons,
-.sheet-arcanum,
-.sheet-notes {
-	display:inline-block;
-}
-
-.charsheet span.sheet-is-hindrance-tab::before,
-.charsheet span.sheet-is-edge-tab::before,
-.charsheet span.sheet-is-armor-tab::before,
-.charsheet span.sheet-is-melee-tab::before,
-.charsheet span.sheet-is-ranged-tab::before,
-.charsheet span.sheet-is-gear-tab::before,
-.charsheet span.sheet-is-spellsd-tab::before,
-.charsheet span.sheet-is-spellsn-tab::before,
-.charsheet span.sheet-is-atts-tab::before,
-.charsheet span.sheet-is-skills-tab::before,
-.charsheet span.sheet-is-mweapons-tab::before,
-.charsheet span.sheet-is-rweapons-tab::before,
-.charsheet span.sheet-is-arcanum-tab::before,
-.charsheet span.sheet-is-notes-tab::before {
-    content: "Hide";
-}
-
-.charsheet span.sheet-is-config::before { /*Close Config: grayish background with black text*/
-	content: "Close Configuration";
-}
-
-.charsheet span.sheet-is-wcSkills::before {
-	content: "Close Wild Card Core Skills";
-}
-
-.charsheet span.sheet-is-mSkills::before {
-	content: "Close Mook Core Skills";
-}
-
-.charsheet span.sheet-is-wcUI::before {
-	content: "Close UI Tweaks Configuration";
-}
-
-.charsheet span.sheet-is-gameSettings::before {
-	content: "Close Game Settings Configuration";
-}
-
-.charsheet span.sheet-is-hindrance-tab,
-.charsheet span.sheet-is-edge-tab,
-.charsheet span.sheet-is-armor-tab,
-.charsheet span.sheet-is-melee-tab,
-.charsheet span.sheet-is-ranged-tab,
-.charsheet span.sheet-is-gear-tab,
-.charsheet span.sheet-is-spellsd-tab,
-.charsheet span.sheet-is-spellsn-tab,
-.charsheet span.sheet-is-atts-tab,
-.charsheet span.sheet-is-skills-tab,
-.charsheet span.sheet-is-mweapons-tab,
-.charsheet span.sheet-is-rweapons-tab,
-.charsheet span.sheet-is-arcanum-tab,
-.charsheet span.sheet-is-notes-tab,
-.charsheet span.sheet-is-config,
-.charsheet span.sheet-is-wcSkills,
-.charsheet span.sheet-is-mSkills,
-.charsheet span.sheet-is-wcUI,
-.charsheet span.sheet-is-gameSettings {
-    text-align: center;
-    display: inline-block;    
-    width: 20%;
-    height: 16px;
-    font-size: 9px;
-    /*background: #65763c;*/
-    background: #c7c3b0; /*#93537c;*/
-	color: black; /*white;*/
-	font-weight: bold;
-	border-radius: 4px;
-	margin-left: -20%;
-}
-
-.charsheet span.sheet-is-config,
-.charsheet span.sheet-is-wcSkills,
-.charsheet span.sheet-is-mSkills,
-.charsheet span.sheet-is-wcUI,
-.charsheet span.sheet-is-gameSettings { /*Close Config: grayish background with black text*/
-	background-color: #c7c3b0;
+.sheet-standardtext {
+	background-color: transparent;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
 	color: black;
+	font-weight: bold;
 }
 
-.charsheet .sheet-HideHindrance:checked + span.sheet-is-hindrance-tab,
-.charsheet .sheet-HideEdges:checked + span.sheet-is-edge-tab,
-.charsheet .sheet-HideArmor:checked + span.sheet-is-armor-tab,
-.charsheet .sheet-HideMelee:checked + span.sheet-is-melee-tab,
-.charsheet .sheet-HideRanged:checked + span.sheet-is-ranged-tab,
-.charsheet .sheet-HideGear:checked + span.sheet-is-gear-tab,
-.charsheet .sheet-HideSpellsd:checked + span.sheet-is-spellsd-tab,
-.charsheet .sheet-HideSpellsn:checked + span.sheet-is-spellsn-tab,
-.charsheet .sheet-HideAtts:checked + span.sheet-is-atts-tab,
-.charsheet .sheet-HideSkills:checked + span.sheet-is-skills-tab,
-.charsheet .sheet-HideMWeapons:checked + span.sheet-is-mweapons-tab,
-.charsheet .sheet-HideRWeapons:checked + span.sheet-is-rweapons-tab,
-.charsheet .sheet-HideArcanum:checked + span.sheet-is-arcanum-tab,
-.charsheet .sheet-HideNotes:checked + span.sheet-is-notes-tab { /*Green Background with White Text*/
-	background: black; /*#65763c;*/     
-    color: #c7c3b0; /*white;*/
-	border-radius: 4px;
+.charsheet input[type=text].sheet-standard {
+	width: 140px;
+	border-top: none;
+	border-right: none;
+	border-left: none;
+	border-bottom: solid 1px;
+	/*background-color: transparent;*/
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
+	font-weight: bold;
 }
 
-.charsheet .sheet-HideConfig:checked + span.sheet-is-config,
-.charsheet .sheet-HideWCSkills:checked + span.sheet-is-wcSkills,
-.charsheet .sheet-HidemSkills:checked + span.sheet-is-mSkills,
-.charsheet .sheet-HideUITweaks:checked + span.sheet-is-wcUI,
-.charsheet .sheet-HideGameSettings:checked + span.sheet-is-gameSettings { /*Show Configuration Button: Black background with grayish text*/
-	background: black;
-	border-radius: 4px;
-	color: white;
-}
-
-.charsheet .sheet-HideHindrance:checked + span.sheet-is-hindrance-tab::before {
-	content: "Show Hindrances";
-}
-
-.charsheet .sheet-HideEdges:checked + span.sheet-is-edge-tab::before {
-	content: "Show Edges";
-}
-
-.charsheet .sheet-HideArmor:checked + span.sheet-is-armor-tab::before {
-	content: "Show Armor";
-}
-
-.charsheet .sheet-HideMelee:checked + span.sheet-is-melee-tab::before {
-	content: "Show Melee Weapons";
-}
-
-.charsheet .sheet-HideRanged:checked + span.sheet-is-ranged-tab::before {
-	content: "Show Ranged Weapons";
-}
-
-.charsheet .sheet-HideGear:checked + span.sheet-is-gear-tab::before {
-	content: "Show Gear";
-}
-
-.charsheet .sheet-HideSpellsd:checked + span.sheet-is-spellsd-tab::before {
-	content: "Show Damage-causing Spells";
-}
-
-.charsheet .sheet-HideSpellsn:checked + span.sheet-is-spellsn-tab::before {
-	content: "Show Non-damage-causing Spells";
-}
-
-.charsheet .sheet-HideAtts:checked + span.sheet-is-atts-tab::before {
-	content: "Show Attributes & Edges";
-}
-
-.charsheet .sheet-HideSkills:checked + span.sheet-is-skills-tab::before {
-	content: "Show Skills & Armor";
-}
-
-.charsheet .sheet-HideMWeapons:checked + span.sheet-is-mweapons-tab::before {
-	content: "Show Melee Weapons & Gear";
-}
-
-.charsheet .sheet-HideRWeapons:checked + span.sheet-is-rweapons-tab::before {
-	content: "Show Ranged Weapons";
-}
-
-.charsheet .sheet-HideArcanum:checked + span.sheet-is-arcanum-tab::before {
-	content: "Show Arcanum";
-}
-
-.charsheet .sheet-HideNotes:checked + span.sheet-is-notes-tab::before {
-	content: "Show Notes";
-}
-
-.charsheet .sheet-HideConfig:checked + span.sheet-is-config::before { /*Show Configuration: Black background with grayish text*/
-	content: "Configuration";
-}
-
-.charsheet .sheet-HideWCSkills:checked + span.sheet-is-wcSkills::before {
-	content: "Show Wild Card Core Skills";
-}
-
-.charsheet .sheet-HidemSkills:checked + span.sheet-is-mSkills::before {
-	content: "Show Mook Core Skills";
-}
-
-.charsheet .sheet-HideUITweaks:checked + span.sheet-is-wcUI::before {
-	content: "Show UI Tweaks Configuration";
-}
-
-.charsheet .sheet-HideGameSettings:checked + span.sheet-is-gameSettings::before {
-	content: "Show Game Settings Configuration";
-}
-
-/* End NPC Sections Hiding */
-
-
-.sheet-skills label {
-    display:inline-block;
-    text-align:left;
-    width:75px;
-}
-
-.charsheet label {
-    display: inline-block;
-    text-align: left;
-    width:75px;
+input.sheet-standardQuest {
+	width: 140px;
+	border-top: none;
+	border-right: none;
+	border-left: none;
+	border-bottom: solid 1px;
+	/*color: transparent;*/
+	background-color: transparent;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
 }
 
 .sheet-smalltextarea{
@@ -1001,6 +790,189 @@ div.sheet-core-content { display: none; width:840px;}
 	color: black;
 }
 
+textarea.sheet-Questtextarea {
+	background-color: transparent;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
+}
+
+input.sheet-standardNum {
+	width: 37px;
+	border-top: none;
+	border-right: none;
+	border-left: none;
+	border-bottom: solid 1px;
+	text-align: center;
+	/*color: transparent;*/
+	/*background-color: transparent;*/
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
+	font-weight: bold;
+}
+
+input.sheet-derivedStat {
+	width: 37px;
+	text-align: center;
+	/*background-color: white;*/
+	/*background-color: transparent;*/
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
+	font-weight: bold;
+}
+
+input.sheet-modifier {
+	width: 35px;
+	text-align: center;
+	/*background-color: transparent;*/
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+	color: black;
+	font-weight: bold;
+}
+
+.charsheet select {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	vertical-align: top;
+	padding-top: 0px;
+}
+
+label.sheet-nameRankXp,
+label.sheet-AttributeLabel,
+span.sheet-nameRankXp {
+    width:80px;
+    font-weight: bold;
+    font-size: 12px;
+    padding-left: 5px;
+    padding-right: 5px;
+    /*background-color: #c7c3b0;*/
+    color: black;
+    background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");
+    border-radius: 8px;
+}
+
+.sheet-spaceBetween {
+	/*line-height: 35px;*/ 
+	font-weight: bold; 
+	color: black; 
+	background-image: url('http://www.geeksville.us/roll20/semi-trans75.png');
+}
+
+label.sheet-AttributeLabel {
+	font-size: 15px;
+	line-height: 25px;
+}
+
+.sheet-repeatingHeader {
+	/*text-align: left; */
+	background-color: black; 
+	color: #c7c3b0; 
+	border-radius: 5px;
+	padding-left: 5px;
+	margin-right: 0px;
+	margin-left: 0px;
+}
+
+.sheet-WCSkillsRow {
+	width: 785px; 
+	padding: 5px; 
+	margin-bottom: 5px; 
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+}
+
+button[type=roll].sheet-GM-button::before { 
+    background-image: none;
+    /*background-color: #f2f5d3;*/
+    /*background-color: white;*/
+    font-size: 13px;
+    font-family: sans-serif;
+    content: "gm";
+}
+
+button[type=roll].sheet-GM-button {
+    background-image: none;
+    background-color: #f2f5d3;
+}
+
+.sheet-MooknameRankXp{
+    width:75px;
+}
+
+.sheet-weight {
+	color: black;
+    background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");
+    border-radius: 8px;
+    padding: 5px;
+}
+
+label.sheet-AttributeLabel {
+	width: 60px;
+}
+
+.sheet-AttBorder {
+	border: solid 1px;
+	/*width: 88px;*/
+	width: auto;
+	height: 28px;
+	margin: 0px;
+	padding: 2px;
+	margin-right: 0px;
+	margin-left: -3px;
+	margin-top: -3px;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
+}
+
+.sheet-AttBorder > input.sheet-NewDieType:checked{
+	height: auto;
+	/*margin-top: -2px;*/
+}
+
+.sheet-AttMod {
+	padding: 0px; 
+	width: auto; 
+	margin: 0px; 
+	margin-right: -3px;
+}
+
+.sheet-LinkedAtt {
+	padding: 0px;
+	margin-left:0px;
+	border: none;
+	width: 15px;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");	
+}
+
+.sheet-numSpan {
+	width: 50px;
+	font-size: 12px;
+	font-weight: bold;
+	text-align: center;
+	background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png"); 
+	color: black;
+	display: inline-block;
+}
+
+/*.sheet-additionalrules{
+    width:46%;
+    margin-left:10px;
+    margin-right:10px;
+}*/
+
+.sheet-formula{
+    display:inline-block;
+}
+
+.sheet-skills label {
+    display:inline-block;
+    text-align:left;
+    width:75px;
+}
+
+.charsheet label {
+    display: inline-block;
+    text-align: left;
+    width:75px;
+}
+
 .skilllabel {
     display: inline-block;
     width:200px;
@@ -1012,11 +984,11 @@ div.sheet-core-content { display: none; width:840px;}
     margin-bottom:1px;
 }
 
-.sheet-col strong.sheet-dee {
+/*.sheet-col strong.sheet-dee {
     font-size: 1.4em;
     font-weight: bold;
 	padding-right: 4px;
-}
+}*/
 
 .charsheet input.sheet-short {
 	width: 3.5em;
@@ -1024,43 +996,30 @@ div.sheet-core-content { display: none; width:840px;}
 	background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png"); 
 	color: black;
 }
-/*
-.charsheet {
-	background-image: url("http://www.geeksville.us/roll20/oldMap_v2.png");
-	background-size: 845px 900px;
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: center; 
-    background-origin: content-box;
-}
-*/
+
 .charsheet table td, .charsheet table th {
     font-size: 1em;
     font-weight: bold;
     text-align: right;
 }
 
-.sheet-DStatsTable {
-}
-
-.sheet-DStatsTable th {
-    text-align: center;
-}
-
-.sheet-MacroButtons {
-
-}
-
 select.sheet-dtype {
     width: 35px;
     vertical-align: top;
 	 -webkit-appearance: none;
+	 -moz-appearance: none;
 	background-color: transparent;
 	background-image: url("http://www.geeksville.us/roll20/semi-trans75.png");
 	color: black;
 }
 
-/*Better Die Type Drop Down - Begin*/
+/*.sheet-DStatsTable th {
+    text-align: center;
+}*/
+
+/*----------- End Main Setup -----------*/
+
+/*----------- Dice Icon Drop Down Menu -----------*/
 
 .sheet-dtypeOrig {
 	width: 55px;
@@ -1078,11 +1037,8 @@ select.sheet-dtype {
     /* fixed widths work best;*/
     width: 35px;
     display: none;
-    /*display: inline-block;*/
 }
-/*.sheet-dtypedropdown, .sheet-dietype {
-    display:inline-block;
-}*/
+
 .sheet-dietype {
 	display:inline-block;
 }
@@ -1092,12 +1048,12 @@ select.sheet-dtype {
     width: 35px;
     height: 35px;
 }
+
 .sheet-dietype input,
 .sheet-dietype input + span {
     display:none;
     z-index: 1;
 }
-
 
 .sheet-dietype:hover {
     background: silver;
@@ -1125,6 +1081,7 @@ select.sheet-dtype {
 .sheet-dietype:hover span {
     display: inline-block;
 }
+
 .sheet-d4 {
     /*background-position: -411px -1px;*/
     width: 35px;
@@ -1233,244 +1190,415 @@ select.sheet-dtype {
     display: block;
 }
 
-/*Better Die Type Drop Down - End*/
+/*----------- End Dice Menu -----------*/
 
-/*Font Drop Down Menu*/
-.sheet-fontDropdown {
-    /* fixed widths work best;*/
-    width: 100px;
-    /*border: dotted 1px;*/
-    display: inline-block;
-}
-/*.sheet-fontDropdown, .fontlist {
-    display:inline-block;
-}*/
+/*----------- Hiding/Unhiding Things -----------*/
 
-.sheet-fontlist {
-	display: inline-block;
-}
+/* Hiding */
 
-.sheet-fontlist {
-    vertical-align: middle;
-    width: 100px;
-    height: 20px;
-    /*border: solid 1px;*/
-}
-.sheet-fontlist input,
-.sheet-fontlist input + span {
-    display:none;
-    z-index: 1;
-    /*width: 150px;*/
-}
-
-
-.sheet-fontlist:hover {
-    background: silver;
-    /*position:absolute;*/
-    position: relative;
-    top: -10px;
-    width: 130px;
-    height: auto;
-    z-index: 1;
-    padding: 5px;
-}
-/*.sheet-fontlist:hover > .sheet-font1 {
-    display: none;
-}*/
-
-.sheet-fontlist:hover input ,
-.sheet-fontlist:hover input + span {
-    display:inline-block;
-}
-
-/*Margin placeholder*/
-.sheet-fontlist:hover input + span {
-    /*push the margin to the right
-    just to get the radio and label 
-    to be on their own line*/
-   margin-right: 50%;
-}
-
-.sheet-fontlist:hover span {
-    display: inline-block;
-}
-
-.sheet-font1,
-.sheet-font2,
-.sheet-font3,
-.sheet-font4,
-.sheet-font5,
-.sheet-font6,
-.sheet-font7,
-.sheet-font8,
-.sheet-font9,
-.sheet-font10 {
-    width: 100px;
-    height: 20px;
-    background-image: url("https://www.geeksville.us/roll20/semi-trans.png");
-    background-color: transparent;
-    /*display: inline-block;*/
-    color: black;
-    line-height: 20px;
-    text-align: left;
-    display: inline-block;
-    display: none;
-}
-.sheet-font2 {
-    font-family: "Handwriting";
-    font-size: 200%;
-}
-
-.sheet-font3 {
-    font-family: "Glitch";
-    font-size: 1.8em;
-}
-.sheet-font4 {
-    font-family: "CuttyFruty";
-    font-size: 15px;
-}
-.sheet-font5 {
-    font-family: "Saucy";
-    font-size: 15px;
-    /*font-size: 175%;*/
-}
-.sheet-font6 {
-    font-family: "Rujis";
-    font-size: 15px;
-}
-.sheet-font7 {
-    font-family: "Dashley";
-    font-size: 25px;
-}
-.sheet-font8 {
-    font-family: "Graziano";
-    font-size: 25px;
-}
-/*.sheet-font9 {
-    font-family: "BlackletterHand";
-    font-size: 25px;
-}*/
-.sheet-font10 {
-    font-family: "Architect";
-    font-size: 15px;
-}
-
-.sheet-fontlist:not(:hover) input[value="1"]:checked ~ .sheet-font1,
-.sheet-fontlist:not(:hover) input[value="2"]:checked ~ .sheet-font2,
-.sheet-fontlist:not(:hover) input[value="3"]:checked ~ .sheet-font3,
-.sheet-fontlist:not(:hover) input[value="4"]:checked ~ .sheet-font4,
-.sheet-fontlist:not(:hover) input[value="5"]:checked ~ .sheet-font5,
-.sheet-fontlist:not(:hover) input[value="6"]:checked ~ .sheet-font6,
-.sheet-fontlist:not(:hover) input[value="7"]:checked ~ .sheet-font7,
-.sheet-fontlist:not(:hover) input[value="8"]:checked ~ .sheet-font8,
-.sheet-fontlist:not(:hover) input[value="9"]:checked ~ .sheet-font9,
-.sheet-fontlist:not(:hover) input[value="10"]:checked ~ .sheet-font10 {
-    display: block;
-}
-/*.sheet-fontlist:not(:hover) input[value="2"]:checked ~ .sheet-font2 {
-    display: block;
-}*/
-
-.sheet-useFont2:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont2:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Handwriting"; 
-	font-size: 200%;
-}
-
-.sheet-useFont3:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont3:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Glitch"; 
-	font-size: 175%;
-}
-.sheet-useFont4:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont4:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "CuttyFruty"; 
-	font-size: 125%;
-}
-.sheet-useFont5:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont5:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Saucy";
-	font-size: 150%;
-}
-.sheet-useFont6:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont6:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Rujis";
-}
-.sheet-useFont7:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont7:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Dashley"; 
-	font-size: 175%;
-}
-.sheet-useFont8:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont8:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Graziano"; 
-	font-size: 130%;
-}
-.sheet-useFont9:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont9:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "BlackletterHand"; 
-	font-size: 130%;
-}
-.sheet-useFont10:checked ~ [data-groupname=repeating_quests] > .repitem input.sheet-standardQuest,
-.sheet-useFont10:checked ~ [data-groupname=repeating_quests] > .repitem textarea.sheet-Questtextarea {
-	font-family: "Architect"; 
-	font-size: 75%;
-}
-/*End Font Drop Down Menu*/
-
-select.sheet-atype {
-    width: 85px;
-    vertical-align: top;
-}
-.col1 {
-    width: 600px;   
-}
-
-/*Show and hide things*/
-
-
-.sheet-horror {
+.sheet-arrow:checked ~ *.sheet-formula{
     display:none;
 }
-.sheet-cyberpunk {
-    display:none;
-}
-.sheet-deadlands {
-    display:none;
-}
-.sheet-hasPowers {
-    display:inline;
-    width:15px;
-    margin-left:5px;
-}
-.sheet-hiddenElement{
-    display:none;
-}
-.sheet-iscyberpunk:checked~*.sheet-cyberpunk{
-    display:inline-block;
-}
-.sheet-hasPowers:checked~.sheet-powers {
-    display:block;
+
+.sheet-arrow:checked ~ *.sheet-hindrance{
+	display:none;
 }
 
-button[type=roll].sheet-GM-button::before { 
-    background-image: none;
-    /*background-color: #f2f5d3;*/
-    /*background-color: white;*/
-    font-size: 13px;
-    font-family: sans-serif;
-    content: "gm";
+.sheet-staticBoating,
+.sheet-staticClimbing,
+.sheet-staticDriving,
+.sheet-staticFaith,
+.sheet-staticGambling,
+.sheet-staticGuts,
+.sheet-staticHealing,
+.sheet-staticIntimidation,
+.sheet-staticInvestigation,
+.sheet-staticLockpicking,
+.sheet-staticNotice,
+.sheet-staticPersuasion,
+.sheet-staticPiloting,
+.sheet-staticPsionics,
+.sheet-staticRepair,
+.sheet-staticRiding,
+.sheet-staticShooting,
+.sheet-staticSpellcasting,
+.sheet-staticStealth,
+.sheet-staticStreetwise,
+.sheet-staticSurvival,
+.sheet-staticSwimming,
+.sheet-staticTaunt,
+.sheet-staticThrowing,
+.sheet-staticTracking,
+.sheet-staticRitual,
+.sheet-staticWeirdScience,
+.sheet-Fame,
+.sheet-Homeworld,
+.sheet-Augmentations,
+.sheet-aug528,
+.sheet-aug9212,
+.sheet-Species,
+.sheet-Occupation,
+.sheet-ShipName,
+.sheet-Sanity,
+.sheet-civilian,
+.sheet-Grit,
+.sheet-WorstNightmare,
+.sheet-Injuries,
+.sheet-useHB,
+.sheet-Firewall,
+.sheet-Strain,
+.sheet-StreetCred,
+.sheet-useSpecies:checked ~ *.sheet-Race,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_meleeweapons] > .repitem .sheet-useStandard,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_rangeweapons] > .repitem .sheet-useStandard,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_dmgspells] > .repitem .sheet-useStandard,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mmeleeweapons] > .repitem .sheet-useStandard,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mrangeweapons] > .repitem .sheet-useStandard,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mdmgspells] > .repitem .sheet-useStandard,
+.sheet-useRasieHB:checked ~ [data-groupname=repeating_sailingShip] > .repitem .sheet-useStandard,
+.sheet-HideHindrance:checked ~ *.sheet-hindrance,
+.sheet-HideEdges:checked ~ *.sheet-edge,
+.sheet-HideArmor:checked ~ *.sheet-armor,
+.sheet-HideMelee:checked ~ *.sheet-melee,
+.sheet-HideRanged:checked ~ *[class^="sheet-ranged"],
+.sheet-HideGear:checked ~ *.sheet-gear,
+.sheet-HideSpellsd:checked ~ *.sheet-spellsd,
+.sheet-HideSpellsn:checked ~ *.sheet-spellsn,
+.sheet-HideAtts:checked ~ *.sheet-atts,
+.sheet-HideSkills:checked ~ *.sheet-mskills,
+.sheet-HideMWeapons:checked ~ *.sheet-mweapons,
+.sheet-HideRWeapons:checked ~ *.sheet-rweapons,
+.sheet-HideArcanum:checked ~ *.sheet-arcanum,
+.sheet-HideNotes:checked ~ *.sheet-notes,
+.sheet-HideConfig:checked ~ *.sheet-config,
+.sheet-HideWCSkills:checked ~ *.sheet-wcSkills,
+.sheet-HidemSkills:checked ~ *.sheet-mSkills,
+.sheet-HideUITweaks:checked ~ *.sheet-UITweaks,
+.sheet-HideGameSettings:checked ~ *.sheet-GameSettings,
+.sheet-use9212:not(:checked) ~ .sheet-augEnd,
+.sheet-use9212:not(:checked) ~ .sheet-aEnd,
+.sheet-use9212:checked ~ .sheet-use528:checked,
+.sheet-use528:not(:checked) ~ .sheet-hide528,
+.sheet-h528:checked ~ .sheet-use528,
+.sheet-h528:checked ~ span.sheet-528,
+.sheet-h9212:checked ~ .sheet-use9212,
+.sheet-h9212:checked ~ span.sheet-9212,
+.sheet-h9212:checked ~ .sheet-hide528:checked,
+.sheet-h9212:checked ~ span.sheet-h528,
+.sheet-use528:not(:checked) ~ .sheet-use9212,
+.sheet-use528:not(:checked) ~ span.sheet-9212,
+.sheet-HideSShipEdges:checked ~ .sheet-SShipEdges,
+.sheet-HideSShipWeapons:checked ~ .sheet-SShipWeapons,
+.sheet-HideSShipCrew:checked ~ .sheet-SShipCrew {
+	display:none;
 }
 
-button[type=roll].sheet-GM-button {
-    background-image: none;
-    background-color: #f2f5d3;
+/*Showing*/
+
+.sheet-hindrance,
+.sheet-edge,
+.sheet-armor,
+.sheet-melee,
+.sheet-ranged,
+.sheet-gear,
+.sheet-spellsd,
+.sheet-spellsn,
+.sheet-atts,
+.sheet-mskills,
+.sheet-mweapons,
+.sheet-rweapons,
+.sheet-arcanum,
+.sheet-notes,
+.sheet-StaticSkill:checked + *.sheet-staticBoating,
+.sheet-StaticSkill:checked + *.sheet-staticClimbing,
+.sheet-StaticSkill:checked + *.sheet-staticDriving,
+.sheet-StaticSkill:checked + *.sheet-staticFaith,
+.sheet-StaticSkill:checked + *.sheet-staticGambling,
+.sheet-StaticSkill:checked + *.sheet-staticGuts,
+.sheet-StaticSkill:checked + *.sheet-staticHealing,
+.sheet-StaticSkill:checked + *.sheet-staticIntimidation,
+.sheet-StaticSkill:checked + *.sheet-staticInvestigation,
+.sheet-StaticSkill:checked + *.sheet-staticLockpicking,
+.sheet-StaticSkill:checked + *.sheet-staticNotice,
+.sheet-StaticSkill:checked + *.sheet-staticPersuasion,
+.sheet-StaticSkill:checked + *.sheet-staticPiloting,
+.sheet-StaticSkill:checked + *.sheet-staticPsionics,
+.sheet-StaticSkill:checked + *.sheet-staticRepair,
+.sheet-StaticSkill:checked + *.sheet-staticRiding,
+.sheet-StaticSkill:checked + *.sheet-staticShooting,
+.sheet-StaticSkill:checked + *.sheet-staticSpellcasting,
+.sheet-StaticSkill:checked + *.sheet-staticStealth,
+.sheet-StaticSkill:checked + *.sheet-staticStreetwise,
+.sheet-StaticSkill:checked + *.sheet-staticSurvival,
+.sheet-StaticSkill:checked + *.sheet-staticSwimming,
+.sheet-StaticSkill:checked + *.sheet-staticTaunt,
+.sheet-StaticSkill:checked + *.sheet-staticThrowing,
+.sheet-StaticSkill:checked + *.sheet-staticTracking,
+.sheet-StaticSkill:checked + *.sheet-staticRitual,
+.sheet-StaticSkill:checked + *.sheet-staticWeirdScience,
+.sheet-useFame:checked + *.sheet-Fame,
+.sheet-useHomeworld:checked + *.sheet-Homeworld,
+.sheet-useAugmentations:checked + *.sheet-Augmentations,
+.sheet-useSpecies:checked + *.sheet-Species,
+.sheet-useOccupation:checked + *.sheet-Occupation,
+.sheet-useShipName:checked + *.sheet-ShipName,
+.sheet-useSanity:checked + *.sheet-Sanity,
+.sheet-useCodeName:checked ~ .sheet-civilian,
+.sheet-useGrit:checked + *.sheet-Grit,
+.sheet-useWorstNightmare:checked + *.sheet-WorstNightmare,
+.sheet-useInjuries:checked + *.sheet-Injuries,
+.sheet-useFirewall:checked + *.sheet-Firewall,
+.sheet-useStrain:checked + *.sheet-Strain,
+.sheet-useStreetCred:checked + *.sheet-StreetCred,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_meleeweapons] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_rangeweapons] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_dmgspells] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mmeleeweapons] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mrangeweapons] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_mdmgspells] > .repitem .sheet-useHB,
+.sheet-useRaiseHB:checked ~ [data-groupname=repeating_sailingShip] > .repitem .sheet-useHB,
+.sheet-NewDieType:checked + *.sheet-dtypedropdown,
+.sheet-NewDieType:checked ~ [data-groupname=repeating_skills] > .repitem .sheet-dtypedropdown,
+.sheet-WDNewDieType:checked + *.sheet-dtypedropdown,
+.sheet-WDNewDieType:checked ~ [data-groupname=repeating_skills] > .repitem .sheet-dtypedropdown,
+.sheet-use528:checked ~ *.sheet-aug528,
+.sheet-use9212:checked ~ *.sheet-aug9212 {
+	display:inline-block;
 }
 
-input[type=number] {
-    -moz-appearance: textfield;
+/*Modify Content*/
+
+.charsheet span.sheet-is-hindrance-tab::before,
+.charsheet span.sheet-is-edge-tab::before,
+.charsheet span.sheet-is-armor-tab::before,
+.charsheet span.sheet-is-melee-tab::before,
+.charsheet span.sheet-is-ranged-tab::before,
+.charsheet span.sheet-is-gear-tab::before,
+.charsheet span.sheet-is-spellsd-tab::before,
+.charsheet span.sheet-is-spellsn-tab::before,
+.charsheet span.sheet-is-atts-tab::before,
+.charsheet span.sheet-is-skills-tab::before,
+.charsheet span.sheet-is-mweapons-tab::before,
+.charsheet span.sheet-is-rweapons-tab::before,
+.charsheet span.sheet-is-arcanum-tab::before,
+.charsheet span.sheet-is-notes-tab::before,
+.charsheet span.sheet-HideSSEdges::before,
+.charsheet span.sheet-HideSSWeapons::before,
+.charsheet span.sheet-HideSSCrew::before {
+    content: "Hide";
 }
-input[type=number]::-webkit-outer-spin-button,
-input[type=number]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
+
+.charsheet span.sheet-is-config::before { /*Close Config: grayish background with black text*/
+	content: "Close Configuration";
 }
+
+.charsheet span.sheet-is-wcSkills::before {
+	content: "Close Wild Card Core Skills";
+}
+
+.charsheet span.sheet-is-mSkills::before {
+	content: "Close Mook Core Skills";
+}
+
+.charsheet span.sheet-is-wcUI::before {
+	content: "Close UI Tweaks Configuration";
+}
+
+.charsheet span.sheet-is-gameSettings::before {
+	content: "Close Game Settings Configuration";
+}
+
+.charsheet .sheet-use528:not(:checked) + span.sheet-528::before,
+.charsheet .sheet-use9212:not(:checked) + span.sheet-9212::before {
+	content: "Add";
+}
+
+.charsheet .sheet-use528:checked + span.sheet-528::before,
+.charsheet .sheet-hide528:checked + span.sheet-h528::before,
+.charsheet .sheet-augEnd:checked + span.sheet-aEnd::before {
+	content: "Remove";
+}
+
+.charsheet .sheet-HideArmor:checked + span.sheet-is-armor-tab::before,
+.charsheet .sheet-HideMelee:checked + span.sheet-is-melee-tab::before,
+.charsheet .sheet-HideRanged:checked + span.sheet-is-ranged-tab::before,
+.charsheet .sheet-HideGear:checked + span.sheet-is-gear-tab::before,
+.charsheet .sheet-HideSpellsd:checked + span.sheet-is-spellsd-tab::before,
+.charsheet .sheet-HideSpellsn:checked + span.sheet-is-spellsn-tab::before,
+.charsheet .sheet-HideEdges:checked + span.sheet-is-edge-tab::before,
+.charsheet .sheet-HideHindrance:checked + span.sheet-is-hindrance-tab::before,
+.charsheet .sheet-HideSShipEdges:checked + span.sheet-HideSSEdges::before,
+.charsheet .sheet-HideSShipWeapons:checked + span.sheet-HideSSWeapons::before,
+.charsheet .sheet-HideSShipCrew:checked + span.sheet-HideSSCrew::before {
+	content: "Show";
+}
+
+.charsheet .sheet-HideAtts:checked + span.sheet-is-atts-tab::before {
+	content: "Show Attributes & Edges";
+}
+
+.charsheet .sheet-HideSkills:checked + span.sheet-is-skills-tab::before {
+	content: "Show Skills & Armor";
+}
+
+.charsheet .sheet-HideMWeapons:checked + span.sheet-is-mweapons-tab::before {
+	content: "Show Melee Weapons & Gear";
+}
+
+.charsheet .sheet-HideRWeapons:checked + span.sheet-is-rweapons-tab::before {
+	content: "Show Ranged Weapons";
+}
+
+.charsheet .sheet-HideArcanum:checked + span.sheet-is-arcanum-tab::before {
+	content: "Show Arcanum";
+}
+
+.charsheet .sheet-HideNotes:checked + span.sheet-is-notes-tab::before {
+	content: "Show Notes";
+}
+
+.charsheet .sheet-HideConfig:checked + span.sheet-is-config::before { /*Show Configuration: Black background with grayish text*/
+	content: "Configuration";
+}
+
+.charsheet .sheet-HideWCSkills:checked + span.sheet-is-wcSkills::before {
+	content: "Show Wild Card Core Skills";
+}
+
+.charsheet .sheet-HidemSkills:checked + span.sheet-is-mSkills::before {
+	content: "Show Mook Core Skills";
+}
+
+.charsheet .sheet-HideUITweaks:checked + span.sheet-is-wcUI::before {
+	content: "Show UI Tweaks Configuration";
+}
+
+.charsheet .sheet-HideGameSettings:checked + span.sheet-is-gameSettings::before {
+	content: "Show Game Settings Configuration";
+}
+
+/*Modify Display*/
+ /*span classes*/
+.charsheet span.sheet-is-hindrance-tab,
+.charsheet span.sheet-is-edge-tab,
+.charsheet span.sheet-is-armor-tab,
+.charsheet span.sheet-is-melee-tab,
+.charsheet span.sheet-is-ranged-tab,
+.charsheet span.sheet-is-gear-tab,
+.charsheet span.sheet-is-spellsd-tab,
+.charsheet span.sheet-is-spellsn-tab,
+.charsheet span.sheet-is-atts-tab,
+.charsheet span.sheet-is-skills-tab,
+.charsheet span.sheet-is-mweapons-tab,
+.charsheet span.sheet-is-rweapons-tab,
+.charsheet span.sheet-is-arcanum-tab,
+.charsheet span.sheet-is-notes-tab,
+.charsheet span.sheet-is-config,
+.charsheet span.sheet-is-wcSkills,
+.charsheet span.sheet-is-mSkills,
+.charsheet span.sheet-is-wcUI,
+.charsheet span.sheet-is-gameSettings,
+.charsheet span.sheet-528,
+.charsheet span.sheet-9212,
+.charsheet span.sheet-aEnd,
+.charsheet span.sheet-h528,
+.charsheet span.sheet-HideSSEdges,
+.charsheet span.sheet-HideSSWeapons,
+.charsheet span.sheet-HideSSCrew {
+    text-align: center;
+    display: inline-block;    
+    width: 20%;
+    height: 16px;
+    font-size: 9px;
+    /*background: #65763c;*/
+    background: #c7c3b0; /*#93537c;*/
+	color: black; /*white;*/
+	font-weight: bold;
+	border-radius: 4px;
+	margin-left: -20%;
+}
+
+/*The Classes for the Input Field*/
+.sheet-HideHindrance,
+.sheet-HideEdges,
+.sheet-HideArmor,
+.sheet-HideMelee,
+.sheet-HideRanged,
+.sheet-HideGear,
+.sheet-HideSpellsd,
+.sheet-HideSpellsn,
+.sheet-HideAtts,
+.sheet-HideSkills,
+.sheet-HideMWeapons,
+.sheet-HideRWeapons,
+.sheet-HideArcanum,
+.sheet-HideNotes,
+.sheet-HideConfig,
+.sheet-HideWCSkills,
+.sheet-HidemSkills,
+.sheet-HideUITweaks,
+.sheet-HideGameSettings,
+.sheet-use528,
+.sheet-use9212,
+.sheet-augEnd,
+.sheet-hide528,
+.sheet-HideSShipEdges,
+.sheet-HideSShipWeapons,
+.sheet-HideSShipCrew {
+    width: 20%;
+    height: 16px;
+    cursor: pointer;	
+	position: relative;
+	opacity: 0;
+	z-index: 9999;
+}
+
+.charsheet span.sheet-is-config,
+.charsheet span.sheet-is-wcSkills,
+.charsheet span.sheet-is-mSkills,
+.charsheet span.sheet-is-wcUI,
+.charsheet span.sheet-is-gameSettings,
+.charsheet .sheet-use528:checked + span.sheet-528,
+.charsheet .sheet-use9212:checked + span.sheet-9212,
+.charsheet .sheet-augEnd:checked + span.sheet-aEnd,
+.charsheet .sheet-hide528:checked + span.sheet-528 { /*Close Config: grayish background with black text*/
+	background-color: #c7c3b0;
+	color: black;
+}
+
+.charsheet .sheet-HideHindrance:checked + span.sheet-is-hindrance-tab,
+.charsheet .sheet-HideEdges:checked + span.sheet-is-edge-tab,
+.charsheet .sheet-HideArmor:checked + span.sheet-is-armor-tab,
+.charsheet .sheet-HideMelee:checked + span.sheet-is-melee-tab,
+.charsheet .sheet-HideRanged:checked + span.sheet-is-ranged-tab,
+.charsheet .sheet-HideGear:checked + span.sheet-is-gear-tab,
+.charsheet .sheet-HideSpellsd:checked + span.sheet-is-spellsd-tab,
+.charsheet .sheet-HideSpellsn:checked + span.sheet-is-spellsn-tab,
+.charsheet .sheet-HideAtts:checked + span.sheet-is-atts-tab,
+.charsheet .sheet-HideSkills:checked + span.sheet-is-skills-tab,
+.charsheet .sheet-HideMWeapons:checked + span.sheet-is-mweapons-tab,
+.charsheet .sheet-HideRWeapons:checked + span.sheet-is-rweapons-tab,
+.charsheet .sheet-HideArcanum:checked + span.sheet-is-arcanum-tab,
+.charsheet .sheet-HideNotes:checked + span.sheet-is-notes-tab,
+.charsheet .sheet-use528:not(:checked) + span.sheet-528,
+.charsheet .sheet-use9212:not(:checked) + span.sheet-9212,
+.charsheet .sheet-augEnd:not(:checked) + span.sheet-aEnd,
+.charsheet .sheet-HideSShipEdges:checked + span.sheet-HideSSEdges,
+.charsheet .sheet-HideSShipWeapons:checked + span.sheet-HideSSWeapons,
+.charsheet .sheet-HideSShipCrew:checked + span.sheet-HideSSCrew { /*Green Background with White Text*/
+	background: black; /*#65763c;*/     
+    color: #c7c3b0; /*white;*/
+	border-radius: 4px;
+}
+
+.charsheet .sheet-HideConfig:checked + span.sheet-is-config,
+.charsheet .sheet-HideWCSkills:checked + span.sheet-is-wcSkills,
+.charsheet .sheet-HidemSkills:checked + span.sheet-is-mSkills,
+.charsheet .sheet-HideUITweaks:checked + span.sheet-is-wcUI,
+.charsheet .sheet-HideGameSettings:checked + span.sheet-is-gameSettings { /*Show Configuration Button: Black background with grayish text*/
+	background: black;
+	border-radius: 4px;
+	color: white;
+}
+
+/*----------- End Hiding/Unhiding Things -----------*/

--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.css
@@ -342,7 +342,8 @@ semi-trans-grayish.png = 75% opacity
 }
 
 .sheet-useBackground input[value="7"]:checked ~ *.sheet-background {
-	background-image: url("http://www.geeksville.us/roll20/cyberpunk2.jpg");
+	/*background-image: url("http://www.geeksville.us/roll20/cyberpunk2.jpg");*/
+	background-image: url("http://www.geeksville.us/roll20/cyberpunk-1.5.jpg");
 	background-size: 840px 840px;
     /*background-repeat: no-repeat;*/
     /*background-attachment: fixed;*/

--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
@@ -15,7 +15,7 @@
 				<!-- BEGIN CONFIGURATION STUFF -->
 				<!--                           -->
 				<div class="sheet-config" style='border-style: dotted; border-color: #dbc792; padding: 5px; background-color: white; background-image: none;'>
-					sheet version: 07 Jan 2015
+					sheet version: 05 Jan 2015
 					<div class='sheet-row'><h2 class='sheet-sectionHeader'>CONFIGURATION</h2></div>
 					<input type="checkbox" class="sheet-HideUITweaks" name="attr_wcUIConfig" checked /><span class="sheet-is-wcUI"></span>
 					<div class='UITweaks' style="padding: 10px;">
@@ -388,7 +388,7 @@
 								</div>
 								<input type="checkbox" class="sheet-NewDieType" name="attr_WildDieTypeConfig" style="width: 15px; display: none;" />
 								<div class="sheet-dtypeOrig" style="color: black;">
-									<strong>d</strong><input type="number" name="attr_wilddie" title="@{wilddie}" style='width: 25px; padding-left: 0px; padding-bottom: 6px; margin-left:0px; border: none; background-color: transparent; font-weight: bold; color: black;' value="6"/>
+									<strong>d</strong><input type="number" name="attr_wilddie" title="@{wilddie}" style='width: 25px; padding-left: 0px; padding-bottom: 8px; margin-left:0px; border: none; background-color: transparent; font-weight: bold; color: black;' value="6"/>
 								</div>
 								<input type="checkbox" class="sheet-useThreatRating" name="attr_ThreatRating" style="width: 15px; display:none;" />
 								<label class='sheet-Rank-n-XP sheet-nameRankXp'></label>

--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
@@ -3,6 +3,10 @@
 		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="1" checked />
 		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="2" />
 		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="3" />
+		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="4" />
+		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="5" />
+		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="6" />
+		<input type="radio" class="sheet-useBackground" style="display: none;" name="attr_background" value="7" />
 		<!-- Be sure to update the CSS with the file information) -->
 		<div class='sheet-background'>
 			<div class='sheet-cdiv'>
@@ -11,48 +15,93 @@
 				<!-- BEGIN CONFIGURATION STUFF -->
 				<!--                           -->
 				<div class="sheet-config" style='border-style: dotted; border-color: #dbc792; padding: 5px; background-color: white; background-image: none;'>
-					sheet version: 26, Dec. 2014
+					sheet version: 05 Jan 2015
 					<div class='sheet-row'><h2 class='sheet-sectionHeader'>CONFIGURATION</h2></div>
 					<input type="checkbox" class="sheet-HideUITweaks" name="attr_wcUIConfig" checked /><span class="sheet-is-wcUI"></span>
 					<div class='UITweaks' style="padding: 10px;">
-						<span class="sheet-5pxshim"></span><input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px;" />Use Dice Drop Down Menus (Attributes & Skills)<br />
-						<input type="checkbox" class="sheet-NewDieType" name="attr_WildDieTypeConfig" style="width: 15px;" />Use Dice Drop Down Menus (Wild Die)<br />
-						Quest Font Type:
-						<!-- If you're going to add more fonts, you will need to update the CSS file.  
-								o Add the appropriate details via an @font-face 
-								o Update the Font Drop Down Menu section
-								o Update this html file in the Quest Log section with the additon.
-						-->
-						<div class="sheet-fontDropdown">
-							<div class="sheet-fontlist">
-								<input type="radio" style="width: 10px;" name="attr_font" value="1" checked="true" /> <span>Default</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="2" /> <span style='font-family: "Handwriting"; font-size: 175%;'>Option 1</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="3" /> <span style='font-family: "Glitch"; font-size: 175%;'>Option 2</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="4" /> <span style='font-family: "CuttyFruty"; font-size: 95%;'>Option 3</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="5" /> <span style='font-family: "Saucy";'>Option 4</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="6" /> <span style='font-family: "Rujis";'>Option 5</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="7" /> <span style='font-family: "Dashley"; font-size: 130%;'>Option 6</span>
-								<input type="radio" style="width: 10px;" name="attr_font" value="8" /> <span style='font-family: "Graziano"; font-size: 130%;'>Option 7</span>
-								<!--<input type="radio" style="width: 10px;" name="attr_font" value="9" /> <span style='font-family: "BlackletterHand"; font-size: 130%;'>Option 8</span>-->
-								<input type="radio" style="width: 10px;" name="attr_font" value="10" /> <span style='font-family: "Architect"; font-size: 75%;'>Option 8</span>
-								<div class="sheet-font1">Default</div>
-								<div class="sheet-font2">Handwriting</div>
-								<div class="sheet-font3">Glitch</div>
-								<div class="sheet-font4">CuttyFruty</div>
-								<div class="sheet-font5">Saucy</div>
-								<div class="sheet-font6">Rujis</div>
-								<div class="sheet-font7">Dashley</div>
-								<div class="sheet-font8">Graziano</div>
-								<!--<div class="sheet-font9">Blackletter Hand</div>-->
-								<div class="sheet-font10">Architect</div>
+						<div class="sheet-row">
+							<div class="sheet-2colrow">
+								<div class="sheet-col">
+									<h3>Backgrounds</h3>
+										<span class="sheet-5pxshim">
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="1" title="No Background Image" checked /> No Background Image<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="7" title="Cyberpunk" /> Cypberpunk<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="5" title="Last Parsec" /> Last Parsec<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="4" title="Noir" /> Noir<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="2" title="Old Map (PotSM)" /> Old Map<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="6" title="Supers" /> Superhero<br />
+											<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="3" title="Zombiepocalypse" /> Zombie-esque<br />
+										</span>
+								</div>
+								<div class="sheet-col">
+									<h3>Logos</h3>
+										<span class="sheet-5pxshim">
+											<input type="radio" name="attr_logo" value="1" title="Savage Worlds Deluxe" style="width: 15px; display: none;" checked /><input type="checkbox" style="width: 15px;" name="attr_logo" value="1" /> Savage Worlds Deluxe <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="4" title="Zombie SWD" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="4" /> Savage Worlds Deluxe (Bloodied) <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="6" title="Deadlands" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="6" /> Deadlands <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="7" title="DeadlandsNoir" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="7" /> Deadlands: Noir <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="8" title="DeadlandsHoE" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="8" /> Deadlands: Hell on Earth <br />
+											<input type="radio" name="attr_logo" value="9" title="Interface Zero 2.0" style="width: 15px; display: none;" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="9" /> Interface Zero 2.0 <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="3" title="The Last Parsec" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="3" /> The Last Parsec <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="5" title="Necessary Evil" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="5" /> Necessary Evil <br />
+											<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="2" title="Pirates of the Spanish Main" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="2" /> Pirates of the Spanish Main <br />
+											<!-- Need to update the Disclaimer Information section of the CSS File with the appropriate information
+												 Also need to update the bottom of this html page; be sure to use the checkbox input and not the radio input-->
+										</span>
+								</div>
 							</div>
 						</div>
-					</div>
+						<div class="sheet-row">
+							<h4 class="sheet-subsectionHeader">Other Miscellaneous Tweaks</h4>
+							<div class="sheet-col" style="padding-right: 10px; margin-right: 0px; border-right: solid 1px;">
+								<span class="sheet-5pxshim"></span><input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px;" />Use Dice Drop Down Menus (Attributes & Skills)<br />
+								<input type="checkbox" class="sheet-NewDieType" name="attr_WildDieTypeConfig" style="width: 15px;" />Use Dice Drop Down Menus (Wild Die)<br />
+								<input type="checkbox" class="hideArcanum" name="attr_ArcanumTab" style="width: 15px;"> Hide the Arcanum Tab
+								
+							</div>
+							<div class="sheet-col" style="margin-left: -5px; border-left: solid 1px; padding-left: 10px;">
+								Quest Font Type: 
+								<!-- If you're going to add more fonts, you will need to update the CSS file.  
+										o Add the appropriate details via an @font-face 
+										o Update the Font Drop Down Menu section
+										o Update this html file in the Quest Log section with the additon.
+								-->
+								<div class="sheet-fontDropdown">
+									<div class="sheet-fontlist">
+										<input type="radio" style="width: 10px;" name="attr_font" value="1" checked="true" /> <span>Default</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="2" /> <span style='font-family: "Handwriting"; font-size: 175%;'>Option 1</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="3" /> <span style='font-family: "Glitch"; font-size: 175%;'>Option 2</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="4" /> <span style='font-family: "CuttyFruty"; font-size: 95%;'>Option 3</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="5" /> <span style='font-family: "Saucy";'>Option 4</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="6" /> <span style='font-family: "Rujis";'>Option 5</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="7" /> <span style='font-family: "Dashley"; font-size: 130%;'>Option 6</span>
+										<input type="radio" style="width: 10px;" name="attr_font" value="8" /> <span style='font-family: "Graziano"; font-size: 130%;'>Option 7</span>
+										<!--<input type="radio" style="width: 10px;" name="attr_font" value="9" /> <span style='font-family: "BlackletterHand"; font-size: 130%;'>Option 8</span>-->
+										<input type="radio" style="width: 10px;" name="attr_font" value="10" /> <span style='font-family: "Architect"; font-size: 75%;'>Option 8</span>
+										<div class="sheet-font1">Default</div>
+										<div class="sheet-font2">Handwriting</div>
+										<div class="sheet-font3">Glitch</div>
+										<div class="sheet-font4">CuttyFruty</div>
+										<div class="sheet-font5">Saucy</div>
+										<div class="sheet-font6">Rujis</div>
+										<div class="sheet-font7">Dashley</div>
+										<div class="sheet-font8">Graziano</div>
+										<!--<div class="sheet-font9">Blackletter Hand</div>-->
+										<div class="sheet-font10">Architect</div>
+									</div>
+								</div><!--End font drop down-->
+							</div>
+						</div><!--End 2colrow-->
+					</div> <!--End UI Tweaks-->
 					<input type="checkbox" class="sheet-HideGameSettings" name="attr_SettingsConfig" checked /><span class="sheet-is-gameSettings"></span>
 					<div class='GameSettings' style="padding: 10px;">
-						<div class="sheet-3colrow">
-							<div class="sheet-col">
-								<h3>Additional Setting Fields</h3>
+						<div class="sheet-row">
+							<h4 class="sheet-subsectionHeader">Home Brew Rules</h4>
+								<span title="Provides a dropdown menu to select the bonus damage die type instead of the standard d6 only."><input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px;" />Variable Bonus Damage die type</span><br />
+						</div>
+						<div class="sheet-row">
+							<h3>Setting Modifications</h3>
+							<div class="sheet-3colrow">									
 								<!-- Settings that have been incorporated already:
 										o The Last Parsec
 										o Pirates of the Spanish Main
@@ -61,37 +110,36 @@
 										o Deadlands
 										o 50 Fathoms
 										o Low Life -->
-								<span class="sheet-5pxshim">
-									<span title="Replaces 'Money' with 'Clams'. Appropriate for Low Life or any other setting where Clams may be an appropriate replacement for money."><input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" style="width: 15px;" value="2" />Clams</span><br />
-									<span title="Useful for games where the character is known by a code- or superhero name such as Necessary Evil or spy themed games."><input type="checkbox" class="sheet-useCodeName" name="attr_codename" style="width: 15px;" />Code Name</span><br />
-									<span title="Used to track how famous a character is. Settings like Pirates of the Spanish Main use this field."><input type="checkbox" class="sheet-useFame" name="attr_potsmFame" style="width: 15px;" />Fame</span><br />
-									<span title="A measure of one's resistance against horrors. Useful in Horror-esque settings such as Deadlands. This is a derived stat based on the character's Rank."><input type="checkbox" class="sheet-useGrit" name="attr_DLGrit" style="width: 15px;" />Grit</span><br />
-									<span title="Can be used for Sci-Fi settings like The Last Parsec, etc."><input type="checkbox" class="sheet-useHomeworld" name="attr_tlpHW" style="padding-left: 10px; width: 15px;" />Home World</span><br />
-									<span title="Can be used for any setting where a character's occupation is important."><input type="checkbox" class="sheet-useOccupation" name="attr_tlpOccupation" style="width: 15px;" />Occupation</span><br />
-									<span title="Replaces 'Money' with 'Pieces of Eight'. Appropriate for 50 Fathoms or any other Pirate themed setting."><input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" style="width: 15px;" value="1" />Pieces of Eight</span><br />
-									<span title="Modify the Physical Appearance Text Area to include the Origins of Parahuman Abilties. Useful for Necessary Evil and other Superhero-esque settings."><input type="checkbox" class="sheet-useParaHuman" name="attr_powerOrigins" style="width: 15px;" />Origin of Parahuman Abilities</span><br />
-									<span title="Used to track a character's sanity. Useful for most Horroresque settings. This is a derived stat based on (Spirit/2)+2."><input type="checkbox" class="sheet-useSanity" name="attr_tdsanity" style="width: 15px;" />Sanity<br /></span>	
-									<span title="Can be used for any setting where the characters may have a ship of some sort."><input type="checkbox" class="sheet-useShipName" name="attr_tlpShipName" style="width: 15px;" />Ship Name</span><br />	
-									<span title="Can be used for Sci-Fi settings like The Last Parsec, or any setting where Species is used instead of Race."><input type="checkbox" class="sheet-useSpecies" name="attr_tlpSpecies" style="width: 15px;" />Species</span><br />
-									<span title="Change the Rank designation to Threat Rating ala Necessary Evil."><input type="checkbox" class="sheet-useThreatRating" name="attr_ThreatRating" style="width: 15px;" />Threat Rating (Rank)</span><br />
-									<span title="Record the Character's Worst Nightmare. This is important for Deadlands, but may be useful for other settings where a character's worst dreams can come true."><input type="checkbox" class="sheet-useWorstNightmare" name="attr_worstNightmare" style="width: 15px;" />Worst Nightmare</span><br />
-							</div>
-							<div class="sheet-col">
-								<h3>Backgrounds</h3>
-									<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="1" title="No Background Image" checked /> No Background Image<br />
-									<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="2" title="Old Map (PotSM)" /> Old Map (Pirates of the Spanish Main)<br />
-									<input type="checkbox" class="sheet-useBackground" style="width: 15px;" name="attr_background" value="3" title="Zombiepocalypse" /> Generic Zombie-esque Background
-							</div>
-							<div class="sheet-col">
-								<h3>Logos</h3>
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="1" title="Savage Worlds Deluxe" checked="checked"/><input type="checkbox" style="width: 15px;" name="attr_logo" value="1" /> Savage Worlds Deluxe <br />
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="4" title="Zombie SWD" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="4" /> Savage Worlds Deluxe (Bloodied) <br />
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="6" title="Deadlands" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="6" /> Deadlands <br />
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="3" title="The Last Parsec" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="3" /> The Last Parsec <br />
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="5" title="Necessary Evil" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="5" /> Necessary Evil <br />
-								<input type="radio" class="sheet-ShowLogo" style="width: 15px; display: none;" name="attr_logo" value="2" title="Pirates of the Spanish Main" /><input type="checkbox" style="width: 15px;" name="attr_logo" value="2" /> Pirates of the Spanish Main <br />
-								<!-- Need to update the Disclaimer Information section of the CSS File with the appropriate information
-								     Also need to update the bottom of this html page; be sure to use the checkbox input and not the radio input-->
+								<!-- When updating this section, will likely need to modify the CSS file Section:
+									/*----------- Hiding/Unhiding Things -----------*/
+								-->
+								<div class="sheet-col">
+									<h4 class="sheet-subsectionHeader">Additional Derived Stats</h4>
+										<!--Fame--><span title="Used to track how famous a character is. Settings like Pirates of the Spanish Main use this field."><input type="checkbox" class="sheet-useFame" name="attr_potsmFame" style="width: 15px;" />Fame</span><br />
+										<!--Firewall--><span title="Protects a character from being hacked. Starts at 4 and can be modified. This field is useful for settings like Interface Zero 2.0 or other Cyberpunk settings."><input type="checkbox" class="sheet-useFirewall" style="width: 15px;" name="attr_izFirewall" />Firewall</span><br />
+										<!--Grit--><span title="A measure of one's resistance against horrors. Useful in Horror-esque settings such as Deadlands. This is a derived stat based on the character's Rank."><input type="checkbox" class="sheet-useGrit" name="attr_DLGrit" style="width: 15px;" />Grit</span><br />
+										<!--Sanity--><span title="Used to track a character's sanity. Useful for most Horroresque settings. This is a derived stat based on (Spirit/2)+2."><input type="checkbox" class="sheet-useSanity" name="attr_tdsanity" style="width: 15px;" />Sanity<br /></span>
+										<!--Strain--><span title="Used to measure how much strain a character is under due to augmentation from bioware. This field is useful for settings like Interface Zero 2.0 or other Cyberpunk settings."><input type="checkbox" class="sheet-useStrain" style="width: 15px;" name="attr_izStrain" />Strain</span><br />
+										<!--Street Cred--><span title="Used to measure a character's reputation on the streets. Base = 2 per Character Rank. This field is useful for settings like Interface Zero 2.0 or other Cyberpunk settings."><input type="checkbox" class="sheet-useStreetCred" style="width: 15px;" name="attr_izStreetCred" />Street Cred</span></br>
+								</div>
+								<div class="sheet-col">
+									<h4 class="sheet-subsectionHeader">Field Replacements</h4>
+										<!--Clams--><span title="Replaces 'Money' with 'Clams'. Appropriate for Low Life or any other setting where Clams may be an appropriate replacement for money."><input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" style="width: 15px;" value="2" />Clams (Money)</span><br />
+										<!--Code Name--><span title="Useful for games where the character is known by a code- or superhero name such as Necessary Evil or spy themed games. This will add an additional field for Civilian Name."><input type="checkbox" class="sheet-useCodeName" name="attr_codename" style="width: 15px;" />Code Name (Character Name)</span><br />
+										<!--Pieces of Eight--><span title="Replaces 'Money' with 'Pieces of Eight'. Appropriate for 50 Fathoms or any other Pirate themed setting."><input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" style="width: 15px;" value="1" />Pieces of Eight (Money)</span><br />
+										<!--Origina of Parahuman Abilities--><span title="Modify the Physical Appearance Text Area to include the Origins of Parahuman Abilties. Useful for Necessary Evil and other Superhero-esque settings."><input type="checkbox" class="sheet-useParaHuman" name="attr_powerOrigins" style="width: 15px;" />Origin of Parahuman Abilities</span><br />	
+										<!--Species--><span title="Can be used for Sci-Fi settings like The Last Parsec, or any setting where Species is used instead of Race."><input type="checkbox" class="sheet-useSpecies" name="attr_tlpSpecies" style="width: 15px;" />Species (Race)</span><br />
+										<!--Threat Rating--><span title="Change the Rank designation to Threat Rating ala Necessary Evil."><input type="checkbox" class="sheet-useThreatRating" name="attr_ThreatRating" style="width: 15px;" />Threat Rating (Rank)</span><br />
+								</div>
+								<div class="sheet-col">
+									<h4 class="sheet-subsectionHeader">Additional Fields</h4>
+										<!--Augmentation--><span title="Record the Character's Augmentations. Appropriate for Interface Zero 2.0 or any other cyberpunk/sci-fi setting where people can implant augmentation devicds."><input type="checkbox" class="sheet-useAugmentations" name="attr_augment" style="width: 15px;" />Augmentations</span><br />
+										<!--Homeworld--><span title="Can be used for Sci-Fi settings like The Last Parsec, etc."><input type="checkbox" class="sheet-useHomeworld" name="attr_tlpHW" style="padding-left: 10px; width: 15px;" />Home World</span><br />
+										<!--Occupation--><span title="Can be used for any setting where a character's occupation is important."><input type="checkbox" class="sheet-useOccupation" name="attr_tlpOccupation" style="width: 15px;" />Occupation</span><br />
+										<!--Ship Name--><span title="Can be used for any setting where the characters may have a ship of some sort."><input type="checkbox" class="sheet-useShipName" name="attr_tlpShipName" style="width: 15px;" />Ship Name</span><br />
+										<!--Worst Nightmare--><span title="Record the Character's Worst Nightmare. This is important for Deadlands, but may be useful for other settings where a character's worst dreams can come true."><input type="checkbox" class="sheet-useWorstNightmare" name="attr_worstNightmare" style="width: 15px;" />Worst Nightmare</span><br />
+										<!--Permanent Injuries--><span title="Record the Character's Permanent Injuries."><input type="checkbox" class="sheet-useInjuries" name="attr_permInjuries" style="width: 15px;" />Permanent Injuries</span><br />
+								</div>
 							</div>
 						</div>
 					</div>
@@ -102,7 +150,9 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticBoating" style='width:15px;' /> Show Boating <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticClimbing" style='width:15px;' /> Show Climbing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticDriving" style='width:15px;' /> Show Driving <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticFaith" style="width: 15px;" /> Show Faith <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticGambling" style='width:15px;' /> Show Gambling <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticGuts" style='width:15px;' /> Show Guts <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticHealing" style='width:15px;' /> Show Healing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticIntimidation" style='width:15px;' /> Show Intimidation <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticInvestigation" style='width:15px;' /> Show Investigation <br />
@@ -112,11 +162,14 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticNotice" style='width:15px;' /> Show Notice <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticPersuasion" style='width:15px;' /> Show Persuasion <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticPiloting" style='width:15px;' /> Show Piloting <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticPsionics" style='width:15px;' /> Show Psionics <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticRepair" style='width:15px;' /> Show Repair <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticRiding" style='width:15px;' /> Show Riding <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticRitual" style='width:15px;' /> Show Ritual <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticShooting" style='width:15px;' /> Show Shooting <br />
 							</div>
 							<div class='sheet-col'>
+								<input class="StaticSkill" type="checkbox" name="attr_staticSpellcasting" style='width:15px;' /> Show Spellcasting <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticStealth" style='width:15px;' /> Show Stealth <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticStreetwise" style='width:15px;' /> Show Streetwise <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticSurvival" style='width:15px;' /> Show Survival <br />
@@ -124,6 +177,7 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticTaunt" style='width:15px;' /> Show Taunt <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticThrowing" style='width:15px;' /> Show Throwing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticTracking" style='width:15px;' /> Show Tracking <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticWeirdScience" style='width:15px;' /> Show Weird Science <br />
 							</div>
 						</div>
 					</div><!-- End Wild Card Core Skills -->
@@ -135,7 +189,9 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticmBoating" style='width:15px;' /> Show Boating <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmClimbing" style='width:15px;' /> Show Climbing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmDriving" style='width:15px;' /> Show Driving <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticmFaith" style="width: 15px;" /> Show Faith <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmGambling" style='width:15px;' /> Show Gambling <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticmGuts" style='width:15px;' /> Show Guts <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmHealing" style='width:15px;' /> Show Healing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmIntimidation" style='width:15px;' /> Show Intimidation <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmInvestigation" style='width:15px;' /> Show Investigation <br />
@@ -145,11 +201,14 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticmNotice" style='width:15px;' /> Show Notice <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmPersuasion" style='width:15px;' /> Show Persuasion <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmPiloting" style='width:15px;' /> Show Piloting <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticmPsionics" style='width:15px;' /> Show Psionics <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmRepair" style='width:15px;' /> Show Repair <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmRiding" style='width:15px;' /> Show Riding <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticmRitual" style='width:15px;' /> Show Ritual <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmShooting" style='width:15px;' /> Show Shooting <br />
 							</div>
 							<div class='sheet-col'>
+								<input class="StaticSkill" type="checkbox" name="attr_staticmSpellcasting" style='width:15px;' /> Show Spellcasting <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmStealth" style='width:15px;' /> Show Stealth <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmStreetwise" style='width:15px;' /> Show Streetwise <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmSurvival" style='width:15px;' /> Show Survival <br />
@@ -157,6 +216,7 @@
 								<input class="StaticSkill" type="checkbox" name="attr_staticmTaunt" style='width:15px;' /> Show Taunt <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmThrowing" style='width:15px;' /> Show Throwing <br />
 								<input class="StaticSkill" type="checkbox" name="attr_staticmTracking" style='width:15px;' /> Show Tracking <br />
+								<input class="StaticSkill" type="checkbox" name="attr_staticmWeirdScience" style='width:15px;' /> Show Weird Science <br />
 							</div>
 						</div>
 					</div><!-- End Mook Core Skills -->
@@ -175,8 +235,11 @@
 					<span class="sheet-tab sheet-tab3" style='line-height: 40px;'>SKILLS</span>
 					<input type="radio" class="sheet-tab sheet-tab4" name="attr_core-tab" value="4" title="Equipment" /> 
 					<span class="sheet-tab sheet-tab4" style='line-height: 40px;'>EQUIPMENT</span>
+					
+					<input type="checkbox" class="sheet-hideArcanum" name="attr_ArcanumTab" style="width: 15px; display: none;">
 					<input type="radio" class="sheet-tab sheet-tab5" name="attr_core-tab" value="5" title="Arcanum" /> 
 					<span class="sheet-tab sheet-tab5" style='line-height: 40px;'>ARCANUM</span>
+					
 					<input type="radio" class="sheet-tab sheet-tab6" name="attr_core-tab" value="6" title="Journal" /> 
 					<span class="sheet-tab sheet-tab6" style='line-height: 40px;'>JOURNAL</span>
 					<input type="radio" class="sheet-tab sheet-tab99" name="attr_core-tab" value="99" title="All" />
@@ -241,13 +304,29 @@
 									<span class="sheet-numSpan">&nbsp;</span>
 									<input type="number" name="attr_sanityCur" title="@{sanityCur}" class="sheet-derivedStat" value="@{sanity} + @{sanityMod}" disabled="true" /><br />
 								</div>
+								<label class='sheet-nameRankXp'>Charisma:</label>
+									<input type="number" name="attr_charisma" class="sheet-derivedStat" title="@{charisma}" value="0"/>
+									<input type="number" name="attr_charismaMod" title="@{charismaMod}" class="sheet-standardNum" value="0" />
+									<span class="sheet-numSpan">&nbsp;</span>
+									<input type="number" name="attr_charismaCur" title="@{charismaCur}" class="sheet-derivedStat" value="@{charisma} + @{charismaMod}" disabled="true" /><br />
+								<input type="checkbox" class="sheet-useFame" style="width: 15px; display: none;" name="attr_potsmFame" />
 								
-								<label class='sheet-nameRankXp'>Toughness:</label>
-									<input type="number" name="attr_toughness" title="@{toughness}" class="sheet-derivedStat" value="floor(((@{vigor}+@{viMod})/2)+2)" disabled="true" />
-									<input type="number" name="attr_tufnessMod" title="@{tufnessMod}" class="sheet-standardNum" value="0" />
-									<input type="hidden" name="attr_tufnsPlusMod"  title="@{tufnsPlusMod}" value="(@{toughnessbase})+{@toughnessMod}" />
-									<input type="number" name="attr_toughnessArmor" title="@{toughnessArmor}" class="sheet-standardNum" value="0" />&nbsp;
-									<input type="number" name="attr_toughnesscur" title="@{toughnesscur}" class="sheet-derivedStat" value="(@{toughness})+(@{tufnessMod})+(@{toughnessArmor})" disabled="true" /><br />
+								<div class="sheet-Fame">
+									<label class='sheet-nameRankXp'>Fame:</label>
+									<input class="sheet-derivedStat" type="number" name="attr_fame" title="@{fame}" value="0"/>
+									<input type="number" name="attr_fameMod" title="@{fameMod}" class="sheet-standardNum" value="0" />
+									<span class="sheet-numSpan">&nbsp;</span>
+									<input type="number" name="attr_fameCur" title="@{fameCur}" class="sheet-derivedStat" value="@{fame} + @{fameMod}" disabled="true" /><br />
+								</div>
+								
+								<input type="checkbox" class="sheet-useFirewall" style="width: 15px; display: none;" name="attr_izFirewall" />
+								<div class="sheet-Firewall">
+									<label class='sheet-nameRankXp'>Firewall:</label>
+									<input class="sheet-derivedStat" type="number" name="attr_Firewall" title="@{Firewall}" value="4"/>
+									<input type="number" name="attr_FirewallMod" title="@{FirewallMod}" class="sheet-standardNum" value="0" />
+									<span class="sheet-numSpan">&nbsp;</span>
+									<input type="number" name="attr_FirewallCur" title="@{FirewallCur}" class="sheet-derivedStat" value="@{Firewall} + @{FirewallMod}" disabled="true" /><br />
+								</div>
 								
 								<input type="checkbox" class="sheet-useGrit" name="attr_DLGrit" style="width: 15px; display: none;" />
 								<div class="sheet-Grit">
@@ -258,11 +337,44 @@
 									<input type="number" name="attr_gritCur" title="@{gritCur}" class="sheet-derivedStat" value="@{grit} + @{gritMod}" disabled="true" /><br />
 								</div>
 								
+								<label class='sheet-nameRankXp'>Toughness:</label>
+									<input type="number" name="attr_toughness" title="@{toughness}" class="sheet-derivedStat" value="floor(((@{vigor}+@{viMod})/2)+2)" disabled="true" />
+									<input type="number" name="attr_tufnessMod" title="@{tufnessMod}" class="sheet-standardNum" value="0" />
+									<input type="hidden" name="attr_tufnsPlusMod"  title="@{tufnsPlusMod}" value="(@{toughnessbase})+{@toughnessMod}" />
+									<input type="number" name="attr_toughnessArmor" title="@{toughnessArmor}" class="sheet-standardNum" value="0" />&nbsp;
+									<input type="number" name="attr_toughnesscur" title="@{toughnesscur}" class="sheet-derivedStat" value="(@{toughness})+(@{tufnessMod})+(@{toughnessArmor})" disabled="true" /><br />
+								
+								<input type="checkbox" class="sheet-useStreetCred" style="width: 15px; display: none;" name="attr_izStreetCred" />
+								<div class="sheet-StreetCred">
+									<div class="sheet-col" style="width: 90px;"> </div><div class="sheet-numSpan" style="border-top-left-radius: 5px; border-bottom-left-radius: 5px;">Base</div><div class="sheet-numSpan">Mod</div><div class="sheet-numSpan">Current</div><div class="sheet-numSpan" style="width: 55px; border-top-right-radius: 5px; border-bottom-right-radius: 5px;">Max</div><br />
+									<label class='sheet-nameRankXp'>Street Cred:</label>
+									<input class="sheet-derivedStat" type="number" name="attr_StreetCred" title="@{StreetCred}" value="@{Rank}*2" disabled="true"/>
+									<input type="number" name="attr_StreetCredMod" title="@{StreetCredMod}" class="sheet-standardNum" value="0" />
+									<!--<span class="sheet-numSpan">&nbsp;</span>-->
+									<input type="number" name="attr_StreetCredCur" title="@{StreetCredCur}" class="sheet-derivedStat" value="@{StreetCred} + @{StreetCredMod}" disabled="true" />
+									<input type="number" name="attr_maxStreetCredCur" title="@{maxStreetCredCur}" class="sheet-derivedStat" value="10" /><br />
+								</div>
+								
+								<input type="checkbox" class="sheet-useStrain" style="width: 15px; display: none;" name="attr_izStrain" />
+								<div class="sheet-Strain">
+									<div class="sheet-col" style="width: 90px;"> </div><div class="sheet-numSpan" style="border-top-left-radius: 5px; border-bottom-left-radius: 5px;">Max</div><div class="sheet-numSpan">&nbsp;</div><div class="sheet-numSpan">Mod</div><div class="sheet-numSpan" style="width: 55px; border-top-right-radius: 5px; border-bottom-right-radius: 5px;">Current</div><br />
+									<!--<div class="sheet-col" style="width:90px;"> </di><div class="sheet-numSpan" style="border-top-left-radius: 5px; border-bottom-left-radius: 5px;">Max</div><div class="sheet-numSpan">Mod</div><div class="sheet-numSpan"> </div><div class="sheet-numSpan" style="width: 55px; border-top-right-radius: 5px; border-bottom-right-radius: 5px;">Current</div><br />-->
+									<label class='sheet-nameRankXp'>Strain:</label>
+									<input class="sheet-derivedStat" type="number" name="attr_Strain_max" title="@{Strain_max}" />
+									<span class="sheet-numSpan">&nbsp;</span>
+									<input type="number" name="attr_StrainMod" title="@{StrainMod}" class="sheet-standardNum" value="0" />
+									<input type="number" name="attr_StrainCur" title="@{StrainCur}" class="sheet-derivedStat" value="@{totalStrain} + @{StrainMod}" disabled="true" /><br />
+								</div>
+								
+							</div>
+							<!-- Third Column of Demographics -->
+							<div class='sheet-col' style='width:220px;'>
+								<br />
 								<label class='sheet-nameRankXp'>Wild Die:</label>
 								<input type="checkbox" class="sheet-NewDieType" name="attr_WildDieTypeConfig" style="width: 15px; display: none;" />
 								<div class="sheet-dtypedropdown" style="width: 45px;">
 									<div class="sheet-dietype">
-										<input type="radio" name="attr_wilddie" title="@{agility}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+										<input type="radio" name="attr_wilddie" value="4" title="@{wilddie}" checked="true" style="width:10px;" /> <span>d4</span>
 										<input type="radio" name="attr_wilddie" value="6" title="@{wilddie}" style="width:10px;"/> <span>d6</span>
 										<input type="radio" name="attr_wilddie" value="8" title="@{wilddie}" style="width:10px;"/> <span>d8</span>
 										<input type="radio" name="attr_wilddie" value="10" title="@{wilddie}" style="width:10px;"/> <span>d10</span>
@@ -277,17 +389,6 @@
 								<input type="checkbox" class="sheet-NewDieType" name="attr_WildDieTypeConfig" style="width: 15px; display: none;" />
 								<div class="sheet-dtypeOrig" style="color: black;">
 									<strong>d</strong><input type="number" name="attr_wilddie" title="@{wilddie}" style='width: 25px; padding-left: 0px; padding-bottom: 6px; margin-left:0px; border: none; background-color: transparent; font-weight: bold; color: black;' value="6"/>
-								</div>
-							</div>
-							<!-- Third Column of Demographics -->
-							<div class='sheet-col' style='width:220px;'>
-								<br />
-								<label class='sheet-nameRankXp'>Charisma:</label>
-									<input type="number" name="attr_charisma" class="sheet-standardNum" title="@{charisma}" value="0"/>
-								<input type="checkbox" class="sheet-useFame" style="display: none;" name="attr_potsmFame" style="width: 15px;" />
-								<div class="sheet-Fame">
-									<label class='sheet-nameRankXp'>Fame:</label>
-									<input class="sheet-standardNum" type="number" name="attr_fame" title="@{fame}" value="0"/>
 								</div>
 								<input type="checkbox" class="sheet-useThreatRating" name="attr_ThreatRating" style="width: 15px; display:none;" />
 								<label class='sheet-Rank-n-XP sheet-nameRankXp'></label>
@@ -358,9 +459,10 @@
 												<option value="12">d12</option>
 											 </select>
 										</div><span style="font-weight: bold;">
-										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_agMod" title="@{agMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;">&nbsp;+&nbsp;<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_agrollMod" title="@{agrollMod}" value="0" />
+										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_agMod" title="@{agMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;"><span class="sheet-spaceBetween">&nbsp;+&nbsp;</span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_agrollMod" title="@{agrollMod}" value="0" />
 										<button type='roll' name='roll_AgilityRoll' title="@{AgilityRoll}" value='/em @{character_name} attempts to be agile and rolls [[{1d@{agility}![Agility]+@{agMod}[Agility Modifier],1d@{wilddie}![Wild Die]}kh1 + @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><button type='roll' class="sheet-GM-button" name='roll_gmAgilityRoll' title="@{gmAgilityRoll}" value='/w gm @{character_name} attempts to be agile and rolls [[{1d@{agility}![Agility]+@{agMod}[Agility Modifier],1d@{wilddie}![Wild Die]}kh1 + @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
-										<input type='hidden' name=attr_rollAgility value='/em @{character_name} attempts to be agile and rolls [[{1d@{agility}![Agility]+@{agMod}[Agility Modifier],1d@{wilddie}![Wild Die]}kh1 + @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' /></div>
+										<input type='hidden' name=attr_rollAgility value='/em @{character_name} attempts to be agile and rolls [[{1d@{agility}![Agility]+@{agMod}[Agility Modifier],1d@{wilddie}![Wild Die]}kh1 + @{agrollMod}[Agility Roll Modifier] + @{ttmod}[Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' />
+									</div>
 									<div class="sheet-col" style="width: auto; margin: 0px; margin-bottom: 10px;"><label class="sheet-AttributeLabel">Smarts:</label></div>
 									<div class="sheet-col sheet-AttBorder" style="margin-bottom: 10px;">
 										<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
@@ -388,7 +490,7 @@
 												<option value="12">d12</option>
 											</select>
 										</div><span style="font-weight: bold;">
-										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_smMod" title="@{smMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;">&nbsp;+&nbsp;<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_smrollMod" title="@{smrollMod}" value="0" />
+										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_smMod" title="@{smMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;"><span class="sheet-spaceBetween">&nbsp;+&nbsp;</span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_smrollMod" title="@{smrollMod}" value="0" />
 										<input type="hidden" name="attr_fullsmarts" value="d@{smarts}" />
 										<button type='roll' name='roll_SmartsRoll' title="@{SmartsRoll}" value='/em @{character_name} attempts to be smart and rolls [[{1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><button type='roll' class="sheet-GM-button" name='roll_gmSmartsRoll' title="@{gmSmartsRoll}" value='/w gm @{character_name} attempts to be smart and rolls [[{1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
 										<input type='hidden' name='attr_rollSmarts' value='/em @{character_name} attempts to be smart and rolls [[{1d@{smarts}![Smarts]+@{smMod}[Smarts Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{smrollMod}[Smarts Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' /></div>
@@ -419,7 +521,7 @@
 												<option value="12">d12</option>
 											 </select>
 										 </div><span style="font-weight: bold;">
-										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_spMod" title="@{spMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;">&nbsp;+&nbsp;<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_sprollMod" title="@{sprollMod}" value="0" />
+										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_spMod" title="@{spMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;"><span class="sheet-spaceBetween">&nbsp;+&nbsp;</span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_sprollMod" title="@{sprollMod}" value="0" />
 										<button type='roll' name='roll_SpiritRoll' title="@{SpiritRoll}" value='/em @{character_name} attempts to be spirited and rolls [[{1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><button type='roll' class="sheet-GM-button" name='roll_gmSpiritRoll' title="@{gmSpiritRoll}" value='/w gm @{character_name} attempts to be spirited and rolls [[{1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
 										<input type='hidden' name='attr_rollSpirit' value='/em @{character_name} attempts to be spirited and rolls [[{1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{sprollMod}[Spirit Roll Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]' /></div>
 									<div class="sheet-col" style="width: auto; margin: 0px; margin-bottom: 10px;"><label class="sheet-AttributeLabel">Strength:</label></div>
@@ -449,7 +551,7 @@
 												<option value="12">d12</option>
 											 </select>
 										 </div><span style="font-weight: bold;">
-										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_stMod" title="@{stMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;">&nbsp;+&nbsp;<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_strollMod" title="@{strollMod}" value="0" />
+										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_stMod" title="@{stMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;"><span class="sheet-spaceBetween">&nbsp;+&nbsp;</span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_strollMod" title="@{strollMod}" value="0" />
 										<button type='roll' name='roll_StrengthRoll' title="@{StrengthRoll}" value='/em @{character_name} attempts to be strong and rolls [[{1d@{strength}![Strength]+@{stMod}[Strength Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + (@{encumbrance})[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><button type='roll' class="sheet-GM-button" name='roll_gmStrengthRoll' title="@{gmStrengthRoll}" value='/w gm @{character_name} attempts to be strong and rolls [[{1d@{strength}![Strength]+@{stMod}[Strength Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + (@{encumbrance})[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
 										<input type='hidden' name='attr_rollStrength' value='/em @{character_name} attempts to be strong and rolls [[{1d@{strength}![Strength]+@{stMod}[Strength Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{strollMod}[Strength Roll Modifier] + @{ttmod}[Modifiers] +@{dmgmod}[Damage Modifiers] + @{encumbrance}[Encumbrance Penalty] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' /></div>
 									<div class="sheet-col" style="width: auto; margin: 0px; margin-bottom: 10px;"><label class="sheet-AttributeLabel">Vigor:</label></div>
@@ -480,7 +582,7 @@
 												<option value="12">d12</option>
 											 </select>
 										 </div><span style="font-weight: bold;">
-										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_viMod" title="@{viMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;">&nbsp;+&nbsp;<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_virollMod" title="@{virollMod}" value="0" />
+										 + </span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_viMod" title="@{viMod}" value="0" /></div><div class="sheet-col sheet-AttMod" style="margin-bottom: 10px;"><span class="sheet-spaceBetween">&nbsp;+&nbsp;</span><input class="sheet-modifier" style="width: 35px;" type="number" name="attr_virollMod" title="@{virollMod}" value="0" />
 										<button type='roll' name='roll_VigorRoll' title="@{VigorRoll}" value='/em @{character_name} attempts to be healthy and rolls [[{1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier], 1d@{wilddie}![Wild Die]}kh1 +@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><button type='roll' class="sheet-GM-button" name='roll_gmVigorRoll' title="@{gmVigorRoll}" value='/w gm @{character_name} attempts to be healthy and rolls [[{1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier], 1d@{wilddie}![Wild Die]}kh1 +@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button>
 										<input type='hidden' name='attr_rollVigor' value='/em @{character_name} attempts to be healthy and rolls [[{1d@{vigor}![Vigor]+@{viMod}[Vigor Modifier], 1d@{wilddie}![Wild Die]}kh1 +@{virollMod}[Vigor Roll Modifier]+ @{ttmod}[Modifiers] - @{Wounds}[Wounds] - @{fatigue}[Fatigue]]]' /></div>
 								</p>
@@ -490,14 +592,19 @@
 								<div class="sheet-row" style="padding: 10px;">
 									<div class='sheet-col' style="width: 48%; text-align: center;">
 										<label class="sheet-nameRankXp" style="width: 45px;">Wounds</label><br />
-										<input class="sheet-standardNum" style="width: 35px;" type="number" name="attr_wounds" title="@{wounds}" style='margin-left:4px;' value="0"/><span style="line-height: 35px; font-weight: bold; color: black; background-image: url('http://www.geeksville.us/roll20/semi-trans.png');"> of </span>
+										<input class="sheet-standardNum" style="width: 35px;" type="number" name="attr_wounds" title="@{wounds}" style='margin-left:4px;' value="0"/><span class="sheet-spaceBetween"> of </span>
 										<input class="sheet-standardNum" style="width: 35px; border: none;" type="number" name="attr_wounds_max" title="@{wounds_max}" value="3" disabled="true"/>
 									</div>
 									<div class="sheet-col" style="width: 48%;  text-align: center;">
 										<label class="sheet-nameRankXp" style="width: 45px;">Fatigue</label><br />
-										<input class="sheet-standardNum" style="width: 35px;" type="number" name="attr_fatigue" title="@{fatigue}" style='margin-left:4px;' value="0"/><span style="line-height: 35px; font-weight: bold; color: black; background-image: url('http://www.geeksville.us/roll20/semi-trans.png');"> of </span>
+										<input class="sheet-standardNum" style="width: 35px;" type="number" name="attr_fatigue" title="@{fatigue}" style='margin-left:4px;' value="0"/><span class="sheet-spaceBetween"> of </span>
 										<input class="sheet-standardNum" style="width: 35px; border: none;" type="number" name="attr_fatigue_max" title="@{fatigue_max}" value="2" disabled="true"/>
 									</div>
+								</div>
+								<input type="checkbox" class="sheet-useInjuries" name="attr_permInjuries" style="width: 15px; display: none;" />
+								<div class="sheet-Injuries" style="padding: 10px; width: 90%;">
+									<h4 class="sheet-subsectionHeader">Permanent Injuries</h4>
+									<textarea class="sheet-standardtext" name='attr_injuries' style="height: 40px; width: 95%;"></textarea>
 								</div>
 								<p style='text-align: center;'>
 									<div class="sheet-ShowLogo">
@@ -507,12 +614,18 @@
 										<input type="radio" name="attr_logo" value="4" title="Savage Worlds (Bloodied)" style="display:none;"/>
 										<input type="radio" name="attr_logo" value="5" title="Necessary Evil" style="width: 15px; display: none;"  />
 										<input type="radio" name="attr_logo" value="6" title="Deadlands" style="width: 15px; display: none;"  />
+										<input type="radio" name="attr_logo" value="7" title="DeadlandsNoir" style="width: 15px; display: none;"    />
+										<input type="radio" name="attr_logo" value="8" title="DeadlandsHoE" style="width: 15px; display: none;"    />
+										<input type="radio" name="attr_logo" value="9" title="Interface Zero 2.0" style="width: 15px; display: none;" />
 										<div class="sheet-SWD"><img src="http://i.imgur.com/iwIoTlT.png" /></div>
 										<div class="sheet-PotSM"><img src="http://www.peginc.com/wp-content/uploads/2013/02/PotSM_Logo.png" /></div>
 										<div class="sheet-TLP"><img src="http://www.geeksville.us/roll20/Last_Parsec_Logo.png" /></div>
 										<div class="sheet-Zombie"><img src="http://www.geeksville.us/roll20/SWDZlogo_v2.png" /></div>
 										<div class="sheet-NecessaryEvil"><img src="http://www.geeksville.us/roll20/NecessaryEvil_trans.png" /></div>
 										<div class="sheet-Deadlands"><img src="http://www.geeksville.us/roll20/Deadlands.png" /></div>
+										<div class="sheet-DeadlandsNoir"><img src="http://www.geeksville.us/roll20/DLNoir_dark.png" /></div>
+										<div class="sheet-DeadlandsHoE"><img src="http://www.geeksville.us/roll20/HOE.png" /></div>
+										<div class="sheet-InterfaceZero"><img src="http://www.geeksville.us/roll20/iz_logo.png" /></div>
 										<!-- Remember to update the Character Sheet Logo section of the CSS File-->
 									</div>
 									<!--<img src="http://i.imgur.com/iwIoTlT.png" style="max-height: 100px; max-width: 250px;" /><br/>-->
@@ -521,6 +634,9 @@
 							<div class='sheet-col' style='width:250px; text-align:bottom;'>
 								<h2 class="sheet-subsectionHeader">Miscellaneous</h2><br />
 								<p>
+									<label class="sheet-nameRankXp" style='width:140px; font-size: 80%'>Become Unshaken Modifier</label>
+										<input type="number" class="sheet-standardNum" name="attr_UnshakenMod" title="@{UnshakenMod}" style='margin-left:4px;' value="0"/>
+										<button type='roll' name='roll_Unshaken' title="@{Unshaken}" value='/em @{character_name} rolls attempts to become unshaken and gets [[{1d@{spirit}![Spirit]+@{spMod}[Spirit Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{UnshakenMod}[Unshaken Modifier] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]'></button><br />
 									<label class="sheet-nameRankXp" style='width:140px;'>Trait Test Modifier</label>
 										<input type="number" class="sheet-modifier" name="attr_ttmod" title="@{ttmod}" style='margin-left:4px;' value="0"/><br />
 									<label class="sheet-nameRankXp" style='width:140px;'>Damage Modifier</label>
@@ -559,7 +675,8 @@
 		
 					<div class="sheet-section-edges" style="width: 800px;"><!-- Begin Edges/Hindrances Tab -->
 						<div class='sheet-row'><h2 class='sheet-sectionHeader'>EDGES & HINDRANCES</h2></div>
-						<div class='sheet-row' style="padding-bottom: 5px;">
+						<input class="sheet-HideHindrance" type="checkbox" name="attr_is_hindrance" /><span class="sheet-is-hindrance-tab"> Hindrances</span>
+						<div class='sheet-row sheet-hindrance' style="padding-bottom: 5px;">
 							<div class='sheet-col' style='width:157px;'>
 								<h3 class="sheet-repeatingHeader">Hindrance</h3>
 							</div>
@@ -567,7 +684,6 @@
 								<h3 class="sheet-repeatingHeader">Description</h3>
 							</div>
 						</div>
-						<input class="sheet-HideHindrance" type="checkbox" name="attr_is_hindrance" /><span class="sheet-is-hindrance-tab"></span>
 						<div class='sheet-row sheet-hindrance'> <br />
 							<fieldset class="repeating_hindrances">
 								<div class='sheet-col' style='width:157px;'>
@@ -579,7 +695,8 @@
 							</fieldset>
 						</div>
 						<hr />
-						<div class='sheet-row'>
+						<input class="sheet-HideEdges" type="checkbox" name="attr_is_edge" /><span class="sheet-is-edge-tab"> Edges</span>
+						<div class='sheet-row sheet-edge'>
 							<div class='sheet-col' style='width:157px;'>
 								<h3 class="sheet-repeatingHeader">Edges</h3>
 							</div>
@@ -590,7 +707,7 @@
 								<h3 class="sheet-repeatingHeader">Notes</h3>
 							</div>
 						</div>
-						<input class="sheet-HideEdges" type="checkbox" name="attr_is_edge" /><span class="sheet-is-edge-tab"></span>
+						
 						<div class='sheet-row sheet-edge'>
 							<br />
 							<fieldset class="repeating_edges">
@@ -611,22 +728,45 @@
 					<div class="sheet-section-skills" style="width: 800px;"><!-- Begin Skills -->
 						<div class='sheet-row'><h2 class='sheet-sectionHeader'>SKILLS</h2></div>
 						<div class='sheet-row'>
-							<div class='sheet-col' style='width:280px;'>
+							<!-- Unskilled -->
+							<div class="sheet-row sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px; margin-left: 5px; margin-top: 5px;'>
+									<input type="hidden" name="attr_Unskilled" value="4" />
+									<label style="width: 60px;">Unskilled</label> + <input type="checkbox" name="attr_JackOfAllTrades" value="2" style="width:15px" /> Jack of All Trades
+								</div>
+								<div class='sheet-col' style='width:115px;'>&nbsp;</div>
+								<div class='sheet-col' style='width:120px;'>&nbsp;</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_UnskilledEncumbrance" title="@{UnskilledEncumbrance}" value="1" style="width:20px;" />
+								</div>
+								<div class='sheet-col' style='width:81px;'>
+									<button type='roll' name='roll_UnskilledRoll' title="@{UnskilledRoll}" value='/em @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmUnskilledRoll' title="@{gmUnskilledRoll}" value='/w gm @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollUnskilled' value='/em @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div>
+							<!--End Unskilled-->
+							<div class='sheet-col' style='width:95px;'>
+								<h3 class="sheet-repeatingHeader">Rank</h3>
+							</div>
+							<div class='sheet-col' style='width:185px;'><!--originally 280px-->
 								<h3 class="sheet-repeatingHeader">Skill</h3>
 							</div>
-							<div class='sheet-col' style='width:180px;'>
-								<h3 class="sheet-repeatingHeader">Linked Attribute</h3>
+							<div class='sheet-col' style='width:115px;'><!-- Originally 180px -->
+								<h3 class="sheet-repeatingHeader">Linked Att</h3>
 							</div>
-							<div class='sheet-col' style='width:190px; text-align:center;'>
-								<h3 class="sheet-repeatingHeader">Apply Encumbrance</h3>
+							<div class='sheet-col' style="width: 120px; text-align:center;">
+								<h3 class="sheet-repeatingHeader">Skill Mod</h3>
+							</div>
+							<div class='sheet-col' style='width:135px; text-align:center;'>
+								<h3 class="sheet-repeatingHeader">Encumbrance</h3> <!-- Originally 190px -->
 							</div>
 							<div class='sheet-col' style='width:80px;'>
 								<h3 class="repeatingHeader" style="font-size: 15px;">Roll For It</h3>
 							</div>
-						</div>
+						</div><!--End of Row-->
 						<div class='sheet-row'>
 							<br />
-							<div class="sheet-row sheet-WCSkillsRow">
+							<!--<div class="sheet-row sheet-WCSkillsRow">
 								<div class='sheet-col' style='width:280px;'>
 									<input type="hidden" name="attr_Unskilled" value="4" />
 									<label style="width: 60px;">Unskilled</label> + <input type="checkbox" name="attr_JackOfAllTrades" value="2" style="width:15px" /> Jack of All Trades
@@ -639,7 +779,7 @@
 									<button type='roll' name='roll_UnskilledRoll' title="@{UnskilledRoll}" value='/em @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmUnskilledRoll' title="@{gmUnskilledRoll}" value='/w gm @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
 									<input type='hidden' name='attr_rollUnskilled' value='/em @{character_name} attempts to not suck and rolls: [[{1d@{Unskilled}![Unskilled], 1d@{wilddie}![Wild Die]}kh1 -2[Unskilled Penalty] + {0,@{JackOfAllTrades}}kh1[Jack of All Trades Modifier] + @{ttmod}[Modifiers] +(@{UnskilledEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
-							</div>
+							</div>-->
 							<!-- Break -->
 							<div class="sheet-row sheet-WCSkillsRow">
 								<div class='sheet-col' style='width:280px;'>
@@ -670,17 +810,20 @@
 									</div>+ <input class="sheet-modifier" style="width: 35px;" type="number" name="attr_FightingMod" title="@{FightingMod}" value="0" />
 									<label style='width:152px;'>&nbsp;Fighting</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedFightingAtt" title="@{LinkedFightingAtt}" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedFighting}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedFightingAtt" title="@{LinkedFightingAtt}" value="@{LinkedFighting}" disabled="true" />
 									<input type="hidden" name="attr_LinkedFighting" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
-									<input type="checkbox" name="attr_FightingEncumbrance" title="@{FightingEncumbrance}" value="1" style="width:20px;" checked disabled="true" />
+								<div class='sheet-col' style='width:120px; text-align:center;'> +
+									<input type="number" class="sheet-modifier" name="attr_FightingskillMod" title="@{FightingskillMod}" value="0" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_FightingRoll' title="@{FightingRoll}" value='/em @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting], 1d@{wilddie}![Wild Die]}kh1 + @{FightingMod}[Fighting Modifiers] + @{ttmod}[Situational Modifiers] +(@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmFightingRoll' title="@{gmFightingRoll}" value='/w gm @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting], 1d@{wilddie}![Wild Die]}kh1 + @{FightingMod}[Fighting Modifiers] + @{ttmod}[Situational Modifiers] +(@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollFighting' value='/em @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting], 1d@{wilddie}![Wild Die]}kh1 + @{FightingMod}[Fighting Modifiers] + @{ttmod}[Situational Modifiers] + (@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_FightingEncumbrance" title="@{FightingEncumbrance}" value="1" style="width:20px; text-align: center;" checked disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_FightingRoll' title="@{FightingRoll}" value='/em @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting] + @{FightingMod}[Fighting Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{FightingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmFightingRoll' title="@{gmFightingRoll}" value='/w gm @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting] + @{FightingMod}[Fighting Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{FightingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollFighting' value='/em @{character_name} attempts to hit something and rolls [[{1d@{fighting}![Fighting] + @{FightingMod}[Fighting Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{FightingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] + (@{FightingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div>
 							<!-- Static Skills -->
@@ -715,17 +858,20 @@
 									</div>+ <input type="number" name="attr_BoatingMod" title="@{BoatingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Boating</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedBoatingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedBoating}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedBoatingAtt" value="@{LinkedBoating}" disabled="true" />
 									<input type="hidden" name="attr_LinkedBoating" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_BoatingskillMod" title="@{BoatingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_BoatingEncumbrance" title="@{BoatingEncumbrance}" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_BoatingRoll' title="@{BoatingRoll}" value='/em @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmBoatingRoll' title="@{gmBoatingRoll}" value='/w gm @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollBoating' value='/em @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_BoatingRoll' title="@{BoatingRoll}" value='/em @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{BoatingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmBoatingRoll' title="@{gmBoatingRoll}" value='/w gm @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{BoatingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollBoating' value='/em @{character_name} attempts to boat and rolls [[{1d@{boating}![Boating] + @{BoatingMod}[Boating Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{BoatingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{BoatingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> <!-- End Boating -->
 				
@@ -760,17 +906,20 @@
 									</div>+ <input type="number" name="attr_ClimbingMod" title="@{ClimbingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Climbing</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedClimbingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedClimbing}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedClimbingAtt" value="@{LinkedClimbing}" disabled="true" />
 									<input type="hidden" name="attr_LinkedClimbing" value="@{strength}" />
-									<label style='width:90px;'>&nbsp;Strength</label>
+									<label style='width:75px;'>&nbsp;Strength</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_ClimbingskillMod" title="@{ClimbingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_ClimbingEncumbrance" title="@{ClimbingEncumbrance}" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_ClimbingRoll' title="@{ClimbingRoll}" value='/em @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmClimbingRoll' title="@{gmClimbingRoll}" value='/w gm @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollClimbing' value='/em @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_ClimbingRoll' title="@{ClimbingRoll}" value='/em @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ClimbingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmClimbingRoll' title="@{gmClimbingRoll}" value='/w gm @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ClimbingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollClimbing' value='/em @{character_name} attempts to climb and rolls [[{1d@{Climbing}![Climbing] + @{ClimbingMod}[Climbing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ClimbingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ClimbingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div>
 							<!-- End Climbing -->
@@ -806,21 +955,73 @@
 									</div>+ <input type="number" name="attr_DrivingMod" title="@{DrivingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Driving</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedDrivingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedDriving}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedDrivingAtt" value="@{LinkedDriving}" disabled="true" />
 									<input type="hidden" name="attr_LinkedDriving" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_DrivingskillMod" title="@{DrivingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_DrivingEncumbrance" title="@{DrivingEncumbrance}" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_DrivingRoll' title="@{DrivingRoll}" value='/em @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmDrivingRoll' title="@{gmDrivingRoll}" value='/w gm @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollDriving' value='/em @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_DrivingRoll' title="@{DrivingRoll}" value='/em @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{DrivingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmDrivingRoll' title="@{gmDrivingRoll}" value='/w gm @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{DrivingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollDriving' value='/em @{character_name} attempts to drive and rolls [[{1d@{Driving}![Driving] + @{DrivingMod}[Driving Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{DrivingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{DrivingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Driving (Agility) -->
-				
+							
+							<!-- Faith (Spirit) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticFaith" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_Faith" title="@{Faith}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_Faith" title="@{Faith}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_Faith" title="@{Faith}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_Faith" title="@{Faith}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_Faith" title="@{Faith}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_Faith" title="@{Faith}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_FaithMod" title="@{FaithMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Faith</label>
+								</div>
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedFaithAtt" value="@{LinkedGambling}" disabled="true" />
+									<input type="hidden" name="attr_LinkedFaith" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_FaithskillMod" title="@{FaithskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_FaithEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_FaithRoll' title="@{FaithRoll}" value='/em @{character_name} attempts to be faithful and rolls [[{1d@{Faith}![Faith] + @{FaithMod}[Faith Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{FaithskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmFaithRoll' title="@{gmFaithRoll}" value='/w gm @{character_name} attempts to be faithful and rolls [[{1d@{Faith}![Faith] + @{FaithMod}[Faith Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{FaithskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollFaith' value='/em @{character_name} attempts to be faithful and rolls [[{1d@{Faith}![Faith] + @{FaithMod}[Faith Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{FaithskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End Faith -->
+							
 							<!-- Gambling (Smarts) -->
 							<input class="sheet-StaticSkill" type="checkbox" name="attr_staticGambling" style='display:none;'/>
 							<div class="sheet-staticGambling  sheet-WCSkillsRow">
@@ -852,20 +1053,72 @@
 									</div>+ <input type="number" name="attr_GamblingMod" title="@{GamblingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Gambling</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedGamblingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedGambling}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGamblingAtt" value="@{LinkedGambling}" disabled="true" />
 									<input type="hidden" name="attr_LinkedGambling" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_GamblingskillMod" title="@{GamblingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_GamblingEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_GamblingRoll' title="@{GamblingRoll}" value='/em @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmGamblingRoll' title="@{gmGamblingRoll}" value='/w gm @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollGambling' value='/em @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_GamblingRoll' title="@{GamblingRoll}" value='/em @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GamblingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmGamblingRoll' title="@{gmGamblingRoll}" value='/w gm @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GamblingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollGambling' value='/em @{character_name} attempts to gamble and rolls [[{1d@{Gambling}![Gambling] + @{GamblingMod}[Gambling Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GamblingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Gambling -->
+							
+							<!-- Guts (Spirit) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticGuts" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_Guts" title="@{Guts}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_Guts" title="@{Guts}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_Guts" title="@{Guts}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_Guts" title="@{Guts}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_Guts" title="@{Guts}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_Guts" title="@{Guts}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_GutsMod" title="@{GutsMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Guts</label>
+								</div>
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGutsAtt" value="@{LinkedGuts}" disabled="true" />
+									<input type="hidden" name="attr_LinkedGuts" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_GutsskillMod" title="@{GutsskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_GutsEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_GutsRoll' title="@{GutsRoll}" value='/em @{character_name} attempts to be gutsy and rolls [[{1d@{Guts}![Guts] + @{GutsMod}[Guts Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GutsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmGutsRoll' title="@{gmGutsRoll}" value='/w gm @{character_name} attempts to be faithful and rolls [[{1d@{Guts}![Guts] + @{GutsMod}[Guts Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GutsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollGuts' value='/em @{character_name} attempts to be gutsy and rolls [[{1d@{Guts}![Guts] + @{GutsMod}[Guts Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{GutsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End Guts -->
 				
 							<!-- Healing (Smarts) -->
 							<input class="sheet-StaticSkill" type="checkbox" name="attr_staticHealing" style='display:none;'/>
@@ -898,17 +1151,20 @@
 									</div>+ <input type="number" name="attr_HealingMod" title="@{HealingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Healing</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedHealingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedHealing}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedHealingAtt" value="@{LinkedHealing}" disabled="true" />
 									<input type="hidden" name="attr_LinkedHealing" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_HealingskillMod" title="@{HealingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_HealingEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_HealingRoll' title="@{HealingRoll}" value='/em @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmHealingRoll' title="@{gmHealingRoll}" value='/w gm @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollHealing' value='/em @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_HealingRoll' title="@{HealingRoll}" value='/em @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{HealingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmHealingRoll' title="@{gmHealingRoll}" value='/w gm @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{HealingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollHealing' value='/em @{character_name} attempts to heal and rolls [[{1d@{Healing}![Healing] + @{HealingMod}[Healing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{HealingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Healing -->
@@ -944,17 +1200,20 @@
 									</div>+ <input type="number" name="attr_IntimidationMod" title="@{IntimidationMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Intimidation</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedIntimidationAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedIntimidation}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedIntimidationAtt" value="@{LinkedIntimidation}" disabled="true" />
 									<input type="hidden" name="attr_LinkedIntimidation" value="@{spirit}" />
-									<label style='width:90px;'>&nbsp;Spirit</label>
+									<label style='width:75px;'>&nbsp;Spirit</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_IntimidationskillMod" title="@{IntimidationskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_IntimidationEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_IntimidationRoll' title="@{IntimidationRoll}" value='/em @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmIntimidationRoll' title="@{gmIntimidationRoll}" value='/w gm @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollIntimidation' value='/em @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_IntimidationRoll' title="@{IntimidationRoll}" value='/em @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmIntimidationRoll' title="@{gmIntimidationRoll}" value='/w gm @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollIntimidation' value='/em @{character_name} attempts to intimidate and rolls [[{1d@{Intimidation}![Intimidation] + @{IntimidationMod}[Intimidation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Intimidation -->
@@ -990,17 +1249,20 @@
 									</div>+ <input type="number" name="attr_InvestigationMod" title="@{InvestigationMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Investigation</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedInvestigationAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedInvestigation}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedInvestigationAtt" value="@{LinkedInvestigation}" disabled="true" />
 									<input type="hidden" name="attr_LinkedInvestigation" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_InvestigationskillMod" title="@{InvestigationskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_InvestigationEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_InvestigationRoll' title="@{InvestigationRoll}" value='/em @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmInvestigationRoll' title="@{gmInvestigationRoll}" value='/w gm @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollInvestigation' value='/em @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_InvestigationRoll' title="@{InvestigationRoll}" value='/em @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmInvestigationRoll' title="@{gmInvestigationRoll}" value='/w gm @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollInvestigation' value='/em @{character_name} attempts to investigate and rolls [[{1d@{Investigation}![Investigation] + @{InvestigationMod}[Investigation Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{tbd} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Investigation -->
@@ -1036,17 +1298,20 @@
 									</div>+ <input type="number" name="attr_LockpickingMod" title="@{lockpickingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Lockpicking</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedLockpickingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedLockpicking}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedLockpickingAtt" value="@{LinkedLockpicking}" disabled="true" />
 									<input type="hidden" name="attr_LinkedLockpicking" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_LockpickingskillMod" title="@{LockpickingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_LockpickingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_LockpickingRoll' title="@{LockpickingRoll}" value='/em @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmLockpickingRoll' title="@{gmLockpickingRoll}" value='/w gm @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollLockpicking' value='/em @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_LockpickingRoll' title="@{LockpickingRoll}" value='/em @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{LockpickingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmLockpickingRoll' title="@{gmLockpickingRoll}" value='/w gm @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{LockpickingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollLockpicking' value='/em @{character_name} attempts to lockpick and rolls [[{1d@{Lockpicking}![Lockpicking] + @{LockpickingMod}[Lockpicking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{LockpickingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{LockpickingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Lockpicking (Agility) -->
@@ -1082,17 +1347,20 @@
 									</div>+ <input type="number" name="attr_NoticeMod" title="@{NoticeMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Notice</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedNoticeAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedNotice}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedNoticeAtt" value="@{LinkedNotice}" disabled="true" />
 									<input type="hidden" name="attr_LinkedNotice" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_NoticeskillMod" title="@{NoticeskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_NoticeEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_NoticeRoll' title="@{NoticeRoll}" value='/em @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmNoticeRoll' title="@{gmNoticeRoll}" value='/w gm @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollNotice' value='/em @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_NoticeRoll' title="@{NoticeRoll}" value='/em @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{NoticeskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmNoticeRoll' title="@{gmNoticeRoll}" value='/w gm @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{NoticeskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollNotice' value='/em @{character_name} attempts to notice and rolls [[{1d@{Notice}![Notice] + @{NoticeMod}[Notice Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{NoticeskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Notice -->
@@ -1128,17 +1396,20 @@
 									</div>+ <input type="number" name="attr_PersuasionMod" title="@{PersuasionMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Persuasion</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedPersuasionAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedPersuasion}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedPersuasionAtt" value="@{LinkedPersuasion}" disabled="true" />
 									<input type="hidden" name="attr_LinkedPersuasion" value="@{spirit}" />
-									<label style='width:90px;'>&nbsp;Spirit</label>
+									<label style='width:75px;'>&nbsp;Spirit</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_PersuasionskillMod" title="@{PersuasionskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_PersuasionEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_PersuasionRoll' title="@{PersuasionRoll}" value='/em @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmPersuasionRoll' title="@{gmPersuasionRoll}" value='/w gm @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollPersuasion' value='/em @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_PersuasionRoll' title="@{PersuasionRoll}" value='/em @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PersuasionskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmPersuasionRoll' title="@{gmPersuasionRoll}" value='/w gm @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PersuasionskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollPersuasion' value='/em @{character_name} attempts to persuade and rolls [[{1d@{Persuasion}![Persuasion] + @{PersuasionMod}[Persuasion Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PersuasionskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Persuasion -->
@@ -1174,20 +1445,84 @@
 									</div>+ <input type="number" name="attr_PilotingMod" title="@{PilotingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Piloting</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedPilotingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedPiloting}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedPilotingAtt" value="@{LinkedPiloting}" disabled="true" />
 									<input type="hidden" name="attr_LinkedPiloting" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_PilotingskillMod" title="@{PilotingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_PilotingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_PilotingRoll' title="@{PilotingRoll}" value='/em @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmPilotingRoll' title="@{gmPilotingRoll}" value='/w gm @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollPiloting' value='/em @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_PilotingRoll' title="@{PilotingRoll}" value='/em @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PilotingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmPilotingRoll' title="@{gmPilotingRoll}" value='/w gm @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PilotingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollPiloting' value='/em @{character_name} attempts to pilot and rolls [[{1d@{Piloting}![Piloting] + @{PilotingMod}[Piloting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PilotingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{PilotingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Piloting (Agility) -->
+							
+							<!-- Psionics (TBD) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticPsionics" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_Psionics" title="@{Psionics}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_Psionics" title="@{Psionics}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_Psionics" title="@{Psionics}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_Psionics" title="@{Psionics}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_Psionics" title="@{Psionics}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_Psionics" title="@{Psionics}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_PsionicsMod" title="@{PsionicsMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Psionics</label>
+								</div>
+								<!--<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGutsAtt" value="@{LinkedGuts}" disabled="true" />
+									<input type="hidden" name="attr_LinkedGuts" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>-->
+								<div class='sheet-col' style='width:115px;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedPsionicsAttScore" value="@{LinkedPsionicsAtt}" disabled="true" />
+									<label style='width:75px;'>
+										<select name="attr_LinkedPsionicsAtt" class="atype" style="width: 100px; font-size: 15px; font-weight: bold; border: none; background-color: transparent;">
+											<option value="@{agility}">Agility</option>
+											<option value="@{smarts}" selected>Smarts</option>
+											<option value="@{spirit}">Spirit</option>
+											<option value="@{strength}">Strength</option>
+											<option value="@{vigor}">Vigor</option>
+										</select>
+									</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_PsionicsskillMod" title="@{PsionicsskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_PsionicsEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_PsionicsRoll' title="@{PsionicsRoll}" value='/em @{character_name} attempts to use Psionics and rolls [[{1d@{Psionics}![Psionics] + @{PsionicsMod}[Psionics Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PsionicsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmPsionicsRoll' title="@{gmPsionicsRoll}" value='/w gm @{character_name} attempts to use Psionics and rolls [[{1d@{Psionics}![Psionics] + @{PsionicsMod}[Psionics Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PsionicsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollPsionics' value='/em @{character_name} attempts to use Psionics and rolls [[{1d@{Psionics}![Psionics] + @{PsionicsMod}[Psionics Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{PsionicsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End Psionics -->
 				
 							<!-- Repair (Smarts) -->
 							<input class="sheet-StaticSkill" type="checkbox" name="attr_staticRepair" style='display:none;'/>
@@ -1220,17 +1555,20 @@
 									</div>+ <input type="number" name="attr_RepairMod" title="@{RepairMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Repair</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedRepairAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedRepair}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedRepairAtt" value="@{LinkedRepair}" disabled="true" />
 									<input type="hidden" name="attr_LinkedRepair" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_RepairskillMod" title="@{RepairskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_RepairEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_RepairRoll' title="@{RepairRoll}" value='/em @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmRepairRoll' title="@{gmRepairRoll}" value='/w gm @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollRepair' value='/em @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_RepairRoll' title="@{RepairRoll}" value='/em @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RepairskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmRepairRoll' title="@{gmRepairRoll}" value='/w gm @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RepairskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollRepair' value='/em @{character_name} attempts to repair and rolls [[{1d@{Repair}![Repair] + @{RepairMod}[Repair Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RepairskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Repair -->
@@ -1266,20 +1604,84 @@
 									</div>+ <input type="number" name="attr_RidingMod" title="@{RidingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Riding</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedRidingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedRiding}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedRidingAtt" value="@{LinkedRiding}" disabled="true" />
 									<input type="hidden" name="attr_LinkedRiding" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_RidingskillMod" title="@{RidingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_RidingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_RidingRoll' title="@{RidingRoll}" value='/em @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmRidingRoll' title="@{gmRidingRoll}" value='/w gm @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollRiding' value='/em @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_RidingRoll' title="@{RidingRoll}" value='/em @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RidingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmRidingRoll' title="@{gmRidingRoll}" value='/w gm @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RidingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollRiding' value='/em @{character_name} attempts to ride and rolls [[{1d@{Riding}![Riding] + @{RidingMod}[Riding Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RidingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{RidingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Riding (Agility) -->
+							
+							<!-- Ritual (TBD) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticRitual" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_Ritual" title="@{Ritual}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_Ritual" title="@{Ritual}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_Ritual" title="@{Ritual}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_Ritual" title="@{Ritual}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_Ritual" title="@{Ritual}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_Ritual" title="@{Ritual}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_RitualMod" title="@{RitualMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Ritual</label>
+								</div>
+								<!--<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGutsAtt" value="@{LinkedGuts}" disabled="true" />
+									<input type="hidden" name="attr_LinkedGuts" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>-->
+								<div class='sheet-col' style='width:115px;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedRitualAttScore" value="@{LinkedRitualAtt}" disabled="true" />
+									<label style='width:75px;'>
+										<select name="attr_LinkedRitualAtt" class="atype" style="width: 100px; font-size: 15px; font-weight: bold; border: none; background-color: transparent;">
+											<option value="@{agility}">Agility</option>
+											<option value="@{smarts}">Smarts</option>
+											<option value="@{spirit}" selected>Spirit</option>
+											<option value="@{strength}">Strength</option>
+											<option value="@{vigor}">Vigor</option>
+										</select>
+									</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_RitualsskillMod" title="@{RitualsskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_RitualEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_RitualRoll' title="@{RitualRoll}" value='/em @{character_name} attempts a ritual and rolls [[{1d@{Ritual}![Ritual] + @{RitualMod}[Ritual Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RitualsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmRitualRoll' title="@{gmRitualRoll}" value='/w gm @{character_name} attempts a ritual and rolls [[{1d@{Ritual}![Ritual] + @{RitualMod}[Ritual Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RitualsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollRitual' value='/em @{character_name} attempts a ritual and rolls [[{1d@{Ritual}![Ritual] + @{RitualMod}[Ritual Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{RitualsskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End Ritual -->
 				
 							<!-- Shooting (Agility) -->
 							<input class="sheet-StaticSkill" type="checkbox" name="attr_staticShooting" style='display:none;'/>
@@ -1312,20 +1714,84 @@
 									</div>+ <input type="number" name="attr_ShootingMod" title="@{ShootingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Shooting</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedShootingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedShooting}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedShootingAtt" value="@{LinkedShooting}" disabled="true" />
 									<input type="hidden" name="attr_LinkedShooting" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_ShootingskillMod" title="@{ShootingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_ShootingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_ShootingRoll' title="@{ShootingRoll}" value='/em @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmShootingRoll' title="@{gmShootingRoll}" value='/w gm @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollShooting' value='/em @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_ShootingRoll' title="@{ShootingRoll}" value='/em @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ShootingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmShootingRoll' title="@{gmShootingRoll}" value='/w gm @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ShootingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollShooting' value='/em @{character_name} attempts to shoot and rolls [[{1d@{Shooting}![Shooting] + @{ShootingMod}[Shooting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ShootingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ShootingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Shooting (Agility) -->
+							
+							<!-- Spellcasting (TBD) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticSpellcasting" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_Spellcasting" title="@{Spellcasting}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_Spellcasting" title="@{Spellcasting}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_Spellcasting" title="@{Spellcasting}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_Spellcasting" title="@{Spellcasting}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_Spellcasting" title="@{Spellcasting}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_Spellcasting" title="@{Spellcasting}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_SpellcastingMod" title="@{SpellcastingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Spellcasting</label>
+								</div>
+								<!--<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGutsAtt" value="@{LinkedGuts}" disabled="true" />
+									<input type="hidden" name="attr_LinkedGuts" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>-->
+								<div class='sheet-col' style='width:115px;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedSpellcastingAttScore" value="@{LinkedSpellcastingAtt}" disabled="true" />
+									<label style='width:75px;'>
+										<select name="attr_LinkedSpellcastingAtt" class="atype" style="width: 100px; font-size: 15px; font-weight: bold; border: none; background-color: transparent;">
+											<option value="@{agility}">Agility</option>
+											<option value="@{smarts}" selected>Smarts</option>
+											<option value="@{spirit}">Spirit</option>
+											<option value="@{strength}">Strength</option>
+											<option value="@{vigor}">Vigor</option>
+										</select>
+									</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_SpellcastingskillMod" title="@{SpellcastingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_SpellcastingEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_SpellcastingRoll' title="@{SpellcastingRoll}" value='/em @{character_name} attempts to cast a spell and rolls [[{1d@{Spellcasting}![Spellcasting] + @{SpellcastingMod}[Spellcasting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SpellcastingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSpellcastingRoll' title="@{gmSpellcastingRoll}" value='/w gm @{character_name} attempts to cast a spell and rolls [[{1d@{Spellcasting}![Spellcasting] + @{SpellcastingMod}[Spellcasting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SpellcastingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollSpellcasting' value='/em @{character_name} attempts to cast a spell and rolls [[{1d@{Spellcasting}![Spellcasting] + @{SpellcastingMod}[Spellcasting Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SpellcastingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End Spellcasting -->
 				
 							<!-- Stealth (Agility) -->
 							<input class="sheet-StaticSkill" type="checkbox" name="attr_staticStealth" style='display:none;'/>
@@ -1358,17 +1824,20 @@
 									</div>+ <input type="number" name="attr_StealthMod" title="@{StealthMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Stealth</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedStealthAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedStealth}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedStealthAtt" value="@{LinkedStealth}" disabled="true" />
 									<input type="hidden" name="attr_LinkedStealth" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_StealthskillMod" title="@{StealthskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_StealthEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_StealthRoll' title="@{StealthRoll}" value='/em @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmStealthRoll' title="@{gmStealthRoll}" value='/w gm @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollStealth' value='/em @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_StealthRoll' title="@{StealthRoll}" value='/em @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StealthskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmStealthRoll' title="@{gmStealthRoll}" value='/w gm @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StealthskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollStealth' value='/em @{character_name} attempts to be stealthy and rolls [[{1d@{Stealth}![Stealth] + @{StealthMod}[Stealth Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StealthskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{StealthEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Stealth (Agility) -->
@@ -1404,17 +1873,20 @@
 									</div>+ <input type="number" name="attr_StreetwiseMod" title="@{StreetwiseMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Streetwise</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedStreetwiseAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedStreetwise}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedStreetwiseAtt" value="@{LinkedStreetwise}" disabled="true" />
 									<input type="hidden" name="attr_LinkedStreetwise" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_StreetwiseskillMod" title="@{StreetwiseskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_StreetwiseEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_StreetwiseRoll' title="@{StreetwiseRoll}" value='/em @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmStreetwiseRoll' title="@{gmStreetwiseRoll}" value='/w gm @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollStreetwise' value='/em @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_StreetwiseRoll' title="@{StreetwiseRoll}" value='/em @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StreetwiseskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmStreetwiseRoll' title="@{gmStreetwiseRoll}" value='/w gm @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StreetwiseskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollStreetwise' value='/em @{character_name} attempts to be streetwise and rolls [[{1d@{Streetwise}![Streetwise] + @{StreetwiseMod}[Streetwise Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{StreetwiseskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Streetwise -->
@@ -1450,17 +1922,20 @@
 									</div>+ <input type="number" name="attr_SurvivalMod" title="@{SurvivalMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Survival</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedSurvivalAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedSurvival}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedSurvivalAtt" value="@{LinkedSurvival}" disabled="true" />
 									<input type="hidden" name="attr_LinkedSurvival" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_SurvivalskillMod" title="@{SurvivalskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_SurvivalEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_SurvivalRoll' title="@{SurvivalRoll}" value='/em @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSurvivalRoll' title="@{gmSurvivalRoll}" value='/w gm @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollSurvival' value='/em @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_SurvivalRoll' title="@{SurvivalRoll}" value='/em @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SurvivalskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSurvivalRoll' title="@{gmSurvivalRoll}" value='/w gm @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SurvivalskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollSurvival' value='/em @{character_name} attempts to survive and rolls [[{1d@{Survival}![Survival] + @{SurvivalMod}[Survival Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SurvivalskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Survival -->
@@ -1496,17 +1971,20 @@
 									</div>+ <input type="number" name="attr_SwimmingMod" title="@{SwimmingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Swimming</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedSwimmingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedSwimming}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedSwimmingAtt" value="@{LinkedSwimming}" disabled="true" />
 									<input type="hidden" name="attr_LinkedSwimming" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_SwimmingskillMod" title="@{SwimmingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_SwimmingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_SwimmingRoll' title="@{SwimmingRoll}" value='/em @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSwimmingRoll' title="@{gmSwimmingRoll}" value='/w gm @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollSwimming' value='/em @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_SwimmingRoll' title="@{SwimmingRoll}" value='/em @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SwimmingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSwimmingRoll' title="@{gmSwimmingRoll}" value='/w gm @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SwimmingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollSwimming' value='/em @{character_name} attempts to swim and rolls [[{1d@{Swimming}![Swimming] + @{SwimmingMod}[Swimming Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{SwimmingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SwimmingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Swimming (Agility) -->
@@ -1542,17 +2020,20 @@
 									</div>+ <input type="number" name="attr_TauntMod" title="@{TauntMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Taunt</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedTauntAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedTaunt}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedTauntAtt" value="@{LinkedTaunt}" disabled="true" />
 									<input type="hidden" name="attr_LinkedTaunt" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_TauntskillMod" title="@{TauntskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_TauntEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_TauntRoll' title="@{TauntRoll}" value='/em @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmTauntRoll' title="@{gmTauntRoll}" value='/w gm @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollTaunt' value='/em @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_TauntRoll' title="@{TauntRoll}" value='/em @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TauntskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmTauntRoll' title="@{gmTauntRoll}" value='/w gm @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TauntskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollTaunt' value='/em @{character_name} attempts to taunt and rolls [[{1d@{Taunt}![Taunt] + @{TauntMod}[Taunt Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TauntskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Taunt -->
@@ -1588,17 +2069,20 @@
 									</div>+ <input type="number" name="attr_ThrowingMod" title="@{ThrowingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Throwing</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedThrowingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedThrowing}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedThrowingAtt" value="@{LinkedThrowing}" disabled="true" />
 									<input type="hidden" name="attr_LinkedThrowing" value="@{agility}" />
-									<label style='width:90px;'>&nbsp;Agility</label>
+									<label style='width:75px;'>&nbsp;Agility</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_ThrowingskillMod" title="@{ThrowingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_ThrowingEncumbrance" value="1" style="width:20px;" checked disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_ThrowingRoll' title="@{ThrowingRoll}" value='/em @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmThrowingRoll' title="@{gmThrowingRoll}" value='/w gm @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollThrowing' value='/em @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_ThrowingRoll' title="@{ThrowingRoll}" value='/em @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ThrowingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmThrowingRoll' title="@{gmThrowingRoll}" value='/w gm @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ThrowingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollThrowing' value='/em @{character_name} attempts to throw and rolls [[{1d@{Throwing}![Throwing] + @{ThrowingMod}[Throwing Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ThrowingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{ThrowingEncumbrance}*@{encumbrance}[Encumbrance Penalty]) - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Throwing (Agility) -->
@@ -1634,20 +2118,84 @@
 									</div>+ <input type="number" name="attr_TrackingMod" title="@{TrackingMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 									<label style='width:152px;'>&nbsp;Tracking</label>
 								</div>
-								<div class='sheet-col' style='width:180px; text-align:left;'>
-									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedTrackingAtt" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedTracking}" disabled="true" />
+								<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedTrackingAtt" value="@{LinkedTracking}" disabled="true" />
 									<input type="hidden" name="attr_LinkedTracking" value="@{smarts}" />
-									<label style='width:90px;'>&nbsp;Smarts</label>
+									<label style='width:75px;'>&nbsp;Smarts</label>
 								</div>
-								<div class='sheet-col' style='width:190px; text-align:center;'>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_TrackingskillMod" title="@{TrackingskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
 									<input type="checkbox" name="attr_TrackingEncumbrance" value="1" style="width:20px;" disabled="true" />
 								</div>
-								<div class='sheet-col' style='width:124px;'>
-									<button type='roll' name='roll_TrackingRoll' title="@{TrackingRoll}" value='/em @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmTrackingRoll'title="@{gmTrackingRoll}"  value='/w gm @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-									<input type='hidden' name='attr_rollTracking' value='/em @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_TrackingRoll' title="@{TrackingRoll}" value='/em @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TrackingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmTrackingRoll'title="@{gmTrackingRoll}"  value='/w gm @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TrackingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollTracking' value='/em @{character_name} attempts to track and rolls [[{1d@{Tracking}![Tracking] + @{TrackingMod}[Tracking Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{TrackingskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 								</div>
 							</div> 
 							<!-- End Tracking -->
+							
+							<!-- WeirdScience (TBD) -->
+							<input class="StaticSkill" type="checkbox" name="attr_staticWeirdScience" style="width: 15px; display: none;" />
+							<div class="sheet-staticFaith  sheet-WCSkillsRow">
+								<div class='sheet-col' style='width:280px;'>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypedropdown">
+										<div class="sheet-dietype">
+											<input type="radio" name="attr_WeirdScience" title="@{WeirdScience}" value="4" checked="true" style="width:10px;" /> <span>d4</span>
+											<input type="radio" name="attr_WeirdScience" title="@{WeirdScience}" value="6" style="width:10px;"/> <span>d6</span>
+											<input type="radio" name="attr_WeirdScience" title="@{WeirdScience}" value="8" style="width:10px;"/> <span>d8</span>
+											<input type="radio" name="attr_WeirdScience" title="@{WeirdScience}" value="10" style="width:10px;"/> <span>d10</span>
+											<input type="radio" name="attr_WeirdScience" title="@{WeirdScience}" value="12" style="width:10px;"/> <span>d12</span>
+											<div class="sheet-d4">d</div>
+											<div class="sheet-d6">f</div>
+											<div class="sheet-d8">h</div>
+											<div class="sheet-d10">k</div>
+											<div class="sheet-d12">l</div>
+										</div>
+									</div>
+									<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />
+									<div class="sheet-dtypeOrig">
+										<select name="attr_WeirdScience" title="@{WeirdScience}" class="dtype" value="4">
+											<option value="4" selected>d4</option>
+											<option value="6">d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>
+									</div>+ <input type="number" name="attr_WeirdScienceMod" title="@{WeirdScienceMod}" class="sheet-modifier" style="width:35px;" value="0"/>
+									<label style='width:152px;'>&nbsp;Weird Science</label>
+								</div>
+								<!--<div class='sheet-col' style='width:115px; text-align:left;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedGutsAtt" value="@{LinkedGuts}" disabled="true" />
+									<input type="hidden" name="attr_LinkedGuts" value="@{spirit}" />
+									<label style='width:75px;'>&nbsp;Spirit</label>
+								</div>-->
+								<div class='sheet-col' style='width:115px;'>
+									<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedWeirdScienceAttScore" value="@{LinkedWeirdScienceAtt}" disabled="true" />
+									<label style='width:75px;'>
+										<select name="attr_LinkedWeirdScienceAtt" class="atype" style="width: 100px; font-size: 15px; font-weight: bold; border: none; background-color: transparent;">
+											<option value="@{agility}">Agility</option>
+											<option value="@{smarts}" selected>Smarts</option>
+											<option value="@{spirit}">Spirit</option>
+											<option value="@{strength}">Strength</option>
+											<option value="@{vigor}">Vigor</option>
+										</select>
+									</label>
+								</div>
+								<div class='sheet-col' style='width:120px; text-align:center;'>
+									+ <input type="number" class="sheet-modifier" name="attr_WeirdScienceskillMod" title="@{WeirdScienceskillMod}" value="0" />
+								</div>
+								<div class='sheet-col' style='width:135px; text-align:center;'>
+									<input type="checkbox" name="attr_WeirdScienceEncumbrance" value="1" style="width:20px;" disabled="true" />
+								</div>
+								<div class='sheet-col' style='width:120px;'>
+									<button type='roll' name='roll_WeirdScienceRoll' title="@{WeirdScienceRoll}" value='/em @{character_name} attempts some weird science and rolls [[{1d@{WeirdScience}![WeirdScience] + @{WeirdScienceMod}[WeirdScience Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{WeirdScienceskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmWeirdScienceRoll' title="@{gmWeirdScienceRoll}" value='/w gm @{character_name} attempts some weird science and rolls [[{1d@{WeirdScience}![WeirdScience] + @{WeirdScienceMod}[WeirdScience Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{WeirdScienceskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+									<input type='hidden' name='attr_rollWeirdScience' value='/em @{character_name} attempts some weird science and rolls [[{1d@{WeirdScience}![WeirdScience] + @{WeirdScienceMod}[WeirdScience Modifiers], 1d@{wilddie}![Wild Die]}kh1 + @{WeirdScienceskillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+								</div>
+							</div> 
+							<!-- End WeirdScience -->
 				
 							<!-- End Static Skills -->
 							<!--<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />-->
@@ -1681,10 +2229,10 @@
 										</div>-->+ <input type="number" name="attr_SkillNameMod" title="@{repeating_skills_#_SkillNameMod}" class="sheet-modifier" style="width:35px;" value="0"/>
 										<input class="sheet-standard" type="text" name="attr_SkillName" title="@{repeating_skills_#_SkillName}" placeholder="Skill Name" style='width:152px; font-size: 15px; font-weight: bold;'/>
 									</div>
-									<div class='sheet-col' style='width:178px;'>
-										<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" name="attr_LinkedSkillNameAttScore" style='padding: 0px; margin-left:0px; border: none; color: transparent;' value="@{LinkedSkillNameAtt}" disabled="true" />
-										<label style='width:100px;'>
-											<select name="attr_LinkedSkillNameAtt" class="atype" style="font-size: 15px; font-weight: bold; border: none; background-color: transparent;">
+									<div class='sheet-col' style='width:114px;'> <!--originally 178px-->
+										<span style='text-align:bottom; font-weight:bold;'>d</span><input type="number" class="sheet-LinkedAtt" style="width: 15px;" name="attr_LinkedSkillNameAttScore" value="@{LinkedSkillNameAtt}" disabled="true" />
+										<label style='width:75px;'>
+											<select name="attr_LinkedSkillNameAtt" class="atype" style="font-size: 15px; font-weight: bold; border: none; background-color: transparent; width:75px;">
 												<option value="Select">Select</option>
 												<option value="@{agility}">Agility</option>
 												<option value="@{smarts}">Smarts</option>
@@ -1694,17 +2242,20 @@
 											</select>
 										</label>
 									</div>
-									<div class='sheet-col' style='width:193px; text-align:center;'>
+									<div class='sheet-col' style='width:120px; text-align:center;'>
+										+ <input type="number" class="sheet-modifier" name="attr_SkillMod" title="@{repeating_skills_#_SkillMod}" value="0" />
+									</div>
+									<div class='sheet-col' style='width:138px; text-align:center;'>
 										<input type="checkbox" name="attr_SkillEncumbrance" value="1" style="width:20px;" />
 									</div>
-									<div class='sheet-col' style='width:90px;'>
-										<button type='roll' name='roll_SkillNameRoll' title="@{repeating_skills_#_SkillNameRoll}" value='/em @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}], 1d@{wilddie}![Wild Die]}kh1 + @{SkillNameMod}[Skill Modifiers] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSkillNameRoll' title="@{repeating_skills_#_gmSkillNameRoll}" value='/w gm @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}], 1d@{wilddie}![Wild Die]}kh1 + @{SkillNameMod}[Skill Modifiers] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
-										<input type='hidden' name='attr_rollSkill' value='/em @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}], 1d@{wilddie}![Wild Die]}kh1 + @{SkillNameMod}[Skill Modifiers] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
+									<div class='sheet-col' style='width:90px; margin-left: -1px;'>
+										<button type='roll' name='roll_SkillNameRoll' title="@{repeating_skills_#_SkillNameRoll}" value='/em @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}] + @{SkillNameMod}[Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{SkillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSkillNameRoll' title="@{repeating_skills_#_gmSkillNameRoll}" value='/w gm @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}] + @{SkillNameMod}[Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{SkillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'></button>
+										<input type='hidden' name='attr_rollSkill' value='/em @{character_name} attempts to do something with @{SkillName} and rolls: [[{1d@{SkillNameRank}![@{SkillName}] + @{SkillNameMod}[Rank Modifier], 1d@{wilddie}![Wild Die]}kh1 + @{SkillMod} [Skill Modifier] + @{ttmod}[Situational Modifiers] +(@{SkillEncumbrance}*@{encumbrance})[Encumbrance Penalty] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!' />
 									</div>
 								</div>
 							</fieldset>
 						</div>
-						<input type='checkbox' name='attr_SkillFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+						<input type='checkbox' name='attr_SkillFormula' class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 						<div class='sheet-formula' style='width:785px; height:60px; border:solid; border-width:1px;'>
 							<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do something with @{repeating_skills_0_SkillName} and rolls: [[{1d@{repeating_skills_0_SkillNameRank}![@{repeating_skills_0_SkillName}], 1d@{wilddie}![Wild Die]}kh1 + @{repeating_skills_0_SkillNameMod}[Other Modifiers] + @{ttmod}[Modifiers] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!'</textarea><br />
 							<span style='color:red;'>
@@ -1717,10 +2268,10 @@
 					<div class="sheet-section-gear" style="width: 800px;"><!-- Begin Equipment Tab -->
 						<div class='sheet-row'><h2 class='sheet-sectionHeader'>EQUIPMENT</h2></div>
 						<!-- Begin Armor -->
-						<h3 class="sheet-subsectionHeader" style="margin: 5px;">Armor</h3>
-						<span class="sheet-spacer"></span>
-						<input class="sheet-HideArmor" type="checkbox" name="attr_is_armor" /><span class="sheet-is-armor-tab" /></span>
+						<input class="sheet-HideArmor" type="checkbox" name="attr_is_armor" /><span class="sheet-is-armor-tab" /> Armor</span>
+						<div class="sheet-armor" style="width: 100%; margin: -5px; padding: 0px;"><h3 class="sheet-subsectionHeader" style="margin: 5px;">Armor</h3></div>
 						<div class="sheet-armor">
+							<span class="sheet-spacer"></span>
 							<div class='sheet-row'>
 								<div class='sheet-col' style='width:125px;'> <!-- Armor Type (150px) -->
 									<h4 class="sheet-repeatingHeader">Armor Type</h4>
@@ -1761,10 +2312,10 @@
 								<div class='sheet-col' style='width:85px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:10px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:90px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:240px; text-align:right;'> <!-- Protection (100px)-->
+								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (100px)-->
 									<h4 class="sheet-weight">Total Weight:</h4>
 								</div>
 								<div class='sheet-col' style='width:60px;'> <!-- Weight (60px)-->
@@ -1778,10 +2329,10 @@
 								<div class='sheet-col' style='width:85px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:10px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:90px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:240px; text-align:right;'> <!-- Protection (240px)-->
+								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (240px)-->
 									<h4 class="sheet-weight">Total Weight Carried:</h4>
 								</div>
 								<div class='sheet-col' style='width:60px;'> <!-- Weight (60px)-->
@@ -1794,10 +2345,10 @@
 						</div><!-- End Armor -->
 						<hr />
 						<!-- Begin Weapons -->
-						<h3 class="sheet-subsectionHeader" style="margin: 5px;">Melee Weapons / Strength-based Weapons</h3>
-						<span class="sheet-spacer"></span>
-						<input class="sheet-HideMelee" type="checkbox" name="attr_is_melee" /><span class="sheet-is-melee-tab"></span>
+						<input class="sheet-HideMelee" type="checkbox" name="attr_is_melee" /><span class="sheet-is-melee-tab"> Melee Weapons</span>
+						<div class="sheet-melee" style="width: 100%; margin: -5px; padding: 0px;"><h3 class="sheet-subsectionHeader" style="margin: 5px;">Melee Weapons / Strength-based Weapons</h3></div>
 						<div class="sheet-melee">
+							<span class="sheet-spacer"></span>
 							<div class='sheet-row'>
 								<div class='sheet-col' style='width:120px;'> <!-- Weapon Type (150px) -->
 									<h4 class="sheet-repeatingHeader">Weapon Type</h4>
@@ -1805,7 +2356,7 @@
 								<div class='sheet-col' style='width:180px;'> <!-- Damage (200px) -->
 									<h4 class="sheet-repeatingHeader">Damage</h4>
 								</div>
-								<div class='sheet-col' style='width:60px;'> <!-- Raise/Bonus Damage (60px)-->
+								<div class='sheet-col' style='width:60px; text-align: center;'> <!-- Raise/Bonus Damage (60px)-->
 									<h4 class="sheet-repeatingHeader">Raise</h4>
 								</div>
 								<div class='sheet-col' style='width:60px;'> <!-- Weight (60px)-->
@@ -1816,6 +2367,7 @@
 								</div>
 							</div>
 							<br />
+							<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 							<fieldset class="repeating_meleeweapons">
 								<div class='sheet-row sheet-WCSkillsRow' style="width: 790px;">
 									<div class='sheet-col' style='width:120px;'> <!-- Weapon Type (150px) -->
@@ -1829,13 +2381,13 @@
 											<option value="8!">d8</option>
 											<option value="10!">d10</option>
 											<option value="12!">d12</option>
-											<option value="12!+1">d12+1</option>
+											<!--<option value="12!+1">d12+1</option>
 											<option value="12!+2">d12+2</option>
 											<option value="12!+3">d12+3</option>
-											<option value="12!+4">d12+4</option>
+											<option value="12!+4">d12+4</option>-->
 										</select>+<input class="sheet-modifier" type="number" name="attr_MDmgMod" title="@{repeating_meleeweapons_#_MDmgMod}" value="0" />
 									</div>
-									<div class='sheet-col' style='width:60px;'> <!-- Bonus Damage (60px)-->
+									<div class='sheet-useHB' style='width:60px; text-align: center;'> <!-- Bonus Damage (60px)-->
 										<select name="attr_DmgRaise" title="@{repeating_meleeweapons_#_DmgRaise}" class="dtype">
 											<option value="0">n/a</option>
 											<option value="4!">d4</option>
@@ -1844,6 +2396,9 @@
 											<option value="10!">d10</option>
 											<option value="12!">d12</option>
 										</select>
+									</div>
+									<div class='sheet-useStandard sheet-col' style='width:60px; text-align: center;'>
+										<input type="checkbox" name="attr_DmgRaise" title="@{repeating_meleeweapons_#_DmgRaise}" value="6!" />
 									</div>
 									<div class='sheet-col' style='width:60px;'> <!-- Weight (60px)-->
 										<input type="number" name="attr_WeaponWeight" title="@{repeating_meleeweapons_#_WeaponWeight}" class="sheet-standardNum" />
@@ -1888,7 +2443,7 @@
 									&nbsp;
 								</div>
 							</div><!-- End Weight Boxes -->
-							<input type='checkbox' name='attr_MeleeFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+							<input type='checkbox' name='attr_MeleeFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 							<div class='sheet-formula' style='width:785px; height:60px; border:solid; border-width:1px;'>
 								<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do damage with a @{repeating_meleeweapons_0_WeaponType} and rolls: [[1d@{Strength}![Strength]+1d@{repeating_meleeweapons_0_DmgType}+@{repeating_meleeweapons_0_MDmgMod}[Weapon Damage]+@{dmgmod}[Damage Modifier]+1d@{repeating_meleeweapons_0_DmgRaise}[Bonus Damage] - @{wounds}[Wounds] - @{fatigue}[Fatigue]]]!</textarea><br />
 								<span style='color:red;'>
@@ -1898,10 +2453,10 @@
 							</div>
 						</div><!-- End Melee Weapons -->
 						<hr />
-						<h3 class="sheet-subsectionHeader" style="margin: 5px;">Ranged Weapons / Non-Strength-based Weapons</h3><!-- Begin Ranged Weapons -->
-						<span class="sheet-spacer"></span>
-						<input class="sheet-HideRanged" type="checkbox" name="attr_is_ranged" /><span class="sheet-is-ranged-tab"></span>
+						<input class="sheet-HideRanged" type="checkbox" name="attr_is_ranged" /><span class="sheet-is-ranged-tab"> Ranged Weapons</span><br />
+						<div class="sheet-ranged" style="width: 100%; margin: -5px; padding: 0px;"><h3 class="sheet-subsectionHeader" style="margin: 5px;">Ranged Weapons / Non-Strength-based Weapons</h3></div><!-- Begin Ranged Weapons -->
 						<div class="sheet-ranged">
+							<span class="sheet-spacer"></span>
 							<div class='sheet-row'>
 								<div class='sheet-col' style='width:150px;'> <!-- Weapon Type (150px) -->
 									<h4 class="sheet-repeatingHeader">Weapon Type</h4>
@@ -1915,7 +2470,7 @@
 								<div class='sheet-col' style='width:130px;'> <!-- Damage (167px) -->
 									<h4 class="sheet-repeatingHeader">Damage</h4>
 								</div>
-								<div class='sheet-col' style='width:45px;'> <!-- Raise/Bonus Damage (60px)-->
+								<div class='sheet-col' style='width:45px; text-align: center;'> <!-- Raise/Bonus Damage (60px)-->
 									<h4 class="sheet-repeatingHeader">Raise</h4>
 								</div>
 								<div class='sheet-col' style='width:55px;'> <!-- Weight (45px)-->
@@ -1926,6 +2481,7 @@
 								</div>
 							</div>
 							<br />
+							<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 							<fieldset class="repeating_rangeweapons">
 								<div class='sheet-row sheet-WCSkillsRow' style="width: 790px;">
 									<div class='sheet-col' style='width:150px;'> <!-- Weapon Type (150px) -->
@@ -1947,7 +2503,7 @@
 											<option value="d12!">d12</option>
 										</select>+<input class="sheet-modifier" style="width: 35px;" type="number" name="attr_RDmgMod" title="@{repeating_rangeweapons_#_RDmgMod}" value="0" style='margin:0px;' /> 
 									</div>
-									<div class='sheet-col' style='width:45px;'> <!-- Bonus Damage (60px)-->
+									<div class='sheet-useHB' style='width:45px; text-align: center;'> <!-- Bonus Damage (60px)-->
 										<select name="attr_RDmgRaise" title="@{repeating_rangeweapons_#_RDmgRaise}" class="dtype">
 											<option value="1d0">n/a</option>
 											<option value="1d4!">d4</option>
@@ -1956,6 +2512,9 @@
 											<option value="1d10!">d10</option>
 											<option value="1d12!">d12</option>
 										</select>
+									</div>
+									<div class='sheet-useStandard sheet-col' style='width:45px; text-align: center;'>
+										<input type="checkbox" name="attr_RDmgRaise" title="@{repeating_rangeweapons_#_RDmgRaise}" value="1d6!" />
 									</div>
 									<div class='sheet-col' style='width:55px;'> <!-- Weight (45px)-->
 										<input type="number" name="attr_RWeaponWeight" title="@{repeating_rangeweapons_#_RWeaponWeight}" class="sheet-standardNum" />
@@ -1970,7 +2529,7 @@
 								<div class='sheet-col' style='width:150px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:145px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:50px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
 								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (100px)-->
@@ -1984,7 +2543,7 @@
 								<div class='sheet-col' style='width:150px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:145px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:50px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
 								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (100px)-->
@@ -1994,7 +2553,7 @@
 									<input type="number" name="attr_rangedtotalweightcarried" title="@{rangedtotalweightcarried}" class="sheet-standardNum" value="0" />
 								</div>
 							</div>
-							<input type='checkbox' name='attr_RangeFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+							<input type='checkbox' name='attr_RangeFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 							<div class='sheet-formula' style='width:785px; height:60px; border:solid; border-width:1px;'>
 								<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do damage with a @{repeating_rangeweapons_0_RWeaponType} and rolls: [[@{repeating_rangeweapons_0_NoDmgDice}@{repeating_rangeweapons_0_RDmgType}+@{repeating_rangeweapons_0_RDmgMod}[Weapon Damage]+@{dmgmod}[Damage Modifier]+@{repeating_rangeweapons_0_RDmgRaise}[Bonus Damage]]]!</textarea><br />
 								<span style='color:red;'>
@@ -2004,15 +2563,96 @@
 							</div>
 						</div><!-- End Range Weapons -->
 						<hr />
-						<h3 class="sheet-subsectionHeader" style="margin: 5px;">Gear</h3><!-- Begin Gear -->
-						<input class="sheet-HideGear" type="checkbox" name="attr_is_gear" /><span class="sheet-is-gear-tab" /></span>
+						<!-- Start Augmentations -->
+						<input type="checkbox" class="sheet-useAugmentations" name="attr_augment" style="width: 15px; display: none;" />
+						<div class='sheet-Augmentations'>
+							<h3 class="sheet-subsectionHeader">Augmentations</h3>
+							<div class='sheet-col' style='width:200px;'> <!-- Weapon Type (150px) -->
+								<h4 class="sheet-repeatingHeader">Augmentation</h4>
+							</div>
+							<div class='sheet-col' style='width:50px;'> <!-- Weapon Type (150px) -->
+								<h4 class="sheet-repeatingHeader">Strain</h4>
+							</div>
+							<div class='sheet-col' style='width:540px;'> <!-- Weapon Type (150px) -->
+								<h4 class="sheet-repeatingHeader">Details</h4>
+							</div>
+							<div class='sheet-aug124' style="margin: 0px;"> <!--First set of 4 fields-->
+								<input type="text" class="sheet-standard" name="attr_augment1" title="@{augment1}" placeholder="Augmentation 1" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain1" title="@{augStrain1}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets1" title="@{augDeets1}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment2" title="@{augment2}" placeholder="Augmentation 2" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain2" title="@{augStrain2}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets2" title="@{augDeets2}" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment3" title="@{augment3}" placeholder="Augmentation 3" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain3" title="@{augStrain3}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets3" title="@{augDeets3}" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment4" title="@{augment4}" placeholder="Augmentation 4" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain4" title="@{augStrain4}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets4" title="@{augDeets4}" style="width:530px; height: 50px;"></textarea>
+							</div>
+							
+							<input type="checkbox" class="sheet-h9212" name="attr_aug9212" style="display:none;" />
+							<input type="checkbox" class="sheet-h528" name="attr_aug258" style="display:none;" />
+							<input type="checkbox" class="sheet-use528" name="attr_aug258" /><span class="sheet-528"> 4 rows</span><br />
+							<div class='sheet-aug528' style="margin-top: -18px;">
+								<input type="text" class="sheet-standard" name="attr_augment5" title="@{augment5}" placeholder="Augmentation 5" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain5" title="@{augStrain5}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets5" title="@{augDeets5}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment6" title="@{augment6}" placeholder="Augmentation 6" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain6" title="@{augStrain6}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets6" title="@{augDeets6}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment7" title="@{augment7}" placeholder="Augmentation 7" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain7" title="@{augStrain7}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets7" title="@{augDeets7}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment8" title="@{augment8}" placeholder="Augmentation 8" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain8" title="@{augStrain8}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets8" title="@{augDeets8}" row="2" style="width:530px; height: 50px;"></textarea><br />
+							</div>
+							<input type="checkbox" class="sheet-hide528" name="attr_aug258" /><span class="sheet-h528"> 4 rows</span><br />
+							
+							<input type="checkbox" class="sheet-use9212" name="attr_aug9212" /><span class="sheet-9212"> 4 rows</span><br />
+							<div class='sheet-aug9212' style="margin-top: -18px;"> <!--Third set of 4 fields-->
+								<input type="text" class="sheet-standard" name="attr_augment9" title="@{augment9}" placeholder="Augmentation 9" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain9" title="@{augStrain9}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets9" title="@{augDeets9}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment10" title="@{augment10}" placeholder="Augmentation 10" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain10" title="@{augStrain10}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets10" title="@{augDeets10}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment11" title="@{augment11}" placeholder="Augmentation 11" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain11" title="@{augStrain11}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets11" title="@{augDeets11}" row="2" style="width:530px; height: 50px;"></textarea><br />
+								
+								<input type="text" class="sheet-standard" name="attr_augment12" title="@{augment12}" placeholder="Augmentation 12" style="width:200px;"/>
+								<input type="number" class="sheet-standardNum" name="attr_augStrain12" title="@{augStrain12}" style="width:50px;" value="0" />
+								<textarea class="sheet-standardtext" name="attr_augDeets12" title="@{augDeets12}" row="2" style="width:530px; height: 50px;"></textarea><br />
+							</div>
+							<input type="checkbox" class="sheet-augEnd" name="attr_aug9212" /><span class="sheet-aEnd"> 4 rows</span><br />
+							<div class="sheet-row">
+								<div class="sheet-col" style="width:100px;">&nbsp;</div>
+								<div class="sheet-col" style="width:100px;"><h4 class="sheet-weight">Total Strain:</h4></div>
+								<div class="sheet-col" style="width:50px;">
+									<input type="number" class="sheet-standardNum" name="attr_totalStrain" title="@{totalStrain}" value="0+@{augStrain1}+@{augStrain2}+@{augStrain3}+@{augStrain4}+@{augStrain5}+@{augStrain6}+@{augStrain7}+@{augStrain8}+@{augStrain9}+@{augStrain10}+@{augStrain11}+@{augStrain12}" disabled="true" />
+								</div>
+							</div>
+							<hr />
+						</div>
+						<input class="sheet-HideGear" type="checkbox" name="attr_is_gear" /><span class="sheet-is-gear-tab" /> Gear</span>
+						<div class="sheet-gear" style="width:100%; margin: -5px; padding: 0px;"><h3 class="sheet-subsectionHeader" style="margin: 5px;">Gear</h3></div><!-- Begin Gear -->
 						<div class="sheet-gear">
 							<textarea name="attr_gear" class="sheet-standardtext" style='width:775px;'></textarea>
 							<div class='sheet-row'><!-- Set up the Total Weight box -->
 								<div class='sheet-col' style='width:150px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:145px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:50px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
 								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (100px)-->
@@ -2026,7 +2666,7 @@
 								<div class='sheet-col' style='width:150px;'> <!-- Armor Type (150px) -->
 									&nbsp;
 								</div>
-								<div class='sheet-col' style='width:145px;'> <!-- Area Protcted (150px) -->
+								<div class='sheet-col' style='width:50px;'> <!-- Area Protcted (150px) -->
 									&nbsp;
 								</div>
 								<div class='sheet-col' style='width:160px; text-align:right;'> <!-- Protection (100px)-->
@@ -2039,7 +2679,7 @@
 						</div>
 						<span class="sheet-spacer"></span>
 					</div><!-- End Equipment Tab -->
-		
+					<input type="checkbox" class="sheet-hideArcanum" name="attr_ArcanumTab" style="width: 15px; display: none;">
 					<div class="sheet-section-arcanum" style="width: 800px;"><!-- Begin Arcanum -->
 						<div class='sheet-row'><h2 class='sheet-sectionHeader'>ARCANUM</h2></div>
 						<span class="sheet-spacer"></span>
@@ -2049,10 +2689,10 @@
 						<br />
 						<!-- Damaging Spells -->
 							<!-- Spell, Duration, Cost, Damage, Effects/Trappings -->
-						<h3 class="sheet-subsectionHeader">Spells (Damaging)</h3>
-						<span class="sheet-spacer"></span>
-						<input class="sheet-HideSpellsd" type="checkbox" name="attr_is_spellsd" /><span class="sheet-is-spellsd-tab"></span>
+						<input class="sheet-HideSpellsd" type="checkbox" name="attr_is_spellsd" /><span class="sheet-is-spellsd-tab"> Damage-causing Spells</span>
+						<div class="sheet-spellsd" style="width: 100%;"><h3 class="sheet-subsectionHeader">Spells (Damaging)</h3></div>
 						<div class="sheet-spellsd">
+							<span class="sheet-spacer"></span>
 							<div class='sheet-row'>
 								<div class='sheet-col' style='width:100px;'> <!-- Spell (150px) -->
 									<h4 class="sheet-subsectionHeader">Spell</h4>
@@ -2066,16 +2706,17 @@
 								<div class='sheet-col' style='width:125px;'> <!-- Damage (167px) -->
 									<h4 class="sheet-subsectionHeader">Damage</h4>
 								</div>
-								<div class='sheet-col' style='width:40px;'> <!-- Raise/Bonus Damage (60px)-->
+								<div class='sheet-col' style='width:40px; text-align: center;'> <!-- Raise/Bonus Damage (60px)-->
 									<h4 class="sheet-subsectionHeader">Raise</h4>
 								</div>
-								<div class='sheet-col' style='width:358px;'> <!-- Trappings/Notes (333px) -->
+								<div class='sheet-col' style='width:370px;'> <!-- Trappings/Notes (333px) -->
 									<h4 class="sheet-subsectionHeader">Trappings/Notes</h4>
 								</div>
 							</div>
 							<span class="sheet-spacer"></span>
+							<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 							<fieldset class="repeating_dmgspells">
-								<div class='sheet-row sheet-WCSkillsRow' style="width: 770px;">
+								<div class='sheet-row sheet-WCSkillsRow' style="width: 790px;">
 									<div class='sheet-col' style='width:100px;'> <!-- Spell (100px) -->
 										<input class="sheet-standard" style='width:95px;' type="text" name="attr_Spell" title="@{repeating_dmgspells_#_Spell}" />
 									</div>
@@ -2096,7 +2737,7 @@
 										</select><span style="font-weight: bold;"> + </span>
 										<input class="sheet-modifier" style="width:35px; margin:0px;" type="number" name="attr_SDmgMod" title="@{repeating_dmgspells_#_SDmgMod}" value="0" /> 
 									</div>
-									<div class='sheet-col' style='width:40px;'> <!-- Bonus Damage (60px)-->
+									<div class='sheet-useHB' style='width:40px; text-align: center;'> <!-- Bonus Damage (60px)-->
 										<select name="attr_SDmgRaise" title="@{repeating_dmgspells_#_SDmgRaise}" class="dtype">
 											<option value="1d0">n/a</option>
 											<option value="1d4!">d4</option>
@@ -2106,13 +2747,16 @@
 											<option value="1d12!">d12</option>
 										</select>
 									</div>
-									<div class='sheet-col' style='width:355px;'> <!-- Notes (224px) -->
+									<div class='sheet-useStandard sheet-col' style='width:40px; text-align: center;'>
+										<input type="checkbox" name="attr_SDmgRaise" title="@{repeating_dmgspells_#_SDmgRaise}" value="1d6!" />
+									</div>
+									<div class='sheet-col' style='width:370px;'> <!-- Notes (224px) -->
 										<textarea name="attr_DmgSpellNotes" title="@{repeating_dmgspells_#_DmgSpellNotes}" class="sheet-standardtext" style="height:50px; width:280px;"></textarea>
 										<button type='roll' name='roll_SpellRoll' title="@{repeating_dmgspells_#_SpellRoll}" value='/em @{character_name} attempts to do damage with the @{Spell} spell and rolls: [[@{NoSpllDmgDice}@{SDmgType}+@{SDmgMod}+@{dmgmod}[Damage Modifier]+@{SDmgRaise}[Bonus Damage]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmSpellRoll' title="@{repeating_dmgspells_#_gmSpellRoll}" value='/w gm @{character_name} attempts to do damage with the @{Spell} spell and rolls: [[@{NoSpllDmgDice}@{SDmgType}+@{SDmgMod}+@{dmgmod}[Damage Modifier]+@{SDmgRaise}[Bonus Damage]]]!'></button>
 									</div>
 								</div>
 							</fieldset>
-							<input type='checkbox' name='attr_SpellFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+							<input type='checkbox' name='attr_SpellFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 							<div class='sheet-formula' style='width:785px; height:60px; border:solid; border-width:1px;'>
 								<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do damage with a @{repeating_dmgspells_0_Spell} and rolls: [[@{repeating_dmgspells_0_NoSpllDice}@{repeating_dmgspells_0_SDmgType}+@{repeating_dmgspells_0_SDmgMod}[Spell Damage]+@{dmgmod}[Damage Modifier]+@{repeating_dmgspells_0_SDmgRaise}[Bonus Damage]]]!</textarea><br />
 								<span style='color:red;'>
@@ -2123,10 +2767,10 @@
 						</div>
 						<!-- Non-Damaging Spells -->
 						<hr />
-						<h3 class="sheet-subsectionHeader">Spells (Non-Damaging)</h3>
-						<span class="sheet-spacer"></span>
-						<input class="sheet-HideSpellsn" type="checkbox" name="attr_is_spellsn" /><span class="sheet-is-spellsn-tab"></span>
+						<input class="sheet-HideSpellsn" type="checkbox" name="attr_is_spellsn" /><span class="sheet-is-spellsn-tab"> Non-damage-causing Spells</span>
+						<div class="sheet-spellsn" style="width: 100%;"><h3 class="sheet-subsectionHeader">Spells (Non-Damaging)</h3></div>
 						<div class="sheet-spellsn">
+							<span class="sheet-spacer"></span>
 							<div class='sheet-row'>
 								<div class='sheet-col' style='width:100px;'> <!-- Spell (100px) -->
 									<h4 class="sheet-subsectionHeader">Spell</h4>
@@ -2209,8 +2853,33 @@
 				<!--           -->
 				<div class="sheet-npc" style='width:810px; background-color:#e0e0e0;'>
 					<div class='sheet-row' style="width: 800px;"><!-- Beign First Row of Basic Info -->
-						<div class='sheet-col' style='width:270px;'>
-							<table>
+						<div class='sheet-col' style='width:245px;'>
+							<br />
+							<input type="checkbox" class="sheet-useCodeName" name="attr_codename" style="width: 15px; display: none;" />
+								<label class='sheet-characterName sheet-nameRankXp'></label>
+									<input class="sheet-standard" type="text" title="@{character_name}" name="attr_character_name"/><br />
+								<div class="sheet-civilian">
+									<label class='sheet-nameRankXp' style="font-size: 11px;">Civilian Name:</label>
+									<input class="sheet-standard" type="text" title="@{mcivilian_name}" name="attr_mcivilian_name"/><br />
+								</div>
+								<input type="checkbox" class="sheet-useHomeworld" name="attr_tlpHW" style="width: 15px; display: none;" />
+								<div class="sheet-Homeworld">
+									<label class='sheet-nameRankXp'>Homeworld:</label>
+									<input class="sheet-standard" type="text" name="attr_mhomeworld" title="@{mhomeworld}" />
+								</div>
+								<input type="checkbox" class="sheet-useSpecies" name="attr_tlpSpecies" style="width: 15px; display: none;" />
+								<div class="sheet-Species">
+									<label class='sheet-nameRankXp'>Species:</label>
+									<input class="sheet-standard" type="text" name="attr_mrace" title="@{mrace}" />
+								</div>
+								<div class="sheet-Race">
+									<label class='sheet-nameRankXp'>Race:</label>
+									<input class="sheet-standard" type="text" name="attr_mrace" title="@{mrace}" />
+								</div>
+								<label class='sheet-nameRankXp'>Gender/Age:</label>
+									<input class="sheet-standard" style="width: 95px;" type="text" name="attr_mgender" title="@{mgender}"/>&nbsp;&nbsp;<input class="sheet-standard" style="width: 38px;  text-align: center;" type="text" name="attr_mage" title="@{mage}" />
+								
+							<!--<table>
 								<tr>
 									<td style='text-align:left;'>
 										<br /><label class="sheet-MooknameRankXp">Name:</label>
@@ -2243,11 +2912,91 @@
 										<input type="number" name="attr_mfatigue_max" title="@{mfatigue_max}" value="2" disabled="true"/>
 									</td>
 								</tr>
-							</table>
+							</table>-->
 						</div>
 						<!-- Second Column -->
-						<div class='sheet-col' style='width:309px;'>
-							<table class='sheet-DStatsTable'>
+						<div class='sheet-col' style='width:300px;'> <!-- was originall 309px -->
+							<div class="sheet-col" style="width: 90px;"> </div><div class="sheet-numSpan" style="border-top-left-radius: 5px; border-bottom-left-radius: 5px;">Base</div><div class="sheet-numSpan">Mod</div><div class="sheet-numSpan">Armor</div><div class="sheet-numSpan" style="width: 55px; border-top-right-radius: 5px; border-bottom-right-radius: 5px;">Current</div><br />
+							<label class='sheet-nameRankXp'>Pace:</label>
+								<input type="number" name="attr_mpace" title="@{mpace}" class="sheet-derivedStat" style="text-align: center;" value="6" />
+								<input type="number" name="attr_mpaceMod" title="@{mpaceMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mpaceCur" title="@{mpaceCur}" class="sheet-derivedStat" value="@{mpace}+@{mpaceMod}" disabled="true" /><br />
+				
+							<label class='sheet-nameRankXp'>Parry:</label>
+								<input type="number" name="attr_mparry" title="@{mparry}" class="sheet-derivedStat" style='color: black;' value="floor((@{mFighting}+@{mFightingMod})/2)+2" disabled="true" />
+								<input type="number" name="attr_mparryMod" title="@{mparryMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mparryCur" title="@{mparryCur}" class="sheet-derivedStat" value="@{mparry} + @{mparryMod}" disabled="true" /><br />
+				
+							<input type="checkbox" class="sheet-useSanity" name="attr_tdsanity" style="width: 15px; display: none;" />
+							<div class="sheet-Sanity">
+								<label class='sheet-nameRankXp'>Sanity:</label>
+								<input type="number" name="attr_msanity" title="@{msanity}" class="sheet-derivedStat" style='color: black;' value="floor((@{mspirit}+@{mspMod})/2)+2" disabled="true" />
+								<input type="number" name="attr_msanityMod" title="@{msanityMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_msanityCur" title="@{msanityCur}" class="sheet-derivedStat" value="@{msanity} + @{msanityMod}" disabled="true" /><br />
+							</div>
+							<label class='sheet-nameRankXp'>Charisma:</label>
+								<input type="number" name="attr_mcharisma" class="sheet-derivedStat" title="@{mcharisma}" value="0"/>
+								<input type="number" name="attr_mcharismaMod" title="@{mcharismaMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mcharismaCur" title="@{mcharismaCur}" class="sheet-derivedStat" value="@{mcharisma} + @{mcharismaMod}" disabled="true" /><br />
+								
+							<input type="checkbox" class="sheet-useFame" style="width: 15px; display: none;" name="attr_potsmFame" />
+							<div class="sheet-Fame">
+								<label class='sheet-nameRankXp'>Fame:</label>
+								<input class="sheet-derivedStat" type="number" name="attr_mfame" title="@{mfame}" value="0"/>
+								<input type="number" name="attr_mfameMod" title="@{mfameMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mfameCur" title="@{mfameCur}" class="sheet-derivedStat" value="@{mfame} + @{mfameMod}" disabled="true" /><br />
+							</div>
+							
+							<input type="checkbox" class="sheet-useFirewall" style="width: 15px; display: none;" name="attr_izFirewall" />
+							<div class="sheet-Firewall">
+								<label class='sheet-nameRankXp'>Firewall:</label>
+								<input class="sheet-derivedStat" type="number" name="attr_mFirewall" title="@{mFirewall}" value="4"/>
+								<input type="number" name="attr_mFirewallMod" title="@{mFirewallMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mFirewallCur" title="@{mFirewallCur}" class="sheet-derivedStat" value="@{mFirewall} + @{mFirewallMod}" disabled="true" /><br />
+							</div>
+							
+							<input type="checkbox" class="sheet-useStrain" style="width: 15px; display: none;" name="attr_izStrain" />
+							<div class="sheet-Strain">
+								<label class='sheet-nameRankXp'>Strain:</label>
+								<input class="sheet-derivedStat" type="number" name="attr_mStrain" title="@{mStrain}" value="4"/>
+								<input type="number" name="attr_mStrainMod" title="@{mStrainMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mStrainCur" title="@{mStrainCur}" class="sheet-derivedStat" value="@{mStrain} + @{mStrainMod}" disabled="true" /><br />
+							</div>
+							
+							<input type="checkbox" class="sheet-useGrit" name="attr_DLGrit" style="width: 15px; display: none;" />
+							<div class="sheet-Grit">
+								<label class='sheet-nameRankXp'>Grit:</label>
+								<input type="number" name="attr_mgrit" title="@{mgrit}" class="sheet-derivedStat" style='color: black;' value="@{mrank}" disabled="true" />
+								<input type="number" name="attr_mgritMod" title="@{mgritMod}" class="sheet-standardNum" value="0" />
+								<span class="sheet-numSpan">&nbsp;</span>
+								<input type="number" name="attr_mgritCur" title="@{mgritCur}" class="sheet-derivedStat" value="@{mgrit} + @{mgritMod}" disabled="true" /><br />
+							</div>
+							
+							<label class='sheet-nameRankXp'>Toughness:</label>
+								<input type="number" name="attr_mtoughness" title="@{mtoughness}" class="sheet-derivedStat" value="floor(((@{mvigor}+@{mviMod})/2)+2)" disabled="true" />
+								<input type="number" name="attr_mtufnessMod" title="@{mtufnessMod}" class="sheet-standardNum" value="0" />
+								<input type="hidden" name="attr_mtufnsPlusMod"  title="@{mtufnsPlusMod}" value="(@{mtoughnessbase})+{@toughnessMod}" />
+								<input type="number" name="attr_mtoughnessArmor" title="@{mtoughnessArmor}" class="sheet-standardNum" value="0" />&nbsp;
+								<input type="number" name="attr_mtoughnesscur" title="@{mtoughnesscur}" class="sheet-derivedStat" value="(@{mtoughness})+(@{mtufnessMod})+(@{mtoughnessArmor})" disabled="true" /><br />
+							
+							<input type="checkbox" class="sheet-useStreetCred" style="width: 15px; display: none;" name="attr_izStreetCred" />
+							<div class="sheet-StreetCred">
+								<div class="sheet-col" style="width: 90px;"> </div><div class="sheet-numSpan" style="border-top-left-radius: 5px; border-bottom-left-radius: 5px;">Base</div><div class="sheet-numSpan">Mod</div><div class="sheet-numSpan">Current</div><div class="sheet-numSpan" style="width: 55px; border-top-right-radius: 5px; border-bottom-right-radius: 5px;">Max</div><br />
+								<label class='sheet-nameRankXp'>Street Cred:</label>
+								<input class="sheet-derivedStat" type="number" name="attr_mStreetCred" title="@{mStreetCred}" value="@{mRank}*2" disabled="true"/>
+								<input type="number" name="attr_mStreetCredMod" title="@{mStreetCredMod}" class="sheet-standardNum" value="0" />
+								<!--<span class="sheet-numSpan">&nbsp;</span>-->
+								<input type="number" name="attr_mStreetCredCur" title="@{mStreetCredCur}" class="sheet-derivedStat" value="@{mStreetCred} + @{mStreetCredMod}" disabled="true" />
+								<input type="number" name="attr_mmaxStreetCredCur" title="@{mmaxStreetCredCur}" class="sheet-derivedStat" value="10" /><br />
+							</div>
+							<!--<table class='sheet-DStatsTable'>
 								<thead>
 									<tr>
 										<th></th>
@@ -2284,11 +3033,45 @@
 										<td><input type="number" name="attr_mtoughnesscur" title="@{mtoughnesscur}" class="sheet-short" value="(@{mtoughnessbase})+(@{mtufnessMod})+(@{mtoughnessArmor})" disabled="true" /></td>
 									</tr>
 								</tbody
-							</table>
+							</table>-->
 						</div>
 						<!-- Third Column -->
-						<div class='sheet-col' style='width:200px;'>
-							<table>
+						<div class='sheet-col' style='width:220px;'>
+							<br />
+							<input type="checkbox" class="sheet-useThreatRating" name="attr_ThreatRating" style="width: 15px; display:none;" />
+							<label class='sheet-Rank-n-XP sheet-nameRankXp'></label>
+								<input class="sheet-standardNum" type="number" name="attr_mxp" title="@{mxp}"/>
+								<select name='attr_mrank' title="@{mrank}" value='novice' class='sheet-rank' style='opacity: 0.75; width:69px; border: none; border-bottom: solid black 1px;'>
+									<option value='1'>Novice</option>
+									<option value='2'>Seasoned</option>
+									<option value='3'>Veteran</option>
+									<option value='4'>Heroic</option>
+									<option value='5'>Legendary</option>
+								</select><br />
+							<input type="checkbox" class="sheet-useOccupation" name="attr_tlpOccupation" style="width: 15px; display: none;" />
+							<div class="Occupation">
+								<label class='sheet-nameRankXp'>Occupation:</label>
+									<input class="sheet-standard" style="width: 117px;" type="text" name="attr_moccupation" title="@{moccupation}" />
+							</div>
+							<div class="sheet-usePieces">
+								<input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" value="0" checked style="width: 15px; display: none;" />
+								<input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" value="1" style="width: 15px; display: none;" />
+								<input type="checkbox" class="sheet-usePieces" name="attr_50fPo8Clams" value="2" style="width: 15px; display: none;" />
+								<label class='sheet-Money sheet-nameRankXp'></label>
+									<input class="sheet-standard" style="width: 117px;" type="text" name="attr_mmoney" title="@{mmoney}" value="0"/>
+							</div>
+							<input type="checkbox" class="sheet-useShipName" name="attr_tlpShipName" style="width: 15px; display: none;" />
+							<div class="ShipName">
+								<label class='sheet-nameRankXp' style="font-size: 12px;">Ship's Name:</label>
+									<input class="sheet-standard" style="width: 117px;" type="text" name="attr_mshipname" title="@{mshipname}" />
+							</div>
+							<label class="sheet-nameRankXp">Wounds:</label>
+								<input type="number" class="sheet-standardNum" name="attr_mwounds" title="@{mwounds}" style='margin-left:4px;' value="0"/> of 
+								<input type="number" class="sheet-standardNum" name="attr_mwounds_max" title="@{mwounds_max}" value="3" disabled="true"/><br />
+							<label class="sheet-nameRankXp">Fatigue:</label>
+								<input type="number" class="sheet-standardNum" name="attr_mfatigue" title="@{mfatigue}" style='margin-left:4px;' value="0"/> of 
+								<input type="number" class="sheet-standardNum" name="attr_mfatigue_max" title="@{mfatigue_max}" value="2" disabled="true"/>
+							<!--<table>
 								<tr>
 									<td style='text-align:left;'>
 										<br /><label class='sheet-MooknameRankXp'>Age:</label>
@@ -2319,7 +3102,7 @@
 										<input type="text" name="attr_mmoney" title="@{mmoney}" value="0" style='width:100px;'/>
 									</td>
 								</tr>
-							</table>
+							</table>-->
 						</div> <!-- End Third Column -->
 					</div> <!-- End First Row of Core Info -->
 						<!-- End Core -->
@@ -2522,6 +3305,26 @@
 										</div>
 									</div> 
 									<!-- End Driving (Agility) -->
+									
+									<!-- Faith (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmFaith" style='display:none;'/>
+									<div class="sheet-staticFaith" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;Faith</label>
+											<select name="attr_mFaith" title="@{mFaith}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mFaithMod" title="@{mFaithMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mFaithRoll' title="@{mFaithRoll}" value='/em @{character_name} attempts to be faithful and rolls [[(1d@{mFaith}![Faith] + @{mFaithMod}[Faith Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmFaithRoll' title="@{gmmFaithRoll}" value='/w gm @{character_name} attempts to be faithful and rolls [[(1d@{mFaith}![Faith] + @{mFaithMod}[Faith Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmFaith' value='/em @{character_name} attempts to be faithful and rolls [[(1d@{mFaith}![Faith] + @{mFaithMod}[Faith Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End Faith (Agility) -->
 				
 									<!-- Gambling (Smarts) -->
 									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmGambling" style='display:none;'/>
@@ -2542,6 +3345,26 @@
 										</div>
 									</div> 
 									<!-- End Gambling -->
+									
+									<!-- Guts (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmGuts" style='display:none;'/>
+									<div class="sheet-staticGuts" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;Guts</label>
+											<select name="attr_mGuts" title="@{mGuts}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mGutsMod" title="@{mGutsMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mGutsRoll' title="@{mGutsRoll}" value='/em @{character_name} attempts to be gutsy and rolls [[(1d@{mGuts}![Guts] + @{mGutsMod}[Guts Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmGutsRoll' title="@{gmmGutsRoll}" value='/w gm @{character_name} attempts to be gutsy and rolls [[(1d@{mGuts}![Guts] + @{mGutsMod}[Guts Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmGuts' value='/em @{character_name} attempts to be gutsy and rolls [[(1d@{mGuts}![Guts] + @{mGutsMod}[Guts Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End Guts (Agility) -->
 				
 									<!-- Healing (Smarts) -->
 									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmHealing" style='display:none;'/>
@@ -2683,6 +3506,26 @@
 										</div>
 									</div> 
 									<!-- End Piloting (Agility) -->
+									
+									<!-- Psionics (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmPsionics" style='display:none;'/>
+									<div class="sheet-staticPsionics" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;Psionics</label>
+											<select name="attr_mPsionics" title="@{mPsionics}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mPsionicsMod" title="@{mPsionicsMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mPsionicsRoll' title="@{mPsionicsRoll}" value='/em @{character_name} attempts to use psionics and rolls [[(1d@{mPsionics}![Psionics] + @{mPsionicsMod}[Psionics Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmPsionicsRoll' title="@{gmmPsionicsRoll}" value='/w gm @{character_name} attempts to use psionics and rolls [[(1d@{mPsionics}![Psionics] + @{mPsionicsMod}[Psionics Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmPsionics' value='/em @{character_name} attempts to use psionics and rolls [[(1d@{mPsionics}![Psionics] + @{mPsionicsMod}[Psionics Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End Psionics (Agility) -->
 				
 									<!-- Repair (Smarts) -->
 									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmRepair" style='display:none;'/>
@@ -2723,6 +3566,26 @@
 										</div>
 									</div> 
 									<!-- End Riding (Agility) -->
+									
+									<!-- Ritual (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmRitual" style='display:none;'/>
+									<div class="sheet-staticRitual" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;Ritual</label>
+											<select name="attr_mRitual" title="@{mRitual}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mRitualMod" title="@{mRitualMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mRitualRoll' title="@{mRitualRoll}" value='/em @{character_name} attempts to perform a ritual and rolls [[(1d@{mRitual}![Ritual] + @{mRitualMod}[Ritual Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmRitualRoll' title="@{gmmRitualRoll}" value='/w gm @{character_name} attempts to perform a ritual and rolls [[(1d@{mRitual}![Ritual] + @{mRitualMod}[Ritual Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmRitual' value='/em @{character_name} attempts to perform a ritual and rolls [[(1d@{mRitual}![Ritual] + @{mRitualMod}[Ritual Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End Ritual (Agility) -->
 				
 									<!-- Shooting (Agility) -->
 									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmShooting" style='display:none;'/>
@@ -2743,6 +3606,26 @@
 										</div>
 									</div> 
 									<!-- End Shooting (Agility) -->
+									
+									<!-- Spellcasting (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmSpellcasting" style='display:none;'/>
+									<div class="sheet-staticSpellcasting" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;Spellcasting</label>
+											<select name="attr_mSpellcasting" title="@{mSpellcasting}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mSpellcastingMod" title="@{mSpellcastingMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mSpellcastingRoll' title="@{mSpellcastingRoll}" value='/em @{character_name} attempts to cast a spell and rolls [[(1d@{mSpellcasting}![Spellcasting] + @{mSpellcastingMod}[Spellcasting Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmSpellcastingRoll' title="@{gmmSpellcastingRoll}" value='/w gm @{character_name} attempts to cast a spell and rolls [[(1d@{mSpellcasting}![Spellcasting] + @{mSpellcastingMod}[Spellcasting Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmSpellcasting' value='/em @{character_name} attempts to cast a spell and rolls [[(1d@{mSpellcasting}![Spellcasting] + @{mSpellcastingMod}[Spellcasting Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End Spellcasting (Agility) -->
 				
 									<!-- Stealth (Agility) -->
 									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmStealth" style='display:none;'/>
@@ -2883,6 +3766,26 @@
 										</div>
 									</div> 
 									<!-- End Tracking -->
+									
+									<!-- WeirdScience (Agility) -->
+									<input class="sheet-StaticSkill" type="checkbox" name="attr_staticmWeirdScience" style='display:none;'/>
+									<div class="sheet-staticWeirdScience" style='width:324px;'>
+										<div class='sheet-col' style='width:185px;'>
+											<label style='width:90px; font-size: 14px;'>&nbsp;WeirdScience</label>
+											<select name="attr_mWeirdScience" title="@{mWeirdScience}" class="dtype" value="4">
+												<option value="4" selected>d4</option>
+												<option value="6">d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</select>+<input type="number" name="attr_mWeirdScienceMod" title="@{mWeirdScienceMod}" class="sheet-modifier" value="0" style='width:35px;'/>
+										</div>
+										<div class='sheet-col' style='width:70px;'>
+											<button type='roll' name='roll_mWeirdScienceRoll' title="@{mWeirdScienceRoll}" value='/em @{character_name} attempts some Weird Science and rolls [[(1d@{mWeirdScience}![WeirdScience] + @{mWeirdScienceMod}[WeirdScience Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmWeirdScienceRoll' title="@{gmmWeirdScienceRoll}" value='/w gm @{character_name} attempts some Weird Science and rolls [[(1d@{mWeirdScience}![WeirdScience] + @{mWeirdScienceMod}[WeirdScience Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'></button>
+											<input type='hidden' name='attr_rollmWeirdScience' value='/em @{character_name} attempts some Weird Science and rolls [[(1d@{mWeirdScience}![WeirdScience] + @{mWeirdScienceMod}[WeirdScience Modifiers]) + @{mttmod}[Situational Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!' />
+										</div>
+									</div> 
+									<!-- End WeirdScience (Agility) -->
 				
 									<!-- End Static Skills -->
 									<fieldset class="repeating_mskills">
@@ -2904,7 +3807,7 @@
 											</div>
 										</div>
 									</fieldset>
-									<input type='checkbox' name='attr_mSkillsFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+									<input type='checkbox' name='attr_mSkillsFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 									<div class='sheet-formula' style='width:440px; height:80px; border:solid; border-width:1px;'>
 										<textarea style='width:430px; height:70px;'>/em @{character_name} attempts to do something with @{repeating_mskills_0_mSkillName} and rolls: [[1d@{repeating_mskills_0_mSkillNameRank}![@{repeating_mskills_0_mSkillName}]+ @{repeating_mskills_0_mSkillNameMod}[Other Modifiers] + @{mttmod}[Modifiers] - @{mwounds}[Wounds] - @{mfatigue}[Fatigue]]]!'</textarea><br />
 										<span style='color:red;'>
@@ -2970,6 +3873,7 @@
 									</div>
 								</div>
 								<br />
+								<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 								<fieldset class="repeating_mmeleeweapons">
 									<div class='sheet-row' style='width: 460px;'>
 										<div class='sheet-col' style='width:140px;'> <!-- Weapon Type (150px) -->
@@ -2985,7 +3889,7 @@
 												<option value="12!">d12</option>
 											</select>+<input type="number" name="attr_mMDmgMod" title="@{repeating_mmeleeweapons_#_mMDmgMod}" value="0" />
 										</div>
-										<div class='sheet-col' style='width:60px;'> <!-- Bonus Damage (60px)-->
+										<div class='sheet-useHB' style='width:60px;'> <!-- Bonus Damage (60px)-->
 											<select name="attr_mDmgRaise" title="@{repeating_mmeleeweapons_#_mDmgRaise}" class="dtype">
 												<option value="0">n/a</option>
 												<option value="4!">d4</option>
@@ -2995,12 +3899,15 @@
 												<option value="12!">d12</option>
 											</select>
 										</div>
+										<div class="sheet-useStandard sheet-col" style='width:60px; text-align: center;'>
+											<input type="checkbox" style="width: 15px;" name="attr_mDmgRaise" title="@{repeating_mmeleeweapons_#_mDmgRaise}" value="6!" />
+										</div>
 										<div class='sheet-col' style='width:70px;'> <!-- Notes (344px) -->
 											<button type='roll' name='roll_mWeaponTypeRoll' title="@{repeating_mmeleeweapons_#_mWeaponTypeRoll}" value='/em @{character_name} attempts to do damage with a @{mWeaponType} and rolls: [[1d@{mStrength}![Strength]+1d@{mDmgType}+@{mMDmgMod}[Weapon Damage]+@{mdmgmod}[Damage Modifier]+1d@{mDmgRaise}[Bonus Damage]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmWeaponTypeRoll' title="@{repeating_mmeleeweapons_#_gmmWeaponTypeRoll}" value='/w gm @{character_name} attempts to do damage with a @{mWeaponType} and rolls: [[1d@{mStrength}![Strength]+1d@{mDmgType}+@{mMDmgMod}[Weapon Damage]+@{mdmgmod}[Damage Modifier]+1d@{mDmgRaise}[Bonus Damage]]]!'></button>
 										</div>
 									</div>
 								</fieldset>
-								<input type='checkbox' name='attr_mMeleeFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+								<input type='checkbox' name='attr_mMeleeFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 								<div class='sheet-formula' style='width:440px; height:80px; border:solid; border-width:1px;'>
 									<textarea style='width:430px; height:70px;'>/em @{character_name} attempts to do damage with a @{repeating_mmeleeweapons_0_mWeaponType} and rolls: [[1d@{Strength}![Strength]+1d@{repeating_mmeleeweapons_0_mDmgType}+@{repeating_mmeleeweapons_0_mMDmgMod}[Weapon Damage]+@{mdmgmod}[Damage Modifier]+1d@{repeating_mmeleeweapons_0_mDmgRaise}[Bonus Damage]]]!</textarea><br />
 									<span style='color:red;'>
@@ -3034,7 +3941,7 @@
 									<div class='sheet-col' style='width:125px; border-bottom-style:dashed; border-width:1px;'> <!-- Damage (167px) -->
 										<h4>Damage</h4>
 									</div>
-									<div class='sheet-col' style='width:50px; border-bottom-style:dashed; border-width:1px;'> <!-- Raise/Bonus Damage (60px)-->
+									<div class='sheet-col' style='width:50px; border-bottom-style:dashed; border-width:1px; text-align: center;'> <!-- Raise/Bonus Damage (60px)-->
 										<h4>Raise</h4>
 									</div>
 									<div class='sheet-col' style='width:55px; border-bottom-style:dashed; border-width:1px;'> <!-- Weight (45px)-->
@@ -3045,6 +3952,7 @@
 									</div>
 								</div>
 								<br />
+								<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 								<fieldset class="repeating_mrangeweapons">
 									<div class='sheet-row'>
 										<div class='sheet-col' style='width:125px;'> <!-- Weapon Type (150px) -->
@@ -3066,7 +3974,7 @@
 												<option value="d12!">d12</option>
 											</select>+<input type="number" name="attr_mRDmgMod" title="@{repeating_mrangeweapons_#_mRDmgMod}" class="sheet-modifier" style="width: 35px;" value="0" style='margin:0px;' /> 
 										</div>
-										<div class='sheet-col' style='width:50px;'> <!-- Bonus Damage (60px)-->
+										<div class='sheet-useHB' style='width:50px;'> <!-- Bonus Damage (60px)-->
 											<select name="attr_mRDmgRaise" title="@{repeating_mrangeweapons_#_mRDmgRaise}" class="dtype">
 												<option value="1d0">n/a</option>
 												<option value="1d4!">d4</option>
@@ -3075,6 +3983,9 @@
 												<option value="1d10!">d10</option>
 												<option value="1d12!">d12</option>
 											</select>
+										</div>
+										<div class="sheet-useStandard sheet-col" style='width:50px; text-align: center;'>
+											<input type="checkbox" name="attr_mRDmgRaise" title="@{repeating_mrangeweapons_#_mRDmgRaise}" value="1d6!" />
 										</div>
 										<div class='sheet-col' style='width:55px;'> <!-- Weight (45px)-->
 											<input type="number" name="attr_mRWeaponWeight" title="@{repeating_mrangeweapons_#_mRWeaponWeight}" class="sheet-short" />
@@ -3085,7 +3996,7 @@
 										</div>
 									</div>
 								</fieldset>
-								<input type='checkbox' name='attr_mRangeFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+								<input type='checkbox' name='attr_mRangeFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 								<div class='sheet-formula' style='width:785px; height:60px; border:solid 1px;'>
 									<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do damage with a @{repeating_mrangeweapons_0_mRWeaponType} and rolls: [[@{repeating_mrangeweapons_0_mNoDmgDice}@{repeating_mrangeweapons_0_mRDmgType}+@{mdmgmod}[Damage Modifier]+@{repeating_mrangeweapons_0_mRDmgMod}[Weapon Damage]+@{repeating_mrangeweapons_0_mRDmgRaise}[Bonus Damage]]]!</textarea><br />
 									<span style='color:red;'>
@@ -3118,7 +4029,7 @@
 								<div class='sheet-col' style='width:125px; border-bottom-style:dashed; border-width:1px;'> <!-- Damage (167px) -->
 									<h4>Damage</h4>
 								</div>
-								<div class='sheet-col' style='width:50px; border-bottom-style:dashed; border-width:1px;'> <!-- Raise/Bonus Damage (60px)-->
+								<div class='sheet-col' style='width:50px; border-bottom-style:dashed; border-width:1px; text-align: center;'> <!-- Raise/Bonus Damage (60px)-->
 									<h4>Raise</h4>
 								</div>
 								<div class='sheet-col' style='width:370px; border-bottom-style:dashed; border-width:1px;'> <!-- Trappings/Notes (333px) -->
@@ -3126,6 +4037,7 @@
 								</div>
 							</div>
 							<br />
+							<input type="checkbox" class="sheet-useRaiseHB" name="attr_RaiseHBRule" style="width: 15px; display: none;" />
 							<fieldset class="repeating_mdmgspells">
 								<div class='sheet-row'>
 									<div class='sheet-col' style='width:100px;'> <!-- Spell (100px) -->
@@ -3147,7 +4059,7 @@
 											<option value="d12!">d12</option>
 										</select>+<input type="number" name="attr_mSDmgMod" title="@{repeating_mdmgspells_#_mSDmgMod}" class="sheet-modifier" style="width: 35px;" value="0" style='margin:0px;' /> 
 									</div>
-									<div class='sheet-col' style='width:50px;'> <!-- Bonus Damage (60px)-->
+									<div class='sheet-useHB' style='width:50px; text-align: center;'> <!-- Bonus Damage (60px)-->
 										<select name="attr_mSDmgRaise" title="@{repeating_mdmgspells_#_mSDmgRaise}" class="dtype">
 											<option value="1d0">n/a</option>
 											<option value="1d4!">d4</option>
@@ -3157,13 +4069,16 @@
 											<option value="1d12!">d12</option>
 										</select>
 									</div>
+									<div class="sheet-useStandard sheet-col" style='width:50px; text-align: center;'>
+											<input type="checkbox" name="attr_mSDmgRaise" title="@{repeating_mdmgspells_#_mSDmgRaise}" value="1d6!" />
+										</div>
 									<div class='sheet-col' style='width:370px;'> <!-- Notes (224px) -->
 										<textarea name="attr_mDmgSpellNotes" title="@{repeating_mdmgspells_#_mDmgSpellNotes}" class="sheet-smalltextarea" style="height:50px; width:288px;"></textarea>
 										<button type='roll' name='roll_mSpellRoll' title="@{repeating_mdmgspells_#_mSpellRoll}" value='/em @{character_name} attempts to do damage with the @{mSpell} spell and rolls: [[@{mNoSpllDmgDice}@{mSDmgType}+@{mSDmgMod}+@{dmgmod}[Damage Modifier]+@{mSDmgRaise}[Bonus Damage]]]!'></button><button type='roll' class="sheet-GM-button" name='roll_gmmSpellRoll' title="@{repeating_mdmgspells_#_gmmSpellRoll}" value='/w gm @{character_name} attempts to do damage with the @{mSpell} spell and rolls: [[@{mNoSpllDmgDice}@{mSDmgType}+@{mSDmgMod}+@{dmgmod}[Damage Modifier]+@{mSDmgRaise}[Bonus Damage]]]!'></button>
 									</div>
 								</div>
 							</fieldset>
-							<input type='checkbox' name='attr_mSpellFormula'class='arrow' style='width:15px;' checked='checked'/> Hide Macro Formula
+							<input type='checkbox' name='attr_mSpellFormula'class='arrow' style='width:15px;' checked='checked'/> <span class="sheet-spaceBetween"> &nbsp; Hide Macro Formula &nbsp; </span>
 							<div class='sheet-formula' style='width:785px; height:60px; border: solid 1px;'>
 								<textarea style='width:775px; height:50px;'>/em @{character_name} attempts to do damage with a @{repeating_mdmgspells_0_mSpell} and rolls: [[@{repeating_mdmgspells_0_mNoSpllDice}@{repeating_mdmgspells_0_mSDmgType}+@{repeating_mdmgspells_0_SDmgMod}[Spell Damage]+@{mdmgmod}[Damage Modifier]+@{repeating_mdmgspells_0_mSDmgRaise}[Bonus Damage]]]!</textarea><br />
 								<span style='color:red;'>
@@ -3193,6 +4108,10 @@
 		<input type="checkbox" name="attr_logo" value="4" title="Savage Worlds (Bloodied)" style="display:none;"/><span class="sheet-disclaimer"></span>
 		<input type="checkbox" name="attr_logo" value="5" title="Necessary Evil" style="width: 15px; display: none;"  /><span class="sheet-disclaimer"></span>
 		<input type="checkbox" name="attr_logo" value="6" title="Deadlands" style="width: 15px; display: none;" /><span class="sheet-disclaimer"></span>
+		<input type="checkbox" name="attr_logo" value="7" title="Deadlands:Noir" style="width: 15px; display: none;" /><span class="sheet-disclaimer"></span>
+		<input type="checkbox" name="attr_logo" value="8" title="Deadlands:HoE" style="width: 15px; display: none;" /><span class="sheet-disclaimer"></span>
+		<input type="checkbox" name="attr_logo" value="9" title="Interface Zero 2.0" style="width: 15px; display: none;" /><span class="sheet-disclaimer"></span>
 		<span class="sheet-disclaimer"></span>
+		<span class="sheet-CoURL">Visit their website at: </span>
 	</div>
 </div>

--- a/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
+++ b/SavageWorlds-Tabbed/SW_CharSheet-tabbed.html
@@ -15,7 +15,7 @@
 				<!-- BEGIN CONFIGURATION STUFF -->
 				<!--                           -->
 				<div class="sheet-config" style='border-style: dotted; border-color: #dbc792; padding: 5px; background-color: white; background-image: none;'>
-					sheet version: 05 Jan 2015
+					sheet version: 07 Jan 2015
 					<div class='sheet-row'><h2 class='sheet-sectionHeader'>CONFIGURATION</h2></div>
 					<input type="checkbox" class="sheet-HideUITweaks" name="attr_wcUIConfig" checked /><span class="sheet-is-wcUI"></span>
 					<div class='UITweaks' style="padding: 10px;">
@@ -426,12 +426,13 @@
 								<h2 class="sheet-subsectionHeader">Attributes</h2>
 								<p>
 									<div class='sheet-row' style='width:260px;'> <!-- Head Row for Attributes -->
-										<div class='sheet-col' style='width:60px;'>&nbsp;</div>
-										<div class='sheet-col' style='width:50px;'>&nbsp;</div>
-										<div class='sheet-col' style='width:40px; font-size: 10px; text-align: center;'>&nbsp;</div>
+										<div class='sheet-col' style='width:65px;'>&nbsp;</div>
+										<!--<div class='sheet-col' style='width:50px;'>&nbsp;</div>-->
+										<div class='sheet-col' style='width:90px; font-size: 12px; font-weight: bold; color: black; text-align: center; border-radius: 5px; background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");'>Rank</div>
 										<div class='sheet-col' style='width:14px;'>&nbsp;</div>
-										<div class='sheet-col' style='width:33px; font-size: 10px; font-weight: bold; text-align: center; border-radius: 5px; background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");'>Mod</div>
+										<div class='sheet-col' style='width:33px; font-size: 10px; font-weight: bold; color: black; text-align: center; border-radius: 5px; background-image: url("http://www.geeksville.us/roll20/semi-trans-grayish.png");'>Mod</div>
 									</div>
+									<span class="sheet-spacer"></span>
 									<div class="sheet-col" style="width: auto; margin: 0px; margin-bottom: 10px;"><label class="sheet-AttributeLabel">Agility:</label></div>
 									<div class="sheet-col sheet-AttBorder" style="margin-bottom: 10px;">
 										<input type="checkbox" class="sheet-NewDieType" name="attr_DieTypeConfig" style="width: 15px; display: none;" />


### PR DESCRIPTION
Added support for cyberpunk settings by adding Strain and Augmentations as well as Street Cred (for Interface Zero 2.0). 

Added the IZ2.0 Logo as an option. 

Included a couple new Backgrounds. 

Reorganized the CSS so that it’s more logical its groupings. 

Added a Skills Modifier to the Wild Card skill area and a new heading for Skill Rank.

Added an Unshaken Modifier and roll button to the Basic Info Tab.