### PR TITLE
Pathfinder-Neceros: Updated pf_spell to include attacks

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -5643,19 +5643,58 @@ Have questions or feedback? <a href="https://app.roll20.net/forum/post/1498595/p
             {{/name}}
         </td></tr>
     
-    <tr><td><span class="sheet-tcat">School</span> {{school}}<span class="tcat">; Level</span> {{level}}</td></tr>
-    <tr><td><span class="sheet-tcat">Casting Time</span> {{casting_time}}</td></tr>
-    <tr><td><span class="sheet-tcat">Components</span> {{components}}</td></tr>
-    <tr><td><span class="sheet-tcat">Range</span> {{range}}</td></tr>
-    <tr><td><span class="sheet-tcat">Effects/Target</span> {{target}}</td></tr>
-    <tr><td><span class="sheet-tcat">Duration</span> {{duration}}</td></tr>
-    <tr><td><span class="sheet-tcat">Saving Throw</span> {{saving_throw}} **DC** {{dc}};<span class="sheet-tcat"> Spell Resistance</span> {{sr}}</td></tr>
+    {{#school}}<tr><td colspan="2"><span class="sheet-tcat">School</span> {{school}}; {{#level}}<span class="tcat">Level</span> {{level}}{{/level}}</td></tr>{{/school}}
+    {{#casting_time}}<tr><td colspan="2"><span class="sheet-tcat">Casting Time</span> {{casting_time}}</td></tr>{{/casting_time}}
+    {{#components}}<tr><td colspan="2"><span class="sheet-tcat">Components</span> {{components}}</td></tr>{{/components}}
+    {{#range}}<tr><td colspan="2"><span class="sheet-tcat">Range</span> {{range}}</td></tr>{{/range}}
+    {{#target}}<tr><td colspan="2"><span class="sheet-tcat">Effects/Target</span> {{target}}</td></tr>{{/target}}
+    {{#duration}}<tr><td colspan="2"><span class="sheet-tcat">Duration</span> {{duration}}</td></tr>{{/duration}}
+    {{#saving_throw}}<tr><td colspan="2"><span class="sheet-tcat">Saving Throw</span> {{saving_throw}} {{#dc}}**DC** {{dc}}{{/dc}}</td></tr>{{/saving_throw}}
+    {{#sr}}<tr><td colspan="2"><span class="sheet-tcat">Spell Resistance</span> {{sr}}</td></tr>{{/sr}}
+
+    {{#attack}}
+            <tr class="sheet-rolltemplate-pf_attack"><td>Attack</td><td>{{attack}}</td></tr>
+        {{#crit_confirm}}
+            {{#rollWasCrit() attack}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm}}</td></tr>
+            {{/rollWasCrit() attack}}
+        {{/crit_confirm}}
+        {{#damage}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Damage</td><td>{{damage}}</td></tr>
+        {{/damage}}
+        {{#crit_damage}}
+            {{#rollWasCrit() attack}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage}}</td></tr>
+            {{/rollWasCrit() attack}}
+        {{/crit_damage}}
+    {{/attack}}
+    {{^attack}}
+        {{#damage}}
+            <tr class="sheet-rolltemplate-pf_attack"><td>Damage</td><td>{{damage}}</td></tr>
+        {{/damage}}
+    {{/attack}}
     
-    {{#allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description}}
-	   <tr><td><b>{{key}}</b> {{value}}</td></tr>
-    {{/allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description}}
-    
-    <tr><td>{{spell_description}}</td></tr>
+    {{#attack2}}
+            <tr class="sheet-rolltemplate-pf_attack"><td>Attack 2</td><td>{{attack2}}</td></tr>
+        {{#crit_confirm2}}
+            {{#rollWasCrit() attack2}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm2}}</td></tr>
+            {{/rollWasCrit() attack2}}
+            {{/crit_confirm2}}
+        {{#damage2}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Damage</td><td>{{damage2}}</td></tr>
+        {{/damage2}}
+        {{#crit_damage2}}
+            {{#rollWasCrit() attack2}}
+            <tr class="sheet-rolltemplate-pf_attack"><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage2}}</td></tr>
+            {{/rollWasCrit() attack2}}
+        {{/crit_damage2}}
+    {{/attack2}}
+            
+    {{#allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
+       <tr><td colspan="2"><b>{{key}}</b> {{value}}</td></tr>
+    {{/allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
+    {{#spell_description}}<tr><td colspan="2">{{spell_description}}</td></tr>{{/spell_description}}
   </table>
 </rolltemplate>
 

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -1222,7 +1222,7 @@
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">|</span>
                 <span class="sheet-table-data sheet-center"><input type="number" title="@{Max-Skill-Ranks}" name="attr_Max-Skill-Ranks" value="@{total-skill}" disabled></span>
                 <span class="sheet-table-data sheet-center">-</span>
-                <span class="sheet-table-data sheet-center"><input type="number" title="@{Total-Skill-Ranks}" name="attr_Total-Skill-Ranks" value="(@{Acrobatics-ranks} + @{Appraise-ranks} + @{Bluff-ranks} + @{Climb-ranks} + @{Craft-ranks} + @{Craft2-ranks} + @{Craft3-ranks} + @{Diplomacy-ranks} + @{Disable-Device-ranks} + @{Disguise-ranks} + @{Escape-Artist-ranks} + @{Fly-ranks} + @{Handle-Animal-ranks} + @{Heal-ranks} + @{Intimidate-ranks} + @{Knowledge-Arcana-ranks} + @{Knowledge-Dungeoneering-ranks} + @{Knowledge-Engineering-ranks} + @{Knowledge-Geography-ranks} + @{Knowledge-History-ranks} + @{Knowledge-Local-ranks} + @{Knowledge-Nature-ranks} + @{Knowledge-Nobility-ranks} + @{Knowledge-Planes-ranks} + @{Knowledge-Religion-ranks} + @{Linguistics-ranks} + @{Perception-ranks} + @{Perform-ranks} + @{Perform2-ranks} + @{Perform3-ranks} + @{Profession-ranks} + @{Profession2-ranks} + @{Profession3-ranks} + @{Ride-ranks} + @{Sense-Motive-ranks} + @{Sleight-of-Hand-ranks} + @{Spellcraft-ranks} + @{Stealth-ranks} + @{Survival-ranks} + @{Swim-ranks} + @{Use-Magic-Device-ranks} + @{Misc-Skill-0-ranks} + @{Misc-Skill-1-ranks} + @{Misc-Skill-2-ranks} + @{Misc-Skill-3-ranks} + @{Misc-Skill-4-ranks} + @{Misc-Skill-5-ranks})" disabled></span>
+                <span class="sheet-table-data sheet-center"><input type="number" title="@{Total-Skill-Ranks}" name="attr_Total-Skill-Ranks" value="(@{Acrobatics-ranks} + @{Appraise-ranks} + @{Artistry-ranks} + @{Bluff-ranks} + @{Climb-ranks} + @{Craft-ranks} + @{Craft2-ranks} + @{Craft3-ranks} + @{Diplomacy-ranks} + @{Disable-Device-ranks} + @{Disguise-ranks} + @{Escape-Artist-ranks} + @{Fly-ranks} + @{Handle-Animal-ranks} + @{Heal-ranks} + @{Intimidate-ranks} + @{Knowledge-Arcana-ranks} + @{Knowledge-Dungeoneering-ranks} + @{Knowledge-Engineering-ranks} + @{Knowledge-Geography-ranks} + @{Knowledge-History-ranks} + @{Knowledge-Local-ranks} + @{Knowledge-Nature-ranks} + @{Knowledge-Nobility-ranks} + @{Knowledge-Planes-ranks} + @{Knowledge-Religion-ranks} + @{Linguistics-ranks} + @{Lore-ranks} + @{Perception-ranks} + @{Perform-ranks} + @{Perform2-ranks} + @{Perform3-ranks} + @{Profession-ranks} + @{Profession2-ranks} + @{Profession3-ranks} + @{Ride-ranks} + @{Sense-Motive-ranks} + @{Sleight-of-Hand-ranks} + @{Spellcraft-ranks} + @{Stealth-ranks} + @{Survival-ranks} + @{Swim-ranks} + @{Use-Magic-Device-ranks} + @{Misc-Skill-0-ranks} + @{Misc-Skill-1-ranks} + @{Misc-Skill-2-ranks} + @{Misc-Skill-3-ranks} + @{Misc-Skill-4-ranks} + @{Misc-Skill-5-ranks})" disabled></span>
                 <span class="sheet-table-data sheet-center">=</span>
                 <span class="sheet-table-data sheet-center"><input type="number" title="@{Skill-Ranks-Remaining}" name="attr_Skill-Ranks-Remaining" value="(@{Max-Skill-Ranks} - @{Total-Skill-Ranks})" disabled></span>
             </div>
@@ -1323,6 +1323,39 @@
                 <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                 <span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
+            </div>
+            <div class="sheet-table-row">
+                <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Artistry-Check}" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry}} {{Check=[[1d20 + @{Artistry}]]}}" name="roll_Artistry-Check"></button></span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-cs}" type="checkbox" name="attr_Artistry-cs" value="((((3 * @{Artistry-ranks}) + 3) - abs((3 * @{Artistry-ranks}) - 3)) / 2)" /></span>
+                <span class="sheet-table-data sheet-center"></span>
+                <span class="sheet-table-data sheet-left" title="Optional Ruleset">Artistry</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry}" type="number" name="attr_Artistry" value="(@{Artistry-ranks} + @{Artistry-class} + @{Artistry-ability} + @{Artistry-racial} + @{Artistry-feat} + @{Artistry-item} + @{Artistry-misc} - @{condition-fear} - @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+                <span class="sheet-table-data sheet-center">=</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-ranks}" type="number" name="attr_Artistry-ranks" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-class}" type="number" name="attr_Artistry-class" value="@{Artistry-cs}" disabled></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center">
+                    <select title="@{Artistry-ability}" name="attr_Artistry-ability">
+                        <option value="@{STR-mod}">STR</option>
+                        <option value="@{DEX-mod}">DEX</option>
+                        <option value="@{CON-mod}">CON</option>
+                        <option value="@{INT-mod}" selected>INT</option>
+                        <option value="@{WIS-mod}">WIS</option>
+                        <option value="@{CHA-mod}">CHA</option>
+                    </select>
+                </span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-ability}" type="number" name="attr_Artistry-ability-display" value="@{Artistry-ability}" disabled></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-racial}" type="number" name="attr_Artistry-racial" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-feat}" type="number" name="attr_Artistry-feat" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-item}" type="number" name="attr_Artistry-item" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><b>N/A</b></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Artistry-misc}" type="number" name="attr_Artistry-misc" value="0"></span>
             </div>
             <div class="sheet-table-row">
                 <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Bluff-Check}" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[1d20 + @{Bluff}]]}}" name="roll_Bluff-Check"></button></span>
@@ -2112,11 +2145,43 @@
                 <span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center"><input title="@{Linguistics-item}" type="number" name="attr_Linguistics-item" value="0"></span>
                 <span class="sheet-table-data sheet-center">+</span>
-
                 <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                 <span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
             </div>
+    		<div class="sheet-table-row">
+                <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Lore-Check}" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore}} {{Check=[[1d20 + @{Lore}]]}}" name="roll_Lore-Check"></button></span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-cs}" type="checkbox" name="attr_Lore-cs" value="((((3 * @{Lore-ranks}) + 3) - abs((3 * @{Lore-ranks}) - 3)) / 2)" /></span>
+                <span class="sheet-table-data sheet-center"></span>
+                <span class="sheet-table-data sheet-left" title="Optional Ruleset">Lore</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore}" type="number" name="attr_Lore" value="(@{Lore-ranks} + @{Lore-class} + @{Lore-ability} + @{Lore-racial} + @{Lore-feat} + @{Lore-item} + @{Lore-misc} - @{condition-fear} - @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+                <span class="sheet-table-data sheet-center">=</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-ranks}" type="number" name="attr_Lore-ranks" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-class}" type="number" name="attr_Lore-class" value="@{Lore-cs}" disabled></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center">
+                    <select title="@{Lore-ability}" name="attr_Lore-ability">
+                        <option value="@{STR-mod}">STR</option>
+                        <option value="@{DEX-mod}">DEX</option>
+                        <option value="@{CON-mod}">CON</option>
+                        <option value="@{INT-mod}" selected>INT</option>
+                        <option value="@{WIS-mod}">WIS</option>
+                        <option value="@{CHA-mod}">CHA</option>
+                    </select>
+                </span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-ability}" type="number" name="attr_Lore-ability-display" value="@{Lore-ability}" disabled></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-racial}" type="number" name="attr_Lore-racial" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-feat}" type="number" name="attr_Lore-feat" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-item}" type="number" name="attr_Lore-item" value="0"></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><b>N/A</b></span>
+                <span class="sheet-table-data sheet-center">+</span>
+                <span class="sheet-table-data sheet-center"><input title="@{Lore-misc}" type="number" name="attr_Lore-misc" value="0"></span>
+            </div>            
             <div class="sheet-table-row">
                 <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perception-Check}" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[1d20 + @{Perception}]]}}" name="roll_Perception-Check"></button></span>
                 <span class="sheet-table-data sheet-center"><input title="@{Perception-cs}" type="checkbox" name="attr_Perception-cs" value="((((3 * @{Perception-ranks}) + 3) - abs((3 * @{Perception-ranks}) - 3)) / 2)" /></span>
@@ -4936,7 +5001,7 @@
 </div>
 <div class="sheet-npc sheet-section-npc">
     <div class="sheet-table" style="width:100%;background-color:black;color:white;padding-left:10px;">  
-        <span class="sheet-table-data sheet-center" style="width:90%;text-align:left;"><input type="text" title="character_name" name="attr_character_name" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span>         
+        <span class="sheet-table-data sheet-center" style="width:90%;text-align:left;"><input type="text" title="character_name" name="attr_character_name" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span>     	
 		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><b>CR</b></span>
 		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><input type="text" title="npc-cr" name="attr_npc-cr" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span> 
 	</div>
@@ -5385,13 +5450,18 @@
 						<span class="sheet-table-data sheet-left">Appraise</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Appraise}" type="number" name="attr_Appraise" value="(@{Appraise-ranks} + @{Appraise-class} + @{Appraise-ability} + @{Appraise-racial} + @{Appraise-feat} + @{Appraise-item} + @{Appraise-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
-	
+
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Artistry-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry}} {{Check=[[1d20 + [[@{Artistry}]] ]]}}" name="roll_NPC-Artistry-Check"></button></span>
+						<span class="sheet-table-data sheet-left" title="Optional Ruleset">Artistry</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Artistry}" type="number" name="attr_Artistry" value="(@{Artistry-ranks} + @{Artistry-class} + @{Artistry-ability} + @{Artistry-racial} + @{Artistry-feat} + @{Artistry-item} + @{Artistry-misc} - @{condition-fear} -  @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Artistry-misc}" type="number" name="attr_Artistry-misc" value="0"></span>
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Bluff-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[1d20 + @{Bluff}]]}}" name="roll_NPC-Bluff-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Bluff</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Bluff}" type="number" name="attr_Bluff" value="(@{Bluff-ranks} + @{Bluff-class} + @{Bluff-ability} + @{Bluff-racial} + @{Bluff-feat} + @{Bluff-item} + @{Bluff-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Bluff-misc}" type="number" name="attr_Bluff-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Climb-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Climb}} {{Check=[[1d20 + @{Climb}]]}}" name="roll_NPC-Climb-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Climb</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Climb}" type="number" name="attr_Climb" value="(@{Climb-ranks} + @{Climb-class} + @{Climb-ability} + @{Climb-racial} + @{Climb-feat} + @{Climb-item} + @{Climb-acp} + @{Climb-misc})" disabled></span>
@@ -5401,13 +5471,13 @@
 						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:50%;" type="text" name="attr_Craft-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="(@{Craft-ranks} + @{Craft-class} + @{Craft-ability} + @{Craft-racial} + @{Craft-feat} + @{Craft-item} + @{Craft-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft2-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft: @{Craft2-name}}} {{Check=[[1d20 + @{Craft2}]]}}" name="roll_NPC-Craft2-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:50%;" type="text" name="attr_Craft2-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="(@{Craft2-ranks} + @{Craft2-class} + @{Craft2-ability} + @{Craft2-racial} + @{Craft2-feat} + @{Craft2-item} + @{Craft2-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft3-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft: @{Craft3-name}}} {{Check=[[1d20 + @{Craft3}]]}}" name="roll_NPC-Craft3-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:50%;" type="text" name="attr_Craft3-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="(@{Craft3-ranks} + @{Craft3-class} + @{Craft3-ability} + @{Craft3-racial} + @{Craft3-feat} + @{Craft3-item} + @{Craft3-misc})" disabled></span>
@@ -5417,13 +5487,13 @@
 						<span class="sheet-table-data sheet-left">Diplomacy</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Diplomacy}" type="number" name="attr_Diplomacy" value="(@{Diplomacy-ranks} + @{Diplomacy-class} + @{Diplomacy-ability} + @{Diplomacy-racial} + @{Diplomacy-feat} + @{Diplomacy-item} + @{Diplomacy-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Diplomacy-misc}" type="number" name="attr_Diplomacy-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Disable-Device-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disable Device}} {{Check=[[1d20 + @{Disable-Device}]]}}" name="roll_NPC-Disable-Device-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Disable Device</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Disable-Device}" type="number" name="attr_Disable-Device" value="(@{Disable-Device-ranks} + @{Disable-Device-class} + @{Disable-Device-ability} + @{Disable-Device-racial} + @{Disable-Device-feat} + @{Disable-Device-item} + @{Disable-Device-acp} + @{Disable-Device-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Disable-Device-misc}" type="number" name="attr_Disable-Device-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Disguise-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disguise}} {{Check=[[1d20 + @{Disguise}]]}}" name="roll_NPC-Disguise-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Disguise</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Disguise}" type="number" name="attr_Disguise" value="(@{Disguise-ranks} + @{Disguise-class} + @{Disguise-ability} + @{Disguise-racial} + @{Disguise-feat} + @{Disguise-item} + @{Disguise-misc})" disabled></span>
@@ -5433,13 +5503,13 @@
 						<span class="sheet-table-data sheet-left">Escape Artist</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist}" type="number" name="attr_Escape-Artist" value="(@{Escape-Artist-ranks} + @{Escape-Artist-class} + @{Escape-Artist-ability} + @{Escape-Artist-racial} + @{Escape-Artist-feat} + @{Escape-Artist-item} + @{Escape-Artist-acp} + @{Escape-Artist-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-misc}" type="number" name="attr_Escape-Artist-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Fly-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fly}} {{Check=[[1d20 + @{Fly}]]}}" name="roll_NPC-Fly-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Fly</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Fly}" type="number" name="attr_Fly" value="(@{Fly-ranks} + @{Fly-class} + @{Fly-ability} + @{Fly-racial} + @{Fly-feat} + @{Fly-item} + @{Fly-acp} + @{Fly-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Fly-misc}" type="number" name="attr_Fly-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Handle-Animal-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Handle Animal}} {{Check=[[1d20 + @{Handle-Animal}]]}}" name="roll_NPC-Handle-Animal-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Handle Animal</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Handle-Animal}" type="number" name="attr_Handle-Animal" value="(@{Handle-Animal-ranks} + @{Handle-Animal-class} + @{Handle-Animal-ability} + @{Handle-Animal-racial} + @{Handle-Animal-feat} + @{Handle-Animal-item} + @{Handle-Animal-misc})" disabled></span>
@@ -5449,13 +5519,13 @@
 						<span class="sheet-table-data sheet-left">Heal</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Heal}" type="number" name="attr_Heal" value="(@{Heal-ranks} + @{Heal-class} + @{Heal-ability} + @{Heal-racial} + @{Heal-feat} + @{Heal-item} + @{Heal-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Heal-misc}" type="number" name="attr_Heal-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Intimidate-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intimidate}} {{Check=[[1d20 + @{Intimidate}]]}}" name="roll_NPC-Intimidate-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Intimidate</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Intimidate}" type="number" name="attr_Intimidate" value="(@{Intimidate-ranks} + @{Intimidate-class} + @{Intimidate-ability} + @{Intimidate-racial} + @{Intimidate-feat} + @{Intimidate-item} + @{Intimidate-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Intimidate-misc}" type="number" name="attr_Intimidate-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Arcana-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Arcana)}} {{Check=[[1d20 + @{Knowledge-Arcana}]]}}" name="roll_NPC-Knowledge-Arcana-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Arcana)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana}" type="number" name="attr_Knowledge-Arcana" value="(@{Knowledge-Arcana-ranks} + @{Knowledge-Arcana-class} + @{Knowledge-Arcana-ability} + @{Knowledge-Arcana-racial} + @{Knowledge-Arcana-feat} + @{Knowledge-Arcana-item} + @{Knowledge-Arcana-misc})" disabled></span>
@@ -5465,13 +5535,13 @@
 						<span class="sheet-table-data sheet-left">Knowledge (Dungeoneering)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering}" type="number" name="attr_Knowledge-Dungeoneering" value="(@{Knowledge-Dungeoneering-ranks} + @{Knowledge-Dungeoneering-class} + @{Knowledge-Dungeoneering-ability} + @{Knowledge-Dungeoneering-racial} + @{Knowledge-Dungeoneering-feat} + @{Knowledge-Dungeoneering-item} + @{Knowledge-Dungeoneering-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-misc}" type="number" name="attr_Knowledge-Dungeoneering-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Engineering-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Engineering)}} {{Check=[[1d20 + @{Knowledge-Engineering}]]}}" name="roll_NPC-Knowledge-Engineering-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Engineering)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering}" type="number" name="attr_Knowledge-Engineering" value="(@{Knowledge-Engineering-ranks} + @{Knowledge-Engineering-class} + @{Knowledge-Engineering-ability} + @{Knowledge-Engineering-racial} + @{Knowledge-Engineering-feat} + @{Knowledge-Engineering-item} + @{Knowledge-Engineering-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-misc}" type="number" name="attr_Knowledge-Engineering-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Geography-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Geography)}} {{Check=[[1d20 + @{Knowledge-Geography}]]}}" name="roll_NPC-Knowledge-Geography-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Geography)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography}" type="number" name="attr_Knowledge-Geography" value="(@{Knowledge-Geography-ranks} + @{Knowledge-Geography-class} + @{Knowledge-Geography-ability} + @{Knowledge-Geography-racial} + @{Knowledge-Geography-feat} + @{Knowledge-Geography-item} + @{Knowledge-Geography-misc})" disabled></span>
@@ -5481,13 +5551,13 @@
 						<span class="sheet-table-data sheet-left">Knowledge (History)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History}" type="number" name="attr_Knowledge-History" value="(@{Knowledge-History-ranks} + @{Knowledge-History-class} + @{Knowledge-History-ability} + @{Knowledge-History-racial} + @{Knowledge-History-feat} + @{Knowledge-History-item} + @{Knowledge-History-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-misc}" type="number" name="attr_Knowledge-History-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Local-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Local)}} {{Check=[[1d20 + @{Knowledge-Local}]]}}" name="roll_NPC-Knowledge-Local-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Local)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local}" type="number" name="attr_Knowledge-Local" value="(@{Knowledge-Local-ranks} + @{Knowledge-Local-class} + @{Knowledge-Local-ability} + @{Knowledge-Local-racial} + @{Knowledge-Local-feat} + @{Knowledge-Local-item} + @{Knowledge-Local-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-misc}" type="number" name="attr_Knowledge-Local-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Nature-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Nature)}} {{Check=[[1d20 + @{Knowledge-Nature}]]}}" name="roll_NPC-Knowledge-Nature-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Nature)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature}" type="number" name="attr_Knowledge-Nature" value="(@{Knowledge-Nature-ranks} + @{Knowledge-Nature-class} + @{Knowledge-Nature-ability} + @{Knowledge-Nature-racial} + @{Knowledge-Nature-feat} + @{Knowledge-Nature-item} + @{Knowledge-Nature-misc})" disabled></span>
@@ -5497,13 +5567,13 @@
 						<span class="sheet-table-data sheet-left">Knowledge (Nobility)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility}" type="number" name="attr_Knowledge-Nobility" value="(@{Knowledge-Nobility-ranks} + @{Knowledge-Nobility-class} + @{Knowledge-Nobility-ability} + @{Knowledge-Nobility-racial} + @{Knowledge-Nobility-feat} + @{Knowledge-Nobility-item} + @{Knowledge-Nobility-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Planes-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Planes)}} {{Check=[[1d20 + @{Knowledge-Planes}]]}}" name="roll_NPC-Knowledge-Planes-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Planes)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes}" type="number" name="attr_Knowledge-Planes" value="(@{Knowledge-Planes-ranks} + @{Knowledge-Planes-class} + @{Knowledge-Planes-ability} + @{Knowledge-Planes-racial} + @{Knowledge-Planes-feat} + @{Knowledge-Planes-item} + @{Knowledge-Planes-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-misc}" type="number" name="attr_Knowledge-Planes-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Knowledge-Religion-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge (Religion)}} {{Check=[[1d20 + @{Knowledge-Religion}]]}}" name="roll_NPC-Knowledge-Religion-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Knowledge (Religion)</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion}" type="number" name="attr_Knowledge-Religion" value="(@{Knowledge-Religion-ranks} + @{Knowledge-Religion-class} + @{Knowledge-Religion-ability} + @{Knowledge-Religion-racial} + @{Knowledge-Religion-feat} + @{Knowledge-Religion-item} + @{Knowledge-Religion-misc})" disabled></span>
@@ -5513,18 +5583,24 @@
 						<span class="sheet-table-data sheet-left">Linguistics</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Linguistics}" type="number" name="attr_Linguistics" value="(@{Linguistics-ranks} + @{Linguistics-class} + @{Linguistics-ability} + @{Linguistics-racial} + @{Linguistics-feat} + @{Linguistics-item} + @{Linguistics-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Lore-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore}} {{Check=[[1d20 + [[@{Lore}]] ]]}}" name="roll_NPC-Lore-Check"></button></span>
+						<span class="sheet-table-data sheet-left" title="Optional Ruleset">Lore</span>
+						<span class="sheet-table-data sheet-center"><input title="@{Lore}" type="number" name="attr_Lore" value="(@{Lore-ranks} + @{Lore-class} + @{Lore-ability} + @{Lore-racial} + @{Lore-feat} + @{Lore-item} + @{Lore-misc} - @{condition-fear} -  @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+						<span class="sheet-table-data sheet-center"><input title="@{Lore-misc}" type="number" name="attr_Lore-misc" value="0"></span> 
+                                            
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perception-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[1d20 + @{Perception}]]}}" name="roll_NPC-Perception-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Perception</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perception}" type="number" name="attr_Perception" value="(@{Perception-ranks} + @{Perception-class} + @{Perception-ability} + @{Perception-racial} + @{Perception-feat} + @{Perception-item} + @{Perception-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform: @{Perform-name}}} {{Check=[[1d20 + @{Perform}]]}}" name="roll_NPC-Perform-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:50%;" type="text" name="attr_Perform-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="(@{Perform-ranks} + @{Perform-class} + @{Perform-ability} + @{Perform-racial} + @{Perform-feat} + @{Perform-item} + @{Perform-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform2-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform: @{Perform2-name}}} {{Check=[[1d20 + @{Perform2}]]}}" name="roll_NPC-Perform2-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:50%;" type="text" name="attr_Perform2-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="(@{Perform2-ranks} + @{Perform2-class} + @{Perform2-ability} + @{Perform2-racial} + @{Perform2-feat} + @{Perform2-item} + @{Perform2-misc})" disabled></span>
@@ -5534,13 +5610,13 @@
 						<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:50%;" type="text" name="attr_Perform3-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="(@{Perform3-ranks} + @{Perform3-class} + @{Perform3-ability} + @{Perform3-racial} + @{Perform3-feat} + @{Perform3-item} + @{Perform3-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession: @{Profession-name}}} {{Check=[[1d20 + @{Profession}]]}}" name="roll_NPC-Profession-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:50%;" type="text" name="attr_Profession-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="(@{Profession-ranks} + @{Profession-class} + @{Profession-ability} + @{Profession-racial} + @{Profession-feat} + @{Profession-item} + @{Profession-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0"></span>
-	
+					</div>
+                    <div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession2-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession: @{Profession2-name}}} {{Check=[[1d20 + @{Profession2}]]}}" name="roll_NPC-Profession2-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:50%;" type="text" name="attr_Profession2-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="(@{Profession2-ranks} + @{Profession2-class} + @{Profession2-ability} + @{Profession2-racial} + @{Profession2-feat} + @{Profession2-item} + @{Profession2-misc})" disabled></span>
@@ -5550,13 +5626,13 @@
 						<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:50%;" type="text" name="attr_Profession3-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="(@{Profession3-ranks} + @{Profession3-class} + @{Profession3-ability} + @{Profession3-racial} + @{Profession3-feat} + @{Profession3-item} + @{Profession3-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Ride-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ride}} {{Check=[[1d20 + @{Ride}]]}}" name="roll_NPC-Ride-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Ride</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Ride}" type="number" name="attr_Ride" value="(@{Ride-ranks} + @{Ride-class} + @{Ride-ability} + @{Ride-racial} + @{Ride-feat} + @{Ride-item} + @{Ride-acp} + @{Ride-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Ride-misc}" type="number" name="attr_Ride-misc" value="0"></span>
-	
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Sense-Motive-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sense Motive}} {{Check=[[1d20 + @{Sense-Motive}]]}}" name="roll_NPC-Sense-Motive-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Sense Motive</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Sense-Motive}" type="number" name="attr_Sense-Motive" value="(@{Sense-Motive-ranks} + @{Sense-Motive-class} + @{Sense-Motive-ability} + @{Sense-Motive-racial} + @{Sense-Motive-feat} + @{Sense-Motive-item} + @{Sense-Motive-misc})" disabled></span>
@@ -5566,13 +5642,13 @@
 						<span class="sheet-table-data sheet-left">Sleight of Hand</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand}" type="number" name="attr_Sleight-of-Hand" value="(@{Sleight-of-Hand-ranks} + @{Sleight-of-Hand-class} + @{Sleight-of-Hand-ability} + @{Sleight-of-Hand-racial} + @{Sleight-of-Hand-feat} + @{Sleight-of-Hand-item} + @{Sleight-of-Hand-acp} + @{Sleight-of-Hand-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-misc}" type="number" name="attr_Sleight-of-Hand-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Spellcraft-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[1d20 + @{Spellcraft}]]}}" name="roll_NPC-Spellcraft-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Spellcraft</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Spellcraft}" type="number" name="attr_Spellcraft" value="(@{Spellcraft-ranks} + @{Spellcraft-class} + @{Spellcraft-ability} + @{Spellcraft-racial} + @{Spellcraft-feat} + @{Spellcraft-item} + @{Spellcraft-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Spellcraft-misc}" type="number" name="attr_Spellcraft-misc" value="0"></span>
-	
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Stealth-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[1d20 + @{Stealth}]]}}" name="roll_NPC-Stealth-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Stealth</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Stealth}" type="number" name="attr_Stealth" value="(@{Stealth-ranks} + @{Stealth-class} + @{Stealth-ability} + @{Stealth-racial} + @{Stealth-feat} + @{Stealth-item} + @{Stealth-acp} + @{Stealth-misc})" disabled></span>
@@ -5582,13 +5658,13 @@
 						<span class="sheet-table-data sheet-left">Survival</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Survival}" type="number" name="attr_Survival" value="(@{Survival-ranks} + @{Survival-class} + @{Survival-ability} + @{Survival-racial} + @{Survival-feat} + @{Survival-item} + @{Survival-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Survival-misc}" type="number" name="attr_Survival-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Swim-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Swim}} {{Check=[[1d20 + @{Swim}]]}}" name="roll_NPC-Swim-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Swim</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Swim}" type="number" name="attr_Swim" value="(@{Swim-ranks} + @{Swim-class} + @{Swim-ability} + @{Swim-racial} + @{Swim-feat} + @{Swim-item} + @{Swim-acp} + @{Swim-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Swim-misc}" type="number" name="attr_Swim-misc" value="0"></span>
-	
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Use-Magic-Device-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Use Magic Device}} {{Check=[[1d20 + @{Use-Magic-Device}]]}}" name="roll_NPC-Use-Magic-Device-Check"></button></span>
 						<span class="sheet-table-data sheet-left">Use Magic Device</span>
 						<span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device}" type="number" name="attr_Use-Magic-Device" value="(@{Use-Magic-Device-ranks} + @{Use-Magic-Device-class} + @{Use-Magic-Device-ability} + @{Use-Magic-Device-racial} + @{Use-Magic-Device-feat} + @{Use-Magic-Device-item} + @{Use-Magic-Device-misc})" disabled></span>
@@ -5598,13 +5674,13 @@
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-0-name}" name="attr_Misc-Skill-0-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0}" type="number" name="attr_Misc-Skill-0" value="(@{Misc-Skill-0-ranks} + @{Misc-Skill-0-class} + @{Misc-Skill-0-ability} + @{Misc-Skill-0-racial} + @{Misc-Skill-0-feat} + @{Misc-Skill-0-item} + @{Misc-Skill-0-acp} + @{Misc-Skill-0-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-1-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-1-name}}} {{Check=[[1d20 + @{Misc-Skill-1}]]}}" name="roll_NPC-Misc-Skill-1-Check"></button></span>
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-1-name}" name="attr_Misc-Skill-1-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1}" type="number" name="attr_Misc-Skill-1" value="(@{Misc-Skill-1-ranks} + @{Misc-Skill-1-class} + @{Misc-Skill-1-ability} + @{Misc-Skill-1-racial} + @{Misc-Skill-1-feat} + @{Misc-Skill-1-item} + @{Misc-Skill-1-acp} + @{Misc-Skill-1-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0"></span>
-	
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-2-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-2-name}}} {{Check=[[1d20 + @{Misc-Skill-2}]]}}" name="roll_NPC-Misc-Skill-2-Check"></button></span>
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-2-name}" name="attr_Misc-Skill-2-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2}" type="number" name="attr_Misc-Skill-2" value="(@{Misc-Skill-2-ranks} + @{Misc-Skill-2-class} + @{Misc-Skill-2-ability} + @{Misc-Skill-2-racial} + @{Misc-Skill-2-feat} + @{Misc-Skill-2-item} + @{Misc-Skill-2-acp} + @{Misc-Skill-2-misc})" disabled></span>
@@ -5614,13 +5690,13 @@
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-3-name}" name="attr_Misc-Skill-3-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="number" name="attr_Misc-Skill-3" value="(@{Misc-Skill-3-ranks} + @{Misc-Skill-3-class} + @{Misc-Skill-3-ability} + @{Misc-Skill-3-racial} + @{Misc-Skill-3-feat} + @{Misc-Skill-3-item} + @{Misc-Skill-3-acp} + @{Misc-Skill-3-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0"></span>
-					</div>
-					<div class="sheet-table-row">
+					
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-4-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-4-name}}} {{Check=[[1d20 + @{Misc-Skill-4}]]}}" name="roll_NPC-Misc-Skill-4-Check"></button></span>
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-4-name}" name="attr_Misc-Skill-4-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="number" name="attr_Misc-Skill-4" value="(@{Misc-Skill-4-ranks} + @{Misc-Skill-4-class} + @{Misc-Skill-4-ability} + @{Misc-Skill-4-racial} + @{Misc-Skill-4-feat} + @{Misc-Skill-4-item} + @{Misc-Skill-4-acp} + @{Misc-Skill-4-misc})" disabled></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0"></span>
-	
+					</div>
+					<div class="sheet-table-row">
 						<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-5-Check}" type="roll" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-5-name}}} {{Check=[[1d20 + @{Misc-Skill-5}]]}}" name="roll_NPC-Misc-Skill-5-Check"></button></span>
 						<span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-5-name}" name="attr_Misc-Skill-5-name"></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="number" name="attr_Misc-Skill-5" value="(@{Misc-Skill-5-ranks} + @{Misc-Skill-5-class} + @{Misc-Skill-5-ability} + @{Misc-Skill-5-racial} + @{Misc-Skill-5-feat} + @{Misc-Skill-5-item} + @{Misc-Skill-5-acp} + @{Misc-Skill-5-misc})" disabled></span>
@@ -5687,7 +5763,7 @@
 	</div>
 </div>
 <div style="text-align:center;">
-Sheet created by Samuel Marino for Roll20.net | Last updated: <i>2015.04.30</i>
+Sheet created by Samuel Marino for Roll20.net | Last updated: <i>2015.05.03</i>
 <br>
 Have questions or feedback? <a href="https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles" target="_blank">This thread can help: https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles</a>
 </div>

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -5622,7 +5622,7 @@
 	</div>
 </div>
 <div style="text-align:center;">
-Sheet created by Samuel Marino for Roll20.net | Last updated: <i>2015.03.21</i>
+Sheet created by Samuel Marino for Roll20.net | Last updated: <i>2015.04.30</i>
 <br>
 Have questions or feedback? <a href="https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles" target="_blank">This thread can help: https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles</a>
 </div>

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -3233,7 +3233,7 @@
                     <div class="sheet-table">
                         <span class="sheet-table-name">Spells Per Day</span>
                         <div class="sheet-table-row">
-                            <span class="sheet-table-header">Class</span>
+                            <span class="sheet-table-header">Spell-Class-0</span>
                             <span class="sheet-table-header"></span>
                             <span class="sheet-table-header">Total</span>
                             <span class="sheet-table-header"></span>
@@ -3262,7 +3262,7 @@
                             <span class="sheet-table-header">Misc</span>
                         </div>
                         <div class="sheet-table-row">
-                            <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-0-name} [[@{spellclass-0-level}]]}} {{Check=[[1d20 + @{Concentration-0}]]}}">Concentration</button></span>
+                            <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=**@{spellclass-0-name} @{spellclass-0-level}**}} {{Check=[[1d20 + @{Concentration-0}]]}}">Concentration</button></span>
                             <span class="sheet-table-data sheet-center"><input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-0-level} + @{Concentration-0-ability} + @{Concentration-0-misc})" disabled></span>
                             <span class="sheet-table-data sheet-center">=</span>
                             <span class="sheet-table-data sheet-center">
@@ -3431,7 +3431,7 @@
                     <div class="sheet-table">
                         <span class="sheet-table-name">Spells Per Day</span>
                         <div class="sheet-table-row">
-                            <span class="sheet-table-header">Class</span>
+                            <span class="sheet-table-header">Spell-Class-1</span>
                             <span class="sheet-table-header"></span>
                             <span class="sheet-table-header">Total</span>
                             <span class="sheet-table-header"></span>
@@ -3460,7 +3460,7 @@
                             <span class="sheet-table-header">Misc</span>
                         </div>
                         <div class="sheet-table-row">
-                            <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-1}" name="roll_Concentration-Check-1" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-1-name} [[@{spellclass-1-level}]]}} {{Check=[[1d20 + @{Concentration-1}]]}}">Concentration</button></span>
+                            <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-1}" name="roll_Concentration-Check-1" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=**@{spellclass-1-name} @{spellclass-1-level}**}} {{Check=[[1d20 + @{Concentration-1}]]}}">Concentration</button></span>
                             <span class="sheet-table-data sheet-center"><input title="@{Concentration-1}" type="number" name="attr_Concentration-1" value="(@{spellclass-1-level} + @{Concentration-1-ability} + @{Concentration-1-misc})" disabled></span>
                             <span class="sheet-table-data sheet-center">=</span>
                             <span class="sheet-table-data sheet-center">
@@ -3529,6 +3529,7 @@
                             <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-bonus}" type="number" name="attr_spellclass-1-level-2-bonus" value="((((ceil((@{Concentration-1-ability} - 1)/4) + 0) + abs(ceil((@{Concentration-1-ability} - 1)/4) - 0)) / 2))" disabled></span>
                             <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-misc}" type="number" name="attr_spellclass-1-level-2-misc" value="0"></span>
                             <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-2-spells-known}" type="number" name="attr_spellclass-1-level-2-spells-known" value="0"></span>
+
                         </div>
                         <div class="sheet-table-row">
                             <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-3-savedc}" type="number" name="attr_spellclass-1-level-3-savedc" value="(10 + 3 + @{Concentration-1-ability})" disabled></span>
@@ -3713,8 +3714,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-0-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -3817,8 +3820,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-1-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -3921,8 +3926,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-2-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4025,8 +4032,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-3-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4129,8 +4138,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-4-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4233,8 +4244,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-5-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4337,8 +4350,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-6-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4441,8 +4456,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-7-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4545,8 +4562,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-8-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4649,8 +4668,10 @@
                     <span class="sheet-table-data sheet-center sheet-small-label">
                         <select title="@{repeating_lvl-9-spells_X_sr}" name="attr_sr">
                             <option value="" selected>Select SR</option>
-                            <option value="Yes">Yes</option>
-                            <option value="No">No</option>
+<option value="Yes">Yes</option>
+<option value="No">No</option>
+<option value="Yes (Harmless)">Yes (Harmless)</option>
+<option value="No (Harmless)">No (Harmless)</option>
                         </select>
                         <br>SR
                     </span>
@@ -4915,7 +4936,7 @@
 </div>
 <div class="sheet-npc sheet-section-npc">
     <div class="sheet-table" style="width:100%;background-color:black;color:white;padding-left:10px;">  
-        <span class="sheet-table-data sheet-center" style="width:90%;text-align:left;"><input type="text" title="character_name" name="attr_character_name" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span>     	
+        <span class="sheet-table-data sheet-center" style="width:90%;text-align:left;"><input type="text" title="character_name" name="attr_character_name" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span>         
 		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><b>CR</b></span>
 		<span class="sheet-table-data sheet-right" style="width:5%;text-align:right;"><input type="text" title="npc-cr" name="attr_npc-cr" style="background-color:black;color:white;font-weight:bold;border:1px dotted #FFFFFF"/></span> 
 	</div>
@@ -5159,10 +5180,30 @@
 			</div>
 			<br>
 			<div>
-				<b>Spell-Like Abilities</b> (<button style="font-size:100%;" title="NPC-Spell-Class-0-CL-Check" type="roll" name="roll_NPC-Spell-Class-0-CL-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Check=[[1d20 + @{spellclass-0-level} + @{spellclass-0-level-misc}]]}}">CL</button>
-				<input title="spellclass-0-level" type="number" name="attr_spellclass-0-level" value="0">)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-				<input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-show}" name="attr_npc-spell-like-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
-				<div class="sheet-sect">
+				<div class="sheet-table-row">
+				<b>Spell-Like Abilities</b>
+                    <button style="font-size:100%;" title="%{selected|NPC-Spell-Class-0-CL-Check}" type="roll" name="roll_NPC-Spell-Class-0-CL-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-0-name} @{spellclass-0-level}**}} {{Check=[[1d20 + @{spellclass-0-level} + @{spellclass-0-level-misc}]]}}">CL</button>
+					<input title="@{spellclass-0-level-total}" type="number" name="attr_spellclass-0-level-total" value="(@{spellclass-0-level} + @{spellclass-0-level-misc})" disabled>=
+					<input title="@{spellclass-0-level}" type="number" name="attr_spellclass-0-level" value="0">+
+					<input title="@{spellclass-0-level-misc}" type="number" name="attr_spellclass-0-level-misc" value="0">&nbsp;&nbsp;&nbsp;
+					<button style="font-size:100%;" title="%{selected|NPC-Concentration-Check-0}" type="roll" name="roll_NPC-Concentration-Check-0" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=**@{spellclass-0-name} @{spellclass-0-level}**}} {{Check=[[1d20 + @{Concentration-0}]]}}">CC</button>
+                			<input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-0-level} + @{Concentration-0-ability} + @{Concentration-0-misc})" disabled>=
+                			<span class="sheet-table-data sheet-center">
+                				<select title="@{Concentration-0-ability}" name="attr_Concentration-0-ability">
+							<option value="0" selected>None</option>
+							<option value="(@{STR-mod})">STR</option>
+							<option value="(@{DEX-mod})">DEX</option>
+							<option value="(@{CON-mod})">CON</option>
+							<option value="(@{INT-mod})">INT</option>
+							<option value="(@{WIS-mod})">WIS</option>
+							<option value="(@{CHA-mod})">CHA</option>
+						</select>
+                             </span>
+					<input title="@{Concentration-0-mod}" type="number" name="attr_Concentration-0-mod" value="@{Concentration-0-ability}" disabled>+
+					<input title="@{Concentration-0-misc}" type="number" name="attr_Concentration-0-misc" value="0">
+				</div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+					<input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-show}" name="attr_npc-spell-like-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+                     <div class="sheet-sect">
 					<fieldset class="repeating_npc-spell-like-abilities">
 						<span class="sheet-table-data sheet-center sheet-small label" style="width:5%;"><button type="roll" value="@{macro-text}"></button><br>&nbsp;</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_npc-spell-like-abilities_X_used}" type="number" name="attr_used" value="0"><br>Uses/Day</span>
@@ -5171,12 +5212,14 @@
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spell-like-abilities_X_duration}" type="text" name="attr_duration" placeholder="Duration"><br>Duration</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spell-like-abilities_X_save}" type="text" name="attr_save" placeholder="Save"><br>Save</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
-							<select title="@{repeating_npc-spell-like-abilities_X_sr}" name="attr_sr">
-								<option value="Yes">Yes</option>
-								<option value="No" selected>No</option>
-							</select>
-							<br>SR
-						</span>
+						<select title="@{repeating_npc-spell-like-abilities_X_sr}" name="attr_sr">
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+							<option value="Yes (Harmless)">Yes (Harmless)</option>
+							<option value="No (Harmless)">No (Harmless)</option>
+						</select>
+						<br>SR</span>
 						<br>
 						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
 						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spell-like-abilities_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
@@ -5186,8 +5229,27 @@
 			</div>
 			<br>
 			<div>
-				<b>Spells</b> (<button style="font-size:100%;" title="NPC-Spell-Class-1-CL-Check" type="roll" name="roll_NPC-Spell-Class-1-CL-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Check=[[1d20 + @{spellclass-1-level} + @{spellclass-1-level-misc}]]}}">CL</button>
-				<input title="spellclass-1-level" type="number" name="attr_spellclass-1-level" value="0">)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+				<div class="sheet-table-row">
+				<b>Spells</b>
+                		<button style="font-size:100%;" title="%{selected|NPC-Spell-Class-1-CL-Check}" type="roll" name="roll_NPC-Spell-Class-1-CL-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-1-name} @{spellclass-1-level}**}} {{Check=[[1d20 + @{spellclass-1-level} + @{spellclass-1-level-misc}]]}}">CL</button>
+                        	<input title="@{spellclass-1-level-total}" type="number" name="attr_spellclass-1-level-total" value="(@{spellclass-1-level} + @{spellclass-1-level-misc})" disabled>=
+                        	<input title="@{spellclass-1-level}" type="number" name="attr_spellclass-1-level" value="0">+
+                            <input title="@{spellclass-1-level-misc}" type="number" name="attr_spellclass-1-level-misc" value="0">&nbsp;&nbsp;&nbsp;
+                         <button style="font-size:100%;" title="%{selected|NPC-Concentration-Check-1}" type="roll" name="roll_NPC-Concentration-Check-1" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=**@{spellclass-1-name} @{spellclass-1-level}**}} {{Check=[[1d20 + @{Concentration-1}]]}}">CC</button>
+                            <input title="@{Concentration-1}" type="number" name="attr_Concentration-1" value="(@{spellclass-1-level} + @{Concentration-1-ability} + @{Concentration-1-misc})" disabled>=
+							<span class="sheet-table-data sheet-center">
+                            	<select title="@{Concentration-1-ability}" name="attr_Concentration-1-ability">
+                                    <option value="0" selected>None</option>
+                                    <option value="(@{STR-mod})">STR</option>
+                                    <option value="(@{DEX-mod})">DEX</option>
+                                    <option value="(@{CON-mod})">CON</option>
+                                    <option value="(@{INT-mod})">INT</option>
+                                    <option value="(@{WIS-mod})">WIS</option>
+                                    <option value="(@{CHA-mod})">CHA</option>
+                                </select></span>
+					  		<input title="@{Concentration-1-mod}" type="number" name="attr_Concentration-1-mod" value="@{Concentration-1-ability}" disabled>+
+                            <input title="@{Concentration-1-misc}" type="number" name="attr_Concentration-1-misc" value="0">
+                </div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 				<input type="checkbox" class="sheet-sect-show" title="@{npc-spells-show}" name="attr_npc-spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
 				<div class="sheet-sect">
 					<fieldset class="repeating_npc-spells">
@@ -5200,8 +5262,11 @@
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><input title="@{repeating_npc-spells_X_save}" type="text" name="attr_save" placeholder="Save"><br>Save</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
 							<select title="@{repeating_npc-spells_X_sr}" name="attr_sr">
-								<option value="Yes">Yes</option>
-								<option value="No" selected>No</option>
+							<option value="" selected>Select SR</option>
+							<option value="Yes">Yes</option>
+							<option value="No">No</option>
+							<option value="Yes (Harmless)">Yes (Harmless)</option>
+							<option value="No (Harmless)">No (Harmless)</option>
 							</select>
 							<br>SR
 						</span>

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -5763,9 +5763,9 @@
 	</div>
 </div>
 <div style="text-align:center;">
-Sheet created by Samuel Marino for Roll20.net | Last updated: <i>2015.05.03</i>
+Sheet created by Samuel Marino for Roll20.net | Last updated: <i>05.05.2015</i>
 <br>
-Have questions or feedback? <a href="https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles" target="_blank">This thread can help: https://app.roll20.net/forum/post/1498595/pathfinder-sheet-thread-3-ive-run-out-of-titles</a>
+Have questions or feedback? <a href="https://app.roll20.net/forum/post/1915585/pathfinder-sheet-thread-4-life-after-sam#post-1915585" target="_blank">This thread can help: https://app.roll20.net/forum/post/1915585/pathfinder-sheet-thread-4-life-after-sam#post-1915585</a>
 </div>
 
 <!-- Roll Templates -->


### PR DESCRIPTION
added attacks to pf_spell roll template that matches the pf_attack roll
template format. attack and attack2 can be used within a macro using
pf_spell for spell-based attacks. (attack. damage, crit_confirm, crit_damage)