### PR TITLE
Added Creature/Spell regen attributes

### DIFF
--- a/Anima-Beyond-Fantasy/A-BF.html
+++ b/Anima-Beyond-Fantasy/A-BF.html
@@ -1288,9 +1288,11 @@
             </fieldset>
             <div class="dark_row" style="padding-top: 4px;">
                 <div class="cell actual_cell" style="margin-left:5px; width:auto;">Total Cost</div>
-                <input type="number" class="cell" value="0" min="0" style="margin-left:5px;"/>
+                <input type="number" name="attr_daily_spell_creature_totalcost"
+                class="cell" value="0" min="0" style="margin-left:5px;"/>
                 <div class="cell actual_cell"style="margin-left:6px; width:auto;">Final Daily Regen</div>
-                <input class="cell" type="number" value="0"/>
+                <input class="cell" type="number" value="0"
+                name="attr_daily_spell_creature_regen"/>
             </div>
         </div><!-- end active spells and creatures -->
    </div><!-- end first column -->


### PR DESCRIPTION
Added attributes for tracking daily Zeon Regeneration when active creatures/ spells are used. Declaring these attributes somehow missed the initial quality check.