### PR TITLE
Update palladium_megaverse.html

### DIFF
--- a/Palladium Megaverse/palladium_megaverse.html
+++ b/Palladium Megaverse/palladium_megaverse.html
@@ -702,12 +702,16 @@ Palladium Megaverse© Character Sheet <br>
                         <td><input type="number" name="attr_combatskill_numberattacks" value="" /></td>
                         <td><h5>Initiative</h5></td>
                         <td><input type="number" name="attr_combatskill_initiative" value="" /></td>
-                    </tr>
-                    <tr>
                         <td><h5>Damage</h5></td>
                         <td><input type="number" name="attr_combatskill_damage" value="" /></td>
+                    </tr>
+                    <tr>
                         <td><h5>Strike</h5></td>
                         <td><input type="number" name="attr_combatskill_strike" value="" /></td>
+                        <td><h5>Gun Strike</h5></td>
+                        <td><input type="number" name="attr_combatskill_gunstrike" value="" /></td>
+                        <td><h5>Gun Damage</h5></td>
+                        <td><input type="number" name="attr_combatskill_gundamage" value="" /></td>
                     </tr>
                     <tr>
                         <td><h5>Parry</h5></td>


### PR DESCRIPTION
added missing attributes in the combat skill portion. these are used for dice rolls in the quick combat reference section.