### PR TITLE
added optional tie breaker for initiative based on PF's "Higher modifier wins"

### DIFF
--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -129,12 +129,26 @@
 						<div class="sheet-col-1-2">
 							<h4 class="sheet-center">Initiative <span class="sheet-pictos">t</span></h4>
 							<div class="sheet-row sheet-padr">
-								<div class="sheet-col-1-3 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button"><input class="sheet-underlined sheet-center" type="number" name="attr_initiative" value="0" step="1"><br/>Bonus</div>
-								<div class="sheet-col-1-3 sheet-small-label sheet-center"><input class="sheet-underlined" type="number" name="attr_initiative_overall" value="@{dexterity_mod} + @{initiative}" disabled="disabled"><br/>Total</div>
-								<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-initiative sheet-large-button" name="roll_Initiative" value="&{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|initiative_overall} [Initiative Mod] &{tracker} ]]}} @{classactioninitiative}">Initiative</button></div>
+								<div class="sheet-col-1-4 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button">
+									<input class="sheet-underlined sheet-center" type="number" name="attr_initiative" value="0" step="1" />
+									<br/>
+									Bonus
+								</div>
+								<div class="sheet-col-1-4 sheet-small-label sheet-center">
+									<input class="sheet-underlined" type="number" name="attr_initiative_overall" value="@{dexterity_mod} + @{initiative}" disabled="disabled" />
+									<br/>
+									Total
+								</div>
+								<div class="sheet-col-1-5 sheet-small-label sheet-center">
+									<input type="checkbox" name="attr_initiative_tie_breaker" value="(@{initiative_overall}) / 100" />
+									<br/>
+									Tie Breaker
+								</div>
+								<div class="sheet-col-1-4 sheet-center">
+									<button type="roll" class="sheet-initiative sheet-large-button" name="roll_Initiative" value="&{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|initiative_overall} [Initiative Mod] + @{initiative_tie_breaker} [Tie Breaker] &{tracker} ]]}} @{classactioninitiative}">Initiative</button>
+								</div>
 							</div>
 						</div>
-						
 						<div class="sheet-col-1-2 sheet-padl">
 							<h4 class="sheet-center">Armour Class <span class="sheet-pictos-three">b</span></h4>
 							
@@ -11993,9 +12007,23 @@
 			
 			<div class="sheet-col-1-3">
 				<div class="sheet-row sheet-padr">
-					<div class="sheet-col-1-3 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button"><input class="sheet-underlined sheet-center" type="number" name="attr_npc_initiative" value="0" step="1"><br/>Initiative Bonus</div>
-					<div class="sheet-col-1-3 sheet-small-label sheet-center"><input class="sheet-underlined" type="number" name="attr_npc_initiative_overall" value="@{npc_dexterity_mod} + @{npc_initiative}" disabled="disabled"><br/>Total</div>
-					<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-roll" name="roll_NPC_Initiative" value="@{npc_output_option} &{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|npc_initiative_overall} &{tracker} ]]}}">Initiative</button></div>
+					<div class="sheet-col-1-4 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button">
+						<input class="sheet-underlined sheet-center" type="number" name="attr_npc_initiative" value="0" step="1" />
+						<br/>Initiative Bonus
+					</div>
+					<div class="sheet-col-1-4 sheet-small-label sheet-center">
+						<input class="sheet-underlined" type="number" name="attr_npc_initiative_overall" value="@{npc_dexterity_mod} + @{npc_initiative}" disabled="disabled" />
+						<br/>
+						Total
+					</div>
+					<div class="sheet-col-1-5 sheet-small-label sheet-center">
+						<input type="checkbox" name="attr_npc_initiative_tie_breaker" value="(@{npc_initiative_overall}) / 100" />
+						<br/>
+						Tie Breaker
+					</div>
+					<div class="sheet-col-1-4 sheet-center">
+						<button type="roll" class="sheet-roll" name="roll_NPC_Initiative" value="@{npc_output_option} &{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|npc_initiative_overall} [Initiative Mod] + @{npc_initiative_tie_breaker} [Tie Breaker] &{tracker} ]]}}">Initiative</button>
+					</div>
 				</div>
 			</div>
 			
@@ -13533,4 +13561,4 @@
 			</div>
 		</div>
 
-</rolltemplate>
+</rolltemplate>

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -264,40 +264,39 @@
 					</div>
 									
 					<div class="sheet-row">
-					
 						<div class="sheet-col-1-5 sheet-padr sheet-center sheet-margin-top">
-								
 							<input class="sheet-inspiration" type="checkbox" name="attr_inspiration" value="1"><span class="sheet-inspiration-tab"></span>
-
 						</div>
 					
 						<div class="sheet-col-3-5 sheet-padl">
-						
 							<div class="sheet-row">
-								<div class="sheet-col-1-4 sheet-margin-top sheet-small-label">Successes : </div>
+								<div class="sheet-col-1-4 sheet-margin-top sheet-small-label">Successes: </div>
 								<div class="sheet-col-3-4 sheet-center">
 									<input class="sheet-death-save-success" type="checkbox" name="attr_death_save_success_1" value="1"><span class="sheet-death-save-success-tab"></span>
 									<input class="sheet-death-save-success" type="checkbox" name="attr_death_save_success_2" value="1"><span class="sheet-death-save-success-tab"></span>
 									<input class="sheet-death-save-success" type="checkbox" name="attr_death_save_success_3" value="1"><span class="sheet-death-save-success-tab"></span>
 								</div>
 							</div>
-							
-							
+
 							<div class="sheet-row">
-								<div class="sheet-col-1-4 sheet-margin-top sheet-small-label">Failures : </div>
+								<div class="sheet-col-1-4 sheet-margin-top sheet-small-label">Failures: </div>
 								<div class="sheet-col-3-4 sheet-center">
 									<input class="sheet-death-save-fail" type="checkbox" name="attr_death_save_fail_1" value="1"><span class="sheet-death-save-fail-tab"></span>
 									<input class="sheet-death-save-fail" type="checkbox" name="attr_death_save_fail_2" value="1"><span class="sheet-death-save-fail-tab"></span>
 									<input class="sheet-death-save-fail" type="checkbox" name="attr_death_save_fail_3" value="1"><span class="sheet-death-save-fail-tab"></span>
 								</div>
 							</div>
-							
 						</div>
 						
 						<div class="sheet-col-1-5 sheet-margin-top">
-						
 							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-center"><button type="roll" class="sheet-roll" name="roll_Death_Saving_Throw" value="&{template:5eDefault} {{deathsave=1}} {{character_name=@{character_name}}} {{emote=dices with death!}} {{title=Death Save}} {{subheader=@{character_name}}} {{rollname=Death save}} {{roll=[[1d20 + (@{global_saving_bonus})]]}} @{classactiondeathsave} ">Death Saving Throw</button></div>
+								<div class="sheet-col-1 sheet-center">
+									<button type="roll" class="sheet-roll" name="roll_Death_Saving_Throw" value="@{death_save_output_option} &{template:5eDefault} {{deathsave=1}} {{character_name=@{character_name}}} {{emote=dices with death!}} {{title=Death Save}} {{subheader=@{character_name}}} {{rollname=Death save}} {{roll=[[1d20 + (@{global_saving_bonus})]]}} @{classactiondeathsave} ">Death Saving Throw</button>
+									<select name="attr_death_save_output_option" class="sheet-margin-top">
+										<option value=" " selected="selected">Public for all to see</option>
+										<option value="/w GM ">Whispered to the GM</option>
+									</select>
+								</div>
 							</div>
 
 						</div>


### PR DESCRIPTION
This adds a an optional modifier so the initiative tracker can figure out who goes first in the case of a tie. It uses 3.X's system of:

"If two or more combatants have the same initiative check result, the combatants who are tied act in order of total initiative modifier (highest first)"

It takes the whole initiative and divides it by 100. So if you roll a 15 and your initiative mod is 3 your initiative is 15+3+(3/100) = 18.03. Negative makes it lower. The initiative tracker handles it all in the end.

I added it on the PC and NPC sheet both.