### PR TITLE
Martial arts and consistency corrections

### DIFF
--- a/Anima-Beyond-Fantasy/A-BF.html
+++ b/Anima-Beyond-Fantasy/A-BF.html
@@ -17,8 +17,8 @@
         <div class="cell" style="margin-left:14px;">Appear.</div>
     </div>
     <div class="style_row">
-    	<input type="text" name="attr_character_name" style="width:130px;"disabled="true;"/>
-		<input type="text" name="attr_character_height" style="width:55px; "/>
+        <input type="text" name="attr_character_name" style="width:130px;"disabled="true;"/>
+        <input type="text" name="attr_character_height" style="width:55px; "/>
 		<input type="text" name="attr_character_weight" style="width:62px;"/>
         <input type="number" name="attr_character_size" value="10" min="0" />
         <input type="number" name="attr_character_appearance" value="5" min="0" max="10" style="width:50px;"/>  
@@ -363,7 +363,7 @@
         value="@{attack_base}+@{attack_class}+@{dex_mod}" disabled ="true"/>
     </div>
     <div class="dark_row" style="padding-top:5px;">
-        <button type="roll" class="d100-roll-button widebutton" value="/em makes an Attack! [[1d100+@{attack_final}+15*?{Fatigue?|0}]]"></button>
+        <button type="roll" class="d100-roll-button widebutton" value="/em makes an Attack! [[1d100+@{attack_final}+15*?{Fatigue?|0}+?{Modifiers?|0}]]"></button>
     </div>
     </div><!--end attack -->
     <div class="wrapper" style="top:2px;"><!-- block -->
@@ -382,7 +382,7 @@
         value="@{block_base}+@{block_class}+@{dex_mod}" disabled ="true"/>
     </div>
     <div class="dark_row" style="padding-top:5px;">
-        <button type="roll" class="d100-roll-button widebutton" value="/em attempts to Block! [[1d100+@{block_final}+15*?{Fatigue?|0}]]"></button>
+        <button type="roll" class="d100-roll-button widebutton" value="/em attempts to Block! [[1d100+@{block_final}+15*?{Fatigue?|0}+?{Modifiers?|0}]]"></button>
     </div>
     </div><!--end block -->
     <div class="wrapper" style="top:2px;"><!-- dodge -->
@@ -401,7 +401,7 @@
         value="@{dodge_base}+@{dodge_class}+@{agi_mod}" disabled ="true"/>
     </div>
     <div class="dark_row" style="padding-top:5px;">
-        <button type="roll" class="d100-roll-button widebutton" value="/em attempts to Dodge! [[1d100+@{dodge_final}+15*?{Fatigue?|0}]]"></button>
+        <button type="roll" class="d100-roll-button widebutton" value="/em attempts to Dodge! [[1d100+@{dodge_final}+15*?{Fatigue?|0}+?{Modifiers?|0}]]"></button>
     </div>
     </div><!--end dodge -->
    </div><!-- end second row -->
@@ -1053,10 +1053,10 @@
     </div>
     <div style="" class="dark_row">
         <button type="roll" class="widebutton cell d100-roll-button" name="magicprojection_offensiveroll"
-        value="/em Extends their magical force. [[1d100+@{magicprojection_offensive_final}]]"
+        value="/em Extends their magical force. [[1d100+?{Modifiers?|0}+@{magicprojection_offensive_final}]]"
         style="margin-top:4px;"></button>
         <button type="roll" class="widebutton cell d100-roll-button" name="magicprojection_defensiveroll"
-        value="/em Extends their magical force. [[1d100+@{magicprojection_defensive_final}]]"
+        value="/em Extends their magical force. [[1d100+?{Modifiers?|0}+@{magicprojection_defensive_final}]]"
         style="margin-top:4px;"></button>
     </div>
     </div><!-- end magic projection -->
@@ -1419,7 +1419,7 @@
                 </div>
                 <div class="dark_row">
                     <button type="roll" style="width:97%" class="d100-roll-button"
-                    value="/em extends their psychic force! [[1d100+@{projection_final}]]"></button>
+                    value="/em extends their psychic force! [[1d100+?{Modifiers?|0}+@{projection_final}]]"></button>
                 </div>
             </div><!-- end Psychic Projection -->
         </div>
@@ -1638,6 +1638,18 @@
                 <div class="cell ki_cost">(10)</div>
             </div>
             <input type="checkbox" class="ki_learned req_aext" name="attr_ki_eleAttackEarth"/>
+            
+            <div class="ki_row req_aext">
+                <div class="cell ki_indent3 ki_title">Elemental Attack: Light</div>
+                <div class="cell ki_cost">(10)</div>
+            </div>
+            <input type="checkbox" class="ki_learned req_aext" name="attr_ki_eleAttackLight"/>
+            
+            <div class="ki_row req_aext">
+                <div class="cell ki_indent3 ki_title">Elemental Attack: Darkness</div>
+                <div class="cell ki_cost">(10)</div>
+            </div>
+            <input type="checkbox" class="ki_learned req_aext" name="attr_ki_eleAttackDark"/>
             
             <div class="ki_row req_aext">
                 <div class="cell ki_indent3 ki_title">Increased Damage</div>
@@ -2195,7 +2207,7 @@
                         <option value="@{str_mod}+(4*@{target|str_mod})">Str + Target Str x4</option>
                     </select>
                     <input type="number" name="attr_martialart_damage_final"
-                    value="@{martialart_damage_base}+@{martialart_damage_multiplier}*@{martialart_damage_scalar}" disabled="true"/>
+                    value="@{martialart_damage_base}+@{aura_extension}+@{increased_damage}+@{martialart_damage_multiplier}*@{martialart_damage_scalar}" disabled="true"/>
                     <input type="number" name="attr_martialarts_mkgained" value="0" style="margin-left:30px;" min="0"/>
                 </div>
             </div><!--End Martial Arts -->
@@ -2502,7 +2514,7 @@
             value="@{weapon_quality}+@{weapon_basespeed}"/>
             <input type="number" disabled="true" name="attr_weapon_attack" value="@{weapon_quality}+@{attack_final}"/>
             <button type="roll" class="d100-roll-button" 
-            value="/em attacks with @{weapon_name}! [[1d100+?{modifiers?|0}+?{Fatigue?|0}*15+@{weapon_attack}]]"></button>
+            value="/em attacks with @{weapon_name}! [[1d100+?{Fatigue?|0}*15+?{Modifiers?|0}+@{weapon_attack}]]"></button>
             <select name="attr_weapon_shieldval" style="width:65px;">
                 <option value="0">N/A</option>
                 <option value="10">Buckler</option>
@@ -2512,7 +2524,7 @@
             <input type="number" disabled="true" name="attr_weapon_block" 
             value="@{weapon_quality}+@{weapon_shieldval}+@{block_final}"/>
             <button type="roll" class="d100-roll-button"
-            value="/em blocks with @{weapon_name}! [[1d100+?{modifiers?|0}+?{Fatigue?|0}*15+@{weapon_block}]]"></button>
+            value="/em blocks with @{weapon_name}! [[1d100+?{Fatigue?|0}*15+?{Modifiers?|0}+@{weapon_block}]]"></button>
         </div>
         <div class="dark_row">
             <div class="cell" style="margin-left: 10px;">Primary</div>
@@ -2561,7 +2573,7 @@
         <div class="style_row">
             <input type="number" name="attr_weapon_basefort" value="0" min="0"/>
             <input type="number" disabled="true" name="attr_weapon_finalfort"
-            value="2*@{weapon_quality}+10*@{weapon_basefort}+@{aura_extension}"/>
+            value="2*@{weapon_quality}+@{weapon_basefort}+@{aura_extension}"/>
             <input type="number" name="attr_weapon_basebreakage" value="0"/>
             <div class="cell" style="font-size:12pt;font-weight:bold;">+</div>
             <select name="attr_weapon_strbreakage" style="width:75px;">
@@ -2609,11 +2621,11 @@
             <input type="number" disabled="true" name="attr_rangedweapon_attack"
             value="@{rangedweapon_quality}+@{attack_final}"/>
             <button type="roll" class="d100-roll-button" 
-            value="/em attacks with @{rangedweapon_name}! [[1d100+?{modifiers?|0}+?{Fatigue?|0}*15+@{rangedweapon_attack}]]"></button>
+            value="/em attacks with @{rangedweapon_name}! [[1d100+?{Fatigue?|0}*15+?{Modifiers?|0}+@{rangedweapon_attack}]]"></button>
             <input type="number" disabled="true" name="attr_rangedweapon_block"
             value="@{rangedweapon_quality}+@{block_final}"/>
             <button type="roll" class="d100-roll-button"
-            value="/em blocks with @{rangedweapon_name}! [[1d100+?{modifiers?|0}+?{Fatigue?|0}*15+@{rangedweapon_block}]]"></button>
+            value="/em blocks with @{rangedweapon_name}! [[1d100+?{Fatigue?|0}*15+?{Modifiers?|0}+@{rangedweapon_block}]]"></button>
             
         </div>
         <div class="dark_row">
@@ -2674,7 +2686,7 @@
         <div class="style_row">
             <input type="number" name="attr_rangedweapon_basefort" value="0" min="0"/>
             <input type="number" disabled="true" name="attr_rangedweapon_finalfort"
-            value="@{weapon_quality}+10*@{rangedweapon_basefort}"/>
+            value="2*@{rangedweapon_quality}+@{rangedweapon_basefort}+@{aura_extension}"/>
             <input type="number" name="attr_rangedweapon_basebreakage" value="0"/>
             <div class="cell" style="font-size:12pt;font-weight:bold;">+</div>
             <select name="attr_rangedweapon_strbreakage" style="width:75px;">


### PR DESCRIPTION
-Corrected Martial Arts damage calculation for characters with ki abilities
-Added Ki abilities for elemental attacks based on Light and Darkness
-Added modifiers prompt for basic attack/block/dodge rolls to better work with martial arts
-Added modifier prompt for projection rolls for consistency w/ attack/block/dodge
-Corrected weapons to prompt for fatigue before other modifiers to reduce possible user confusion.
-Corrected ranged weapon fortitude being based on melee weapon quality (and the wrong multiplier besides).