### PR TITLE
Changed Unnatural Attributes to Bonus.

### DIFF
--- a/Deathwatch/Deathwatch.html
+++ b/Deathwatch/Deathwatch.html
@@ -113,9 +113,9 @@
                         <button name="roll_WS" type="roll" value="/me Weapon Skill Target [[(@{WeaponSkill}+?{Modifier|0})]] Roll: [[1d100]]"><label>Weapon Skill (WS)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_WeaponSkill" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-WeaponSkill"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-WeaponSkill"  value="0">
                         </div>
                     </div>
                 </div>
@@ -140,9 +140,9 @@
                         <button name="roll_BS" type="roll" value="/me Ballistic Skill Target: [[(@{BallisticSkill}+?{Modifier|0})]] Roll: [[1d100]]"><label>Ballistic Skill (BS)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_BallisticSkill" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-BallisticSkill"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-BallisticSkill"  value="0">
                         </div>
                     </div>
                 </div>
@@ -167,9 +167,9 @@
                         <button name="roll_S" type="roll" value="/me Strength Target: [[(@{Strength}+?{Modifier|0})]] Roll: [[1d100]]"><label>Strength<br/>(S)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Strength" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Strength"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Strength"  value="0">
                         </div>
                     </div>
                 </div>
@@ -194,9 +194,9 @@
                         <button name="roll_T" type="roll" value="/me Toughness Target: [[(@{Toughness}+?{Modifier|0})]] Roll: [[1d100]]"><label>Toughness (T)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Toughness" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Toughness"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Toughness"  value="0">
                         </div>
                     </div>
                 </div>
@@ -221,9 +221,9 @@
                         <button name="roll_Ag" type="roll" value="/me Agility Target: [[(@{Agility}+?{Modifier|0})]] Roll: [[1d100]]"><label>Agility <br/>(Ag)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Agility" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Agility"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Agility"  value="0">
                         </div>
                     </div>
                 </div>
@@ -252,9 +252,9 @@
                         <button name="roll_Int" type="roll" value="/me Intelligence Target: [[(@{Intelligence}+?{Modifier|0})]] Roll: [[1d100]]"><label>Intelligence (Int)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Intelligence" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Intelligence"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Intelligence"  value="0">
                         </div>
                     </div>
                 </div>
@@ -279,9 +279,9 @@
                         <button name="roll_Per" type="roll" value="/me Perception Target: [[(@{Perception}+?{Modifier|0})]] Roll: [[1d100]]"><label>Perception (Per)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Perception" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Perception"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Perception"  value="0">
                         </div>
                     </div>
                 </div>
@@ -306,9 +306,9 @@
                         <button name="roll_WP" type="roll" value="/me Willpower Target: [[(@{Willpower}+?{Modifier|0})]] Roll: [[1d100]]"><label>Willpower (WP)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Willpower" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Willpower"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Willpower"  value="0">
                         </div>
                     </div>
                 </div>
@@ -333,9 +333,9 @@
                         <button name="roll_Fel" type="roll" value="/me Fellowship Target: [[(@{Fellowship}+?{Modifier|0})]] Roll: [[1d100]]"><label>Fellowship (Fel)</label></button>
                     </div>
                     <div class="sheet-col">
-                        <div class="sheet-unnatural_box">
+                        <div class="sheet-bonus_box">
                             <input name="attr_Fellowship" type="text" value="0">
-                            <input type="text" class="sheet-unnatural" name="attr_unnatural-Fellowship"  value="0">
+                            <input type="text" class="sheet-bonus" name="attr_bonus-Fellowship"  value="0">
                         </div>
                     </div>
                 </div>
@@ -2126,7 +2126,7 @@
                     <input name="attr_meleeweaponpen" type="text" value="0">
                 </div>
                 <div class="sheet-item" style="width:16%">
-                    <button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})">
+                    <button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+(@{bonus-Strength}/10)]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})">
                         <label>Damage</label>
                     </button>
                 </div>
@@ -2154,25 +2154,25 @@
                 <label>Half Move: </label>
             </div>
             <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)">
+                <input disabled="true" name="attr_HalfMove" type="number" value="@{bonus-Agility}">
             </div>
             <div class="sheet-item" style="width:20%">
                 <label>Full Move: </label>
             </div>
             <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10))">
+                <input disabled="true" name="attr_FullMove" type="number" value="2*@{bonus-Agility}">
             </div>
             <div class="sheet-item" style="width:16%">
                 <label>Charge: </label>
             </div>
             <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10))">
+                <input disabled="true" name="attr_ChargeMove" type="number" value="3*@{bonus-Agility}">
             </div>
             <div class="sheet-item" style="width:10%">
                 <label>Run: </label>
             </div>
             <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10))">
+                <input disabled="true" name="attr_RunMove" type="number" value="6*@{bonus-Agility}">
             </div>
         </div>
         <div class="sheet-row">
@@ -2183,7 +2183,7 @@
                 <label>Threshold:</label>
             </div>
             <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FatigueThreshold" type="number" value="floor(@{Willpower}/10)+floor(@{Toughness}/10)">
+                <input disabled="true" name="attr_FatigueThreshold" type="number" value="floor(@{Willpower}/10)+@{bonus-Toughness}">
             </div>
             <div class="sheet-item" style="width:16%">
                 <label>Current: </label>
@@ -2201,22 +2201,22 @@
             <div class="sheet-col">
                 <div class="sheet-armourblock"></div>
                 <div class="sheet-quickborder sheet-armourblock">
-                    <label>Head</label> <input name="attr_HArmour" type="number"> <label>(1-10)</label> <input disabled="true" name="attr_HTotal" type="number" value="@{HArmour}+floor(@{Toughness}/10)">
+                    <label>Head</label> <input name="attr_HArmour" type="number"> <label>(1-10)</label> <input disabled="true" name="attr_HTotal" type="number" value="@{HArmour}+@{bonus-Toughness}">
                 </div><br>
                 <div class="sheet-quickborder sheet-armourblock">
-                    <label>AR</label> <input name="attr_ArArmour" type="number"> <label>(11-20)</label> <input disabled="true" name="attr_ArTotal" type="number" value="@{ArArmour}+floor(@{Toughness}/10)">
+                    <label>AR</label> <input name="attr_ArArmour" type="number"> <label>(11-20)</label> <input disabled="true" name="attr_ArTotal" type="number" value="@{ArArmour}+@{bonus-Toughness}">
                 </div>
                 <div class="sheet-quickborder sheet-armourblock">
-                    <label>Body</label> <input name="attr_BArmour" type="number"> <label>(31-70)</label> <input disabled="true" name="attr_BTotal" type="number" value="@{BArmour}+floor(@{Toughness}/10)">
+                    <label>Body</label> <input name="attr_BArmour" type="number"> <label>(31-70)</label> <input disabled="true" name="attr_BTotal" type="number" value="@{BArmour}+@{bonus-Toughness}">
                 </div>
                 <div class="sheet-quickborder sheet-armourblock">
-                    <label>AL</label> <input name="attr_AlArmour" type="number"> <label>(21-30)</label> <input disabled="true" name="attr_AlTotal" type="number" value="@{AlArmour}+floor(@{Toughness}/10)">
+                    <label>AL</label> <input name="attr_AlArmour" type="number"> <label>(21-30)</label> <input disabled="true" name="attr_AlTotal" type="number" value="@{AlArmour}+@{bonus-Toughness}">
                 </div>
                 <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LR</label> <input name="attr_LrArmour" type="number"> <label>(71-85)</label> <input disabled="true" name="attr_LrTotal" type="number" value="@{LrArmour}+floor(@{Toughness}/10)">
+                    <label>LR</label> <input name="attr_LrArmour" type="number"> <label>(71-85)</label> <input disabled="true" name="attr_LrTotal" type="number" value="@{LrArmour}+@{bonus-Toughness}">
                 </div>
                 <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LL</label> <input name="attr_LlArmour" type="number"> <label>(86-00)</label> <input disabled="true" name="attr_LlTotal" type="number" value="@{LlArmour}+floor(@{Toughness}/10)">
+                    <label>LL</label> <input name="attr_LlArmour" type="number"> <label>(86-00)</label> <input disabled="true" name="attr_LlTotal" type="number" value="@{LlArmour}+@{bonus-Toughness}">
                 </div>
             </div>
         


### PR DESCRIPTION
40k rpgs have two systems for using characteristics; one uses the raw with misc modifiers. The other uses the characteristic bonuses (First Number). The problem is how this sheet is done does not take into consideration what those bonuses do. EX: Strength bonus for a Space Marine is Strength x2 +20. But it reads off the raw characteristic not allowing for modifiers of those bonuses. The changes here allow the player to input those bonuses and make the system that use them read off of that.