### PR TITLE
Microlite20 - Bugfixes, Additions, and Visual Rearranging

### DIFF
--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -637,7 +637,7 @@
 	</div>
 
 	<div class="sheet-col">
-		<h3 style="text-align: center;">Equipment</h3>
+		<h3 style="text-align: center;">Inventory</h3>
 		<textarea name="attr_equipment"></textarea>
 	</div>
 </div>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -1,23 +1,50 @@
 <div class="sheet-3colrow">
 	<div class="sheet-col">
-		<label>Name:</label> <input name="attr_character_name" value=
-		"Name" type="text"><br>
-		<label>Hair Color</label> <input name="attr_hair_color"
-		value="Hair Color" type="text"><br>
-		<label>Eye Color</label> <input name="attr_eye_color" value=
-		"Eye Color" type="text"><br>
-		<label>Gender</label> <select name="attr_gender">
-			<option value="1">
-				Male
-			</option>
-			<option value="2">
-				Female
-			</option>
-		</select><br>
-		<label>Height</label> <input name="attr_height" value="6"
-		type="number"><br>
-		<label>Weight:</label> <input name="attr_weight" value="55"
-		type="number">
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Name</label></td>
+				<td>
+					<input name="attr_character_name" value="Name" type="text">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Hair Color</label></td>
+				<td>
+					<input name="attr_hair_color" value="Hair Color" type="text">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Eye Color</label></td>
+				<td>
+					<input name="attr_eye_color" value="Eye Color" type="text">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Gender</label></td>
+				<td>
+					<select name="attr_gender" style="width: 95px">
+						<option value="1">
+							Male
+						</option>
+						<option value="2">
+							Female
+						</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td><label>Height</label></td>
+				<td>
+					<input name="attr_height" value="6"	type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Weight:</label></td>
+				<td>
+					<input name="attr_weight" value="55" type="number">
+				<td>
+			</tr>
+		</table>
 	</div>
 
 	<div class="sheet-col">
@@ -26,84 +53,107 @@
 	</div>
 
 	<div class="sheet-col">
-		<label>Race</label> <select name="attr_race">
-			<option value="1">
-				Human
-			</option>
-
-			<option value="0.7">
-				Elf
-			</option>
-
-			<option value="0.6">
-				Dwarf
-			</option>
-
-			<option value="0.5">
-				Halfling
-			</option>
-			<option value="0.4">
-				Gnome
-			</option>
-			<option value="0.3">
-				Half-orc
-			</option>
-			<option value="0.2">
-				Half-elf
-			</option>
-			<option value="0.1">
-				Lizardman
-			</option>
-		</select><br>
-		<label>Class</label> <select name="attr_class">
-			<option value="16">
-				Fighter
-			</option>
-
-			<option value="12">
-				Rogue
-			</option>
-
-			<option value="10">
-				Mage
-			</option>
-
-			<option value="8">
-				Cleric
-			</option>
-			<option value="-14">
-				Paladin
-			</option>
-			<option value="-11">
-				Ranger
-			</option>
-			
-			<option value="6">
-				Illusionist
-			</option>
-			
-			<option value="4">
-				Druid
-			</option>
-			
-			<option value="2">
-				Bard
-			</option>
-			
-			
-		</select><br>
-		<label>Level</label> <input name="attr_level" value="1" type=
-		"number"><br>
-		<label>Encounter Levels</label> <input name="attr_encounter_levels"
-		value="0" type="number"><br>
-		<label>Hit Points (HP)</label> <input name="attr_hit_points"
-		value="14" title="(STR + 1d6/level)" type="number"><br>
-		<label>Armor Class (AC)</label> <input disabled="true" name=
-		"attr_armor_class" title="(10 + DEX Bonus + Armor Bonus)" type=
-		"number" value="10 + @{dexterity_bonus} + @{armor_bonus}"><br>
-		<label>Caster Difficulty Class (DC)</label> <input disabled="true"
-		name="attr_caster_dc" title="(10 + Level + Mind Bonus)" type=
-		"number" value="@{level}+@{mind_bonus}+10">
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Race</label></td>
+				<td>
+					<select name="attr_race" style="width: 100px">
+						<option value="1">
+							Human
+						</option>
+						<option value="0.7">
+							Elf
+						</option>
+						<option value="0.6">
+							Dwarf
+						</option>
+						<option value="0.5">
+							Halfling
+						</option>
+						<option value="0.4">
+							Gnome
+						</option>
+						<option value="0.3">
+							Half-orc
+						</option>
+						<option value="0.2">
+							Half-elf
+						</option>
+						<option value="0.1">
+							Lizardman
+						</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td><label>Class</label></td>
+				<td>
+					<select name="attr_class" style="width: 100px">
+						<option value="16">
+							Fighter
+						</option>
+						<option value="12">
+							Rogue
+						</option>
+						<option value="10">
+							Mage
+						</option>
+						<option value="8">
+							Cleric
+						</option>
+						<option value="-14">
+							Paladin
+						</option>
+						<option value="-11">
+							Ranger
+						</option>
+						
+						<option value="6">
+							Illusionist
+						</option>
+						
+						<option value="4">
+							Druid
+						</option>
+						
+						<option value="2">
+							Bard
+						</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td><label>Level</label></td>
+				<td>
+					<input name="attr_level" value="1" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Encounter Levels</label></td>
+				<td>
+					<input name="attr_encounter_levels"	value="0" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Hit Points (HP)</label></td>
+				<td>
+					<input name="attr_hit_points" value="14" title="(STR + 1d6/level)" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Armor Class (AC)</label></td>
+				<td>
+					<input disabled="true" name="attr_armor_class" title="(10 + DEX Bonus + Armor Bonus)" type="number" value="10 + @{dexterity_bonus} + @{armor_bonus} + @{shield_bonus}">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Caster Difficulty Class (DC)</label></td>
+				<td>
+					<input disabled="true" name="attr_caster_dc" title="(10 + Level + Mind Bonus)" 
+					type="number" value="@{level}+@{mind_bonus}+10">
+				</td>
+			</tr>
+		</table>
 	</div>
 </div>
 <hr>
@@ -163,16 +213,38 @@
 		<hr>
 
 		<h3 style="margin-bottom: 10px; text-align: center;">Skills</h3>
-		<label>Physical</label><input class="sheet-short" name=
-		"attr_physical" value="1" type="number"><br>
-		<label>Subterfuge</label> <input class="sheet-short" name=
-		"attr_subterfuge" value="1" type="number"><br>
-		<label>Knowledge</label> <input class="sheet-short" name=
-		"attr_knowledge" value="1" type="number">
-		<label>Communication</label> <input class="sheet-short" name=
-		"attr_communication" value="1" type="number">
-		<label>Survival</label> <input class="sheet-short" name=
-		"attr_survival" value="0" type="number">
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Physical</label></td>
+				<td>
+					<input class="sheet-short" name="attr_physical" value="1" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Subterfuge</label></td>
+				<td>
+					<input class="sheet-short" name="attr_subterfuge" value="1" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Knowledge</label></td>
+				<td>
+					<input class="sheet-short" name="attr_knowledge" value="1" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Communication</label></td>
+				<td>
+					<input class="sheet-short" name="attr_communication" value="1" type="number">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Survival</label></td>
+				<td>
+					<input class="sheet-short" name="attr_survival" value="0" type="number">
+				</td>
+			</tr>
+		</table>
 	</div>
 
 	<div class="sheet-col">
@@ -192,6 +264,21 @@
 			</thead>
 
 			<tbody>
+				<tr>
+					<td>Stat Roll</td>
+
+					<td><button type="roll" value=
+					"/roll d20+@{strength_bonus} \ Strength Check - d20 + strength bonus">
+					</button></td>
+
+					<td><button type="roll" value=
+					"/roll d20+@{dexterity_bonus} \ Dexterity Check - d20 + dexterity bonus">
+					</button></td>
+
+					<td><button type="roll" value=
+					"/roll d20+@{mind_bonus} \ Mind Check - d20 + mind bonus">
+					</button></td>
+				</tr>
 				<tr>
 					<td>Physical</td>
 
@@ -396,11 +483,36 @@
 <hr />
 <div class="sheet-3colrow">
 	<div class="sheet-col">
-		<h3 style="text-align: center;">Armor</h3><label>Name</label> <input name=
-		"attr_armor_name" value="Armor Name" type="text">
-		<label>Armor Bonus</label> <input name="attr_armor_bonus"
-		value="0" type="number">
+		<h3 style="text-align: center;">Armor</h3>
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Armor Name</label></td>
+				<td>
+					<input name="attr_armor_name" value="Armor Name" type="text">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Armor Bonus</label></td>
+				<td>
+					<input name="attr_armor_bonus" value="0" type="number">
+				</td>
+			</tr>
+		</table>
 		<hr>
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Shield Name</label></td>
+				<td>
+					<input name="attr_shield_name" value="Shield Name" type="text">
+				</td>
+			</tr>
+			<tr>
+				<td><label>Shield Bonus</label></td>
+				<td>
+					<input name="attr_shield_bonus" value="0" type="number">
+				</td>
+			</tr>
+		</table>
 
 		<h3 style="text-align: center;">Wealth</h3>
 
@@ -453,60 +565,79 @@
 		<h3 style="text-align: center;">Weapons</h3>
 
 		<fieldset class="repeating_weapons">
-			<label>Name</label> <input name="attr_weapon_name"
-			value="Weapon Name" type="text"> <label>Dice
-			Number</label> <input name="attr_dnum" value="1"
-			type="number"> <label>Dice Type</label> <select class=
-			"sheet-dtype" name="attr_dtype">
-				<option value="4">
-					d4
-				</option>
-
-				<option value="6">
-					d6
-				</option>
-
-				<option value="8">
-					d8
-				</option>
-
-				<option value="10">
-					d10
-				</option>
-
-				<option value="12">
-					d12
-				</option>
-			</select> <label>Range Type</label> <select name=
-			"attr_range_type">
-				<option value="2">
-					Melee 1-handed
-				</option>
-				<option value="4">
-					Melee 2-handed
-				</option>
-				<option value="1">
-					Ranged
-				</option>
-			</select> <label>Range Distance(feet)</label>
-			<input name="attr_weapon_range" value="0" type=
-			"number"> <label>Damage Roll</label> <button class=
-			"sheet-button" type="roll" value=
-			"/roll @{dnum}d@{dtype}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((floor(@{range_type}/2))*@{strength_bonus})+((abs(@{class}%2))*(@{range_type}%2)) \ Damage Roll - damage dice + fighter class bonus + melee bonus + ranger class bonus">
-			</button>
+			<table style="width: 100%;">
+				<tr>
+					<td><label>Name</label></td>
+					<td>
+						<input name="attr_weapon_name" value="Weapon Name" 
+						style="width:100px" type="text">
+					</td>
+				</tr>
+				<tr>
+					<td><label>Dice	Number</label></td>
+					<td>
+						<input name="attr_dnum" value="1" type="number">
+					</td>
+				</tr>
+				<tr>
+					<td><label>Dice Type</label></td>
+					<td>
+						<select class="sheet-dtype" name="attr_dtype">
+							<option value="4">
+								d4
+							</option>
+							<option value="6">
+								d6
+							</option>
+							<option value="8">
+								d8
+							</option>
+							<option value="10">
+								d10
+							</option>
+							<option value="12">
+								d12
+							</option>
+						</select> 
+					</td>
+				</tr>
+				<tr>
+					<td><label>Range Type</label></td>
+					<td>
+						<select name="attr_range_type" style="width: 130px">
+							<option value="2">
+								Melee 1-handed
+							</option>
+							<option value="4">
+								Melee 2-handed
+							</option>
+							<option value="1">
+								Ranged
+							</option>
+						</select> 
+					</td>
+				</tr>
+				<tr>
+					<td><label>Range Distance(feet)</label></td>
+					<td>
+						<input name="attr_weapon_range" value="0" type="number"> 
+					</td>
+				</tr>
+				<tr>
+					<td><label>Damage Roll</label></td>
+					<td>
+						<button class="sheet-button" type="roll" 
+						value="/roll @{dnum}d@{dtype}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((floor(@{range_type}/2))*@{strength_bonus})+((abs(@{class}%2))*(@{range_type}%2)) \ Damage Roll - damage dice + fighter class bonus + melee bonus + ranger class bonus">
+						</button>
+					</td>
+				</tr>
+			</table>
 			<hr/>
 		</fieldset>
 	</div>
 
 	<div class="sheet-col">
 		<h3 style="text-align: center;">Equipment</h3>
-
-		<fieldset class="repeating_equipment">
-			<label>Number held</label> <input name=
-			"attr_eq_quantity" value="1" type="number">
-			<label>Item</label> <input name="attr_eq_name"
-			value="Item Name" type="text">
-			<hr/>
-		</fieldset>
+		<textarea name="attr_equipment"></textarea>
 	</div>
 </div>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -310,7 +310,7 @@
 					<td>Missile/Ranged</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + ranger class bonus">
+					"/roll d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + ranger class bonus">
 					</button></td>
 				</tr>
 
@@ -353,7 +353,7 @@
 
 					<td>
 						<button type="roll" value=
-						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2))-2 \ Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + ranger class bonus - attack penalty">
+						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)))-2 \ Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + ranger class bonus - attack penalty">
 						</button>
 					</td>
 				</tr>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -297,7 +297,7 @@
 					<td>Melee</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{melee_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+(@{level}-1) \ Melee Attack Check - d20 + melee attack bonus + fighter class bonus + level modifier">
+					"/roll d20+@{melee_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5))) \ Melee Attack Check - d20 + melee attack bonus + fighter class bonus">
 					</button></td>
 				</tr>
 
@@ -310,7 +310,7 @@
 					<td>Missile/Ranged</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+(@{level}-1)+((abs(@{class}%2)) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + level modifier + ranger class bonus">
+					"/roll d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + ranger class bonus">
 					</button></td>
 				</tr>
 
@@ -323,7 +323,7 @@
 					<td>Magic</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{magic_attack_bonus}+(@{level}-1) \ Magic Attack Check - d20 + magic attack bonus + level modifier">
+					"/roll d20+@{magic_attack_bonus} \ Magic Attack Check - d20 + magic attack bonus">
 					</button></td>
 				</tr>
 				
@@ -345,7 +345,7 @@
 				<tr>
 					<td>
 						<button type="roll" value=
-						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+(@{level}-1) \ Light Weapon Attack Check - d20 + light weapon attack bonus + fighter class bonus + level modifier">
+						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5))) \ Light Weapon Attack Check - d20 + light weapon attack bonus + fighter class bonus">
 						</button>
 					</td>
 
@@ -353,7 +353,7 @@
 
 					<td>
 						<button type="roll" value=
-						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+(@{level}-1)+((abs(@{class}%2))-2 \ Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + level modifier + ranger class bonus - attack penalty">
+						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2))-2 \ Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + ranger class bonus - attack penalty">
 						</button>
 					</td>
 				</tr>

--- a/Microlite20/microlite20.html
+++ b/Microlite20/microlite20.html
@@ -268,30 +268,30 @@
 					<td>Stat Roll</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{strength_bonus} \ Strength Check - d20 + strength bonus">
+					"&{template:default} {{name=Strength Roll}}{{strength=[[d20+@{strength_bonus}]]}} {{note=Strength Check - d20 + strength bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{dexterity_bonus} \ Dexterity Check - d20 + dexterity bonus">
+					"&{template:default} {{name=Dexterity Roll}} {{dexterity=[[d20+@{dexterity_bonus}]]}} {{note=Dexterity Check - d20 + dexterity bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{mind_bonus} \ Mind Check - d20 + mind bonus">
+					"&{template:default} {{name=Mind Roll}} {{mind=[[d20+@{mind_bonus}]]}} {{note=Mind Check - d20 + mind bonus}}">
 					</button></td>
 				</tr>
 				<tr>
 					<td>Physical</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{physical}+@{strength_bonus}+(floor(@{race})) \ Strength + Physical Check - d20 + physical rank + strength bonus + racial bonus">
+					"&{template:default} {{name=Physical+Str}} {{skill roll=[[d20+@{physical}+@{strength_bonus}+(floor(@{race}))]]}} {{note=Strength + Physical Check - d20 + physical rank + strength bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{physical}+@{dexterity_bonus}+(floor(@{race})) \ Dexterity + Physical Check - d20 + physical rank + dexterity bonus + racial bonus">
+					"&{template:default} {{name=Physical+Dex}} {{skill roll=[[d20+@{physical}+@{dexterity_bonus}+(floor(@{race}))]]}} {{note=Dexterity + Physical Check - d20 + physical rank + dexterity bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{physical}+@{mind_bonus}+(floor(@{race})) \ Mind + Physical Check - d20 + physical rank + mind bonus + racial bonus">
+					"&{template:default} {{name=Physical+Mind}} {{skill roll=[[d20+@{physical}+@{mind_bonus}+(floor(@{race}))]]}} {{note=Mind + Physical Check - d20 + physical rank + mind bonus + racial bonus}}">
 					</button></td>
 				</tr>
 
@@ -299,15 +299,15 @@
 					<td>Subterfuge</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{subterfuge}+@{strength_bonus}+(floor(@{race})) \ Strength + Subterfuge Check - d20 + subterfuge rank + strength bonus + racial bonus">
+					"&{template:default} {{name=Subterfuge+Str}} {{skill roll=[[d20+@{subterfuge}+@{strength_bonus}+(floor(@{race}))]]}} {{note=Strength + Subterfuge Check - d20 + subterfuge rank + strength bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{subterfuge}+@{dexterity_bonus}+(floor(@{race})) \ Dexterity + Subterfuge Check - d20 + subterfuge rank + dexterity bonus + racial bonus">
+					"&{template:default} {{name=Subterfuge+Dex}} {{skill roll=[[d20+@{subterfuge}+@{dexterity_bonus}+(floor(@{race}))]]}} {{note=Dexterity + Subterfuge Check - d20 + subterfuge rank + dexterity bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{subterfuge}+@{mind_bonus}+(floor(@{race})) \ Mind + Subterfuge Check - d20 + subterfuge rank + mind bonus + racial bonus">
+					"&{template:default} {{name=Subterfuge+Mind}} {{skill roll=[[d20+@{subterfuge}+@{mind_bonus}+(floor(@{race}))]]}} {{note=Mind + Subterfuge Check - d20 + subterfuge rank + mind bonus + racial bonus}}">
 					</button></td>
 				</tr>
 
@@ -315,15 +315,15 @@
 					<td>Knowledge</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{knowledge}+@{strength_bonus}+(floor(@{race})) \ Strength + Knowledge Check - d20 + knowledge rank + strength bonus + racial bonus">
+					"&{template:default} {{name=Knowledge+Str}} {{skill roll=[[d20+@{knowledge}+@{strength_bonus}+(floor(@{race}))]]}} {{note=Strength + Knowledge Check - d20 + knowledge rank + strength bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{knowledge}+@{dexterity_bonus}+(floor(@{race})) \ Dexterity + Knowledge Check - d20 + knowledge rank + dexterity bonus + racial bonus">
+					"&{template:default} {{name=Knowledge+Dex}} {{skill roll=[[d20+@{knowledge}+@{dexterity_bonus}+(floor(@{race}))]]}} {{note=Dexterity + Knowledge Check - d20 + knowledge rank + dexterity bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{knowledge}+@{mind_bonus}+(floor(@{race})) \ Mind + Knowledge Check - d20+knowledge rank+mind bonus+racial bonus">
+					"&{template:default} {{name=Knowledge+Mind}} {{skill roll=[[d20+@{knowledge}+@{mind_bonus}+(floor(@{race}))]]}} {{note=Mind + Knowledge Check - d20+knowledge rank+mind bonus+racial bonus}}">
 					</button></td>
 				</tr>
 
@@ -331,36 +331,44 @@
 					<td>Communication</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{communication}+@{strength_bonus}+(floor(@{race})) \ Strength + Communication Check - d20 + communication rank + strength bonus + racial bonus">
+					"&{template:default} {{name=Communication+Str}} {{skill roll=[[d20+@{communication}+@{strength_bonus}+(floor(@{race}))]]}} {{note=Strength + Communication Check - d20 + communication rank + strength bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{communication}+@{dexterity_bonus}+(floor(@{race})) \ Dexterity + Communication Check - d20 + communication rank + dexterity bonus+racial bonus">
+					"&{template:default} {{name=Communication+Dex}} {{skill roll=[[d20+@{communication}+@{dexterity_bonus}+(floor(@{race}))]]}} {{note=Dexterity + Communication Check - d20 + communication rank + dexterity bonus+racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{communication}+@{mind_bonus}+(floor(@{race})) \ Mind + Communication Check - d20 + communication rank + mind bonus + racial bonus">
+					"&{template:default} {{name=Communication+Mind}} {{skill roll=[[d20+@{communication}+@{mind_bonus}+(floor(@{race}))]]}} {{note=Mind + Communication Check - d20 + communication rank + mind bonus + racial bonus}}">
 					</button></td>
 				</tr>
 				<tr>
 					<td>Survival</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{survival}+@{strength_bonus}+(floor(@{race})) \ Strength + Survival Check - d20 + survival rank + strength bonus + racial bonus">
+					"&{template:default} {{name=Survival+Str}} {{skill roll=[[d20+@{survival}+@{strength_bonus}+(floor(@{race}))]]}} {{note=Strength + Survival Check - d20 + survival rank + strength bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{survival}+@{dexterity_bonus}+(floor(@{race})) \ Dexterity + Survival Check - d20 + survival rank + dexterity bonus + racial bonus">
+					"&{template:default} {{name=Survival+Dex}} {{skill roll=[[d20+@{survival}+@{dexterity_bonus}+(floor(@{race}))]]}} {{note=Dexterity + Survival Check - d20 + survival rank + dexterity bonus + racial bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{survival}+@{mind_bonus}+(floor(@{race})) \ Mind + Survival Check - d20 + survival rank + mind bonus + racial bonus">
+					"&{template:default} {{name=Survival+Mind}} {{skill roll=[[d20+@{survival}+@{mind_bonus}+(floor(@{race}))]]}} {{note=Mind + Survival Check - d20 + survival rank + mind bonus + racial bonus}}">
 					</button></td>
 				</tr>
 			</tbody>
 		</table>
 		<hr>
-
+		<table style="width: 100%;">
+			<tr>
+				<td><label>Initiative Roll</label></td>
+				<td>
+					<button type="roll" value="&{template:default} {{name=Initiative Roll}} {{initiative=[[d20+@{dexterity_bonus} &{tracker}]]}}"></button>
+				</td>
+			</tr>
+		</table>
+		<hr>
 		<h3 style="text-align: center;">Attack Bonuses and Rolls</h3>
 
 		<table style="width: 100%;">
@@ -383,9 +391,9 @@
 
 					<td>Melee</td>
 
-					<td><button type="roll" value=
-					"/roll d20+@{melee_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5))) \ Melee Attack Check - d20 + melee attack bonus + fighter class bonus">
-					</button></td>
+					<td>
+						<button type="roll" value="&{template:default} {{name=Melee Attack Roll}} {{attack=[[d20+@{melee_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))]]}} {{note=Melee Attack Check - d20 + melee attack bonus + fighter class bonus}}"></button>
+					</td>
 				</tr>
 
 				<tr>
@@ -397,7 +405,7 @@
 					<td>Missile/Ranged</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2))) \ Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + ranger class bonus">
+					"&{template:default} {{name=Missile/Ranged Roll}}{{attack=[[d20+@{missile_attack_bonus} + ((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)))]]}} {{note=Ranged/Missile Attack Check - d20+missile/ranged attack bonus + fighter class bonus + ranger class bonus}}">
 					</button></td>
 				</tr>
 
@@ -410,7 +418,7 @@
 					<td>Magic</td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{magic_attack_bonus} \ Magic Attack Check - d20 + magic attack bonus">
+					"&{template:default} {{name=Magic Roll}}{{attack=[[d20+@{magic_attack_bonus}]]}} {{note=Magic Attack Check - d20 + magic attack bonus}}">
 					</button></td>
 				</tr>
 				
@@ -432,7 +440,7 @@
 				<tr>
 					<td>
 						<button type="roll" value=
-						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5))) \ Light Weapon Attack Check - d20 + light weapon attack bonus + fighter class bonus">
+						"&{template:default} {{name=Light Weapon Roll}} {{attack=[[d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))]]}} {{note=Light Weapon Attack Check - d20 + light weapon attack bonus + fighter class bonus}}">
 						</button>
 					</td>
 
@@ -440,7 +448,7 @@
 
 					<td>
 						<button type="roll" value=
-						"/roll d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)))-2 \ Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + ranger class bonus - attack penalty">
+						"&{template:default} {{name=Dual Wield Roll}} {{attack=[[d20+@{missile_attack_bonus}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((abs(@{class}%2)))-2]]}} {{note=Dual Wield Attack Check - d20 + light weapon attack bonus + fighter class bonus + ranger class bonus - attack penalty}}">
 						</button>
 					</td>
 				</tr>
@@ -465,15 +473,15 @@
 			<tbody>
 				<tr>
 					<td><button type="roll" value=
-					"/roll d20+@{physical}+@{strength_bonus}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5))) \ Fortitude Save - d20+physical rank+strength bonus+racial bonus+paladin bonus">
+					"&{template:default} {{name=Fortitude Save }} {{save=[[d20+@{physical}+@{strength_bonus}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5)))]]}} {{note=Fortitude Save - d20+physical rank+strength bonus+racial bonus+paladin bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{physical}+@{dexterity_bonus}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5))) \ Reflex Save - d20+physical rank+dexterity bonus+racial bonus+paladin bonus">
+					"&{template:default} {{name=Reflex Save}} {{save=[[d20+@{physical}+@{dexterity_bonus}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5)))]]}} {{note=Reflex Save - d20+physical rank+dexterity bonus+racial bonus+paladin bonus}}">
 					</button></td>
 
 					<td><button type="roll" value=
-					"/roll d20+@{mind_bonus}+@{level}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5))) \ Will Save - d20+mind bonus+level+racial bonus+paladin bonus">
+					"&{template:default} {{name=Will Save}} {{save=[[d20+@{mind_bonus}+@{level}+(floor(@{race}))+((floor(abs((-2+@{class}))/16))*(1+floor(@{level}/5)))]]}} {{note=Will Save - d20+mind bonus+level+racial bonus+paladin bonus}}">
 					</button></td>
 				</tr>
 			</tbody>
@@ -627,7 +635,7 @@
 					<td><label>Damage Roll</label></td>
 					<td>
 						<button class="sheet-button" type="roll" 
-						value="/roll @{dnum}d@{dtype}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((floor(@{range_type}/2))*@{strength_bonus})+((abs(@{class}%2))*(@{range_type}%2)) \ Damage Roll - damage dice + fighter class bonus + melee bonus + ranger class bonus">
+						value="&{template:default} {{name=Damage Roll}} {{damage=[[@{dnum}d@{dtype}+((floor(abs(@{class})/16))*(1+floor(@{level}/5)))+((floor(@{range_type}/2))*@{strength_bonus})+((abs(@{class}%2))*(@{range_type}%2))]]}} {{note=Damage Roll - damage dice + fighter class bonus + melee bonus + ranger class bonus}}">
 						</button>
 					</td>
 				</tr>

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -5,6 +5,9 @@ use with Roll20.net and released open source under the MIT License.
 
 ### Changelog ###
 
+**Release 4.1 - March 12, 2015**
+- Fixed logic on attack rolls.  M20's rulebook was worded in a confusing way, which resulted in an additional +1 roll per level on every attack roll.  So this fix removes that additional +1 per level.
+
 **Release 4 - March 10, 2015**
 - Cut down on the verbosity of rolls (took up too much of the chat box)
 - Removed Light Weapons from Missile Attack Roll

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -13,6 +13,8 @@ use with Roll20.net and released open source under the MIT License.
 - Added Stat rolls
 - Changed Equipment section to a single textarea... (nobody wants to painstakingly add every single inventory item to their sheet... much easier to just type it all out).
 - Changed title of Equipment Section to "Inventory"
+- Added Initiative roll (will automatically add to tracker)
+- Changed all roll buttons to use roll templates
 
 **Release 4 - March 10, 2015**
 - Cut down on the verbosity of rolls (took up too much of the chat box)

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -12,6 +12,7 @@ use with Roll20.net and released open source under the MIT License.
 - Added Shield section to add to AC
 - Added Stat rolls
 - Changed Equipment section to a single textarea... (nobody wants to painstakingly add every single inventory item to their sheet... much easier to just type it all out).
+- Changed title of Equipment Section to "Inventory"
 
 **Release 4 - March 10, 2015**
 - Cut down on the verbosity of rolls (took up too much of the chat box)

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -7,6 +7,7 @@ use with Roll20.net and released open source under the MIT License.
 
 **Release 4.1 - March 12, 2015**
 - Fixed logic on attack rolls.  M20's rulebook was worded in a confusing way, which resulted in an additional +1 roll per level on every attack roll.  So this fix removes that additional +1 per level.
+- Fixed Ranger bonus calculation.  Was missing an ending parenthesis, so it wasn't getting calculated.
 
 **Release 4 - March 10, 2015**
 - Cut down on the verbosity of rolls (took up too much of the chat box)

--- a/Microlite20/readme.md
+++ b/Microlite20/readme.md
@@ -8,6 +8,10 @@ use with Roll20.net and released open source under the MIT License.
 **Release 4.1 - March 12, 2015**
 - Fixed logic on attack rolls.  M20's rulebook was worded in a confusing way, which resulted in an additional +1 roll per level on every attack roll.  So this fix removes that additional +1 per level.
 - Fixed Ranger bonus calculation.  Was missing an ending parenthesis, so it wasn't getting calculated.
+- Rearranged the sheet for easier readability
+- Added Shield section to add to AC
+- Added Stat rolls
+- Changed Equipment section to a single textarea... (nobody wants to painstakingly add every single inventory item to their sheet... much easier to just type it all out).
 
 **Release 4 - March 10, 2015**
 - Cut down on the verbosity of rolls (took up too much of the chat box)


### PR DESCRIPTION
M20's rulebook stated that on every level advancement, you had to add +1 to your skills and attack rolls, and +1d6 to your hp.  Unfortunately, this was written for people doing it on pen and paper.  For attack rolls in roll20, those are already calculated.  The +1 will happen naturally with the advancement of a level due to how the attack rolls are calculated.  So, me adding an additional +1 per level was actually incorrect.  Had to remove that.