### PR TITLE
Update Pendragon.html

### DIFF
--- a/Pendragon/Pendragon.html
+++ b/Pendragon/Pendragon.html
@@ -103,61 +103,61 @@
 <hr/>
 <div class="sheet-2colrow">
     <div class="sheet-col">
-        <h3 style="margin-bottom: 10px;">Attributes</h3>
+        <h3 style="margin-bottom: 10px;">ATTRIBUTES</h3>
 
-        <p><label style='display:inline-block;  width:120px;'>SIZE</label><input style='display:inline;' type="number" name="attr_SIZ" class="sheet-carac2" value="10" />
-        </button><button style='display:inline;' type='roll' name='roll_TestSIZ' value='/em @{MYNAME} is doing a SIZE roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{SIZ}+?{modif|0}]] \ SIZE roll @{SIZ} modif. ?{modif|0}'></button><br />
-        <label style='display:inline-block;  width:120px; '>DEXTERITY</label><input style='display:inline;' type="number" name="attr_DEX" class="sheet-carac2" value="10" />
-        <button style='display:inline;' type='roll' name='roll_TestDEX' value='/em @{MYNAME} is doing a DEXTERITY roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{DEX}+?{modif|0}]] \ DEXTERITY roll @{DEX} modif. ?{modif|0}'></button><br />
-        <label style='display:inline-block;  width:120px;'>STRENGTH</label><input  style='display:inline;' type="number" name="attr_STR" class="sheet-carac2" value="10" />
-        <button  style='display:inline;' type='roll' name='roll_TestSTR' value='/em @{MYNAME} is doing a STRENGTH roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{STR}+?{modif|0}]] \ STRENGTH roll @{STR} modif. ?{modif|0}'></button><br />
-        <label style='display:inline-block;  width:120px;'>CONSTITUTION</label><input  style='display:inline;' type="number" name="attr_CON" class="sheet-carac2" value="10" />
-        <button  style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} is doing a CONSTITUTION roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{CON}+?{modif|0}]] \ CONSTITUTION roll @{CON} modif. ?{modif|0}'></button><br />
-        <label style='display:inline-block;  width:120px;'>APPEARENCE</label><input  style='display:inline;' type="number" name="attr_APP" class="sheet-carac2" value="10" />
-        <button  style='display:inline;' type='roll' name='roll_TestFOR' value="/em @{MYNAME} is doing a APPEARENCE roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{APP}+?{modif|0}]] \ APPEARENCE roll @{APP} modif. ?{modif|0}"></button><br />      
+        <p><label style='display:inline-block;  width:120px;'>Size</label><input style='display:inline;' type="number" name="attr_SIZ" class="sheet-carac2" value="10" />
+        </button><button style='display:inline;' type='roll' name='roll_TestSIZ' value='/em @{MYNAME} rolls SIZE with a modifier of ?{modif|0} : \n/roll 1d20<[[@{SIZ}+?{modif|0}]] \ SIZE roll @{SIZ} modif. ?{modif|0}'></button><br />
+        <label style='display:inline-block;  width:120px; '>Dexterity</label><input style='display:inline;' type="number" name="attr_DEX" class="sheet-carac2" value="10" />
+        <button style='display:inline;' type='roll' name='roll_TestDEX' value='/em @{MYNAME} rolls DEXTERITY with a modifier of ?{modif|0} : \n/roll 1d20<[[@{DEX}+?{modif|0}]] \ DEXTERITY roll @{DEX} modif. ?{modif|0}'></button><br />
+        <label style='display:inline-block;  width:120px;'>Strength</label><input  style='display:inline;' type="number" name="attr_STR" class="sheet-carac2" value="10" />
+        <button  style='display:inline;' type='roll' name='roll_TestSTR' value='/em @{MYNAME} rolls STRENGTH with a modifier of ?{modif|0} : \n/roll 1d20<[[@{STR}+?{modif|0}]] \ STRENGTH roll @{STR} modif. ?{modif|0}'></button><br />
+        <label style='display:inline-block;  width:120px;'>Constitution</label><input  style='display:inline;' type="number" name="attr_CON" class="sheet-carac2" value="10" />
+        <button  style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} rolls CONSTITUTION with a modifier of ?{modif|0} : \n/roll 1d20<[[@{CON}+?{modif|0}]] \ CONSTITUTION roll @{CON} modif. ?{modif|0}'></button><br />
+        <label style='display:inline-block;  width:120px;'>Appearance</label><input  style='display:inline;' type="number" name="attr_APP" class="sheet-carac2" value="10" />
+        <button  style='display:inline;' type='roll' name='roll_TestFOR' value="/em @{MYNAME} rolls APPEARENCE with a modifier of ?{modif|0} : \n/roll 1d20<[[@{APP}+?{modif|0}]] \ APPEARENCE roll @{APP} modif. ?{modif|0}"></button><br />      
       
-        <h4 style="margin-bottom: 10px;">Derived statistics</h4>
+        <h3 style="margin-bottom: 10px;">DERIVED STATISTICS</h3>
         <input type="hidden" name="attr_DEG-dice" value="((@{STR} + @{SIZ}) / 6)" disabled="true"/>
-        <label  style='display:inline-block;  width:120px;'>DAMAGE</label><input type="text" name="attr_DAM" class="sheet-carac3" value="(round((@{STR}+@{SIZ})/6)+@{BR-Br2})" disabled="true" />
-        <button style='margin-right:10px;' type='roll' name='roll_TestAttack2' value='/em @{MYNAME} hits the ennemy! \n/r  @{DEG-dice}d6 [basic damage] \n damage points '></button> <label  style='display:inline;'>critical :</label><button type='roll' name='roll_TestAttack2' value='/em @{MYNAME} hits perfectly ! \n/roll @{DEG-dice}d6 + @{DEG-dice}d6  [critical hit] \n damage points'></button><br />
-        <label style='display:inline-block;  width:120px;'>MVT RATE</label><input  style='display:inline;' type="text" name="attr_MOV" class="sheet-carac3" value="round((@{STR}+@{DEX})/10)" disabled="true"/><br />
-        <label style='display:inline-block;  width:120px;'>HEALING RATE</label><input  style='display:inline;' type="text" name="attr_HR" class="sheet-carac3" value="round((@{CON}+@{STR})/10)+@{BR-Pa}" disabled="true"/><br /> 
+        <label  style='display:inline-block;  width:120px;'>Damage</label><input type="text" name="attr_DAM" class="sheet-carac3" value="(round((@{STR}+@{SIZ})/6)+@{BR-Br2})" disabled="true" />
+        <button style='margin-right:10px;' type='roll' name='roll_TestAttack2' value='/em @{MYNAME} hits the ennemy! \n/r  @{DEG-dice}d6 [basic damage] \n damage points '></button> <label  style='display:inline;'>Critical:</label><button type='roll' name='roll_TestAttack2' value='/em @{MYNAME} hits perfectly ! \n/roll @{DEG-dice}d6 + @{DEG-dice}d6  [critical hit] \n damage points'></button><br />
+        <label style='display:inline-block;  width:120px;'>Mvt Rate</label><input  style='display:inline;' type="text" name="attr_MOV" class="sheet-carac3" value="round((@{STR}+@{DEX})/10)" disabled="true"/><br />
+        <label style='display:inline-block;  width:120px;'>Healing Rate</label><input  style='display:inline;' type="text" name="attr_HR" class="sheet-carac3" value="round((@{CON}+@{STR})/10)+@{BR-Pa}" disabled="true"/><br /> 
        
     </div>
     
     <div class="sheet-col">
-        <h3 style="margin-bottom: 10px;">Passions</h3>
+        <h3 style="margin-bottom: 10px;">PASSIONS</h3>
 
-        <p><label style='display:inline-block;  width:170px;'>HONOR</label>
+        <p><label style='display:inline-block;  width:170px;'>Honor</label>
         <input  style='display:inline;' type="number" name="attr_HON" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-honor' value='1' />
-        <button type='roll' name='roll_TestHON' value="/em @{MYNAME} is doing a HONOR roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HON}+?{modif|0}]] \ HONOR roll @{HON} modif. ?{modif|0}"></button><br />
+        <button type='roll' name='roll_TestHON' value="/em @{MYNAME} rolls HONOR with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HON}+?{modif|0}]] \ HONOR roll @{HON} modif. ?{modif|0}"></button><br />
 
-        <label style='display:inline-block;  width:170px;'>LOYALTY</label>
+        <label style='display:inline-block;  width:170px;'>Loyalty</label>
         <input  style='display:inline;' type="number" name="attr_LOY" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-loyaute' value='1' />
-        <button type='roll' name='roll_TestLOY' value="/em @{MYNAME} is doing a LOYALTY roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{LOY}+?{modif|0}]] \ LOYALTY roll @{LOY} modif. ?{modif|0}"></button><br />
+        <button type='roll' name='roll_TestLOY' value="/em @{MYNAME} rolls LOYALTY with a modifier of ?{modif|0} : \n/roll 1d20<[[@{LOY}+?{modif|0}]] \ LOYALTY roll @{LOY} modif. ?{modif|0}"></button><br />
 
-        <label style='display:inline-block;  width:170px;'>HOSPITALITY</label>
+        <label style='display:inline-block;  width:170px;'>Hospitality</label>
         <input  style='display:inline;' type="number" name="attr_HOS" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-hospitalite' value='1' />
-        <button type='roll' name='roll_TestHOS' value="/em @{MYNAME} is doing a HOSPITALITY roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HOS}+?{modif|0}]] \ HOSPITALITY roll @{HOS} modif. ?{modif|0}"></button><br />
+        <button type='roll' name='roll_TestHOS' value="/em @{MYNAME} rolls HOSPITALITY with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HOS}+?{modif|0}]] \ HOSPITALITY roll @{HOS} modif. ?{modif|0}"></button><br />
 
-        <label style='display:inline-block;  width:170px;'>HATE (SAXONS) </label>
+        <label style='display:inline-block;  width:170px;'>Hate (Saxons) </label>
         <input  style='display:inline;' type="number" name="attr_HAT" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-hate' value='1' />
-        <button type='roll' name='roll_TestHAT' value="/em @{MYNAME} is doing a HATRED OF THE SAXONS roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HAT}+?{modif|0}]] \ HATRED OF THE SAXONS roll @{HAT} modif. ?{modif|0}"></button><br />
+        <button type='roll' name='roll_TestHAT' value="/em @{MYNAME} rolls Hate (Saxons) with a modifier of ?{modif|0} : \n/roll 1d20<[[@{HAT}+?{modif|0}]] \ HATRED OF THE SAXONS roll @{HAT} modif. ?{modif|0}"></button><br />
 
-        <label style='display:inline-block;  width:170px;'>LOVE (FAMILY)</label>
+        <label style='display:inline-block;  width:170px;'>Love (Family)</label>
         <input  style='display:inline;' type="number" name="attr_LOV" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-love' value='1' />
-        <button type='roll' name='roll_TestLOV' value="/em @{MYNAME} is doing a LOVE OF FAMILY roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{LOV}+?{modif|0}]] \ LOVE OF FAMILY roll @{LOV} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_TestLOV' value="/em @{MYNAME} rolls Love (Family) with a modifier of ?{modif|0} : \n/roll 1d20<[[@{LOV}+?{modif|0}]] \ LOVE OF FAMILY roll @{LOV} modif. ?{modif|0}"></button>
 
         <!-- additional passions -->
         <fieldset class="repeating_passions" style="margin-top:-20px;">            
         <input style='display:inline-block;  width:185px; background: transparent; border: none; margin-bottom:5px; text-align:left;'  name="attr_Pname" type='text' value="passion name" ><input  style='display:inline;' type="number" name="attr_Pvalue" class="sheet-carac2" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-Pname' value='1' />
-        <button type='roll' name='roll_CB-Pname' value="/em @{MYNAME} is doing a @{Pname} roll with a modifier of ?{modif|0} : \n/roll 1d20<[[@{Pvalue}+?{modif|0}]] \   @{Pname} roll  @{Pvalue} modif. ?{modif|0}"></button><br /> 
+        <button type='roll' name='roll_CB-Pname' value="/em @{MYNAME} rolls @{Pname} with a modifier of ?{modif|0} : \n/roll 1d20<[[@{Pvalue}+?{modif|0}]] \   @{Pname} roll  @{Pvalue} modif. ?{modif|0}"></button><br /> 
         </fieldset>
         </p>
        
@@ -172,159 +172,159 @@
 <!-- 2e partie, traits de personnalité -->
 <div class="sheet-tab-content sheet-tab2">
 
-            <h3 style="margin-bottom: 10px; text-align:center;">Personality Traits</h3>
+            <h3 style="margin-bottom: 10px; text-align:center;">PERSONALITY TRAITS</h3>
 
         <p  style="text-align:center;">
         
-        <button type='roll' name='roll_Test-TCha' value='/em @{MYNAME} is doing a CHASTE roll. \n/roll 1d20<[[@{TCha}+?{modif|0}]] \ CHASTE roll @{TCha}  modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TCha' value='/em @{MYNAME} rolls CHASTE. \n/roll 1d20<[[@{TCha}+?{modif|0}]] \ CHASTE roll @{TCha}  modif. ?{modif|0}'></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TCha' value='1' />
-        <label style='display:inline-block;  width:130px;'>CHASTE</label>
+        <label style='display:inline-block;  width:130px;'>Chaste</label>
         <input  style=style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TCha" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TLus" class="sheet-carac2" value="20-@{TCha}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>LUSTFUL</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Lustful</label>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TLus' value='1' />
-        <button type='roll' name='roll_Test-TLus' value='/em @{MYNAME} is doing a LUSTFUL roll. \n/roll 1d20<[[@{TLus}+?{modif|0}]] \ LUSTFUL roll @{TLus} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TLus' value='/em @{MYNAME} rolls LUSTFUL. \n/roll 1d20<[[@{TLus}+?{modif|0}]] \ LUSTFUL roll @{TLus} modif. ?{modif|0}'></button>
         <br />
-        <button type='roll' name='roll_Test-TEne' value="/em @{MYNAME} is doing an ENERGETIC roll \n/roll 1d20<[[@{TEne}+?{modif|0}]] \ ENERGETIC roll @{TEne} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TEne' value="/em @{MYNAME} rolls ENERGETIC. \n/roll 1d20<[[@{TEne}+?{modif|0}]] \ ENERGETIC roll @{TEne} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TEne' value='1' />
-        <label style='display:inline-block;  width:130px;'>*ENERGETIC</label>
+        <label style='display:inline-block;  width:130px;'>Energetic*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TEne" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TLaz" class="sheet-carac2" value="20-@{TEne}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>LAZY</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Lazy</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TLaz' value='1' />
-        <button type='roll' name='roll_Test-TLaz' value='/em @{MYNAME} is doing a LAZY roll. \n/roll 1d20<[[@{TLaz}+?{modif|0}]] \ LAZY roll @{TLaz} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TLaz' value='/em @{MYNAME} rolls LAZY. \n/roll 1d20<[[@{TLaz}+?{modif|0}]] \ LAZY roll @{TLaz} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TFor' value="/em @{MYNAME} is doing a FORGIVING roll. \n/roll 1d20<[[@{TFor}+?{modif|0}]] \ FORGIVING roll @{TFor} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TFor' value="/em @{MYNAME} rolls FORGIVING. \n/roll 1d20<[[@{TFor}+?{modif|0}]] \ FORGIVING roll @{TFor} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TFor' value='1' />
-        <label style='display:inline-block;  width:130px;'>FORGIVING</label>
+        <label style='display:inline-block;  width:130px;'>Forgiving</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TFor" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TVen" class="sheet-carac2" value="20-@{TFor}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>VENGEFUL</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Vengeful</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TVen' value='1' />
-        <button type='roll' name='roll_Test-TVen' value='/em @{MYNAME} is doing a VENGEFUL roll. \n/roll 1d20<[[@{TVen}+?{modif|0}]] \ VENGEFUL roll @{TVen} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TVen' value='/em @{MYNAME} rolls VENGEFUL. \n/roll 1d20<[[@{TVen}+?{modif|0}]] \ VENGEFUL roll @{TVen} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TGen' value="/em @{MYNAME} is doing a GENEROUS roll. \n/roll 1d20<[[@{TGen}+?{modif|0}]] \ GENEROUS roll @{TGen} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TGen' value="/em @{MYNAME} rolls GENEROUS. \n/roll 1d20<[[@{TGen}+?{modif|0}]] \ GENEROUS roll @{TGen} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TGen' value='1' />
-        <label style='display:inline-block;  width:130px;'>*GENEROUS</label>
+        <label style='display:inline-block;  width:130px;'>Generous*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TGen" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TSel" class="sheet-carac2" value="20-@{TGen}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>SELFISH</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Selfish</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TSel' value='1' />
-        <button type='roll' name='roll_Test-TSel' value='/em @{MYNAME} is doing a SELFISH roll. \n/roll 1d20<[[@{TSel}+?{modif|0}]] \ SELFISH roll @{TSel} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TSel' value='/em @{MYNAME} rolls SELFISH. \n/roll 1d20<[[@{TSel}+?{modif|0}]] \ SELFISH roll @{TSel} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-THon' value="/em @{MYNAME} is doing a HONEST roll. \n/roll 1d20<[[@{THon}+?{modif|0}]] \ HONEST roll @{THon} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-THon' value="/em @{MYNAME} rolls HONEST. \n/roll 1d20<[[@{THon}+?{modif|0}]] \ HONEST roll @{THon} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-THon' value='1' />
-        <label style='display:inline-block;  width:130px;'>HONEST</label>
+        <label style='display:inline-block;  width:130px;'>Honest</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_THon" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TDec" class="sheet-carac2" value="20-@{THon}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>DECEITFUL</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Deceitful</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TDec' value='1' />
-        <button type='roll' name='roll_Test-TDec' value='/em @{MYNAME} is doing a DECEITFUL roll. \n/roll 1d20<[[@{TDec}+?{modif|0}]] \ DECEITFUL roll @{TDec} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TDec' value='/em @{MYNAME} rolls DECEITFUL. \n/roll 1d20<[[@{TDec}+?{modif|0}]] \ DECEITFUL roll @{TDec} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TJus' value="/em @{MYNAME} is doing a JUST roll. \n/roll 1d20<[[@{TJus}+?{modif|0}]] \ JUST roll @{TJus} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TJus' value="/em @{MYNAME} rolls JUST. \n/roll 1d20<[[@{TJus}+?{modif|0}]] \ JUST roll @{TJus} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TJus' value='1' />
-        <label style='display:inline-block;  width:130px;'>*JUST</label>
+        <label style='display:inline-block;  width:130px;'>Just*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TJus" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TArb" class="sheet-carac2" value="20-@{TJus}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>ARBITRARY</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Arbitrary</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TArb' value='1' />
-        <button type='roll' name='roll_Test-TArb' value='/em @{MYNAME} is doing an ARBITRARY roll. \n/roll 1d20<[[@{TArb}+?{modif|0}]] \ ARBITRARY roll @{TArb} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TArb' value='/em @{MYNAME} rolls ARBITRARY. \n/roll 1d20<[[@{TArb}+?{modif|0}]] \ ARBITRARY roll @{TArb} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TMer' value="/em @{MYNAME} is doing a MERCIFUL roll. \n/roll 1d20<[[@{TMer}+?{modif|0}]] \ MERCIFUL roll @{TMer} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TMer' value="/em @{MYNAME} rolls MERCIFUL. \n/roll 1d20<[[@{TMer}+?{modif|0}]] \ MERCIFUL roll @{TMer} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TMer' value='1' />
-        <label style='display:inline-block;  width:130px;'>*MERCIFUL</label>
+        <label style='display:inline-block;  width:130px;'>Merciful*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TMer" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TCru" class="sheet-carac2" value="20-@{TMer}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>CRUEL</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Cruel</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TCru' value='1' />
-        <button type='roll' name='roll_Test-TCru' value='/em @{MYNAME} is doing a CRUEL roll. \n/roll 1d20<[[@{TCru}+?{modif|0}]] \ CRUEL roll @{TCru} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TCru' value='/em @{MYNAME} rolls CRUEL. \n/roll 1d20<[[@{TCru}+?{modif|0}]] \ CRUEL roll @{TCru} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TMod' value="/em @{MYNAME} is doing a MODEST roll. \n/roll 1d20<[[@{TMod}+?{modif|0}]] \ MODEST roll @{TMod} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TMod' value="/em @{MYNAME} rolls MODEST. \n/roll 1d20<[[@{TMod}+?{modif|0}]] \ MODEST roll @{TMod} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TMod' value='1' />
-        <label style='display:inline-block;  width:130px;'>*MODEST</label>
+        <label style='display:inline-block;  width:130px;'>Modest*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TMod" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TPro" class="sheet-carac2" value="20-@{TMod}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>PROUD</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Proud</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TPro' value='1' />
-        <button type='roll' name='roll_Test-TPro' value='/em @{MYNAME} is doing a PROUD roll. \n/roll 1d20<[[@{TPro}+?{modif|0}]] \ PROUD roll @{TPro} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TPro' value='/em @{MYNAME} rolls PROUD. \n/roll 1d20<[[@{TPro}+?{modif|0}]] \ PROUD roll @{TPro} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TPio' value="/em @{MYNAME} is doing a PIOUS roll. \n/roll 1d20<[[@{TPio}+?{modif|0}]] \ PIOUS roll @{TPio} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TPio' value="/em @{MYNAME} rolls SPIRITUAL. \n/roll 1d20<[[@{TPio}+?{modif|0}]] \ SPIRITUAL roll @{TPio} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TPio' value='1' />
-        <label style='display:inline-block;  width:130px;'>SPIRITUAL</label>
+        <label style='display:inline-block;  width:130px;'>Spiritual</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TPio" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TWor" class="sheet-carac2" value="20-@{TPio}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>WORLDLY</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Worldly</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TWor' value='1' />
-        <button type='roll' name='roll_Test-TWor' value='/em @{MYNAME} is doing a WORLDLY roll. \n/roll 1d20<[[@{TWor}+?{modif|0}]] \ WORLDLY roll @{TWor} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TWor' value='/em @{MYNAME} rolls WORLDLY. \n/roll 1d20<[[@{TWor}+?{modif|0}]] \ WORLDLY roll @{TWor} modif. ?{modif|0}'></button>
         <br />
         
-        <button type='roll' name='roll_Test-TPru' value="/em @{MYNAME} is doing a PRUDENT roll. \n/roll 1d20<[[@{TPru}+?{modif|0}]] \ PRUDENT roll @{TPru} modif. ?{modif|0}"></button>
+        <button type='roll' name='roll_Test-TPru' value="/em @{MYNAME} rolls PRUDENT. \n/roll 1d20<[[@{TPru}+?{modif|0}]] \ PRUDENT roll @{TPru} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TPru' value='1' />
-        <label style='display:inline-block;  width:130px;'>PRUDENT</label>
+        <label style='display:inline-block;  width:130px;'>Prudent</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TPru" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TRec" class="sheet-carac2" value="20-@{TPru}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>RECKLESS</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Reckless</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TRec' value='1' />
-        <button type='roll' name='roll_Test-TRec' value='/em @{MYNAME} is doing a RECKLESS roll. \n/roll 1d20<[[@{TRec}+?{modif|0}]] \ RECKLESS roll @{TRec} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TRec' value='/em @{MYNAME} rolls RECKLESS. \n/roll 1d20<[[@{TRec}+?{modif|0}]] \ RECKLESS roll @{TRec} modif. ?{modif|0}'></button>
         <br />
         
-         <button type='roll' name='roll_Test-TTem' value="/em @{MYNAME} is doing a TEMPERATE roll. \n/roll 1d20<[[@{TTem}+?{modif|0}]] \ TEMPERATE roll @{TTem} modif. ?{modif|0}"></button>
+         <button type='roll' name='roll_Test-TTem' value="/em @{MYNAME} rolls TEMPERATE. \n/roll 1d20<[[@{TTem}+?{modif|0}]] \ TEMPERATE roll @{TTem} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TTem' value='1' />
-        <label style='display:inline-block;  width:130px;'>TEMPERATE</label>
+        <label style='display:inline-block;  width:130px;'>Temperate</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TTem" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TInd" class="sheet-carac2" value="20-@{TTem}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>INDULGENT</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Indulgent</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TInd' value='1' />
-        <button type='roll' name='roll_Test-TInd' value='/em @{MYNAME} is doing an INDULGENT roll. \n/roll 1d20<[[@{TInd}+?{modif|0}]] \ INDULGENT roll @{TInd} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TInd' value='/em @{MYNAME} rolls INDULGENT. \n/roll 1d20<[[@{TInd}+?{modif|0}]] \ INDULGENT roll @{TInd} modif. ?{modif|0}'></button>
         <br />
         
-         <button type='roll' name='roll_Test-TTru' value="/em @{MYNAME} is doing a TRUSTING roll. \n/roll 1d20<[[@{TTru}+?{modif|0}]] \ TRUSTING roll @{TTru} modif. ?{modif|0}"></button>
+         <button type='roll' name='roll_Test-TTru' value="/em @{MYNAME} rolls TRUSTING. \n/roll 1d20<[[@{TTru}+?{modif|0}]] \ TRUSTING roll @{TTru} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TTru' value='1' />
-        <label style='display:inline-block;  width:130px;'>TRUSTING</label>
+        <label style='display:inline-block;  width:130px;'>Trusting</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TTru" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TSus" class="sheet-carac2" value="20-@{TTru}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>SUSPICIOUS</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Suspicious</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TSus' value='1' />
-        <button type='roll' name='roll_Test-TSus' value='/em @{MYNAME} is doing a SUSPICIOUS roll. \n/roll 1d20<[[@{TSus}+?{modif|0}]] \ SUSPICIOUS roll @{TSus} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TSus' value='/em @{MYNAME} rolls SUSPICIOUS. \n/roll 1d20<[[@{TSus}+?{modif|0}]] \ SUSPICIOUS roll @{TSus} modif. ?{modif|0}'></button>
         <br />
         
-         <button type='roll' name='roll_Test-TVal' value="/em @{MYNAME} is doing a VALOROUS roll. \n/roll 1d20<[[@{TVal}+?{modif|0}]] \ VALOROUS roll @{TVal} modif. ?{modif|0}"></button>
+         <button type='roll' name='roll_Test-TVal' value="/em @{MYNAME} rolls VALOROUS. \n/roll 1d20<[[@{TVal}+?{modif|0}]] \ VALOROUS roll @{TVal} modif. ?{modif|0}"></button>
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-TVal' value='1' />
-        <label style='display:inline-block;  width:130px;'>*VALOROUS</label>
+        <label style='display:inline-block;  width:130px;'>Valorous*</label>
         <input  style='display:inline; text-align:center;  font-weight:bold;' type="number" name="attr_TVal" class="sheet-carac2" value="10" />
         <label style='display:inline-block;  width:30px; text-align:center'>/</label>
         <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_TCow" class="sheet-carac2" value="20-@{TVal}" disabled="true"/>
-        <label style='display:inline-block;  width:130px; text-align:right'>COWARDLY</label>
+        <label style='display:inline-block;  width:130px; text-align:right'>Cowardly</label>
         <input style='display:inline;  margin-left: 10px; margin-left:10px; margin-right: 10px; ' type='checkbox' name='attr_CB-TCow' value='1' />
-        <button type='roll' name='roll_Test-TCow' value='/em @{MYNAME} is doing a COWARDLY roll. \n/roll 1d20<[[@{TCow}+?{modif|0}]] \ COWARDLY roll @{TCow} modif. ?{modif|0}'></button>
+        <button type='roll' name='roll_Test-TCow' value='/em @{MYNAME} rolls COWARDLY. \n/roll 1d20<[[@{TCow}+?{modif|0}]] \ COWARDLY roll @{TCow} modif. ?{modif|0}'></button>
         <br />
        </p>
-        <h4 style="margin-bottom: 10px;">Chivalry Bonus (80+)  <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_BChe" class="sheet-carac2" value="@{TEne}+@{TGen}+@{TJus}+@{TMer}+@{TMod}+@{TVal}" disabled="true"/>
-       actif <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_flag-BChe' value='1' />
+        <h4 style="margin-bottom: 10px;">Chivalry Bonus (96+)  <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_BChe" class="sheet-carac2" value="@{TEne}+@{TGen}+@{TJus}+@{TMer}+@{TMod}+@{TVal}" disabled="true"/>
+       Active? <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_flag-BChe' value='1' />
            
        </h4>
         <h4 style="margin-bottom: 10px;">Religious Bonus (all >15) <input  style='display:inline; width:35px; text-align:center; font-weight:bold;' type="text" name="attr_BRel" class="sheet-carac2" value="@{flag-bonus}" disabled="true"/>(0 = no, 1 = yes)
        </h4>
-       <h4 style="margin-bottom: 10px;">Directed Traits</h4>
+       <h3 style="margin-bottom: 10px;">Directed Traits</h3>
          <fieldset class="repeating_TD">            
         <select name="attr_TD-trait" class="sheet-long" style='display:inline; background: transparent; border: none;'>
             <option value="@{TCha}">Chaste</option>
@@ -342,7 +342,7 @@
              <option value="@{TCru}">Cruel</option>
             <option value="@{TMod}">Modest</option>
             <option value="@{TPro}">Proud</option>
-            <option value="@{TPio}">Pious</option>
+            <option value="@{TPio}">Spiritual</option>
             <option value="@{TWor}">Worldly</option>
             <option value="@{TPru}">Prudent</option>
              <option value="@{TRec}">Reckless</option>
@@ -354,7 +354,7 @@
             <option value="@{TCow}">Cowardly</option>
         </select>
          <input style='display:inline-block;  width:160px; font-size:1em; background: transparent; border: none;  margin-bottom:5px;'  name="attr_TDcible" type='text' value="target" ><input  style='display:inline;' type="number" name="attr_TD-value" class="sheet-carac2" value="0" />
-         <button style='display:inline;'type='roll' name='roll_Test-TCow' value='/em @{MYNAME} is doing a directed trait roll. \n/roll 1d20<[[@{TD-trait}+@{TD-value}+?{modif|0}]] \ trait @{TD-trait} , target modifier  @{TD-value} modifier ?{modif|0}'></button><br /> 
+         <button style='display:inline;'type='roll' name='roll_Test-TCow' value='/em @{MYNAME} makes a directed trait roll. \n/roll 1d20<[[@{TD-trait}+@{TD-value}+?{modif|0}]] \ trait @{TD-trait} , target modifier  @{TD-value} modifier ?{modif|0}'></button><br /> 
        
         </fieldset>
 
@@ -368,126 +368,126 @@
     <div class="sheet-2colrow">
         <div class="sheet-col">
 
-         <h2 style="margin: 10px;">Skills</h2>
+         <h2 style="margin: 10px;">SKILLS</h2>
             <label style='display:inline-block;  width:120px;'>Awareness</label>
             <input style='display:inline;' type="number" name="attr_awa" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-awa' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sawa' value='/em @{MYNAME} is doing an awareness skill roll. \n/roll 1d20<[[@{awa}+?{modif|0}]] \ awareness skill roll @{awa} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sawa' value='/em @{MYNAME} rolls Awareness. \n/roll 1d20<[[@{awa}+?{modif|0}]] \ awareness skill roll @{awa} modif. ?{modif|0}'></button><br />
    
              <label style='display:inline-block;  width:120px;'>Boating</label>
              <input style='display:inline;' type="number" name="attr_boa" value="0" /> 
              <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-boa' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sboa' value='/em @{MYNAME} is doing a boating skill roll. \n/roll 1d20<[[@{boa}+?{modif|0}]] \ boating skill roll @{boa} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sboa' value='/em @{MYNAME} rolls Boating. \n/roll 1d20<[[@{boa}+?{modif|0}]] \ boating skill roll @{boa} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Compose</label>
             <input style='display:inline;' type="number" name="attr_compo" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-compo' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Scom' value='/em @{MYNAME} is doing a compose skill roll. \n/roll 1d20<[[@{compo}+?{modif|0}]] \ compose skill roll @{compo} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Scom' value='/em @{MYNAME} rolls Compose. \n/roll 1d20<[[@{compo}+?{modif|0}]] \ compose skill roll @{compo} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Courtesy</label>
              <input style='display:inline;' type="number" name="attr_cou" value="0" /> 
              <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-cou' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Scou' value='/em @{MYNAME} is doing a courtesy skill roll. \n/roll 1d20<[[@{cou}+?{modif|0}]] \ courtesy skill roll @{cou} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Scou' value='/em @{MYNAME} rolls Courtesy. \n/roll 1d20<[[@{cou}+?{modif|0}]] \ courtesy skill roll @{cou} modif. ?{modif|0}'></button><br />
 
              <label style='display:inline-block;  width:120px;'>Dancing</label>
             <input style='display:inline;' type="number" name="attr_danse" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-danse' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sdan' value='/em @{MYNAME} is doing a dancing skill roll. \n/roll 1d20<[[@{danse}+?{modif|0}]] \ dancing skill roll @{danse} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sdan' value='/em @{MYNAME} rolls Dancing. \n/roll 1d20<[[@{danse}+?{modif|0}]] \ dancing skill roll @{danse} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Faerie Lore</label>
             <input style='display:inline;' type="number" name="attr_faes" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-faes' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sfae' value='/em @{MYNAME} is doing a faerie lore skill roll. \n/roll 1d20<[[@{faes}+?{modif|0}]] \ faerie lore skill roll @{faes} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sfae' value='/em @{MYNAME} rolls Faerie Lore. \n/roll 1d20<[[@{faes}+?{modif|0}]] \ faerie lore skill roll @{faes} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Falconry</label>
             <input style='display:inline;' type="number" name="attr_fal" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-fal' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sfal' value='/em @{MYNAME} is doing a falconry skill roll. \n/roll 1d20<[[@{fal}+?{modif|0}]] \ falconry skill roll @{fal} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sfal' value='/em @{MYNAME} rolls Falconry. \n/roll 1d20<[[@{fal}+?{modif|0}]] \ falconry skill roll @{fal} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>First Aid</label>
             <input style='display:inline;' type="number" name="attr_fa" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-fa' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sfa' value='/em @{MYNAME} is doing a first aid skill roll.  \n/roll 1d20<[[@{fa}+?{modif|0}]] \ first aid skill roll @{fa} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sfa' value='/em @{MYNAME} rolls First Aid.  \n/roll 1d20<[[@{fa}+?{modif|0}]] \ first aid skill roll @{fa} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Flirting</label>
             <input style='display:inline;' type="number" name="attr_fli" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-fli' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sfli' value='/em @{MYNAME} is doing a flirting skill roll.  \n/roll 1d20<[[@{fli}+?{modif|0}]] \ flirting skill roll @{fli} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sfli' value='/em @{MYNAME} rolls Flirting.  \n/roll 1d20<[[@{fli}+?{modif|0}]] \ flirting skill roll @{fli} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Folklore</label>
             <input style='display:inline;' type="number" name="attr_fol" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-fol' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} is doing a folklore skill roll. \n/roll 1d20<[[@{fol}+?{modif|0}]] \ folklore skill roll @{fol} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} rolls Folklore. \n/roll 1d20<[[@{fol}+?{modif|0}]] \ folklore skill roll @{fol} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Gaming</label>
             <input style='display:inline;' type="number" name="attr_gam" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-gam' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sgam' value='/em @{MYNAME} is doing a gaming skill roll. \n/roll 1d20<[[@{gam}+?{modif|0}]] \ gaming skill roll  @{gam} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sgam' value='/em @{MYNAME} rolls Gaming. \n/roll 1d20<[[@{gam}+?{modif|0}]] \ gaming skill roll  @{gam} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Heraldry</label>
             <input style='display:inline;' type="number" name="attr_her" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-her' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sher' value='/em @{MYNAME} is doing a heraldry skill roll. \n/roll 1d20<[[@{her}+?{modif|0}]] \ heraldry skill roll  @{her} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sher' value='/em @{MYNAME} rolls Heraldry. \n/roll 1d20<[[@{her}+?{modif|0}]] \ heraldry skill roll  @{her} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Hunting</label>
             <input style='display:inline;' type="number" name="attr_hun" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-hun' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Shun' value='/em @{MYNAME} is doing a hunting skill roll. \n/roll 1d20<[[@{hun}+?{modif|0}]] \ hunting skill roll  @{hun} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Shun' value='/em @{MYNAME} rolls Hunting. \n/roll 1d20<[[@{hun}+?{modif|0}]] \ hunting skill roll  @{hun} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Intrigue</label>
             <input style='display:inline;' type="number" name="attr_int" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-int' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sint' value='/em @{MYNAME} is doing an intrigue skill roll. \n/roll 1d20<[[@{int}+?{modif|0}]] \ intrigue skill roll @{int} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sint' value='/em @{MYNAME} rolls Intrigue. \n/roll 1d20<[[@{int}+?{modif|0}]] \ intrigue skill roll @{int} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Orate</label>
             <input style='display:inline;' type="number" name="attr_ora" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-ora' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sora' value='/em @{MYNAME} is doing an orate skill roll. \n/roll 1d20<[[@{ora}+?{modif|0}]] \ orate skill roll @{ora} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sora' value='/em @{MYNAME} rolls Orate skill roll. \n/roll 1d20<[[@{ora}+?{modif|0}]] \ orate skill roll @{ora} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Play</label>
             <input style='display:inline;' type="number" name="attr_pla" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-pla' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} is doing a play skill roll. \n/roll 1d20<[[@{pla}+?{modif|0}]] \ play skill roll @{pla} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} rolls Play. \n/roll 1d20<[[@{pla}+?{modif|0}]] \ play skill roll @{pla} modif. ?{modif|0}'></button><br />
 
-            <label style='display:inline-block;  width:120px;'>read</label>
+            <label style='display:inline-block;  width:120px;'>Read</label>
             <input style='display:inline;' type="number" name="attr_read" value="0" /> 
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-read' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sread' value='/em @{MYNAME} is doing a read skill roll.  \n/roll 1d20<[[@{read}+?{modif|0}]] \ read skill roll  @{read} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sread' value='/em @{MYNAME} rolls Read.  \n/roll 1d20<[[@{read}+?{modif|0}]] \ read skill roll  @{read} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Recognize</label>
             <input style='display:inline;' type="number" name="attr_rec" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-rec' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Srec' value='/em @{MYNAME} is doing a recognize skill roll.  \n/roll 1d20<[[@{rec}+?{modif|0}]] \ recognize skill roll @{rec} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Srec' value='/em @{MYNAME} rolls Recognize.  \n/roll 1d20<[[@{rec}+?{modif|0}]] \ recognize skill roll @{rec} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Religion</label>
             <input style='display:inline;' type="number" name="attr_rel" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-rel' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Srel' value='/em @{MYNAME} is doing a religion skill roll.  \n/roll 1d20<[[@{rel}+?{modif|0}]] \ religion skill roll @{rel} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Srel' value='/em @{MYNAME} rolls Religion.  \n/roll 1d20<[[@{rel}+?{modif|0}]] \ religion skill roll @{rel} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Romance</label>
             <input style='display:inline;' type="number" name="attr_rom" value="0" /> 
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-rom' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} is doing a romance skill roll.  \n/roll 1d20<[[@{rom}+?{modif|0}]] \ romance skill roll @{rom} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestFOR' value='/em @{MYNAME} rolls Romance.  \n/roll 1d20<[[@{rom}+?{modif|0}]] \ romance skill roll @{rom} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Singing</label>
             <input style='display:inline;' type="number" name="attr_sing" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-sing' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Ssing' value='/em @{MYNAME} is doing a singing skill roll. \n/roll 1d20<[[@{sing}+?{modif|0}]] \ singing skill roll @{sing} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Ssing' value='/em @{MYNAME} rolls Singing. \n/roll 1d20<[[@{sing}+?{modif|0}]] \ singing skill roll @{sing} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Stewardship</label>
            <input style='display:inline;' type="number" name="attr_ste" value="0" /> 
            <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-ste' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sste' value='/em @{MYNAME} is doing a stewardship skill roll. \n/roll 1d20<[[@{ste}+?{modif|0}]] \ stewardship skill roll @{ste} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sste' value='/em @{MYNAME} rolls Stewardship. \n/roll 1d20<[[@{ste}+?{modif|0}]] \ stewardship skill roll @{ste} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Swimming</label>
             <input style='display:inline;' type="number" name="attr_swi" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-swi' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Sswi' value='/em @{MYNAME} is doing a swimming skill roll.  \n/roll 1d20<[[@{swi}+?{modif|0}]] \ swimming skill roll @{swi} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Sswi' value='/em @{MYNAME} rolls Swimming.  \n/roll 1d20<[[@{swi}+?{modif|0}]] \ swimming skill roll @{swi} modif. ?{modif|0}'></button><br />
 
             <label style='display:inline-block;  width:120px;'>Tourney</label>
             <input style='display:inline;' type="number" name="attr_tou" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-tou' value='1' />
-            <button style='display:inline;' type='roll' name='roll_Stou' value='/em @{MYNAME} is doing a tourney skill roll.  \n/roll 1d20<[[@{tou}+?{modif|0}]] \ tourney skill roll @{tou} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_Stou' value='/em @{MYNAME} rolls Tourney.  \n/roll 1d20<[[@{tou}+?{modif|0}]] \ tourney skill roll @{tou} modif. ?{modif|0}'></button><br />
             
     
             
@@ -499,43 +499,43 @@
              <label style='display:inline-block;  width:120px;'>Battle</label>
              <input style='display:inline;' type="number" name="attr_bat" value="0" /> 
              <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-bat' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestBat' value='/em @{MYNAME} is doing a battle skill roll.  \n/roll 1d20<[[@{bat}+?{modif|0}]] \ battle skill roll @{bat} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestBat' value='/em @{MYNAME} rolls Battle.  \n/roll 1d20<[[@{bat}+?{modif|0}]] \ battle skill roll @{bat} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Siege</label>
             <input style='display:inline;' type="number" name="attr_siege" class="sheet-comp" value="0" />
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-siege' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestSiege' value='/em @{MYNAME} is doing a siege skill roll. \n/roll 1d20<[[@{siege}+?{modif|0}]] \ siege skill roll  @{siege} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestSiege' value='/em @{MYNAME} rolls Siege. \n/roll 1d20<[[@{siege}+?{modif|0}]] \ siege skill roll  @{siege} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Horsemanship</label>
             <input style='display:inline;' type="number" name="attr_hor" class="sheet-comp" value="0" />
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-hor' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestHor' value='/em @{MYNAME} is doing a horsemanship skill roll. \n/roll 1d20<[[@{hor}+?{modif|0}]] \ horsemanship skill roll @{hor} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestHor' value='/em @{MYNAME} rolls Horsemanship. \n/roll 1d20<[[@{hor}+?{modif|0}]] \ horsemanship skill roll @{hor} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Sword</label>
             <input style='display:inline;' type="number" name="attr_sword" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-sword' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestEpee' value='/em @{MYNAME} is doing a sword skill roll. \n/roll 1d20<[[@{sword}+?{modif|0}]] \ sword skill roll @{sword} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestEpee' value='/em @{MYNAME} attacks with a Sword! \n/roll 1d20<[[@{sword}+?{modif|0}]] \ sword skill roll @{sword} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Lance</label>
             <input style='display:inline;' type="number" name="attr_lance" class="sheet-comp" value="0" />    
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-lance' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestLance' value='/em @{MYNAME} is doing a lance skill roll. \n/roll 1d20<[[@{lance}+?{modif|0}]] \ lance skill roll @{lance} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestLance' value='/em @{MYNAME} charges with a Lance! \n/roll 1d20<[[@{lance}+?{modif|0}]] \ lance skill roll @{lance} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px;'>Spear</label>
             <input style='display:inline;' type="number" name="attr_spear" value="0" /> 
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-spear' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestEpieu' value='/em @{MYNAME} is doing a spear skill roll. \n/roll 1d20<[[@{spear}+?{modif|0}]] \ spear skill roll @{spear} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestEpieu' value='/em @{MYNAME} attacks with a Spear! \n/roll 1d20<[[@{spear}+?{modif|0}]] \ spear skill roll @{spear} modif. ?{modif|0}'></button><br />
             
             <label style='display:inline-block;  width:120px; '>Dagger</label>
             <input style='display:inline;' type="number" name="attr_dagger"  value="0" />
             <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-dagger' value='1' />
-            <button style='display:inline;' type='roll' name='roll_TestDague' value='/em @{MYNAME} is doing a dagger skill roll. \n/roll 1d20<[[@{dagger}+?{modif|0}]] \ dagger skill roll @{dagger} modif. ?{modif|0}'></button><br />
+            <button style='display:inline;' type='roll' name='roll_TestDague' value='/em @{MYNAME} attacks with a Dagger! \n/roll 1d20<[[@{dagger}+?{modif|0}]] \ dagger skill roll @{dagger} modif. ?{modif|0}'></button><br />
              <!-- additional skills -->
         <fieldset class="repeating_comp" style="margin-top:-20px;">            
         <input style='display:inline-block;  width:130px; background: transparent; border: none;  margin-bottom:5px; text-align:left; font-size:1em; '  name="attr_CCname" type='text' value="skill name" >
         <input  style='display:inline;' type="number" name="attr_CCvalue" class="sheet-comp" value="10" />
         <input style='display:inline;  margin-left: 10px; margin-right: 10px;' type='checkbox' name='attr_CB-CCname' value='1' />
-        <button style='display:inline;' type='roll' name='roll_TestCC' value='/em @{MYNAME} is using the skill @{CCname} \n/roll 1d20<[[@{CCvalue}+?{modif|0}]] \  @{CCname} roll @{CCvalue} modif. ?{modif|0}'></button>
+        <button style='display:inline;' type='roll' name='roll_TestCC' value='/em @{MYNAME} tests @{CCname} \n/roll 1d20<[[@{CCvalue}+?{modif|0}]] \  @{CCname} roll @{CCvalue} modif. ?{modif|0}'></button>
         <br /> 
         </fieldset>
 
@@ -557,7 +557,7 @@
 <div class="sheet-tab-content sheet-tab4" style="align:center;">  
     <h2 style="margin: 10px;">Retinue</h2>    
     <div style="display:inline-block; width: 100px; text-align:center; border: 3px solid black; margin:0px;" >Name</div>
-    <div style="display:inline-block; width: 100px; text-align:center; border: 3px solid black;  margin:0px;">Role</div>
+    <div style="display:inline-block; width: 100px; text-align:center; border: 3px solid black; margin:0px;">Role</div>
     <div style="display:inline-block; width: 300px; text-align:center; border: 3px solid black; margin:0px;">Skills</div>
     <div style="display:inline-block; width: 250px; text-align:center; border: 3px solid black; margin:0px;">Notes</div>
           
@@ -594,7 +594,7 @@
     
      <h2 style="margin: 10px;">Family</h2>
      
-    <div style="display:inline-block; width: 100px; text-align:center;     border: 3px solid black; margin:0px;" >Name</div>
+    <div style="display:inline-block; width: 100px; text-align:center; border: 3px solid black; margin:0px;" >Name</div>
     <div style="display:inline-block; width: 100px; text-align:center; border: 3px solid black;  margin:0px;">Role</div>
     <div style="display:inline-block; width: 300px; text-align:center; border: 3px solid black; margin:0px;">Skils</div>
     <div style="display:inline-block; width: 250px; text-align:center; border: 3px solid black; margin:0px;">Notes</div>


### PR DESCRIPTION
Corrected some a few niggling issues with spelling on displayed field labels.
Improved the plain-English syntax on some of the chat box "reporting". Example: "{MYNAME} is doing a CHASTE roll becomes "{MYNAME} rolls CHASTE", etc. It's more natural-sounding syntax for English speakers and it's much more compact.
Changed the Chivalry bonus threshold to 96 per Greg Stafford's official errata.
Changed "Directed Traits" subhead to H3.
Change "actif" label next to Chivalry Bonus to "Active?"
Tweaked the label formation to be consistent across tabs. All headers are now all caps, and other labels under them are upper and lowercase to delineate the hierarchy more clearly.
Moved asterisks on Trait labels to after the label to improve alignment of labels.