### PR TITLE
pathfinder-simple small patch

### DIFF
--- a/pathfinder_simple/pathfinder.html
+++ b/pathfinder_simple/pathfinder.html
@@ -2080,7 +2080,7 @@
                         </div>
                     </div>
                     <div class="sheet-table">
-                        <fieldset class="repeating_lvl-0-spells">
+                        <fieldset class="repeating_lvl-5-spells">
                             <span class="sheet-table-data-center" style="width:5%;"><input title="repeating_lvl-5-spells_X_used" type="number" name="attr_repeating_lvl-5-spells_X_used" value="0"></span>
                             <span class="sheet-table-data-center" style="width:5%;"><input title="repeating_lvl-5-spells_X_used|max" type="number" name="attr_repeating_lvl-5-spells_X_used|max" value="0"></span>
                             <span class="sheet-table-data-center" style="width:20%;"><input title="repeating_lvl-5-spells_X_name" type="text" name="attr_repeating_lvl-5-spells_X_name"></span>


### PR DESCRIPTION
repeating_lvl-5-spells fieldset class was incorrectly set to repeating_lvl-0-spells which caused repeating_lvl-5-spells descriptions to be overwritten by repeating_lvl-0-spells description.