### PR TITLE
Align columns for Skills

### DIFF
--- a/DnD_5e/DnD_5e.css
+++ b/DnD_5e/DnD_5e.css
@@ -312,7 +312,7 @@
 	font-weight: bold;
 	border-radius: 4px;
 
-	width: 79px;
+	width: 78px;
     height: 20px;
     cursor: pointer;	
 	position: relative;

--- a/DnD_5e/DnD_5e.css
+++ b/DnD_5e/DnD_5e.css
@@ -946,6 +946,10 @@ div[class^="sheet-classaction-row"] {
 
  select {
 	font-size: 90%;
+	padding-right: 0;
+ }
+ input {
+	font-size: 100%;
 }
 
  .sheet-important-text {

--- a/DnD_5e/DnD_5e.css
+++ b/DnD_5e/DnD_5e.css
@@ -285,7 +285,8 @@
  input.sheet-tab5:checked ~ div.sheet-section-weapons,
  input.sheet-tab6:checked ~ div.sheet-section-spellbook,
  input.sheet-tab8:checked ~ div.sheet-section-armour,
- input.sheet-tab7:checked ~ div.sheet-section-inventory {
+ input.sheet-tab7:checked ~ div.sheet-section-inventory,
+ input.sheet-tab9:checked ~ div.sheet-section-settings {
 	display: block;
 }
 
@@ -310,8 +311,8 @@
 	color: white;
 	font-weight: bold;
 	border-radius: 4px;
-	
-	width: 87px;
+
+	width: 79px;
     height: 20px;
     cursor: pointer;	
 	position: relative;
@@ -326,6 +327,7 @@
  input.sheet-tab6:checked + span.sheet-tab6,
  input.sheet-tab7:checked + span.sheet-tab7,
  input.sheet-tab8:checked + span.sheet-tab8,
+ input.sheet-tab9:checked + span.sheet-tab9,
  input.sheet-tab99:checked + span.sheet-tab99 {
     background: #ab8b57;    
     color: white;

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -298,25 +298,24 @@
 		</div>
 
 		<div class="sheet-section-skills">
-			
+
 			<h4 class="sheet-center">Skills <span class="sheet-pictos">x</span></h4>
 			<div class="sheet-row">
-			
 				<div class="sheet-col-1-2 sheet-padr">
-				
 					<div class="sheet-row sheet-sub-header">
 						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
 						<div class="sheet-col-7-24 sheet-small-label">Skill</div>
-						<div class="sheet-col-7-24 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Bonus</div>
-						<div class="sheet-col-1-12 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Bonus</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
 						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Pass</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Acrobatics_Check" value="&{template:5eDefault} {{ability=1}} {{title=Acrobatics (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{acrobatics} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{acrobatics} + (@{global_check_bonus}) ]]}} @{classactionacrobatics}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Acrobatics_Check" value="&{template:5eDefault} {{ability=1}} {{title=Acrobatics (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{acrobatics} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{acrobatics} + (@{global_check_bonus}) ]]}} @{classactionacrobatics}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Acrobatics (Dex)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_acrobatics_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -324,15 +323,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_acrobatics_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_acrobatics" value="@{acrobatics_prof_exp}+@{dexterity_mod}+@{acrobatics_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_acrobatics" value="10 + @{acrobatics}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_acrobatics_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_acrobatics" value="@{acrobatics_prof_exp}+@{dexterity_mod}+@{acrobatics_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_acrobatics" value="10 + @{acrobatics}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_AnimalHandling_Check" value="&{template:5eDefault} {{ability=1}} {{title=Animal Handling (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{animalhandling} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{animalhandling} + (@{global_check_bonus}) ]]}}  @{classactionanimalhandling}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_AnimalHandling_Check" value="&{template:5eDefault} {{ability=1}} {{title=Animal Handling (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{animalhandling} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{animalhandling} + (@{global_check_bonus}) ]]}}  @{classactionanimalhandling}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Animal Handling (Wis)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_animalhandling_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -340,15 +346,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_animalhandling_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_animalhandling" value="@{animalhandling_prof_exp}+@{wisdom_mod}+@{animalhandling_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_animalhandling" value="10 + @{animalhandling}" disabled="disabled"></div>
-					</div>		
-					
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_animalhandling_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_animalhandling" value="@{animalhandling_prof_exp}+@{wisdom_mod}+@{animalhandling_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_animalhandling" value="10 + @{animalhandling}" disabled="disabled">
+						</div>
+					</div>
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Arcana_Check" value="&{template:5eDefault} {{ability=1}} {{title=Arcana (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{arcana} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{arcana} + (@{global_check_bonus}) ]]}} @{classactionarcana}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Arcana_Check" value="&{template:5eDefault} {{ability=1}} {{title=Arcana (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{arcana} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{arcana} + (@{global_check_bonus}) ]]}} @{classactionarcana}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Arcana (Int)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_arcana_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -356,15 +369,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_arcana_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_arcana" value="@{arcana_prof_exp}+@{intelligence_mod}+@{arcana_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_arcana" value="10 + @{arcana}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_arcana_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_arcana" value="@{arcana_prof_exp}+@{intelligence_mod}+@{arcana_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_arcana" value="10 + @{arcana}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Athletics_Check" value="&{template:5eDefault} {{ability=1}} {{title=Athletics (STR)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{athletics} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{athletics} + (@{global_check_bonus}) ]]}} @{classactionathletics}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Athletics_Check" value="&{template:5eDefault} {{ability=1}} {{title=Athletics (STR)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{athletics} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{athletics} + (@{global_check_bonus}) ]]}} @{classactionathletics}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Athletics (Str)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_athletics_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -372,15 +392,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_athletics_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_athletics" value="@{athletics_prof_exp}+@{strength_mod}+@{athletics_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_athletics" value="10 + @{athletics}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_athletics_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_athletics" value="@{athletics_prof_exp}+@{strength_mod}+@{athletics_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_athletics" value="10 + @{athletics}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Deception_Check" value="&{template:5eDefault} {{ability=1}} {{title=Deception (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{deception} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{deception} + (@{global_check_bonus}) ]]}} @{classactiondeception}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Deception_Check" value="&{template:5eDefault} {{ability=1}} {{title=Deception (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{deception} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{deception} + (@{global_check_bonus}) ]]}} @{classactiondeception}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Deception (Cha)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_deception_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -388,15 +415,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_deception_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_deception" value="@{deception_prof_exp}+@{charisma_mod}+@{deception_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_deception" value="10 + @{deception}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_deception_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_deception" value="@{deception_prof_exp}+@{charisma_mod}+@{deception_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_deception" value="10 + @{deception}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_History_Check" value="&{template:5eDefault} {{ability=1}} {{title=History (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{history} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{history} + (@{global_check_bonus}) ]]}}  @{classactiondeception}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_History_Check" value="&{template:5eDefault} {{ability=1}} {{title=History (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{history} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{history} + (@{global_check_bonus}) ]]}}  @{classactiondeception}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">History (Int)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_history_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -404,15 +438,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_history_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_history" value="@{history_prof_exp}+@{intelligence_mod}+@{history_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_history" value="10 + @{history}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_history_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_history" value="@{history_prof_exp}+@{intelligence_mod}+@{history_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_history" value="10 + @{history}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Insight_Check" value="&{template:5eDefault} {{ability=1}} {{title=Insight (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{insight} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{insight} + (@{global_check_bonus}) ]]}} @{classactioninsight}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Insight_Check" value="&{template:5eDefault} {{ability=1}} {{title=Insight (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{insight} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{insight} + (@{global_check_bonus}) ]]}} @{classactioninsight}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Insight (Wis)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_insight_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -420,15 +461,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_insight_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_insight" value="@{insight_prof_exp}+@{wisdom_mod}+@{insight_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_insight" value="10 + @{insight}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_insight_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_insight" value="@{insight_prof_exp}+@{wisdom_mod}+@{insight_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_insight" value="10 + @{insight}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Intimidation_Check" value="&{template:5eDefault} {{ability=1}} {{title=Intimidation (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{intimidation} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{intimidation} + (@{global_check_bonus}) ]]}}  @{classactionintimidation}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Intimidation_Check" value="&{template:5eDefault} {{ability=1}} {{title=Intimidation (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{intimidation} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{intimidation} + (@{global_check_bonus}) ]]}}  @{classactionintimidation}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Intimidation (Cha)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_intimidation_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -436,15 +484,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_intimidation_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_intimidation" value="@{intimidation_prof_exp}+@{charisma_mod}+@{intimidation_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_intimidation" value="10 + @{intimidation}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_intimidation_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_intimidation" value="@{intimidation_prof_exp}+@{charisma_mod}+@{intimidation_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_intimidation" value="10 + @{intimidation}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Investigation_Check" value="&{template:5eDefault} {{ability=1}} {{title=Investigation (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{investigation} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{investigation} + (@{global_check_bonus}) ]]}} @{classactioninvestigation}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Investigation_Check" value="&{template:5eDefault} {{ability=1}} {{title=Investigation (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{investigation} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{investigation} + (@{global_check_bonus}) ]]}} @{classactioninvestigation}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Investigation (Int)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_investigation_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -452,28 +507,33 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_investigation_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_investigation" value="@{investigation_prof_exp}+@{intelligence_mod}+@{investigation_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_investigation" value="10 + @{investigation}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_investigation_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_investigation" value="@{investigation_prof_exp}+@{intelligence_mod}+@{investigation_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_investigation" value="10 + @{investigation}" disabled="disabled">
+						</div>
 					</div>
-					
 				</div>
-				
+
 				<div class="sheet-col-1-2">
-				
 					<div class="sheet-row sheet-sub-header">
 						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
 						<div class="sheet-col-7-24 sheet-small-label">Skill</div>
-						<div class="sheet-col-7-24 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Bonus</div>
-						<div class="sheet-col-1-12 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Bonus</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
 						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Pass</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Medicine_Check" value="&{template:5eDefault} {{ability=1}} {{title=Medicine (WIS)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{medicine} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{medicine} + (@{global_check_bonus}) ]]}} @{classactionmedicine}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Medicine_Check" value="&{template:5eDefault} {{ability=1}} {{title=Medicine (WIS)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{medicine} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{medicine} + (@{global_check_bonus}) ]]}} @{classactionmedicine}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Medicine (Wis)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_medicine_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -481,15 +541,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_medicine_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_medicine" value="@{medicine_prof_exp}+@{wisdom_mod}+@{medicine_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_medicine" value="10 + @{medicine}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_medicine_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_medicine" value="@{medicine_prof_exp}+@{wisdom_mod}+@{medicine_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_medicine" value="10 + @{medicine}" disabled="disabled">
+						</div>
 					</div>
-
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Nature_Check" value="&{template:5eDefault} {{ability=1}} {{title=Nature (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{nature} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{nature} + (@{global_check_bonus}) ]]}} @{classactionnature}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Nature_Check" value="&{template:5eDefault} {{ability=1}} {{title=Nature (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{nature} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{nature} + (@{global_check_bonus}) ]]}} @{classactionnature}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Nature (Int)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_nature_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -497,15 +564,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_nature_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_nature" value="@{nature_prof_exp}+@{intelligence_mod}+@{nature_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_nature" value="10 + @{nature}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_nature_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_nature" value="@{nature_prof_exp}+@{intelligence_mod}+@{nature_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_nature" value="10 + @{nature}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Perception_Check" value="&{template:5eDefault} {{ability=1}} {{title=Perception (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{perception} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{perception} + (@{global_check_bonus}) ]]}} @{classactionperception}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Perception_Check" value="&{template:5eDefault} {{ability=1}} {{title=Perception (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{perception} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{perception} + (@{global_check_bonus}) ]]}} @{classactionperception}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Perception (Wis)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_perception_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -513,15 +587,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_perception_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_perception" value="@{perception_prof_exp}+@{wisdom_mod}+@{perception_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_perception" value="10 + @{perception}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_perception_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_perception" value="@{perception_prof_exp}+@{wisdom_mod}+@{perception_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_perception" value="10 + @{perception}" disabled="disabled">
+						</div>
 					</div>
-				
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Performance_Check" value="&{template:5eDefault} {{ability=1}} {{title=Performance (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{performance} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{performance} + (@{global_check_bonus}) ]]}} @{classactionperformance}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Performance_Check" value="&{template:5eDefault} {{ability=1}} {{title=Performance (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{performance} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{performance} + (@{global_check_bonus}) ]]}} @{classactionperformance}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Performance (Cha)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_performance_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -529,15 +610,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_performance_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_performance" value="@{performance_prof_exp}+@{charisma_mod}+@{performance_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_performance" value="10 + @{performance}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_performance_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_performance" value="@{performance_prof_exp}+@{charisma_mod}+@{performance_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_performance" value="10 + @{performance}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Persuasion_Check" value="&{template:5eDefault} {{ability=1}} {{title=Persuasion (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{persuasion} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{persuasion} + (@{global_check_bonus}) ]]}} @{classactionpersuasion}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Persuasion_Check" value="&{template:5eDefault} {{ability=1}} {{title=Persuasion (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{persuasion} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{persuasion} + (@{global_check_bonus}) ]]}} @{classactionpersuasion}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Persuasion (Cha)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_persuasion_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -545,15 +633,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_persuasion_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_persuasion" value="@{persuasion_prof_exp}+@{charisma_mod}+@{persuasion_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_persuasion" value="10 + @{persuasion}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_persuasion_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_persuasion" value="@{persuasion_prof_exp}+@{charisma_mod}+@{persuasion_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_persuasion" value="10 + @{persuasion}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Religion_Check" value="&{template:5eDefault} {{ability=1}} {{title=Religion (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{religion} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{religion} + (@{global_check_bonus}) ]]}} @{classactionreligion}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Religion_Check" value="&{template:5eDefault} {{ability=1}} {{title=Religion (INT)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{religion} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{religion} + (@{global_check_bonus}) ]]}} @{classactionreligion}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Religion (Int)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_religion_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -561,15 +656,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_religion_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_religion" value="@{religion_prof_exp}+@{intelligence_mod}+@{religion_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_religion" value="10 + @{religion}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_religion_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_religion" value="@{religion_prof_exp}+@{intelligence_mod}+@{religion_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_religion" value="10 + @{religion}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_SleightOfHand_Check" value="&{template:5eDefault} {{ability=1}} {{title=Sleight of Hand (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{sleightofhand} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{sleightofhand} + (@{global_check_bonus}) ]]}} @{classactionsleightofhand}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_SleightOfHand_Check" value="&{template:5eDefault} {{ability=1}} {{title=Sleight of Hand (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{sleightofhand} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{sleightofhand} + (@{global_check_bonus}) ]]}} @{classactionsleightofhand}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Sleight of Hand (Dex)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_sleightofhand_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -577,15 +679,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_sleightofhand_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_sleightofhand" value="@{sleightofhand_prof_exp}+@{dexterity_mod}+@{sleightofhand_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_sleightofhand" value="10 + @{sleightofhand}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_sleightofhand_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_sleightofhand" value="@{sleightofhand_prof_exp}+@{dexterity_mod}+@{sleightofhand_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_sleightofhand" value="10 + @{sleightofhand}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Stealth_Check" value="&{template:5eDefault} {{ability=1}} {{title=Stealth (DEX)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{stealth} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{stealth} + (@{global_check_bonus}) ]]}} @{classactionstealth}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Stealth_Check" value="&{template:5eDefault} {{ability=1}} {{title=Stealth (DEX)}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{stealth} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{stealth} + (@{global_check_bonus}) ]]}} @{classactionstealth}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Stealth (Dex)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_stealth_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -593,15 +702,22 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_stealth_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_stealth" value="@{stealth_prof_exp}+@{dexterity_mod}+@{stealth_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_stealth" value="10 + @{stealth}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_stealth_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_stealth" value="@{stealth_prof_exp}+@{dexterity_mod}+@{stealth_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_stealth" value="10 + @{stealth}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Survival_Check" value="&{template:5eDefault} {{ability=1}} {{title=Survival (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{survival} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{survival} + (@{global_check_bonus}) ]]}} @{classactionsurvival}"></button></div>
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Survival_Check" value="&{template:5eDefault} {{ability=1}} {{title=Survival (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{survival} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{survival} + (@{global_check_bonus}) ]]}} @{classactionsurvival}"></button>
+						</div>
 						<div class="sheet-col-7-24 sheet-skill-name">Survival (Wis)</div>
-						<div class="sheet-col-7-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_survival_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -609,34 +725,41 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_survival_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-12"><input type="number" name="attr_survival" value="@{survival_prof_exp}+@{wisdom_mod}+@{survival_bonus}" disabled="disabled"></div>
-						<div class="sheet-col-1-12 sheet-offset-1-24"><input type="number" class="sheet-passive-skill-score" name="attr_passive_survival" value="10 + @{survival}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_survival_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_survival" value="@{survival_prof_exp}+@{wisdom_mod}+@{survival_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_survival" value="10 + @{survival}" disabled="disabled">
+						</div>
 					</div>
-					
 				</div>
-			
+
 			</div>
-			
+
 			<hr />
-			
+
 			<div class="sheet-row">
-			
 				<div class="sheet-col-1-2 sheet-padr">
-			
 					<div class="sheet-row sheet-sub-header">
 						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
-						<div class="sheet-col-7-24 sheet-small-label sheet-center">Skill</div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">Stat</div>
-						<div class="sheet-col-5-24 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Bonus</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-6 sheet-small-label sheet-center">Skill</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">Stat</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Bonus</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Pass</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_1" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_1_name}}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{custom_skill_1} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_1} + (@{global_check_bonus}) ]]}} @{classactioncustom1skill}"></button></div>
-						<div class="sheet-col-7-24"><input type="text" class="sheet-center" name="attr_custom_skill_1_name" value="Custom 1"></div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_1" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_1_name}}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{custom_skill_1} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_1} + (@{global_check_bonus}) ]]}} @{classactioncustom1skill}"></button>
+						</div>
+						<div class="sheet-col-1-6">
+							<input type="text" name="attr_custom_skill_1_name" value="Custom 1">
+						</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">
 							<select name="attr_custom_skill_1_mod">
 								<option value="0">None</option>
 								<option value="@{strength_mod}">STR</option>
@@ -647,7 +770,7 @@
 								<option value="@{charisma_mod}">CHA</option>
 							</select>
 						</div>
-						<div class="sheet-col-5-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_custom_skill_1_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -655,14 +778,24 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_1_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_1" value="@{custom_skill_1_prof_exp}+@{custom_skill_1_mod}+@{custom_skill_1_bonus}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_custom_skill_1_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_custom_skill_1" value="@{custom_skill_1_prof_exp}+@{custom_skill_1_mod}+@{custom_skill_1_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_custom_skill_1" value="10 + @{custom_skill_1}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_2" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_2_name}}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{custom_skill_2} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_2} + (@{global_check_bonus}) ]]}} @{classactioncustom2skill}"></button></div>
-						<div class="sheet-col-7-24"><input type="text" class="sheet-center" name="attr_custom_skill_2_name" value="Custom 2"></div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_2" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_2_name}}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{custom_skill_2} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_2} + (@{global_check_bonus}) ]]}} @{classactioncustom2skill}"></button>
+						</div>
+						<div class="sheet-col-1-6">
+							<input type="text" name="attr_custom_skill_2_name" value="Custom 2">
+						</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">
 							<select name="attr_custom_skill_2_mod">
 								<option value="0">None</option>
 								<option value="@{strength_mod}">STR</option>
@@ -673,7 +806,7 @@
 								<option value="@{charisma_mod}">CHA</option>
 							</select>
 						</div>
-						<div class="sheet-col-5-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_custom_skill_2_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -681,27 +814,35 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_2_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_2" value="@{custom_skill_2_prof_exp}+@{custom_skill_2_mod}+@{custom_skill_2_bonus}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_custom_skill_2_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_custom_skill_2" value="@{custom_skill_2_prof_exp}+@{custom_skill_2_mod}+@{custom_skill_2_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_custom_skill_2" value="10 + @{custom_skill_2}" disabled="disabled">
+						</div>
 					</div>
-					
 				</div>
-				
 				<div class="sheet-col-1-2">
-			
 					<div class="sheet-row sheet-sub-header">
 						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
-						<div class="sheet-col-7-24 sheet-small-label sheet-center">Skill</div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">Stat</div>
-						<div class="sheet-col-5-24 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Bonus</div>
-						<div class="sheet-col-1-8 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-6 sheet-small-label sheet-center">Skill</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">Stat</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Bonus</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Pass</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_3" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_3_name}}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{custom_skill_3} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_3} + (@{global_check_bonus}) ]]}} @{classactioncustom3skill}"></button></div>
-						<div class="sheet-col-7-24"><input type="text" class="sheet-center" name="attr_custom_skill_3_name" value="Custom 3"></div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_3" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_3_name}}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{custom_skill_3} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_3} + (@{global_check_bonus}) ]]}} @{classactioncustom3skill}"></button>
+						</div>
+						<div class="sheet-col-1-6">
+							<input type="text" name="attr_custom_skill_3_name" value="Custom 3">
+						</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">
 							<select name="attr_custom_skill_3_mod">
 								<option value="0">None</option>
 								<option value="@{strength_mod}">STR</option>
@@ -712,7 +853,7 @@
 								<option value="@{charisma_mod}">CHA</option>
 							</select>
 						</div>
-						<div class="sheet-col-5-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_custom_skill_3_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -720,14 +861,24 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_3_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_3" value="@{custom_skill_3_prof_exp}+@{custom_skill_3_mod}+@{custom_skill_3_bonus}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_custom_skill_3_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_custom_skill_3" value="@{custom_skill_3_prof_exp}+@{custom_skill_3_mod}+@{custom_skill_3_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_custom_skill_3" value="10 + @{custom_skill_3}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-12"><button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_4" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_4_name}}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{custom_skill_4} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_4} + (@{global_check_bonus}) ]]}} @{classactioncustom4skill}"></button></div>
-						<div class="sheet-col-7-24"><input type="text" class="sheet-center" name="attr_custom_skill_4_name" value="Custom 4"></div>
-						<div class="sheet-col-1-6 sheet-small-label sheet-center">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Custom_Skill_4" value="&{template:5eDefault} {{ability=1}} {{title=@{custom_skill_4_name}}} {{subheader=@{character_name}}} {{rollname=Result}} {{subheaderright=Ability check}} {{roll=[[ 1d20 + @{custom_skill_4} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{custom_skill_4} + (@{global_check_bonus}) ]]}} @{classactioncustom4skill}"></button>
+						</div>
+						<div class="sheet-col-1-6">
+							<input type="text" name="attr_custom_skill_4_name" value="Custom 4">
+						</div>
+						<div class="sheet-col-1-8 sheet-small-label sheet-center">
 							<select name="attr_custom_skill_4_mod">
 								<option value="0">None</option>
 								<option value="@{strength_mod}">STR</option>
@@ -738,7 +889,7 @@
 								<option value="@{charisma_mod}">CHA</option>
 							</select>
 						</div>
-						<div class="sheet-col-5-24">
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_custom_skill_4_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
@@ -746,124 +897,154 @@
 								<option value="(2*@{PB})">Expertise</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_4_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-8"><input type="number" name="attr_custom_skill_4" value="@{custom_skill_4_prof_exp}+@{custom_skill_4_mod}+@{custom_skill_4_bonus}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_custom_skill_4_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_custom_skill_4" value="@{custom_skill_4_prof_exp}+@{custom_skill_4_mod}+@{custom_skill_4_bonus}" disabled="disabled">
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" class="sheet-passive-skill-score" name="attr_passive_custom_skill_4" value="10 + @{custom_skill_4}" disabled="disabled">
+						</div>
 					</div>
-					
 				</div>
-				
 			</div>
-			
+
 			<hr/>
-			
+
 			<div class="sheet-row">
-			
 				<div class="sheet-col-1-2 sheet-padr">
-			
 					<div class="sheet-row sheet-sub-header">
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">&nbsp;</div>
+						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
 						<div class="sheet-col-2-7 sheet-small-label">Other</div>
-						<div class="sheet-col-2-7 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">Misc</div>
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Misc</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Strength_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (STR)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_strength_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_strength_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledstr}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled STR check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Strength_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (STR)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_strength_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_strength_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledstr}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled STR check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_strength_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_strength_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_strength_check_mod" value="@{strength_mod} + @{basic_strength_bonus} + @{basic_strength_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_strength_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_strength_check_mod" value="@{strength_mod} + @{basic_strength_bonus} + @{basic_strength_prof_exp}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Dexterity_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_dexterity_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_dexterity_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilleddex}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled DEX check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Dexterity_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (DEX)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_dexterity_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_dexterity_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilleddex}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled DEX check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_dexterity_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_dexterity_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_dexterity_check_mod" value="@{dexterity_mod} + @{basic_dexterity_bonus} + @{basic_dexterity_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_dexterity_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_dexterity_check_mod" value="@{dexterity_mod} + @{basic_dexterity_bonus} + @{basic_dexterity_prof_exp}" disabled="disabled">
+						</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Constitution_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (CON)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_constitution_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_constitution_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledcon}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled CON check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Constitution_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (CON)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_constitution_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_constitution_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledcon}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled CON check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_constitution_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_constitution_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_constitution_check_mod" value="@{constitution_mod} + @{basic_constitution_bonus} + @{basic_constitution_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_constitution_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_constitution_check_mod" value="@{constitution_mod} + @{basic_constitution_bonus} + @{basic_constitution_prof_exp}" disabled="disabled">
+						</div>
 					</div>
-
-					
-				
 				</div>
-				
 				<div class="sheet-col-1-2">
-				
 					<div class="sheet-row sheet-sub-header">
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">&nbsp;</div>
+						<div class="sheet-col-1-12 sheet-center sheet-small-label">&nbsp;</div>
 						<div class="sheet-col-2-7 sheet-small-label">Other</div>
-						<div class="sheet-col-2-7 sheet-center sheet-small-label">Proficient</div>
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">Misc</div>
-						<div class="sheet-col-1-7 sheet-center sheet-small-label">Total</div>
+						<div class="sheet-col-1-7 sheet-center sheet-small-label">Proficient</div>
+						<div class="sheet-col-1-9 sheet-center sheet-small-label">Misc</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24 sheet-center sheet-small-label">Total</div>
 					</div>
-					
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Intelligence_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_intelligence_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_intelligence_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledint}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled INT check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Intelligence_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (INT)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_intelligence_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_intelligence_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledint}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled INT check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_intelligence_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_intelligence_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_intelligence_check_mod" value="@{intelligence_mod} + @{basic_intelligence_bonus} + @{basic_intelligence_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_intelligence_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_intelligence_check_mod" value="@{intelligence_mod} + @{basic_intelligence_bonus} + @{basic_intelligence_prof_exp}" disabled="disabled">
+						</div>
 					</div>
-					
+
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Wisdom_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_wisdom_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_wisdom_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledwis}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled WIS check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Wisdom_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (WIS)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_wisdom_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_wisdom_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledwis}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled WIS check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_wisdom_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_wisdom_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_wisdom_check_mod" value="@{wisdom_mod} + @{basic_wisdom_bonus} + @{basic_wisdom_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_wisdom_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_wisdom_check_mod" value="@{wisdom_mod} + @{basic_wisdom_bonus} + @{basic_wisdom_prof_exp}" disabled="disabled">
+						</div>
 					</div>
-					
+
 					<div class="sheet-row sheet-skill-row">
-						<div class="sheet-col-1-7"><button class="sheet-skill-roll" type="roll" name="roll_Basic_Charisma_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_charisma_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_charisma_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledcha}"></button></div>
-						<div class="sheet-col-2-7 sheet-skill-name">(Unskilled CHA check)</div>
-						<div class="sheet-col-2-7">
+						<div class="sheet-col-1-12">
+							<button class="sheet-skill-roll" type="roll" name="roll_Basic_Charisma_Check" value="&{template:5eDefault} {{ability=1}} {{title=Unskilled (CHA)}} {{subheader=@{character_name}}} {{subheaderright=Ability check}} {{rollname=Result}} {{roll=[[ 1d20 + @{basic_charisma_check_mod} + (@{global_check_bonus}) ]]}} {{rolladv=[[ 1d20 + @{basic_charisma_check_mod} + (@{global_check_bonus}) ]]}} @{classactionunskilledcha}"></button>
+						</div>
+						<div class="sheet-col-2-7 sheet-skill-name">Unskilled CHA check</div>
+						<div class="sheet-col-1-7 sheet-small-label">
 							<select name="attr_basic_charisma_prof_exp">
 								<option value="0">No</option>
 								<option value="floor(@{PB} / 2)">Jack of all trades</option>
 							</select>
 						</div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_charisma_bonus" value="0" step="1"/></div>
-						<div class="sheet-col-1-7"><input type="number" name="attr_basic_charisma_check_mod" value="@{charisma_mod} + @{basic_charisma_bonus} + @{basic_charisma_prof_exp}" disabled="disabled"></div>
+						<div class="sheet-col-1-9 sheet-small-label">
+							<input type="number" name="attr_basic_charisma_bonus" value="0" step="1"/>
+						</div>
+						<div class="sheet-col-1-12 sheet-offset-1-24">
+							<input type="number" name="attr_basic_charisma_check_mod" value="@{charisma_mod} + @{basic_charisma_bonus} + @{basic_charisma_prof_exp}" disabled="disabled">
+						</div>
 					</div>
 				</div>
 			</div>
-			
+
 			<hr />
-			
+
 		</div>
 
 		<div class="sheet-section-background">
@@ -13533,4 +13714,4 @@
 			</div>
 		</div>
 
-</rolltemplate>
+</rolltemplate>

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -30,6 +30,8 @@
 		<span class="sheet-tab sheet-tab8">Armour</span>
 		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab7" value="7"/>
 		<span class="sheet-tab sheet-tab7">Inventory</span>
+		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9"/>
+		<span class="sheet-tab sheet-tab9">Settings</span>
 		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab99" value="99"/>
 		<span class="sheet-tab sheet-tab99">Show All</span>
 		
@@ -131,7 +133,7 @@
 							<div class="sheet-row sheet-padr">
 								<div class="sheet-col-1-3 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button"><input class="sheet-underlined sheet-center" type="number" name="attr_initiative" value="0" step="1"><br/>Bonus</div>
 								<div class="sheet-col-1-3 sheet-small-label sheet-center"><input class="sheet-underlined" type="number" name="attr_initiative_overall" value="@{dexterity_mod} + @{initiative}" disabled="disabled"><br/>Total</div>
-								<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-initiative sheet-large-button" name="roll_Initiative" value="&{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|initiative_overall} [Initiative Mod] &{tracker} ]]}} @{classactioninitiative}">Initiative</button></div>
+								<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-initiative sheet-large-button" name="roll_Initiative" value="&{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|initiative_overall} [Initiative Mod] + @{initiative_tie_breaker} [Tie Breaker]  &{tracker} ]]}} @{classactioninitiative}">Initiative</button></div>
 							</div>
 						</div>
 						
@@ -283,7 +285,7 @@
 						<div class="sheet-col-1-5 sheet-margin-top">
 						
 							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-center"><button type="roll" class="sheet-roll" name="roll_Death_Saving_Throw" value="&{template:5eDefault} {{deathsave=1}} {{character_name=@{character_name}}} {{emote=dices with death!}} {{title=Death Save}} {{subheader=@{character_name}}} {{rollname=Death save}} {{roll=[[1d20 + (@{global_saving_bonus})]]}} @{classactiondeathsave} ">Death Saving Throw</button></div>
+								<div class="sheet-col-1 sheet-center"><button type="roll" class="sheet-roll" name="roll_Death_Saving_Throw" value="@{death_save_output_option} &{template:5eDefault} {{deathsave=1}} {{character_name=@{character_name}}} {{emote=dices with death!}} {{title=Death Save}} {{subheader=@{character_name}}} {{rollname=Death save}} {{roll=[[1d20 + (@{global_saving_bonus})]]}} @{classactiondeathsave} ">Death Saving Throw</button></div>
 							</div>
 
 						</div>
@@ -12148,7 +12150,26 @@
 			
 			<hr/>
 		</div>
-	
+
+		<div class="sheet-section-settings">
+			<div class="sheet-row">
+				<div class="sheet-col-1-2 sheet-padr">
+					<div class="sheet-col-1-2 sheet-margin-top sheet-small-label">Whisper Death Saves: </div>
+					<div class="sheet-col-11-24">
+						<select name="attr_death_save_output_option" class="sheet-margin-top">
+							<option value=" " selected="selected">Public for all to see</option>
+							<option value="/w GM ">Whispered to the GM</option>
+						</select>
+					</div>
+				</div>
+				<div class="sheet-col-1-2">
+					<div class="sheet-col-1-2 sheet-margin-top sheet-small-label">Break Initiative Ties: </div>
+					<div class="sheet-col-11-24">
+						<input type="checkbox" name="attr_initiative_tie_breaker" value="(@{initiative_overall}) / 100" />
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 	
 	
@@ -12176,7 +12197,7 @@
 				<div class="sheet-row sheet-padr">
 					<div class="sheet-col-1-3 sheet-small-label sheet-center" title="Only enter additional bonuses to initiative here. Your Dex mod is already included in the macro button"><input class="sheet-underlined sheet-center" type="number" name="attr_npc_initiative" value="0" step="1"><br/>Initiative Bonus</div>
 					<div class="sheet-col-1-3 sheet-small-label sheet-center"><input class="sheet-underlined" type="number" name="attr_npc_initiative_overall" value="@{npc_dexterity_mod} + @{npc_initiative}" disabled="disabled"><br/>Total</div>
-					<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-roll" name="roll_NPC_Initiative" value="@{npc_output_option} &{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|npc_initiative_overall} &{tracker} ]]}}">Initiative</button></div>
+					<div class="sheet-col-1-3 sheet-center"><button type="roll" class="sheet-roll" name="roll_NPC_Initiative" value="@{npc_output_option} &{template:5eDefault} {{title=Initiative}} {{subheader=@{character_name}}} {{rollname=Initiative}} {{roll=[[ 1d20 + @{selected|npc_initiative_overall} [Initiative Mod] + @{npc_initiative_tie_breaker} [Tie Breaker] &{tracker} ]]}}">Initiative</button></div>
 				</div>
 			</div>
 			
@@ -13428,6 +13449,16 @@
 	<hr/>
 		
 		<!-- END AUTO GENERATED NPC ACTION SECTION -->
+
+		<div>Settings</div>
+		<div class="sheet-row">
+			<div class="sheet-col-1-2 sheet-padr">
+				<div class="sheet-col-1-2 sheet-margin-top sheet-small-label">Break Initiative Ties: </div>
+				<div class="sheet-col-11-24">
+					<input type="checkbox" name="attr_npc_initiative_tie_breaker" value="(@{npc_initiative_overall}) / 100" />
+				</div>
+			</div>
+		</div>
 
 	</div>
 	

--- a/DnD_5e/sheet.json
+++ b/DnD_5e/sheet.json
@@ -1,7 +1,7 @@
 {
 	"html": "DnD_5e.html",
 	"css": "DnD_5e.css",
-	"authors": "John Myles (Actoba on Roll20.net, @jmyles85 on Twitter)",
+	"authors": "John Myles (Actoba on Roll20.net, @jmyles85 on Twitter), Mark Lenser (Kryx on Roll20.net, @mlenser on Twitter)",
 	"roll20userid": "427494",
 	"preview": "DnD_5e.png",
 	"instructions": "This sheet is designed for use with the full release of DnD 5th edition.  Where possible, it supports the 'rules as written' as listed in the Basic DnD PDF that's freely available for download, and the Players Handbook (PHB) that was released in August 2014.  Sheet help is available on the roll20 wiki - https://wiki.roll20.net/DnD5e_Character_Sheet  Note: This sheet is NOT compatible with the older playtest ruleset (DnD Next) and if you are still using the Next rules you should use the older, and no longer maintained, DnD Next sheet instead.  It's also advisable to avoid trying to transfer existing characters between this and the older 'Next' sheet as they are not fully compatible."


### PR DESCRIPTION
Align skills so that the columns align across normal skills, custom skills, and untrained skills. Also made the Prof and Bonus/Misc fields slightly smaller font-size so the important info when rolling is bigger in comparison.

Also committed to Actoba's branch here: https://github.com/Actoba/roll20-character-sheets/pull/83