### PR TITLE
Updated inaccurate fomulae

### DIFF
--- a/Anima-Beyond-Fantasy/A-BF.html
+++ b/Anima-Beyond-Fantasy/A-BF.html
@@ -82,7 +82,7 @@
                 <div class="sidebubbled">MR</div>
                 <input type="number" name="attr_resist_magic_special" value="0"/>
                 <input type="number" name="attr_resist_magic_final" 
-                value="@{presence}+@{pow_mod}+@{body_of_emptiness}+@{resist_physical_special}" disabled="true"/>
+                value="@{presence}+@{pow_mod}+@{body_of_emptiness}+@{resist_magic_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their sprit! [[1d100+@{resist_magic_final}]]"></button>
             </div>
             <div class="style_row">

--- a/Anima-Beyond-Fantasy/A-BF.html
+++ b/Anima-Beyond-Fantasy/A-BF.html
@@ -61,35 +61,35 @@
                 <div class="sidebubbled ">PhR</div>
                 <input type="number" name="attr_resist_physical_special" value="0" />
                 <input type="number" name="attr_resist_physical_final" 
-                value="@{presence}+@{con_mod}+@{resist_physical_special}" disabled="true"/>
+                value="@{presence}+@{con_mod}+@{body_of_emptiness}+@{resist_physical_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their body! [[1d100+@{resist_physical_final}]]"></button>
             </div>
             <div class="style_row">
                 <div class=" sidebubbled">DR</div>
                 <input type="number" name="attr_resist_disease_special" value="0"/>
                 <input type="number" name="attr_resist_disease_final" 
-                value="@{presence}+@{con_mod}+@{resist_disease_special}" disabled="true"/>
+                value="@{presence}+@{con_mod}+@{body_of_emptiness}+@{resist_disease_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their body! [[1d100+@{resist_disease_final}]]"></button>
             </div>
             <div class="style_row">
                 <div class="sidebubbled">PsnR</div>
                 <input type="number" name="attr_resist_poison_special" value="0"/>
                 <input type="number" name="attr_resist_poison_final" 
-                value="@{presence}+@{con_mod}+@{resist_poison_special}" disabled="true"/>
+                value="@{presence}+@{con_mod}+@{body_of_emptiness}+@{resist_poison_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their body! [[1d100+@{resist_poison_final}]]"></button>
             </div>    
             <div class="style_row">
                 <div class="sidebubbled">MR</div>
                 <input type="number" name="attr_resist_magic_special" value="0"/>
                 <input type="number" name="attr_resist_magic_final" 
-                value="@{presence}+@{pow_mod}+@{resist_physical_special}" disabled="true"/>
+                value="@{presence}+@{pow_mod}+@{body_of_emptiness}+@{resist_physical_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their sprit! [[1d100+@{resist_magic_final}]]"></button>
             </div>
             <div class="style_row">
                 <div class="sidebubbled">PsyR</div>
                 <input type="number" name="attr_resist_psychic_special" value="0" />
                 <input type="number" name="attr_resist_psychic_final" 
-                value="@{presence}+@{wp_mod}+@{resist_psychic_special}" disabled="true"/>
+                value="@{presence}+@{wp_mod}+@{body_of_emptiness}+@{resist_psychic_special}" disabled="true"/>
                 <button type="roll" class="d100-roll-button" value="/em resists with their mind! [[1d100+@{resist_psychic_final}]]"></button>
             </div>
     </div><!-- end resistances -->
@@ -1538,7 +1538,7 @@
             
             <div class="req_useofki ki_row kidetection">
                 <div class="cell ki_indent1 ki_title">Ki Detection</div>
-                <input type="number" disabled="true" name="attr_ki_detection_value" value="round(@{noti_final}/2 + @{mk_final}/2)"/>
+                <input type="number" disabled="true" name="attr_ki_detection_value" value="round((@{noti_final} + @{mk_final})/2)"/>
                 <button type='roll' value='/em senses nearby presences. [[1d100 + @{ki_detection_value}]]'
                 class="d100-roll-button"></button>
                 <div class="cell ki_cost" style="padding-top: 4px;">(20)</div>
@@ -1945,7 +1945,7 @@
                     <div class="cell ki_title ki_indent1">Body of Emptiness</div>       
                     <div class="ki_cost">(10)</div>
                 </div>
-                <input type="checkbox" name="attr_body_of_emptiness" class="ki_learned req_useofnemesis bodyofempty"/>
+                <input type="checkbox" value="10" name="attr_body_of_emptiness" class="ki_learned req_useofnemesis bodyofempty"/>
                 
                 <div class="ki_row req_bodyofempty">
                     <div class="cell ki_title ki_indent2">No Needs</div>       
@@ -2440,7 +2440,7 @@
             value="@{str_mod}+(@{weapon_twohanded}*@{str_mod})"/>
             <div class="cell" style="font-size:12pt;font-weight:bold;">=</div>
             <input type="number" disabled="true" name="attr_weapon_finaldmg"
-            value="@{weapon_basedmg}+@{weapon_strbonus}+@{weapon_quality}+@{aura_extension}+@{increased_damage}"/>
+            value="@{weapon_basedmg}+@{weapon_strbonus}+2*@{weapon_quality}+@{aura_extension}+@{increased_damage}"/>
         </div>
         <div class="dark_row">
             <div class="cell" style="margin-left: 30px;">Fortitude</div>
@@ -2451,8 +2451,8 @@
         <div class="style_row">
             <input type="number" name="attr_weapon_basefort" value="0" min="0"/>
             <input type="number" disabled="true" name="attr_weapon_finalfort"
-            value="@{weapon_quality}+10*@{weapon_basefort}"/>
-            <input type="number" name="attr_weapon_basebreakage" value="0" min="0"/>
+            value="2*@{weapon_quality}+10*@{weapon_basefort}+@{aura_extension}"/>
+            <input type="number" name="attr_weapon_basebreakage" value="0"/>
             <div class="cell" style="font-size:12pt;font-weight:bold;">+</div>
             <select name="attr_weapon_strbreakage" style="width:75px;">
                     <option value="0">Str 1-8</option>


### PR DESCRIPTION
Corrected Weapon Attack damage calculation.
Corrected Weapon Fortitude calculation.
Corrected Ki Detection formula not properly using order of operations.
Corrected Weapon Breakage to allow negative values. Useful for some weapons such as the whip or net, which have negative breakage.
Corrected resistances to account for Body of Emptiness automatically.