### PR TITLE
Update palladium_megaverse.html

### DIFF
--- a/Palladium Megaverse/palladium_megaverse.html
+++ b/Palladium Megaverse/palladium_megaverse.html
@@ -1,4 +1,4 @@
-Palladium Megaverse® Character Sheet <br>
+Palladium MegaverseÂ© Character Sheet <br>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" title="Basic" checked="checked" />
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Equipment" />
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Magic & Psionics" />
@@ -30,16 +30,25 @@ Palladium Megaverse® Character Sheet <br>
                                 <td><div class="sheet-stats-nickname"><input class="sheet-input-center-aligned" type="text" value="" name="attr_occ" /></div></td>
                             </tr>
                             <tr>
+                                <td><div class="sheet-stats-nickname"><h5>Level</h5></div></td>
+                                <td><div class="sheet-stats-nickname"><input type="text" name="attr_level" /></div></td>
+                            </tr>
+                            <tr>
+                                <td><div class="sheet-stats-nickname"><h5>Experience</h5></div></td>
+                                <td><div class="sheet-stats-nickname"><input type="text" name="attr_experience" /></div></td>
+                            </tr>
+                            <tr>
                                 <td><div class="sheet-stats-nickname"><h5>Alignment</h5></div></td>
                                 <td><select class ="sheet-select" name="attr_alignment_select" value="0" style="width:100%">
                                         <option value="0"> </option>
+                                        <option value="Principled">Principled</option>
                                         <option value="Scrupulous">Scrupulous</option>
-                                        <option value="Unprincipaled">Unprincipaled</option>
+                                        <option value="Unprincipled">Unprincipaled</option>
                                         <option value="Anarchist">Anarchist</option>
+                                        <option value="Taoist">Taoist</option>
                                         <option value="Miscreant">Miscreant</option>
                                         <option value="Abberant">Abberant</option>
                                         <option value="Diabolic">Diabolic</option>
-                                        <option value="Taoist">Taoist</option>
                                     </select></td>
                             </tr>
                             <tr>
@@ -206,11 +215,11 @@ Palladium Megaverse® Character Sheet <br>
                 </tr>
                 <tr>
                     <td><h5>Run</h5></td>
-                    <td><input class="attribute" type="number" value="" name="attr_run_mph" /></td>
-                    <td><input class="attribute" type="number" value="" name="attr_run_ft_melee" /></td>
-                    <td><input class="attribute" type="number" value="" name="attr_run_ft_attack" /></td>
+                    <td><input class="attribute" type="number" value="round(@{spd}*0.68)" disabled="true" name="attr_run_mph" /></td>
+                    <td><input class="attribute" type="number" value="round(@{spd}*15)" disabled="true" name="attr_run_ft_melee" /></td>
+                    <td><input class="attribute" type="number" value="round(@{spd}*15/@{combat_apm})" disabled="true" name="attr_run_ft_attack" /></td>
                     <td><input class="attribute" type="number" value="" name="attr_run_cruising" /></td>
-                    <td><input class="attribute" type="number" value="" name="attr_run_at_max" />minutes</td>
+                    <td><input class="attribute" type="number" value="@{pe}/2" disabled="true" name="attr_run_at_max" />minutes</td>
                 </tr>
             </table>
             <fieldset class="repeating_movement">
@@ -480,6 +489,7 @@ Palladium Megaverse® Character Sheet <br>
 
 <div class="sheet-tab-content sheet-tab4">
     <h1>Skills</h1>
+    <button type="roll" value="/em attempts a ?{Skill name} check.&#x00A;[[d100<?{skill rating}]]&#x00A;Success = 1, Failure = 0" name="skill-roll" ></button> Universal Skill Roll
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <fieldset class="repeating_skill"> 
@@ -518,41 +528,53 @@ Palladium Megaverse® Character Sheet <br>
                                 <option value="expert">Hand to Hand: Expert</option>
                                 <option value="martial">Hand to Hand: Martial Arts</option>
                                 <option value="assassin">Hand to Hand: Assassin</option>
+                                <option value="commando">Hand to Hand: Commando</option>
                                 <option value="zen">Hand to Hand: Zen</option>
                             </select></td>
                     </tr>
                 </table>
-                <table style="width:85%">
-                    <tr>
-                        <td><h5>APM</h5></td>
-                        <td><h5>Damage</h5></td>
-                        <td><h5>Strike</h5></td>
-                        <td><h5>Parry</h5></td>
-                        <td><h5>Dodge</h5></td>
-                        <td><h5>AutoDodge</h5></td>
-                        <td><h5>Roll</h5></td>
-                        <td><h5>Pull Punch</h5></td>
-                        <td><h5>Disarm</h5></td>
-                        <td></td>
-                    </tr>
-                    <tr>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_apm" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_damage" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_strike" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_parry" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_dodge" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input type="checkbox" name="attr_autodoge_checkbox" /><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_autododge" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_roll" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_pull_punch" /></div></td>
-                        <td><div class="sheet-inventory-weapon"><input type="checkbox" name="attr_disarm_checkbox" /><input class="sheet-input-center-aligned" type="number" value="" name="attr_combat_disarm" /></div></td>
-                        <td></td>
-                    </tr>
-                </table>
-                <table>
-                    <tr>
-                        <textarea wrap="soft" class="sheet-textarea" value="" name="attr_combat_details" placeholder="Style Details" /></textarea>
-                    </tr>
-                </table>            
+                <div class="sheet-3colrow">
+                    <div class="sheet-col">
+                        <table>
+                            <tr>
+                                <td><h5>Initiative:</h5></td>
+                                <td><button type="roll" value="Initiative: [[d20+@{combatskill_initiative}+0.1*@{combatskill_initiative}&{tracker}]]" ></button></td>            	
+                            </tr>
+                            <tr>
+                                <td><h5>Strike:</h5></td>
+                                <td><button type="roll" value="Strike: [[d20+@{combatskill_strike}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><h5>Dodge:</h5></td>
+                                <td><button type="roll" value="Dodge: [[d20+@{combatskill_dodge}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><h5>Parry:</h5></td>
+                                <td><button type="roll" value="Parry: [[d20+@{combatskill_parry}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="sheet-col">
+                        <table>
+                            <tr>
+                                <td><h5>Damage:</h5></td>
+                                <td><button type="roll" value="Damage: [[?{Number of dice?|1}d?{Number of sides?|6}+@{combatskill_damage}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><h5>Roll:</h5></td>
+                                <td><button type="roll" value="Roll: [[d20+@{combatskill_roll}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><h5>Pull Punch:</h5></td>
+                                <td><button type="roll" value="Pull Punch: [[d20+@{combatskill_pullpunch}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><input type="checkbox" name="attr_disarm_checkbox" /><b>Disarm:</b></td>
+                                <td><button type="roll" value="Disarm: [[d20+@{combatskill_disarm}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                        </table>
+                    </div>
+                </div>           
             </div>
         </div>
     </div>
@@ -643,13 +665,32 @@ Palladium Megaverse® Character Sheet <br>
             <input type="checkbox" name="attr_combatskill-toggle" class="sheet-arrow" />
             <h4>Combat Skill</h4>
             <div class="body">
-                <input class="sheet-input-center-aligned" type="text" name="attr_combat_skill_name" />
+                <table style="width:85%">
+                    <tr>    
+                        <td><select class ="sheet-select" type="text" name="attr_combatskill_select" value="0" style="margin-bottom:0" >
+                                <option value="0"> </option>
+                                <option value="non_combatant">Non-Combatant</option>
+                                <option value="basic">Hand to Hand: Basic</option>
+                                <option value="expert">Hand to Hand: Expert</option>
+                                <option value="martial">Hand to Hand: Martial Arts</option>
+                                <option value="assassin">Hand to Hand: Assassin</option>
+                                <option value="commando">Hand to Hand: Commando</option>
+                                <option value="zen">Hand to Hand: Zen</option>
+                            </select>
+                            </td>
+                    </tr>
+                </table>
+                <table>
+                     <tr>
+                        <textarea wrap="soft" class="sheet-textarea" value="" placeholder="Style Details" /></textarea>
+                    </tr>
+                </table>
                 <table style="width:75%">
                     <tr>    
                         <td><h5># of Attacks</h5></td>
                         <td><input type="number" name="attr_combatskill_numberattacks" value="" /></td>
                         <td><h5>Initiative</h5></td>
-                        <td><input type="number" name="attr_combatskill_intitiative" value="" /></td>
+                        <td><input type="number" name="attr_combatskill_initiative" value="" /></td>
                     </tr>
                     <tr>
                         <td><h5>Damage</h5></td>
@@ -1076,5 +1117,5 @@ Palladium Megaverse® Character Sheet <br>
 <div style="text-align:center;">         
 Sheet created by <a href="https://app.roll20.net/users/492849/john-w" target="_blank">John W. https://app.roll20.net/users/492849/john-w</a>
 <br>
-Copyright 2013 Palladium Books Inc. Megaverse® is a registered trademark of Palladium. 
+Copyright 2013 Palladium Books Inc. MegaverseÂ© is a registered trademark of Palladium. 
 </div>

--- a/Palladium Megaverse/palladium_megaverse.html
+++ b/Palladium Megaverse/palladium_megaverse.html
@@ -217,7 +217,7 @@ Palladium Megaverse© Character Sheet <br>
                     <td><h5>Run</h5></td>
                     <td><input class="attribute" type="number" value="round(@{spd}*0.68)" disabled="true" name="attr_run_mph" /></td>
                     <td><input class="attribute" type="number" value="round(@{spd}*15)" disabled="true" name="attr_run_ft_melee" /></td>
-                    <td><input class="attribute" type="number" value="round(@{spd}*15/@{combat_apm})" disabled="true" name="attr_run_ft_attack" /></td>
+                    <td><input class="attribute" type="number" value="round(@{spd}*15/@{combatskill_numberattacks})" disabled="true" name="attr_run_ft_attack" /></td>
                     <td><input class="attribute" type="number" value="" name="attr_run_cruising" /></td>
                     <td><input class="attribute" type="number" value="@{pe}/2" disabled="true" name="attr_run_at_max" />minutes</td>
                 </tr>

--- a/Palladium Megaverse/palladium_megaverse.html
+++ b/Palladium Megaverse/palladium_megaverse.html
@@ -532,25 +532,24 @@ Palladium Megaverse© Character Sheet <br>
                                 <option value="zen">Hand to Hand: Zen</option>
                             </select></td>
                     </tr>
+                    <tr>
+                        <td><b>Initiative:</b><button type="roll" value="Initiative: [[d20+@{combatskill_initiative}+0.1*@{combatskill_initiative}&{tracker}]]" ></button></td>                
+                    </tr>
                 </table>
                 <div class="sheet-3colrow">
                     <div class="sheet-col">
                         <table>
                             <tr>
-                                <td><h5>Initiative:</h5></td>
-                                <td><button type="roll" value="Initiative: [[d20+@{combatskill_initiative}+0.1*@{combatskill_initiative}&{tracker}]]" ></button></td>            	
-                            </tr>
-                            <tr>
                                 <td><h5>Strike:</h5></td>
                                 <td><button type="roll" value="Strike: [[d20+@{combatskill_strike}+?{Bonus?|0}]]" ></button></td>                
                             </tr>
                             <tr>
-                                <td><h5>Dodge:</h5></td>
-                                <td><button type="roll" value="Dodge: [[d20+@{combatskill_dodge}+?{Bonus?|0}]]" ></button></td>                
+                                <td><h5>Ranged Strike:</h5></td>
+                                <td><button type="roll" value="Strike: [[d20+@{combatskill_gunstrike}+?{Bonus?|0}]]" ></button></td>                
                             </tr>
                             <tr>
-                                <td><h5>Parry:</h5></td>
-                                <td><button type="roll" value="Parry: [[d20+@{combatskill_parry}+?{Bonus?|0}]]" ></button></td>                
+                                <td><h5>Dodge:</h5></td>
+                                <td><button type="roll" value="Dodge: [[d20+@{combatskill_dodge}+?{Bonus?|0}]]" ></button></td>                
                             </tr>
                         </table>
                     </div>
@@ -561,8 +560,20 @@ Palladium Megaverse© Character Sheet <br>
                                 <td><button type="roll" value="Damage: [[?{Number of dice?|1}d?{Number of sides?|6}+@{combatskill_damage}+?{Bonus?|0}]]" ></button></td>                
                             </tr>
                             <tr>
-                                <td><h5>Roll:</h5></td>
-                                <td><button type="roll" value="Roll: [[d20+@{combatskill_roll}+?{Bonus?|0}]]" ></button></td>                
+                                <td><h5>Ranged Damage:</h5></td>
+                                <td><button type="roll" value="Damage: [[?{Number of dice?|1}d?{Number of sides?|6}+@{combatskill_gundamage}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                            <tr>
+                                <td><h5>Parry:</h5></td>
+                                <td><button type="roll" value="Parry: [[d20+@{combatskill_parry}+?{Bonus?|0}]]" ></button></td>                
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="sheet-col">
+                        <table>
+                            <tr>
+                                <td><h5>Roll</h5></td>
+                                <td><button type="roll" value="Roll: [[d20+@{combatskill_roll}+?{Bonus?|0}]]" ></button></td>
                             </tr>
                             <tr>
                                 <td><h5>Pull Punch:</h5></td>


### PR DESCRIPTION
- Changed "circle dot" to copyright symbol at new lines 1 and 1120
- Added Stat for Level at new lines 33 to 35
- Added Stat for Experience at new lines 36 to 40 
- Changed alignment selections as follows: added Principled, corrected spelling of Unprincipled, moved Taoist above evil alignments; in new lines 44 to 48
- Added calculations to Run Speed values at new lines 218 to 222
- Added universal skill roller at new line 492
- Added Commando to options for combat skill at new line 531
- Complete rework of Quick Combat Reference section to add rollers vice duplicated bonuses, rollers reference attributes entered in the Combat Skills portion; at new lines 536 to 577
- Added Combat Training selection pull down to Combat Skills section at new lines 668 to 682
- Moved Style Details text area to Combat Skills section at new lines 683 to 687
- Corrected spelling of initiative attribute at new line 693