### PR TITLE
Added even more functionality - Microlite20

### DIFF
--- a/Microlite20/microlite20-test.html
+++ b/Microlite20/microlite20-test.html
@@ -26,8 +26,8 @@
                     </label>
                     <div class="col-sm-4">
                         <select class="form-control" name="attr_gender">
-                            <option value="1">Female</option>
-                            <option value="2">Male</option>
+                            <option value="1">Male</option>
+							<option value="2">Female</option>
                         </select>
                     </div>
                 </div>
@@ -36,22 +36,26 @@
                     <label class="col-sm-2 control-label">Race
                     </label>
                     <div class="col-sm-4">
-                        <select class="form-control" name="attr_race">
-                            <option value="1">Human</option>
-                            <option value="2">Elf</option>
-                            <option value="3">Dwarf</option>
-                            <option value="4">Halfling</option>
-                        </select>
+                        <!-- the numbers are assigned as such for a calculation later
+						this calculation will determine the racial skill bonus to all skills
+						if the race selected is human -->
+						<select class="form-control" name="attr_race">
+                            <option value="4">Human</option>
+                            <option value="3">Elf</option>
+                            <option value="2">Dwarf</option>
+                            <option value="1">Halfling</option>
                         </select>
                     </div>
                     <label class="col-sm-2 control-label">
                         Class</label>
                     <div class="col-sm-4">
+					<!-- These numbers are in reverse.  The reason is to accommodate a calculation
+						 for the Fighter damage roll and attack roll bonus.-->
                         <select class="form-control" name="attr_class">
-                            <option value="1">Fighter</option>
-                            <option value="2">Rogue</option>
-                            <option value="3">Mage</option>
-                            <option value="4">Cleric</option>
+                            <option value="4">Fighter</option>
+                            <option value="3">Rogue</option>
+                            <option value="2">Mage</option>
+                            <option value="1">Cleric</option>
                         </select>
                     </div>
                 </div>
@@ -113,11 +117,26 @@
             <div class="row">
                 <h3>Character Statistics</h3>
                 <div class="col-sm-6 col-sm-offset-3">
+				<!-- The calculation for the rolls does bear explaining.  the first part (d20+bonus) is 
+					standard towards the rules, but the part after it is what incorporates the racial
+					bonus.  If you chose a human, you get a +1 to all of your skill rolls.
+					So, if it's always a +1, then we can determine it through an equation.
+					The floor function will round a decimal down to its whole number.  So 1/4, 2/4, and 
+					3/4 will all round down to 0.  Thus, the only race assigned the number 4 is human, 
+					and it'll be the only race that evaluates to "1" in this equation.  With that in
+					mind, simply add the result of the equation to the end of the roll.  If you're
+					not a human, then 0 will get added.  If you ARE human, then 1 will get added.
+					-->
                     <table class="table">
                         <thead>
                             <th>Stat</th>
                             <th>Score</th>
                             <th>Bonus</th>
+							<th>Stat+Physical Roll</th>
+							<th>Stat+Subterfuge Roll</th>
+							<th>Stat+Knowledge Roll</th>
+							<th>Stat+Communication Roll</th>
+							
                         </thead>
                         <tbody>
                             <tr>
@@ -131,6 +150,26 @@
                                      disabled="true"
                                      value="floor((@{strength} - 10) / 2)">
                                 </td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Physical Check - d20+physical rank+strength bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Subterfuge Check - d20+subterfuge rank+strength bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[knowledge rank]@{knowledge}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Knowledge Check - d20+knowledge rank+strength bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[communication rank]@{communication}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Communication Check - d20+communication rank+strength bonus+racial bonus">
+									</button>
+								</td>
                             </tr>
                             <tr>
                                 <td><label class="control-label">Dexterity
@@ -144,6 +183,26 @@
                                      disabled="true"
                                      value="floor((@{dexterity} - 10) / 2)">
                                 </td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Physical Check - d20+physical rank+dexterity bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Subterfuge Check - d20+subterfuge rank+dexterity bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[knowledge rank]@{knowledge}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Knowledge Check - d20+knowledge rank+dexterity bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[communication rank]@{communication}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Communication Check - d20+communication rank+dexterity bonus+racial bonus">
+									</button>
+								</td>
                             </tr>
                             <tr>
                                 <td><label class="control-label">Mind</label>
@@ -153,7 +212,28 @@
                                 <td><input class="form-control" type="number"
                                      name="attr_mind_bonus"
                                      disabled="true"
-                                     value="floor((@{mind} - 10) / 2)"></td>
+                                     value="floor((@{mind} - 10) / 2)">
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Physical Check - d20+physical rank+mind bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Subterfuge Check - d20+subterfuge rank+mind bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[knowledge rank]@{knowledge}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Knowledge Check - d20+knowledge rank+mind bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[communication rank]@{communication}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Communication Check - d20+communication rank+mind bonus+racial bonus">
+									</button>
+								</td>
                             </tr>
                         </tbody>
                     </table>
@@ -176,29 +256,19 @@
                     <div class="form-group">
                         <label class="col-sm-6 col-sm-offset-1 control-label text-center">
                             Armor Class<br>
-                            <small>(1 + DEX Bonus + Armor Bonus)</small>
+                            <small>(10 + DEX Bonus + Armor Bonus)</small>
                         </label>
                         <div class="col-sm-2">
                             <input type="number" class="form-control"
                             name="attr_armor_class" disabled="true"
-                            value="1 + @{dexterity_bonus} + @{armor_bonus}">
+                            value="10 + @{dexterity_bonus} + @{armor_bonus}">
                         </div>
                     </div>
                 </form>
             </div>
-
-            <div class="row">
-                <h3 class="text-center">Armor Bonus</h3>
-                <div class="col-sm-4 col-sm-offset-4">
-                    <input type="number" class="form-control"
-                    name="attr_armor_bonus" placeholder="0">
-                </div>
-            </div>
-
-            <div class="row">
-                <h3>Skills <small>Rank = level + class / race bonus</small>
-                </h3>
-                <div class="col-sm-6 col-sm-offset-3">
+			<div class="row">
+                <h3>Skills</h3>
+				<div class="col-sm-6 col-sm-offset-3">
                     <table class="table">
                         <thead>
                             <th>Skill</th>
@@ -207,7 +277,8 @@
                         <tbody>
                         <tr><td>Physical</td>
                             <td><input type="number" class="form-control"
-                                 name="attr_physical" placeholder="0"></td>
+                                 name="attr_physical" placeholder="0">
+							</td>
                         </tr>
                         <tr><td>Subterfuge</td>
                             <td><input type="number" class="form-control"
@@ -228,16 +299,44 @@
         </div>
 
         <div class="col-sm-6">
+			<h3>Attack Bonuses and Rolls</h3>
             <form class="form-horizontal" role="form">
-                <div class="form-group">
+                <!-- The calculation has to take into account whether or not you chose the fighter 
+					class.  Since roll20 doesn't support conditional statements (yet?), this is the way 
+					around it.  This explanation is rather wordy, so either trust it, or read on.
+					The actual bonus fighters get is +1 to attack rolls, and an additional +1 on every
+					level ending in 5 or 0 (so at level 5, they get an additional +1, and again at
+					level 10, and again every 5 levels onward).
+					The floor function will basically round down any division result that isn't a 
+					whole number to a whole number.  1/5, 2/5, 3/5, 4/5 all equal 0 when floored.  
+					So, floor your level divided by 5, and add 1 to it (because at level 1, you get
+					your first +1 to attack rolls).  1+floor(level/5) will equal 1 at level 1-4, then 2 at level 5-9, then 3 at levels 10-15, and so on.  That resulting number is exactly
+					the same number of +1's to attack rolls you'd get at those levels.
+					
+					But, we have to determine whether or not you chose the fighter class.  The fighter
+					class attribute's value is 4, while the others are less than 4.
+					This means I can floor(class/4) and all but the fighter will return with 0.
+					Simply multiply the entire equation by that resulting number to determine whether
+					or not you actually GET the bonus at all.  If it's a 1 (fighter), then you're 
+					multiplying the equation by 1 (and thus not changing it at all).  But, if it's 0, 
+					it nullifies the whole equation to 0.
+					
+					I'm sure my wording of this is kinda confusing, and I do apologize, but that's the
+					explanation of how it works, and why it works.
+					
+					This bonus is only applied to melee and missile attack rolls, since fighters can't use magic, and the rule says "+1 to all attack rolls".  This means it's a +1 only to the rolls that a fighter could possibly make - melee and ranged. -->
+				<div class="form-group">
                     <label class="col-sm-6 control-label">
-                        Melee Attack Bonus <small>(STR + level)</small>
+                        Melee Attack Bonus <small>(STR + level + Class Bonus)</small>
                     </label>
                     <div class="col-sm-2">
                         <input type="number" class="form-control" 
                         placeholder="0"
                         name="attr_melee_attack_bonus" disabled="true"
                         value="@{strength_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Melee Attack Check - d20+melee attack bonus+class bonus">
+						</button>
                     </div>
                 </div>
 
@@ -250,6 +349,9 @@
                         placeholder="0"
                         name="attr_missile_attack_bonus" disabled="true"
                         value="@{dexterity_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus+class bonus">
+						</button>
                     </div>
                 </div>
 
@@ -262,9 +364,33 @@
                         placeholder="0"
                         name="attr_magic_attack_bonus" disabled="true"
                         value="@{mind_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[magic attack bonus]@{magic_attack_bonus} \ Magic Attack Check">
+						</button>
+                </div>
                     </div>
                 </div>
             </form>
+			<div class="row">
+				<h3>Armor</h3>
+				<div class="col-sm-4 text-center">
+					<strong>Name</strong>
+				</div>
+				<div class="col-sm-2 text-center">
+					<strong>Armor Bonus</strong>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-4">
+					<input type="text" name="attr_armor_name"
+					class="form-control" placeholder="Armor Name"></input>
+				</div>
+				<div class="col-sm-2">
+					<input type="number" name="attr_armor_bonus"
+					class="form-control"
+					placeholder="0"></input>
+				</div>
+			</div>
 
             <div class="row">
                 <h3>Weapons</h3>
@@ -307,59 +433,21 @@
                          name="attr_weapon_range"
                          placeholder="0"></input>
                     </div>
-                    <div class="col-sm-2">
+					<div class="col-sm-2">
                         <button class="form-control" type="roll"
-                        value="/roll @{dnum}d@{dtype}">
+                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Damage Roll - damage dice + class bonus">
                         </button>
                     </div>
                 </fieldset>
             </div>
-
-            <div class="row">
-                <h3>Spells</h3>
-                <div class="col-sm-2 text-center">
-                    <strong>Name</strong>
+			<div class="row">
+				<h3>Caster Difficulty Class (DC)</h3>
+				<div class="col-sm-2 text-center">
+                    <input class="form-control" type="roll"
+						value="10+@{level}+@{mind_bonus}" />
                 </div>
-                <div class="col-sm-2 text-center">
-                    <strong>Level</strong>
-                </div>
-                <div class="col-sm-1 text-center">
-                    <strong>Signature</strong>
-                </div>
-                <div class="col-sm-4 text-center">
-                    <strong>Description</strong>
-                </div>
-            </div>
-
-            <div class="row">
-                <fieldset class="repeating_spells">
-                    <div class="col-sm-2">
-                        <input type="text" name="attr_spell_name"
-                        class="form-control" placeholder="Spell Name"></input>
-                    </div>
-                    <div class="col-sm-2">
-                        <input type="number" name="attr_spell_level"
-                        class="form-control" placeholder="0"></input>
-                    </div>
-                    <div class="col-sm-1" class="text-center">
-                        <input type="checkbox" name="attr_spell_signature"
-                        class="form-control"
-                        style="width:15px; height:15px;"
-                        value="1"></input>
-                    </div>
-                    <div class="col-sm-4">
-                        <input type="text" name="attr_spell_desc"
-                        class="form-control" placeholder="Spell Description">
-                        </input>
-                    </div>
-                    <div class="col-sm-2">
-                        <button class="form-control" type="roll"
-                            value="/me casts @{spell_name} at DC [[10 + @{level} + @{mind_modifier}]] costing [[1 + 2 * @{spell_level} - @{spell_signature}]] HP">
-                        </button>
-                    </div>
-                </fieldset>
-            </div>
-
+				
+			</div>
             <div class="row">
                 <h3>Equipment</h3>
                 <fieldset class="repeating_equipment">
@@ -416,5 +504,6 @@
         </div>
     </div>
 </div>
+
 </body>
 </html>

--- a/Microlite20/microlite20-test.html
+++ b/Microlite20/microlite20-test.html
@@ -473,7 +473,7 @@
 				<h3>Caster Difficulty Class (DC)</h3>
 				<div class="col-sm-2 text-center">
                     <input class="form-control" type="roll"
-						value="10+@{level}+@{mind_bonus}" />
+						value="10+@{level}+@{mind_bonus}" disabled="true"/>
                 </div>
 				
 			</div>

--- a/Microlite20/microlite20-test.html
+++ b/Microlite20/microlite20-test.html
@@ -114,6 +114,7 @@
                 </div>
             </form>
 
+			
             <div class="row">
                 <h3>Character Statistics</h3>
                 <div class="col-sm-6 col-sm-offset-3">
@@ -136,6 +137,7 @@
 							<th>Stat+Subterfuge Roll</th>
 							<th>Stat+Knowledge Roll</th>
 							<th>Stat+Communication Roll</th>
+							<th>Saving Throw</th>
 							
                         </thead>
                         <tbody>
@@ -168,6 +170,11 @@
 								<td>
 									<button class="form-control" type="roll"
 										value="/roll d20+[communication rank]@{communication}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Communication Check - d20+communication rank+strength bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Fortitude Save - d20+physical rank+strength bonus+racial bonus">Fortitude Save
 									</button>
 								</td>
                             </tr>
@@ -203,6 +210,12 @@
 										value="/roll d20+[communication rank]@{communication}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Communication Check - d20+communication rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Reflex Save - d20+physical rank+dexterity bonus+racial bonus">
+										Reflex Save
+									</button>
+								</td>
                             </tr>
                             <tr>
                                 <td><label class="control-label">Mind</label>
@@ -234,6 +247,11 @@
 										value="/roll d20+[communication rank]@{communication}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Communication Check - d20+communication rank+mind bonus+racial bonus">
 									</button>
 								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[mind bonus]@{mind_bonus}+[level]@{level}+[racial bonus]floor(@{race}/4) \ Will Save - d20+mind bonus+level+racial bonus">Will Save
+									</button>
+								</td>
                             </tr>
                         </tbody>
                     </table>
@@ -255,7 +273,7 @@
 
                     <div class="form-group">
                         <label class="col-sm-6 col-sm-offset-1 control-label text-center">
-                            Armor Class<br>
+                            Armor Class (AC)<br>
                             <small>(10 + DEX Bonus + Armor Bonus)</small>
                         </label>
                         <div class="col-sm-2">
@@ -266,6 +284,7 @@
                     </div>
                 </form>
             </div>
+			
 			<div class="row">
                 <h3>Skills</h3>
 				<div class="col-sm-6 col-sm-offset-3">
@@ -335,14 +354,14 @@
                         name="attr_melee_attack_bonus" disabled="true"
                         value="@{strength_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Melee Attack Check - d20+melee attack bonus+class bonus">
+							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[level modifier](@{level}-1) \ Melee Attack Check - d20+melee attack bonus+class bonus+level modifier">
 						</button>
                     </div>
                 </div>
 
                 <div class="form-group">
                     <label class="col-sm-6 control-label">
-                        Missile Attack Bonus <small>(DEX + level)</small>
+                        Missile/Ranged Attack Bonus/Light Weapon Melee Bonus<small>(DEX + level) </small>
                     </label>
                     <div class="col-sm-2">
                         <input type="number" class="form-control" 
@@ -350,7 +369,7 @@
                         name="attr_missile_attack_bonus" disabled="true"
                         value="@{dexterity_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus+class bonus">
+							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[level modifier](@{level}-1) \ Ranged/Missile/Light Weapon Attack Check - d20+missile/ranged attack bonus+class bonus+level modifier">
 						</button>
                     </div>
                 </div>
@@ -365,7 +384,7 @@
                         name="attr_magic_attack_bonus" disabled="true"
                         value="@{mind_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[magic attack bonus]@{magic_attack_bonus} \ Magic Attack Check">
+							value="/roll d20+[magic attack bonus]@{magic_attack_bonus}+[level modifier](@{level}-1) \ Magic Attack Check - d20+magic attack bonus+level modifier">
 						</button>
                 </div>
                     </div>
@@ -398,13 +417,16 @@
                     <strong>Name</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Dice</strong>
+                    <strong>Dice Number</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Type</strong>
+                    <strong>Dice Type</strong>
+                </div>
+				<div class="col-sm-2 text-center">
+                    <strong>Range Type</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Range (m)</strong>
+                    <strong>Range Distance(feet)</strong>
                 </div>
             </div>
 
@@ -428,6 +450,13 @@
                              <option value="12">d12</option>
                         </select>
                     </div>
+					<div class="col-sm-2">
+                        <select name="attr_range_type" class="form-control">
+                             <option value="2">Melee 2-handed</option>
+                             <option value="1">Melee 1-handed</option>
+                             <option value="0">Ranged</option>
+                        </select>
+                    </div>
                     <div class="col-sm-2">
                         <input type="number" class="form-control"
                          name="attr_weapon_range"
@@ -435,7 +464,7 @@
                     </div>
 					<div class="col-sm-2">
                         <button class="form-control" type="roll"
-                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Damage Roll - damage dice + class bonus">
+                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[range bonus](@{range_type}*@{strength_bonus}) \ Damage Roll - damage dice + class bonus + melee bonus">
                         </button>
                     </div>
                 </fieldset>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -462,7 +462,7 @@
 				<h3>Caster Difficulty Class (DC)</h3>
 				<div class="col-sm-2 text-center">
                     <input class="form-control" type="roll"
-						value="10+@{level}+@{mind_bonus}" />
+						value="10+@{level}+@{mind_bonus}" disabled="true"/>
                 </div>
 				
 			</div>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -244,7 +244,7 @@
 
                     <div class="form-group">
                         <label class="col-sm-6 col-sm-offset-1 control-label text-center">
-                            Armor Class<br>
+                            Armor Class (AC)<br>
                             <small>(10 + DEX Bonus + Armor Bonus)</small>
                         </label>
                         <div class="col-sm-2">

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -15,8 +15,8 @@
                     </label>
                     <div class="col-sm-4">
                         <select class="form-control" name="attr_gender">
-                            <option value="1">Female</option>
-                            <option value="2">Male</option>
+                            <option value="1">Male</option>
+							<option value="2">Female</option>
                         </select>
                     </div>
                 </div>
@@ -25,22 +25,26 @@
                     <label class="col-sm-2 control-label">Race
                     </label>
                     <div class="col-sm-4">
-                        <select class="form-control" name="attr_race">
-                            <option value="1">Human</option>
-                            <option value="2">Elf</option>
-                            <option value="3">Dwarf</option>
-                            <option value="4">Halfling</option>
-                        </select>
+                        <!-- the numbers are assigned as such for a calculation later
+						this calculation will determine the racial skill bonus to all skills
+						if the race selected is human -->
+						<select class="form-control" name="attr_race">
+                            <option value="4">Human</option>
+                            <option value="3">Elf</option>
+                            <option value="2">Dwarf</option>
+                            <option value="1">Halfling</option>
                         </select>
                     </div>
                     <label class="col-sm-2 control-label">
                         Class</label>
                     <div class="col-sm-4">
+					<!-- These numbers are in reverse.  The reason is to accommodate a calculation
+						 for the Fighter damage roll and attack roll bonus.-->
                         <select class="form-control" name="attr_class">
-                            <option value="1">Fighter</option>
-                            <option value="2">Rogue</option>
-                            <option value="3">Mage</option>
-                            <option value="4">Cleric</option>
+                            <option value="4">Fighter</option>
+                            <option value="3">Rogue</option>
+                            <option value="2">Mage</option>
+                            <option value="1">Cleric</option>
                         </select>
                     </div>
                 </div>
@@ -102,6 +106,16 @@
             <div class="row">
                 <h3>Character Statistics</h3>
                 <div class="col-sm-6 col-sm-offset-3">
+				<!-- The calculation for the rolls does bear explaining.  the first part (d20+bonus) is 
+					standard towards the rules, but the part after it is what incorporates the racial
+					bonus.  If you chose a human, you get a +1 to all of your skill rolls.
+					So, if it's always a +1, then we can determine it through an equation.
+					The floor function will round a decimal down to its whole number.  So 1/4, 2/4, and 
+					3/4 will all round down to 0.  Thus, the only race assigned the number 4 is human, 
+					and it'll be the only race that evaluates to "1" in this equation.  With that in
+					mind, simply add the result of the equation to the end of the roll.  If you're
+					not a human, then 0 will get added.  If you ARE human, then 1 will get added.
+					-->
                     <table class="table">
                         <thead>
                             <th>Stat</th>
@@ -127,22 +141,22 @@
                                 </td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{physical}+@{strength_bonus}">
+										value="/roll d20+[physical rank]@{physical}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Physical Check - d20+physical rank+strength bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{subterfuge}+@{strength_bonus}">
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Subterfuge Check - d20+subterfuge rank+strength bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{knowledge}+@{strength_bonus}">
+										value="/roll d20+[knowledge rank]@{knowledge}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Knowledge Check - d20+knowledge rank+strength bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{communication}+@{strength_bonus}">
+										value="/roll d20+[communication rank]@{communication}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Communication Check - d20+communication rank+strength bonus+racial bonus">
 									</button>
 								</td>
                             </tr>
@@ -160,22 +174,22 @@
                                 </td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{physical}+@{dexterity_bonus}">
+										value="/roll d20+[physical rank]@{physical}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Physical Check - d20+physical rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{subterfuge}+@{dexterity_bonus}">
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Subterfuge Check - d20+subterfuge rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{knowledge}+@{dexterity_bonus}">
+										value="/roll d20+[knowledge rank]@{knowledge}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Knowledge Check - d20+knowledge rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{communication}+@{dexterity_bonus}">
+										value="/roll d20+[communication rank]@{communication}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Communication Check - d20+communication rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
                             </tr>
@@ -191,22 +205,22 @@
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{physical}+@{mind_bonus}">
+										value="/roll d20+[physical rank]@{physical}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Physical Check - d20+physical rank+mind bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{subterfuge}+@{mind_bonus}">
+										value="/roll d20+[subterfuge rank]@{subterfuge}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Subterfuge Check - d20+subterfuge rank+mind bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{knowledge}+@{mind_bonus}">
+										value="/roll d20+[knowledge rank]@{knowledge}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Knowledge Check - d20+knowledge rank+mind bonus+racial bonus">
 									</button>
 								</td>
 								<td>
 									<button class="form-control" type="roll"
-										value="/roll d20+@{communication}+@{mind_bonus}">
+										value="/roll d20+[communication rank]@{communication}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Communication Check - d20+communication rank+mind bonus+racial bonus">
 									</button>
 								</td>
                             </tr>
@@ -241,19 +255,9 @@
                     </div>
                 </form>
             </div>
-
-            <div class="row">
-                <h3 class="text-center">Armor Bonus</h3>
-                <div class="col-sm-4 col-sm-offset-4">
-                    <input type="number" class="form-control"
-                    name="attr_armor_bonus" placeholder="0">
-                </div>
-            </div>
-
-            <div class="row">
-                <h3>Skills <small>Rank = level + class / race bonus</small>
-                </h3>
-                <div class="col-sm-6 col-sm-offset-3">
+			<div class="row">
+                <h3>Skills</h3>
+				<div class="col-sm-6 col-sm-offset-3">
                     <table class="table">
                         <thead>
                             <th>Skill</th>
@@ -284,16 +288,44 @@
         </div>
 
         <div class="col-sm-6">
+			<h3>Attack Bonuses and Rolls</h3>
             <form class="form-horizontal" role="form">
-                <div class="form-group">
+                <!-- The calculation has to take into account whether or not you chose the fighter 
+					class.  Since roll20 doesn't support conditional statements (yet?), this is the way 
+					around it.  This explanation is rather wordy, so either trust it, or read on.
+					The actual bonus fighters get is +1 to attack rolls, and an additional +1 on every
+					level ending in 5 or 0 (so at level 5, they get an additional +1, and again at
+					level 10, and again every 5 levels onward).
+					The floor function will basically round down any division result that isn't a 
+					whole number to a whole number.  1/5, 2/5, 3/5, 4/5 all equal 0 when floored.  
+					So, floor your level divided by 5, and add 1 to it (because at level 1, you get
+					your first +1 to attack rolls).  1+floor(level/5) will equal 1 at level 1-4, then 2 at level 5-9, then 3 at levels 10-15, and so on.  That resulting number is exactly
+					the same number of +1's to attack rolls you'd get at those levels.
+					
+					But, we have to determine whether or not you chose the fighter class.  The fighter
+					class attribute's value is 4, while the others are less than 4.
+					This means I can floor(class/4) and all but the fighter will return with 0.
+					Simply multiply the entire equation by that resulting number to determine whether
+					or not you actually GET the bonus at all.  If it's a 1 (fighter), then you're 
+					multiplying the equation by 1 (and thus not changing it at all).  But, if it's 0, 
+					it nullifies the whole equation to 0.
+					
+					I'm sure my wording of this is kinda confusing, and I do apologize, but that's the
+					explanation of how it works, and why it works.
+					
+					This bonus is only applied to melee and missile attack rolls, since fighters can't use magic, and the rule says "+1 to all attack rolls".  This means it's a +1 only to the rolls that a fighter could possibly make - melee and ranged. -->
+				<div class="form-group">
                     <label class="col-sm-6 control-label">
-                        Melee Attack Bonus <small>(STR + level)</small>
+                        Melee Attack Bonus <small>(STR + level + Class Bonus)</small>
                     </label>
                     <div class="col-sm-2">
                         <input type="number" class="form-control" 
                         placeholder="0"
                         name="attr_melee_attack_bonus" disabled="true"
                         value="@{strength_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Melee Attack Check - d20+melee attack bonus+class bonus">
+						</button>
                     </div>
                 </div>
 
@@ -306,6 +338,9 @@
                         placeholder="0"
                         name="attr_missile_attack_bonus" disabled="true"
                         value="@{dexterity_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus+class bonus">
+						</button>
                     </div>
                 </div>
 
@@ -318,9 +353,33 @@
                         placeholder="0"
                         name="attr_magic_attack_bonus" disabled="true"
                         value="@{mind_bonus} + @{level}">
+						<button class="form-control" type="roll"
+							value="/roll d20+[magic attack bonus]@{magic_attack_bonus} \ Magic Attack Check">
+						</button>
+                </div>
                     </div>
                 </div>
             </form>
+			<div class="row">
+				<h3>Armor</h3>
+				<div class="col-sm-4 text-center">
+					<strong>Name</strong>
+				</div>
+				<div class="col-sm-2 text-center">
+					<strong>Armor Bonus</strong>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-4">
+					<input type="text" name="attr_armor_name"
+					class="form-control" placeholder="Armor Name"></input>
+				</div>
+				<div class="col-sm-2">
+					<input type="number" name="attr_armor_bonus"
+					class="form-control"
+					placeholder="0"></input>
+				</div>
+			</div>
 
             <div class="row">
                 <h3>Weapons</h3>
@@ -363,59 +422,21 @@
                          name="attr_weapon_range"
                          placeholder="0"></input>
                     </div>
-                    <div class="col-sm-2">
+					<div class="col-sm-2">
                         <button class="form-control" type="roll"
-                        value="/roll @{dnum}d@{dtype}">
+                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Damage Roll - damage dice + class bonus">
                         </button>
                     </div>
                 </fieldset>
             </div>
-
-            <div class="row">
-                <h3>Spells</h3>
-                <div class="col-sm-2 text-center">
-                    <strong>Name</strong>
+			<div class="row">
+				<h3>Caster Difficulty Class (DC)</h3>
+				<div class="col-sm-2 text-center">
+                    <input class="form-control" type="roll"
+						value="10+@{level}+@{mind_bonus}" />
                 </div>
-                <div class="col-sm-2 text-center">
-                    <strong>Level</strong>
-                </div>
-                <div class="col-sm-1 text-center">
-                    <strong>Signature</strong>
-                </div>
-                <div class="col-sm-4 text-center">
-                    <strong>Description</strong>
-                </div>
-            </div>
-
-            <div class="row">
-                <fieldset class="repeating_spells">
-                    <div class="col-sm-2">
-                        <input type="text" name="attr_spell_name"
-                        class="form-control" placeholder="Spell Name"></input>
-                    </div>
-                    <div class="col-sm-2">
-                        <input type="number" name="attr_spell_level"
-                        class="form-control" placeholder="0"></input>
-                    </div>
-                    <div class="col-sm-1" class="text-center">
-                        <input type="checkbox" name="attr_spell_signature"
-                        class="form-control"
-                        style="width:15px; height:15px;"
-                        value="1"></input>
-                    </div>
-                    <div class="col-sm-4">
-                        <input type="text" name="attr_spell_desc"
-                        class="form-control" placeholder="Spell Description">
-                        </input>
-                    </div>
-                    <div class="col-sm-2">
-                        <button class="form-control" type="roll"
-                            value="/me casts @{spell_name} at DC [[10 + @{level} + @{mind_modifier}]] costing [[1 + 2 * @{spell_level} - @{spell_signature}]] HP">
-                        </button>
-                    </div>
-                </fieldset>
-            </div>
-
+				
+			</div>
             <div class="row">
                 <h3>Equipment</h3>
                 <fieldset class="repeating_equipment">

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -103,6 +103,7 @@
                 </div>
             </form>
 
+			
             <div class="row">
                 <h3>Character Statistics</h3>
                 <div class="col-sm-6 col-sm-offset-3">
@@ -125,6 +126,7 @@
 							<th>Stat+Subterfuge Roll</th>
 							<th>Stat+Knowledge Roll</th>
 							<th>Stat+Communication Roll</th>
+							<th>Saving Throw</th>
 							
                         </thead>
                         <tbody>
@@ -157,6 +159,11 @@
 								<td>
 									<button class="form-control" type="roll"
 										value="/roll d20+[communication rank]@{communication}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Strength + Communication Check - d20+communication rank+strength bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[strength bonus]@{strength_bonus}+[racial bonus]floor(@{race}/4) \ Fortitude Save - d20+physical rank+strength bonus+racial bonus">Fortitude Save
 									</button>
 								</td>
                             </tr>
@@ -192,6 +199,12 @@
 										value="/roll d20+[communication rank]@{communication}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Dexterity + Communication Check - d20+communication rank+dexterity bonus+racial bonus">
 									</button>
 								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[physical rank]@{physical}+[dexterity bonus]@{dexterity_bonus}+[racial bonus]floor(@{race}/4) \ Reflex Save - d20+physical rank+dexterity bonus+racial bonus">
+										Reflex Save
+									</button>
+								</td>
                             </tr>
                             <tr>
                                 <td><label class="control-label">Mind</label>
@@ -221,6 +234,11 @@
 								<td>
 									<button class="form-control" type="roll"
 										value="/roll d20+[communication rank]@{communication}+[mind bonus]@{mind_bonus}+[racial bonus]floor(@{race}/4) \ Mind + Communication Check - d20+communication rank+mind bonus+racial bonus">
+									</button>
+								</td>
+								<td>
+									<button class="form-control" type="roll"
+										value="/roll d20+[mind bonus]@{mind_bonus}+[level]@{level}+[racial bonus]floor(@{race}/4) \ Will Save - d20+mind bonus+level+racial bonus">Will Save
 									</button>
 								</td>
                             </tr>
@@ -255,6 +273,7 @@
                     </div>
                 </form>
             </div>
+			
 			<div class="row">
                 <h3>Skills</h3>
 				<div class="col-sm-6 col-sm-offset-3">
@@ -331,7 +350,7 @@
 
                 <div class="form-group">
                     <label class="col-sm-6 control-label">
-                        Missile Attack Bonus <small>(DEX + level)</small>
+                        Missile/Ranged Attack Bonus/Light Weapon Melee Bonus<small>(DEX + level) </small>
                     </label>
                     <div class="col-sm-2">
                         <input type="number" class="form-control" 
@@ -339,7 +358,7 @@
                         name="attr_missile_attack_bonus" disabled="true"
                         value="@{dexterity_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus+class bonus">
+							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile/Light Weapon Attack Check - d20+missile/ranged attack bonus+class bonus">
 						</button>
                     </div>
                 </div>
@@ -387,13 +406,16 @@
                     <strong>Name</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Dice</strong>
+                    <strong>Dice Number</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Type</strong>
+                    <strong>Dice Type</strong>
+                </div>
+				<div class="col-sm-2 text-center">
+                    <strong>Range Type</strong>
                 </div>
                 <div class="col-sm-2 text-center">
-                    <strong>Range (m)</strong>
+                    <strong>Range Distance(feet)</strong>
                 </div>
             </div>
 
@@ -417,6 +439,13 @@
                              <option value="12">d12</option>
                         </select>
                     </div>
+					<div class="col-sm-2">
+                        <select name="attr_range_type" class="form-control">
+                             <option value="2">Melee 2-handed</option>
+                             <option value="1">Melee 1-handed</option>
+                             <option value="0">Ranged</option>
+                        </select>
+                    </div>
                     <div class="col-sm-2">
                         <input type="number" class="form-control"
                          name="attr_weapon_range"
@@ -424,7 +453,7 @@
                     </div>
 					<div class="col-sm-2">
                         <button class="form-control" type="roll"
-                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Damage Roll - damage dice + class bonus">
+                        value="/roll @{dnum}d@{dtype} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[range bonus](@{range_type}*@{strength_bonus}) \ Damage Roll - damage dice + class bonus + melee bonus">
                         </button>
                     </div>
                 </fieldset>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -343,7 +343,7 @@
                         name="attr_melee_attack_bonus" disabled="true"
                         value="@{strength_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Melee Attack Check - d20+melee attack bonus+class bonus">
+							value="/roll d20+[melee attack bonus]@{melee_attack_bonus}+[class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[level modifier](@{level}-1) \ Melee Attack Check - d20+melee attack bonus+class bonus+level modifier">
 						</button>
                     </div>
                 </div>
@@ -358,7 +358,7 @@
                         name="attr_missile_attack_bonus" disabled="true"
                         value="@{dexterity_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5))) \ Ranged/Missile/Light Weapon Attack Check - d20+missile/ranged attack bonus+class bonus">
+							value="/roll d20+[ranged/missile attack bonus]@{missile_attack_bonus} + [class bonus, if applicable]((floor(@{class}/4))*(1+floor(@{level}/5)))+[level modifier](@{level}-1) \ Ranged/Missile/Light Weapon Attack Check - d20+missile/ranged attack bonus+class bonus+level modifier">
 						</button>
                     </div>
                 </div>
@@ -373,7 +373,7 @@
                         name="attr_magic_attack_bonus" disabled="true"
                         value="@{mind_bonus} + @{level}">
 						<button class="form-control" type="roll"
-							value="/roll d20+[magic attack bonus]@{magic_attack_bonus} \ Magic Attack Check">
+							value="/roll d20+[magic attack bonus]@{magic_attack_bonus}+[level modifier](@{level}-1) \ Magic Attack Check - d20+magic attack bonus+level modifier">
 						</button>
                 </div>
                     </div>

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -5,7 +5,7 @@ use with Roll20.net and released open source under the MIT License.
 
 ### Changelog
 
-* Release 3 *
+*Release 3*
 
 - Flipped the order of female and male sexes... Not making a sexist
 statement here, but the default option should be the more common option.

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -3,7 +3,7 @@
 This is a **work in progress** Microlite20 character sheet.  It is designed for
 use with Roll20.net and released open source under the MIT License.
 
-### Changelog
+### Changelog ###
 
 *Release 3*
 

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -5,7 +5,7 @@ use with Roll20.net and released open source under the MIT License.
 
 ### Changelog ###
 
-*Release 3*
+**Release 3**
 
 - Flipped the order of female and male sexes... Not making a sexist
 statement here, but the default option should be the more common option.
@@ -30,9 +30,9 @@ rolls, if fighter is selected.
 - Modified Missile Attack Rolls to include light weapons.
 
 
-* Release 2 *
-Fixed a bug with Armor Class, and added buttons for skill rolls.
+**Release 2**
+- Fixed a bug with Armor Class, and added buttons for skill rolls.
 
-* Initial release - August 12, 2014 *
-First release.  As we playtest with a campaign I expect all the kinks will get
+**Initial release - August 12, 2014**
+- First release.  As we playtest with a campaign I expect all the kinks will get
 worked out. Look for updates within the next two months.

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -6,29 +6,33 @@ use with Roll20.net and released open source under the MIT License.
 ### Changelog
 
 * Release 3
-**Flipped the order of female and male sexes... Not making a sexist
+
+- Flipped the order of female and male sexes... Not making a sexist
 statement here, but the default option should be the more common option.
-**Removed Spells functionality.  Microlite's rule is you can cast any
+- Removed Spells functionality.  Microlite's rule is you can cast any
 spell your level allows, and no player wants to painstakingly add every
 single spell to their character sheet.  
-**Added buttons for attack rolls.  These rolls also incorporate the
+- Added buttons for attack rolls.  These rolls also incorporate the
 fighter class's additional +1 (per 5 levels) paradigm.  These new
 buttons appear beside the attack bonus section.
-**Modified skill check buttons.  They now incorporate the human class
+- Modified skill check buttons.  They now incorporate the human class
 logic of an automatic +1 when human is selected as the race.
-**Added descriptions to the rolls to explain, in chat, what they are, and
+- Added descriptions to the rolls to explain, in chat, what they are, and
 how they were calculated.
-**Added an Armor section to define your armor and the armor class bonus
-**Removed old Armor Bonus section in favor of new Armor section
-**Modified Weapons section to include the fighter bonus to the damage
+- Added an Armor section to define your armor and the armor class bonus
+- Removed old Armor Bonus section in favor of new Armor section
+- Modified Weapons section to include the fighter bonus to the damage
 rolls, if fighter is selected.
-**Added Save Rolls
-**Added weapon range type to weapon section
-**Added Strength Bonus to damage rolls
-**Added level modifier to attack rolls
-**Modified Missile Attack Rolls to include light weapons.
+- Added Save Rolls
+- Added weapon range type to weapon section
+- Added Strength Bonus to damage rolls
+- Added level modifier to attack rolls
+- Modified Missile Attack Rolls to include light weapons.
+
+
 * Release 2
 Fixed a bug with Armor Class, and added buttons for skill rolls.
+
 * Initial release - August 12, 2014
 First release.  As we playtest with a campaign I expect all the kinks will get
 worked out. Look for updates within the next two months.

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -5,16 +5,25 @@ use with Roll20.net and released open source under the MIT License.
 
 ### Changelog
 
-
+* Release 3
+-Flipped the order of female and male sexes... Not making a sexist
+statement here, but the default option should be the more common option.
+-Removed Spells functionality.  Microlite's rule is you can cast any
+spell your level allows, and no player wants to painstakingly add every
+single spell to their character sheet.  
+-Added buttons for attack rolls.  These rolls also incorporate the
+fighter class's additional +1 (per 5 levels) paradigm.  These new
+buttons appear beside the attack bonus section.
+-Modified skill check buttons.  They now incorporate the human class
+logic of an automatic +1 when human is selected as the race.
+-Added descriptions to the rolls to explain, in chat, what they are, and
+how they were calculated.
+-Added an Armor section to define your armor and the armor class bonus
+-Removed old Armor Bonus section in favor of new Armor section
+-Modified Weapons section to include the fighter bonus to the damage
+rolls, if fighter is selected.
+* Release 2
+Fixed a bug with Armor Class, and added buttons for skill rolls.
 * Initial release - August 12, 2014
 First release.  As we playtest with a campaign I expect all the kinks will get
 worked out. Look for updates within the next two months.
-
-### Feedback
-
-Please file issues with the fork on GitHub:
-
-[Microlite20 Roll20 Character Sheets Fork](http://github.com/theonewolf)
----
-
-[@theonewolf](https://app.roll20.net/users/576055/theonewolf)

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -5,7 +5,7 @@ use with Roll20.net and released open source under the MIT License.
 
 ### Changelog
 
-* Release 3
+* Release 3 *
 
 - Flipped the order of female and male sexes... Not making a sexist
 statement here, but the default option should be the more common option.
@@ -30,9 +30,9 @@ rolls, if fighter is selected.
 - Modified Missile Attack Rolls to include light weapons.
 
 
-* Release 2
+* Release 2 *
 Fixed a bug with Armor Class, and added buttons for skill rolls.
 
-* Initial release - August 12, 2014
+* Initial release - August 12, 2014 *
 First release.  As we playtest with a campaign I expect all the kinks will get
 worked out. Look for updates within the next two months.

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -6,22 +6,27 @@ use with Roll20.net and released open source under the MIT License.
 ### Changelog
 
 * Release 3
--Flipped the order of female and male sexes... Not making a sexist
+**Flipped the order of female and male sexes... Not making a sexist
 statement here, but the default option should be the more common option.
--Removed Spells functionality.  Microlite's rule is you can cast any
+**Removed Spells functionality.  Microlite's rule is you can cast any
 spell your level allows, and no player wants to painstakingly add every
 single spell to their character sheet.  
--Added buttons for attack rolls.  These rolls also incorporate the
+**Added buttons for attack rolls.  These rolls also incorporate the
 fighter class's additional +1 (per 5 levels) paradigm.  These new
 buttons appear beside the attack bonus section.
--Modified skill check buttons.  They now incorporate the human class
+**Modified skill check buttons.  They now incorporate the human class
 logic of an automatic +1 when human is selected as the race.
--Added descriptions to the rolls to explain, in chat, what they are, and
+**Added descriptions to the rolls to explain, in chat, what they are, and
 how they were calculated.
--Added an Armor section to define your armor and the armor class bonus
--Removed old Armor Bonus section in favor of new Armor section
--Modified Weapons section to include the fighter bonus to the damage
+**Added an Armor section to define your armor and the armor class bonus
+**Removed old Armor Bonus section in favor of new Armor section
+**Modified Weapons section to include the fighter bonus to the damage
 rolls, if fighter is selected.
+**Added Save Rolls
+**Added weapon range type to weapon section
+**Added Strength Bonus to damage rolls
+**Added level modifier to attack rolls
+**Modified Missile Attack Rolls to include light weapons.
 * Release 2
 Fixed a bug with Armor Class, and added buttons for skill rolls.
 * Initial release - August 12, 2014

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -1,6 +1,6 @@
 # Microlite20 Character Sheet
 
-This is a **work in progress** Microlite20 character sheet.  It is designed for
+This is a Microlite20 character sheet.  It is designed for
 use with Roll20.net and released open source under the MIT License.
 
 ### Changelog ###

--- a/Microlite20/sheet.json
+++ b/Microlite20/sheet.json
@@ -1,7 +1,7 @@
 {
     "html": "microlite20.html",
     "css": "microlite20.css",
-    "authors": "Wolfgang Richter (@theonewolf)",
+    "authors": "Wolfgang Richter (@theonewolf), Hylianux",
     "roll20userid": "576055",
     "preview": "microlite20.png",
     "instructions": "This sheet is designed for use with Microlite20."


### PR DESCRIPTION
The changelog says it all.  I added more roll buttons, and also put restrictions in to add extra bonuses if you chose human as your race and/or chose fighter as your class.  I removed the spell section, since the rules of microlite state that you have access to ALL spells at your given level.  The only way to make use of that section would be to painstakingly add every single spell to the section, effectively making a really really long character sheet.  Not really all that useful.  There's a table in the rulebook that shows you how much each spell level costs, but I wasn't sure if I'd be allowed to include such a table in the character sheet.

Also added Saving Throw rolls, and added in the strength bonus to melee damage rolls.  Modified the attack rolls to include light weapon melee rolls (they use DEX instead of STR) and added the level modifier to each attack roll.

I think that's every possible roll button covered for Microlite20 :)