### PR TITLE
Pathfinder-Neceros updates

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.css
+++ b/Pathfinder-Neceros/pathfinder-neceros.css
@@ -1,122 +1,123 @@
 .sheet-desc-show:not(:checked)~.sheet-desc,
 .sheet-macro-text-show:not(:checked)~.sheet-macro-text,
-.sheet-sect-show:not(:checked)~.sheet-sect {
-    display: none;
+.sheet-sect-show:not(:checked)~.sheet-sect,
+.sheet-options-show:not(:checked)~.sheet-options {
+	display: none;
 }
 
 .sheet-table {
-    display: table;
-    width: 100%;
+	display: table;
+	width: 100%;
 }
 
 .sheet-small-label {
-    font-size: 85%!important;
-    font-style: italic;
-    font-weight: bold;
-    color: black;
+	font-size: 85% !important;
+	font-style: italic;
+	font-weight: bold;
+	color: black;
 }
 
 .sheet-secondary-table-name,
 .sheet-table-name {
-    display: table-caption;
-    text-align: center;
-    font-weight: bold;
-    color: white;
-    background-color: black;
-    width: 100%;
+	display: table-caption;
+	text-align: center;
+	font-weight: bold;
+	color: white;
+	background-color: black;
+	width: 100%;
 }
 
 .sheet-secondary-table-name {
-    background-color: #4a6486 !important;
+	background-color: #4a6486 !important;
 }
 
 .sheet-table-header {
-    display: table-cell;
-    text-align: center;
-    font-style: italic;
-    font-weight: bold;
-    vertical-align: bottom;
-    background-color: lightgray;
+	display: table-cell;
+	text-align: center;
+	font-style: italic;
+	font-weight: bold;
+	vertical-align: bottom;
+	background-color: lightgray;
 }
 
 .sheet-table-data {
-    display: table-cell;
-    vertical-align: middle;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .sheet-table-data label {
-    font-size: 13px;
-    font-weight: normal;
-    display: block;
-    margin: 0 auto;
-    color: black;
+	font-size: 13px;
+	font-weight: normal;
+	display: block;
+	margin: 0 auto;
+	color: black;
 }
 
 .sheet-center {
-    text-align: center;
+	text-align: center;
 }
 
 .sheet-left {
-    text-align: left;
+	text-align: left;
 }
 
 .sheet-right {
-    text-align: right;
+	text-align: right;
 }
 
 .sheet-table-row {
-    display: table-row;
-    vertical-align: bottom;
-    width: 100%;    
+	display: table-row;
+	vertical-align: bottom;
+	width: 100%;    
 }
 
 .sheet-table-row-name {
-    display: table-cell;
-    text-align: center;
-    vertical-align: middle;
-    color: white;
-    background-color: black;
-    font-weight: bold;
+	display: table-cell;
+	text-align: center;
+	vertical-align: middle;
+	color: white;
+	background-color: black;
+	font-weight: bold;
 }
 
 .sheet-label {
-    font-weight: bold;
-    text-align: center;
-    color: black;
+	font-weight: bold;
+	text-align: center;
+	color: black;
 }
 
 input[type="text"], input[type="number"] {
-    background-color: transparent;
-    border: 0 solid black;
-    border-bottom-width: 2px;
+	background-color: transparent;
+	border: 0 solid black;
+	border-bottom-width: 2px;
 }
 
 input[type="text"]:disabled, input[type="number"]:disabled {
-    background-color: rgba(74, 100, 134, 0.28);
-    border: 0 solid black;
+	background-color: rgba(74, 100, 134, 0.28);
+	border: 0 solid black;
 }
 
 input[type="text"], select {
-    width: 100%;
-    margin: 0;
+	width: 100%;
+	margin: 0;
 }
 
 div[class^="sheet-section"] {
-    visibility: hidden;
-    opacity: 0;
-    max-height: 0;
+	visibility: hidden;
+	opacity: 0;
+	max-height: 0;
 	overflow: hidden;
 }
 
 div[class^="sheet-npc"] {
-    visibility: hidden;
-    opacity: 0;
-    max-height: 0;
+	visibility: hidden;
+	opacity: 0;
+	max-height: 0;
 	overflow: hidden;
 }
 
 b[title],span[title] {
-    cursor: help;
+	cursor: help;
 }
 
 input.sheet-spells_level-tab99:checked ~ div[class^="sheet-section"],
@@ -129,13 +130,13 @@ input.sheet-tab99:checked ~ div[class^="sheet-section"] {
 }
 
 .sheet-tab {
-    border-radius: 7px 7px 0 0;
+	border-radius: 7px 7px 0 0;
 }
 
 input.sheet-tab {
-    width: 70px;
-    height: 20px;
-    cursor: pointer;
+	width: 70px;
+	height: 20px;
+	cursor: pointer;
 	position: relative;
 	opacity: 0;
 	z-index: 9999;
@@ -144,55 +145,54 @@ input.sheet-tab {
 input.sheet-skill-tab,
 input.sheet-spell_level,
 input.sheet-spellclass {
-    /*width: 70px;
-    height: 20px;*/
-    margin-left: 0;
+	/*width: 70px;
+	height: 20px;*/
+	margin-left: 0;
 }
 
 span.sheet-tab {
 	text-align: center;
-    display: inline-block;
+	display: inline-block;
 	font-size: 13px;
 	background: #4a6486;
 	color: white;
 	font-weight: bold;
 
 	width: 70px;
-    height: 20px;
-    cursor: pointer;
+	height: 20px;
+	cursor: pointer;
 	position: relative;
 	margin-left: -75px;
 }
 
 span.sheet-skill-tab,
 span.sheet-spellclass {
-    width: 100px;
+	width: 100px;
 }
 
 input.sheet-tab::before {
-    content: attr(title);
-    text-align: center;
-    display: inline-block;
-    width: 100%;
-    height: 100%;
-
-    background: black;
+	content: attr(title);
+	text-align: center;
+	display: inline-block;
+	width: 100%;
+	height: 100%;
+	background: black;
 	color: white;
 	font-weight: bold;
 }
 
 input.sheet-tab:checked::before {
-    background: gray;
-    color: white;
+	background: gray;
+	color: white;
 }
 
 .sheet-header-row {
-    width: 100%;
-    background-color: #000;
-    color: #fff;
-    padding-left: 10px;
-    min-height: 1em;
-    margin-bottom: 0.5em;
+	width: 100%;
+	background-color: #000;
+	color: #fff;
+	padding-left: 10px;
+	min-height: 1em;
+	margin-bottom: 0.5em;
 }
 
 input.sheet-tab1:checked ~ div.sheet-section-core,
@@ -223,7 +223,7 @@ input.sheet-spells_level-tab9:checked ~ div.sheet-section-level-9,
 input.sheet-spellclass-tab0:checked ~ div.sheet-section-spellclass-0,
 input.sheet-spellclass-tab1:checked ~ div.sheet-section-spellclass-1,
 input.sheet-spellclass-tab2:checked ~ div.sheet-section-spellclass-2 {
-    max-height: 999999px;
+	max-height: 999999px;
 	visibility: visible;
 	opacity: 1;
 	transition: opacity 0.5s linear 0s;
@@ -260,22 +260,22 @@ input.sheet-spells_level-tab99:checked + span.sheet-spells_level-tab99,
 input.sheet-spellclass-tab0:checked + span.sheet-spellclass-tab0,
 input.sheet-spellclass-tab1:checked + span.sheet-spellclass-tab1,
 input.sheet-spellclass-tab2:checked + span.sheet-spellclass-tab2 {
-    background: black;
-    color: white;
+	background: black;
+	color: white;
 }
 
 .sheet-tab11 {
-    display:none !important;
+	display:none !important;
 }
 
 .sheet-pictos {
-  font-family: "Pictos";
-  font-size: 14px;
+	font-family: "Pictos";
+	font-size: 14px;
 }
 
 .sheet-text-button {
-    font-size: 100%;
-    color: white;
+	font-size: 100%;
+	color: white;
 	background-color: black;
 	border: 0;
 }
@@ -284,21 +284,20 @@ button,
 button:hover,
 button:active
 {
-    background-image: none;
+	background-image: none;
 }
 
 input[type="checkbox"] + span:not(.sheet-not-sheet-show)::before
 {
-    margin-right: 4px;
-    line-height: 14px;
-    text-align: center;
-    display: inline-block;
-    vertical-align: middle;
-
-    content: "[show]";
-    width: 14px;
-    height: 14px;
-    font-size: 12px;
+	margin-right: 4px;
+	line-height: 14px;
+	text-align: center;
+	display: inline-block;
+	vertical-align: middle;
+	content: "[show]";
+	width: 14px;
+	height: 14px;
+	font-size: 12px;
 }
 
 input[type="checkbox"]:checked + span:not(.sheet-not-sheet-show)::before
@@ -307,61 +306,60 @@ input[type="checkbox"]:checked + span:not(.sheet-not-sheet-show)::before
 }
 
 input[name*="condition"]:checked + b:not(.sheet-offCase) {
-    background-color: #4a6486;
-    color: white;
-    border-radius: 5px;
-    padding-right: 5px;
-    padding-bottom: 1px;
-    padding-top: 1px;
+	background-color: #4a6486;
+	color: white;
+	border-radius: 5px;
+	padding-right: 5px;
+	padding-bottom: 1px;
+	padding-top: 1px;
 }
 
 .sheet-no-pad-right {
-    padding-right: 0!important;
+	padding-right: 0 !important;
 }
 
 hr {
-
-    border-color: black;
-
+	border-color: black;
+	margin:5px 0;
 }
 
 .sheet-npc-hr {
-    padding: 0;
-    margin: 0;
+	padding: 0;
+	margin: 0;
 }
 
 .sheet-margin-bottom {
-    margin-bottom: 15px;
+	margin-bottom: 15px;
 }
 
 .sheet-margin-top {
-    margin-top: 15px;
+	margin-top: 15px;
 }
 
 textarea {
-    box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 .sheet-spellrange-header {
-    width: 15%;
+	width: 15%;
 }
 
 .sheet-spellrange-data {
-    width: 100% !important;
-    text-align: center !important;
+	width: 100% !important;
+	text-align: center !important;
 }
 
 .sheet-iterative-attack-value {
-    width:24% !important;
+	width:24% !important;
 }
 
 .sheet-iterative-macro {
-    width:90% !important;
+	width:90% !important;
 }
 
 .sheet-iterative_attack_section {
-    margin-bottom:0.5em !important;
-    margin-left: 2px !important;
+	margin-bottom:0.5em !important;
+	margin-left: 2px !important;
 }
 
 /*Roll Templates*/
@@ -376,28 +374,28 @@ textarea {
   	-moz-box-shadow: 2px 2px 5px #000;
 	-webkit-box-shadow: 2px 2px 5px #000;
 	box-shadow: 2px 2px 5px #000;
-    overflow: hidden;
+	overflow: hidden;
 }
 
 .sheet-rolltemplate-pf_spell .sheet-header {
 	background-color: #000;
-    border: 1px solid #000;
+	border: 1px solid #000;
 	margin: 2px 25px 2px 25px;
 	color: white;
 	font-family: "Helvetica Neue",Helvetica,sans-serif;
-    font-size: 1.2em;
+	font-size: 1.2em;
 	font-weight: bold;
   	text-align: left;
 }
 
-.sheet-rolltemplate-pf_spell .sheet-header a{
+.sheet-rolltemplate-pf_spell .sheet-header a {
 	color: white;
 	text-decoration: underline;
 }
 
 .sheet-rolltemplate-pf_spell td {
 	padding: 5px;
-    line-height: 1em;
+	line-height: 1em;
 	vertical-align: top;
 	text-align: left;
 }
@@ -444,13 +442,13 @@ textarea {
   	-moz-box-shadow: 2px 2px 5px #000;
 	-webkit-box-shadow: 2px 2px 5px #000;
 	box-shadow:2px 2px 5px #000;
-    overflow: hidden;
+	overflow: hidden;
 }
 
 .sheet-rolltemplate-pf_attack .sheet-header {
 	background-color: #000;
 	margin: 2px 25px 2px 25px;
-    border: 1px solid #000;
+	border: 1px solid #000;
 	color: white;
 	font-family:"Helvetica Neue",Helvetica,sans-serif;
 	font-size: 1em;
@@ -458,24 +456,24 @@ textarea {
   	text-align: center;
 }
 
-.sheet-rolltemplate-pf_attack .sheet-header a{
+.sheet-rolltemplate-pf_attack .sheet-header a {
 	color: white;
 	text-decoration: underline;
 }
 
 .sheet-rolltemplate-pf_attack td {
 	padding: 5px;
-    line-height: 1.4em;
+	line-height: 1.4em;
 	vertical-align: top;
-	text-align:right
+	text-align:right;
 }
 .sheet-rolltemplate-pf_attack tr:nth-child(odd) {
 	background-color: #D3D3D3;
 }
 
 .sheet-rolltemplate-pf_attack td:nth-child(odd) {
-    text-align: left;
-    font-weight:bold
+	text-align: left;
+	font-weight:bold;
 }
 
 .sheet-rolltemplate-pf_attack .inlinerollresult  {
@@ -489,15 +487,84 @@ textarea {
 
 .sheet-rolltemplate-pf_attack .inlinerollresult.fullcrit {
 	color: white;
-	background-color: #3FB315
+	background-color: #3FB315;
 }
 
 .sheet-rolltemplate-pf_attack .inlinerollresult.fullfail {
 	color: white;
-	background-color: #B31515
+	background-color: #B31515;
 }
 
 .sheet-rolltemplate-pf_attack .inlinerollresult.importantroll {
+	color: white;
+	background-color: #4A57ED;
+}
+
+/* Defense */
+.sheet-rolltemplate-pf_defense table {
+	width: 100%;
+	background-color: white;
+	border:2px solid #000;
+	border-spacing: 0;
+	border-collapse: separate;
+	border-radius: 5px;
+  	-moz-box-shadow: 2px 2px 5px #000;
+	-webkit-box-shadow: 2px 2px 5px #000;
+	box-shadow:2px 2px 5px #000;
+	overflow: hidden;
+}
+
+.sheet-rolltemplate-pf_defense .sheet-header {
+	background-color: #000;
+	margin: 2px 25px 2px 25px;
+	border: 1px solid #000;
+	color: white;
+	font-family:"Helvetica Neue",Helvetica,sans-serif;
+	font-size: 1em;
+	font-weight: bold;
+  	text-align: center;
+}
+
+.sheet-rolltemplate-pf_defense .sheet-header a {
+	color: white;
+	text-decoration: underline;
+}
+
+.sheet-rolltemplate-pf_defense td {
+	padding: 5px;
+	line-height: 1.4em;
+	vertical-align: top;
+	text-align:right;
+}
+.sheet-rolltemplate-pf_defense tr:nth-child(odd) {
+	background-color: #D3D3D3;
+}
+
+.sheet-rolltemplate-pf_defense td:nth-child(odd) {
+	text-align: left;
+	font-weight:bold;
+}
+
+.sheet-rolltemplate-pf_defense .inlinerollresult  {
+	color: white;
+	background-color: black;
+	border-color: black;
+	display: inline;
+	min-width: 1.5em;
+	text-align: center;
+}
+
+.sheet-rolltemplate-pf_defense .inlinerollresult.fullcrit {
+	color: white;
+	background-color: #3FB315;
+}
+
+.sheet-rolltemplate-pf_defense .inlinerollresult.fullfail {
+	color: white;
+	background-color: #B31515;
+}
+
+.sheet-rolltemplate-pf_defense .inlinerollresult.importantroll {
 	color: white;
 	background-color: #4A57ED;
 }
@@ -513,13 +580,13 @@ textarea {
   	-moz-box-shadow: 2px 2px 5px #000;
 	-webkit-box-shadow: 2px 2px 5px #000;
 	box-shadow:2px 2px 5px #000;
-    overflow: hidden;
+	overflow: hidden;
 }
 
 .sheet-rolltemplate-pf_generic .sheet-header {
 	background-color: #000;
 	margin: 2px 25px 2px 25px;
-    border: 1px solid #000;
+	border: 1px solid #000;
 	color: white;
 	font-family:"Helvetica Neue",Helvetica,sans-serif;
 	font-size: 1em;
@@ -527,24 +594,24 @@ textarea {
   	text-align: center;
 }
 
-.sheet-rolltemplate-pf_generic .sheet-header a{
+.sheet-rolltemplate-pf_generic .sheet-header a {
 	color: white;
 	text-decoration: underline;
 }
 
 .sheet-rolltemplate-pf_generic td {
 	padding: 5px;
-    line-height: 1.4em;
+	line-height: 1.4em;
 	vertical-align: top;
-	text-align:right
+	text-align:right;
 }
 .sheet-rolltemplate-pf_generic tr:nth-child(odd) {
 	background-color: #D3D3D3;
 }
 
 .sheet-rolltemplate-pf_generic td:nth-child(odd) {
-    text-align: left;
-    font-weight:bold
+	text-align: left;
+	font-weight:bold;
 }
 
 .sheet-rolltemplate-pf_generic .inlinerollresult  {
@@ -558,12 +625,12 @@ textarea {
 
 .sheet-rolltemplate-pf_generic .inlinerollresult.fullcrit {
 	color: white;
-	background-color: #3FB315
+	background-color: #3FB315;
 }
 
 .sheet-rolltemplate-pf_generic .inlinerollresult.fullfail {
 	color: white;
-	background-color: #B31515
+	background-color: #B31515;
 }
 
 .sheet-rolltemplate-pf_generic .inlinerollresult.importantroll {
@@ -582,13 +649,13 @@ textarea {
   	-moz-box-shadow: 2px 2px 5px #000;
 	-webkit-box-shadow: 2px 2px 5px #000;
 	box-shadow:2px 2px 5px #000;
-    overflow: hidden;
+	overflow: hidden;
 }
 
 .sheet-rolltemplate-pf_block .sheet-header {
 	background-color: #000;
 	margin: 2px 25px 2px 25px;
-    border: 1px solid #000;
+	border: 1px solid #000;
 	color: white;
 	font-family:"Helvetica Neue",Helvetica,sans-serif;
 	font-size: 1em;
@@ -596,16 +663,16 @@ textarea {
   	text-align: center;
 }
 
-.sheet-rolltemplate-pf_block .sheet-header a{
+.sheet-rolltemplate-pf_block .sheet-header a {
 	color: white;
 	text-decoration: underline;
 }
 
 .sheet-rolltemplate-pf_block td {
 	padding: 5px;
-    line-height: 1.4em;
+	line-height: 1.4em;
 	vertical-align: top;
-	text-align:right
+	text-align:right;
 }
 .sheet-rolltemplate-pf_block tr:nth-child(odd) {
 	background-color: #D3D3D3;

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -60,7 +60,7 @@
                 <span class="sheet-table-header">Drain</span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|STR-Check}" type="roll" name="roll_STR-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Strength}} {{Check=[[ 1d20 + [[ @{STR-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">STR</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|STR-Check}" type="roll" name="roll_STR-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Strength}} {{Check=[[ 1d20 + [[ @{STR-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">STR</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR}" type="number" name="attr_STR" value="(@{STR-base} + [[ @{STR-enhance} ]] + [[ @{STR-misc} ]] + [[ @{STR-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-mod}" type="number" name="attr_STR-mod" value="((floor(@{STR}/2)-5) + floor(@{STR-temp}/2) - (floor(abs(@{STR-damage})/2)) - (floor(abs(@{STR-penalty})/2)) - [[ @{condition-fatigued} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -75,7 +75,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{STR-drain}" type="number" name="attr_STR-drain" value="0" max="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|DEX-Check}" type="roll" name="roll_DEX-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Dexterity}} {{Check=[[ 1d20 + [[ @{DEX-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">DEX</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|DEX-Check}" type="roll" name="roll_DEX-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Dexterity}} {{Check=[[ 1d20 + [[ @{DEX-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">DEX</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX}" type="number" name="attr_DEX" value="(@{DEX-base} + [[ @{DEX-enhance} ]] + [[ @{DEX-misc} ]] + [[ @{DEX-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-mod}" type="number" name="attr_DEX-mod" value="((floor(@{DEX}/2)-5) + floor(@{DEX-temp}/2) - (floor(abs(@{DEX-damage})/2)) - (floor(abs(@{DEX-penalty})/2)) - [[ @{condition-entangled} ]] - [[ @{condition-grappled} ]] - [[ @{condition-fatigued} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -90,7 +90,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{DEX-drain}" type="number" name="attr_DEX-drain" value="0" max="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CON-Check}" type="roll" name="roll_CON-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Constitution}} {{Check=[[ 1d20 + [[ @{CON-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">CON</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CON-Check}" type="roll" name="roll_CON-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Constitution}} {{Check=[[ 1d20 + [[ @{CON-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">CON</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON}" type="number" name="attr_CON" value="(@{CON-base} + [[ @{CON-enhance} ]] + [[ @{CON-misc} ]] + [[ @{CON-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-mod}" type="number" name="attr_CON-mod" value="((floor(@{CON}/2)-5) + floor(@{CON-temp}/2) - (floor(abs(@{CON-damage})/2)) - (floor(abs(@{CON-penalty})/2)))" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -105,7 +105,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CON-drain}" type="number" name="attr_CON-drain" value="0" max="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|INT-Check}" type="roll" name="roll_INT-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intelligence}} {{Check=[[ 1d20 + [[ @{INT-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">INT</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|INT-Check}" type="roll" name="roll_INT-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intelligence}} {{Check=[[ 1d20 + [[ @{INT-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">INT</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT}" type="number" name="attr_INT" value="(@{INT-base} + [[ @{INT-enhance} ]] + [[ @{INT-misc} ]] + [[ @{INT-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-mod}" type="number" name="attr_INT-mod" value="((floor(@{INT}/2)-5) + floor(@{INT-temp}/2) - (floor(abs(@{INT-damage})/2)) - (floor(abs(@{INT-penalty})/2)))" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -120,7 +120,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{INT-drain}" type="number" name="attr_INT-drain" value="0" max="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|WIS-Check}" type="roll" name="roll_WIS-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Wisdom}} {{Check=[[ 1d20 + [[ @{WIS-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">WIS</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|WIS-Check}" type="roll" name="roll_WIS-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Wisdom}} {{Check=[[ 1d20 + [[ @{WIS-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">WIS</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS}" type="number" name="attr_WIS" value="(@{WIS-base} + [[ @{WIS-enhance} ]] + [[ @{WIS-misc} ]] + [[ @{WIS-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-mod}" type="number" name="attr_WIS-mod" value="((floor(@{WIS}/2)-5) + floor(@{WIS-temp}/2) - (floor(abs(@{WIS-damage})/2)) - (floor(abs(@{WIS-penalty})/2)))" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -135,7 +135,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{WIS-drain}" type="number" name="attr_WIS-drain" value="0" max="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CHA-Check}" type="roll" name="roll_CHA-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Charisma}} {{Check=[[ 1d20 + [[ @{CHA-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]]  ]]}}">CHA</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|CHA-Check}" type="roll" name="roll_CHA-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Charisma}} {{Check=[[ 1d20 + [[ @{CHA-mod} ]] - [[ @{condition-Wounds} ]] + [[ @{condition-Drained} ]] ]]}}">CHA</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA}" type="number" name="attr_CHA" value="(@{CHA-base} + [[ @{CHA-enhance} ]] + [[ @{CHA-misc} ]] + [[ @{CHA-drain} ]])" disabled></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{CHA-mod}" type="number" name="attr_CHA-mod" value="((floor(@{CHA}/2)-5) + floor(@{CHA-temp}/2) - (floor(abs(@{CHA-damage})/2)) - (floor(abs(@{CHA-penalty})/2)))" disabled></span>
                 <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;"><b>|</b></span>
@@ -700,21 +700,21 @@
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Special Defenses</span>
             <div class="sheet-table-row">
-                <span class="sheet-table-header sheet-center">DR</span>
-                <span class="sheet-table-header sheet-center">Resistances</span>
-                <span class="sheet-table-header sheet-center">Immunities</span>
-                <span class="sheet-table-header sheet-center">Weaknesses</span>
-                <span class="sheet-table-header sheet-center">SR</span>
+                <span class="sheet-table-header sheet-center" title="Damage Reduction: The amount of damage ignored and the type of weapon that negates the ability. (e.g. 5/silver)">DR</span>
+                <span class="sheet-table-header sheet-center" title="Ignores some damage of the indicated type each time it takes damage of that kind. (e.g. acid 10)">Resistances</span>
+                <span class="sheet-table-header sheet-center" title="Takes no damage from listed sources. (e.g. acid, fire, paralysis)">Immunities</span>
+                <span class="sheet-table-header sheet-center" title="Adverse conditions may apply if applicable. (e.g. sunlight powerlessness/staggered)">Weaknesses</span>
+                <span class="sheet-table-header sheet-center" title="Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.">SR</span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-data sheet-center"><input title="@{DR}" type="text" name="attr_DR" placeholder="Damage resistances"></span>
+                <span class="sheet-table-data sheet-center"><input title="@{DR}" type="text" name="attr_DR" placeholder="Damage Reduction"></span>
                 <span class="sheet-table-data sheet-center"><input title="@{resistances}" type="text" name="attr_resistances" placeholder="Resistances"></span>
                 <span class="sheet-table-data sheet-center"><input title="@{immunities}" type="text" name="attr_immunities" placeholder="Immunities"></span>
                 <span class="sheet-table-data sheet-center"><input title="@{weaknesses}" type="text" name="attr_weaknesses" placeholder="Weaknesses"></span>
                 <span class="sheet-table-data sheet-center"><input title="@{SR}" type="number" name="attr_SR" value="0"></span>
-            </div>
-        </div>
-        <br>
+            </div>  		
+        </div>    
+	  <br>	   	  
     </div>
     <div>
         <b>Armor Penalties&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
@@ -773,7 +773,7 @@
                 <span class="sheet-table-header">Temp</span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" ><button class="sheet-text-button" title="%{selected|Fort-Save}" type="roll" name="roll_Fort-Save" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fortitude}} {{Save=[[ 1d20 + [[ @{Fort} ]]  ]]}}">Fort</button></span>
+                <span class="sheet-table-row-name" ><button class="sheet-text-button" title="%{selected|Fort-Save}" type="roll" name="roll_Fort-Save" value="&{template:pf_defense} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fortitude}} {{Save=[[ 1d20 + [[ @{Fort} ]] ]]}} @{save_options}">Fort</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort}" type="number" name="attr_Fort" value="(@{total-Fort} + @{CON-mod} + @{Fort-trait} + @{Fort-enhance} + @{Fort-resist} + @{Fort-misc} + @{Fort-temp} - @{condition-fear} - @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
                 <span class="sheet-table-data sheet-center">=</span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Fort}" type="number" name="attr_Fort-base" value="@{total-Fort}" disabled></span>
@@ -791,7 +791,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Fort-temp}" type="number" name="attr_Fort-temp" value="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Ref-Save}" type="roll" name="roll_Ref-Save" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Reflex}} {{Save=[[ 1d20 + [[ @{Ref} ]]  ]]}}">Ref</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Ref-Save}" type="roll" name="roll_Ref-Save" value="&{template:pf_defense} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Reflex}} {{Save=[[ 1d20 + [[ @{Ref} ]] ]]}} @{save_options}">Ref</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref}" type="number" name="attr_Ref" value="(@{total-Ref} + @{DEX-mod} + @{Ref-trait} + @{Ref-enhance} + @{Ref-resist} + @{Ref-misc} + @{Ref-temp} - @{condition-fear} - @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
                 <span class="sheet-table-data sheet-center">=</span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Ref}" type="number" name="attr_Ref-base" value="@{total-Ref}" disabled></span>
@@ -809,7 +809,7 @@
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Ref-temp}" type="number" name="attr_Ref-temp" value="0"></span>
             </div>
             <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Will-Save}" type="roll" name="roll_Will-Save" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Will}} {{Save=[[ 1d20 + [[ @{Will} ]]  ]]}}">Will</button></span>
+                <span class="sheet-table-row-name" style="text-align:left;"><button class="sheet-text-button" title="%{selected|Will-Save}" type="roll" name="roll_Will-Save" value="&{template:pf_defense} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Will}} {{Save=[[ 1d20 + [[ @{Will} ]] ]]}} @{save_options}">Will</button></span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will}" type="number" name="attr_Will" value="(@{total-Will} + @{WIS-mod} + @{Will-trait} + @{Will-enhance} + @{Will-resist} + @{Will-misc} + @{Will-temp} - @{condition-fear} - @{condition-sickened} + @{condition-drained} - @{condition-Wounds})" disabled></span>
                 <span class="sheet-table-data sheet-center">=</span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{total-Will}" type="number" name="attr_Will-base" value="@{total-Will}" disabled></span>
@@ -826,9 +826,43 @@
                 <span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center"><input style="width:100%;" title="@{Will-temp}" type="number" name="attr_Will-temp" value="0"></span>
             </div>
-        </div>
-        <br>
+	</div>
     </div>
+    <div>
+        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+        <input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>    
+		<input type="hidden" name="attr_var_dr_notes" value="{{dr_notes=@{DR}}}"/>
+            <input type="hidden" name="attr_var_resistances_notes" value="{{resistances_notes=@{resistances}}}"/>
+            <input type="hidden" name="attr_var_immunities_notes" value="{{immunities_notes=@{immunities}}}"/>
+            <input type="hidden" name="attr_var_weaknesses_notes" value="{{weaknesses_notes=@{weaknesses}}}"/>
+		<input type="hidden" name="attr_var_sr_notes" value="{{sr_notes=@{SR}}}"/>
+		<input type="hidden" name="attr_var_armor_notes" value="{{armor_notes=@{Armor-notes}}}"/>
+            <input type="hidden" name="attr_var_save_notes" value="{{save_notes=@{Save-notes}}}"/>
+            <input type="hidden" name="attr_var_cmd_notes" value="{{cmd_notes=@{cmd-notes}}}"/>
+            <input type="hidden" name="attr_var_defense_notes" value="{{defense_notes=@{defense-notes}}}"/>	
+		
+		<div class="sheet-table sheet-options">
+			<div class="sheet-table-row sheet-table-header">
+                    <span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these additional attributes with saving throws?">Include info?</b></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_dr_notes" value="@{var_dr_notes}" title="@{toggle_dr_notes}"/><b title="Show Damage Reduction"> DR</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_resistances_notes" value="@{var_resistances_notes}" title="Show Resistances"/><b title="Show Resistances"> Resistances</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_immunities_notes" value="@{var_immunities_notes}" title="Show Immunities"/><b title="Show Immunities"> Immunities</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_weaknesses_notes" value="@{var_weaknesses_notes}" title="Show Weaknesses"/><b title="Show Weaknesses"> Weaknesses</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{toggle_sr_notes}"/><b title="Show Spell Resistance"> SR</b></label></span>
+			</div>
+			
+			<div class="sheet-table-row sheet-table-header">
+                    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_armor_notes" value="@{var_armor_notes}" title="@{toggle_armor_notes}"/><b title="Show Armor Notes"> Armor Notes</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_save_notes" value="@{var_save_notes}" title="@{toggle_save_notes}"/><b title="Show Save Notes"> Save Notes</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_cmd_notes" value="@{var_cmd_notes}" title="@{toggle_cmd_notes}"/><b title="Show CMD Notes"> CMD Notes</b></label></span>
+			  <span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_defense_notes" value="@{var_defense_notes}" title="@{toggle_defense_notes}"/><b title="Show Defense Notes"> Defense Notes</b></label></span>
+                    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+			</div>
+            </div>
+            <input type="hidden" name="attr_save_options" value="@{toggle_dr_notes} @{toggle_resistances_notes} @{toggle_immunities_notes} @{toggle_weaknesses_notes} @{toggle_sr_notes} @{toggle_armor_notes} @{toggle_save_notes} @{toggle_cmd_notes} @{toggle_defense_notes}"/>	
+	</div>
+	<br>
     <div>
         <b>Armor and Shield&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
         <input type="checkbox" class="sheet-sect-show" title="@{armor-shield-show}" name="attr_armor-shield-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
@@ -933,336 +967,461 @@
     <br>
 </div>
 <div class="sheet-section sheet-section-attacks">
-    <div class="sheet-table sheet-header-row">&nbsp;</div>
-    <div>
-        <b>Attack and Combat Maneuver Bonuses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{attack-bonuses-show}" name="attr_attack-bonuses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
-        <div class="sheet-table sheet-sect">
-            <span class="sheet-table-name">Attack and Combat Maneuver Bonuses</span>
-            <div class="sheet-table-row">
-                <span class="sheet-table-header">Attack</span>
-                <span class="sheet-table-header">Total</span>
-                <span class="sheet-table-header"></span>
-                <span class="sheet-table-header">BAB</span>
-                <span class="sheet-table-header"></span>
-                <span class="sheet-table-header">Ability</span>
-                <span class="sheet-table-header">Mod</span>
-                <span class="sheet-table-header"></span>
-                <span class="sheet-table-header">Size</span>
-                <span class="sheet-table-header"></span>
-                <span class="sheet-table-header">Misc</span>
-                <span class="sheet-table-header"></span>
-                <span class="sheet-table-header">Temp</span>
-                <span class="sheet-table-header">|</span>
-                <span class="sheet-table-header">Penalty</span>
-            </div>
-            <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Melee-Attack-Roll}" name="roll_Melee-Attack-Roll" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Melee Attack}} {{Check=[[  1d20 + [[ @{attk-melee} ]]  ]]}}">Melee</button></span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-melee}" type="number" name="attr_attk-melee" value="(@{bab} + @{attk-melee-ability} + @{size} + @{attk-melee-misc} + @{attk-melee-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} - @{condition-prone} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
-                <span class="sheet-table-data sheet-center">=</span>
-                <span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
+	<div class="sheet-table sheet-header-row">&nbsp;</div>
+	<div>
+		<b>Attack and Combat Maneuver Bonuses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-bonuses-show}" name="attr_attack-bonuses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Attack and Combat Maneuver Bonuses</span>
+			<div class="sheet-table-row">
+				<span class="sheet-table-header">Attack</span>
+				<span class="sheet-table-header">Total</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">BAB</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Ability</span>
+				<span class="sheet-table-header">Mod</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Size</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Misc</span>
+				<span class="sheet-table-header"></span>
+				<span class="sheet-table-header">Temp</span>
+				<span class="sheet-table-header">|</span>
+				<span class="sheet-table-header">Penalty</span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Melee-Attack-Roll}" name="roll_Melee-Attack-Roll" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Melee Attack}} {{Check=[[ 1d20 + [[ @{attk-melee} ]] ]]}}">Melee</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee}" type="number" name="attr_attk-melee" value="(@{bab} + @{attk-melee-ability} + @{size} + @{attk-melee-misc} + @{attk-melee-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} - @{condition-prone} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center">
                     <select title="@{attk-melee-ability}" name="attr_attk-melee-ability">
-                        <option value="0">None</option>
-                        <option value="@{STR-mod}" selected>STR</option>
-                        <option value="@{DEX-mod}">DEX</option>
-                        <option value="@{CON-mod}">CON</option>
-                        <option value="@{INT-mod}">INT</option>
-                        <option value="@{WIS-mod}">WIS</option>
-                        <option value="@{CHA-mod}">CHA</option>
+	                    <option value="0">None</option>
+	                    <option value="@{STR-mod}" selected>STR</option>
+	                    <option value="@{DEX-mod}">DEX</option>
+	                    <option value="@{CON-mod}">CON</option>
+	                    <option value="@{INT-mod}">INT</option>
+	                    <option value="@{WIS-mod}">WIS</option>
+	                    <option value="@{CHA-mod}">CHA</option>
                     </select>
                 </span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-melee-ability-value}" type="number" name="attr_attk-melee-ability-value" value="@{attk-melee-ability}" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-melee-size" value="@{size}" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-melee-misc}" type="number" name="attr_attk-melee-misc" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-melee-temp}" type="number" name="attr_attk-melee-temp" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
-            </div>
-            <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Ranged-Attack-Roll}" name="roll_Ranged-Attack-Roll" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ranged Attack}} {{Check=[[ 1d20 + [[ @{attk-ranged} ]]  ]]}}">Ranged</button></span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-ranged}" type="number" name="attr_attk-ranged" value="(@{bab} + @{attk-ranged-ability} + @{size} + @{attk-ranged-misc} + @{attk-ranged-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
-                <span class="sheet-table-data sheet-center">=</span>
-                <span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-ability-value}" type="number" name="attr_attk-melee-ability-value" value="@{attk-melee-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-melee-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-misc}" type="number" name="attr_attk-melee-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-melee-temp}" type="number" name="attr_attk-melee-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|Ranged-Attack-Roll}" name="roll_Ranged-Attack-Roll" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ranged Attack}} {{Check=[[ 1d20 + [[ @{attk-ranged} ]] ]]}}">Ranged</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged}" type="number" name="attr_attk-ranged" value="(@{bab} + @{attk-ranged-ability} + @{size} + @{attk-ranged-misc} + @{attk-ranged-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center">
                     <select title="@{attk-ranged-ability}" name="attr_attk-ranged-ability">
-                        <option value="0">None</option>
-                        <option value="@{STR-mod}">STR</option>
-                        <option value="@{DEX-mod}" selected>DEX</option>
-                        <option value="@{CON-mod}">CON</option>
-                        <option value="@{INT-mod}">INT</option>
-                        <option value="@{WIS-mod}">WIS</option>
-                        <option value="@{CHA-mod}">CHA</option>
+	                    <option value="0">None</option>
+	                    <option value="@{STR-mod}">STR</option>
+	                    <option value="@{DEX-mod}" selected>DEX</option>
+	                    <option value="@{CON-mod}">CON</option>
+	                    <option value="@{INT-mod}">INT</option>
+	                    <option value="@{WIS-mod}">WIS</option>
+	                    <option value="@{CHA-mod}">CHA</option>
                     </select>
                 </span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-ranged-ability-value}" type="number" name="attr_attk-ranged-ability-value" value="@{attk-ranged-ability}" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-ranged-size" value="@{size}" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-ranged-misc}" type="number" name="attr_attk-ranged-misc" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-ranged-temp}" type="number" name="attr_attk-ranged-temp" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
-            </div>
-            <div class="sheet-table-row">
-                <span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|CMB-Check}" name="roll_CMB-Check" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]]  ]]}}">CMB</button></span>
-                <span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
-                <span class="sheet-table-data sheet-center">=</span>
-                <span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-ability-value}" type="number" name="attr_attk-ranged-ability-value" value="@{attk-ranged-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{size}" type="number" name="attr_attk-ranged-size" value="@{size}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-misc}" type="number" name="attr_attk-ranged-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-ranged-temp}" type="number" name="attr_attk-ranged-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+			<div class="sheet-table-row">
+				<span class="sheet-table-row-name" style="text-align:left;width:10%;"><button class="sheet-text-button" type="roll" title="%{selected|CMB-Check}" name="roll_CMB-Check" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]] ]]}}">CMB</button></span>
+				<span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} + @{attk-penalty} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled></span>
+				<span class="sheet-table-data sheet-center">=</span>
+				<span class="sheet-table-data sheet-center"><input title="@{bab}" type="number" name="attr_bab" value="(@{class-0-bab} + [[ @{class-1-bab} ]] + [[ @{class-2-bab} ]] + [[ @{class-3-bab} ]] + [[ @{class-4-bab} ]])" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
                 <span class="sheet-table-data sheet-center">
                     <select title="@{attk-CMB-ability}" name="attr_attk-CMB-ability">
-                        <option value="0">None</option>
-                        <option value="@{STR-mod}" selected>STR</option>
-                        <option value="@{DEX-mod}">DEX</option>
-                        <option value="@{CON-mod}">CON</option>
-                        <option value="@{INT-mod}">INT</option>
-                        <option value="@{WIS-mod}">WIS</option>
-                        <option value="@{CHA-mod}">CHA</option>
+	                    <option value="0">None</option>
+	                    <option value="@{STR-mod}" selected>STR</option>
+	                    <option value="@{DEX-mod}">DEX</option>
+	                    <option value="@{CON-mod}">CON</option>
+	                    <option value="@{INT-mod}">INT</option>
+	                    <option value="@{WIS-mod}">WIS</option>
+	                    <option value="@{CHA-mod}">CHA</option>
                     </select>
                 </span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-CMB-ability-value}" type="number" name="attr_attk-CMB-ability-value" value="@{attk-CMB-ability}" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-CMB-size}" type="number" name="attr_attk-CMB-size" value="(@{size} * -1)" disabled></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-CMB-temp}" type="number" name="attr_attk-CMB-temp" value="0"></span>
-                <span class="sheet-table-data sheet-center">+</span>
-                <span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
-            </div>
-        </div>
-        <br>
-    </div>
-    <div>
-        <b>Attack Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{attack-notes-show}" name="attr_attack-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
-        <div class="sheet-table sheet-sect">
-            <div class="sheet-table">
-                <div class="sheet-table-row">
-                    <div class="sheet-table-data sheet-center">
-                        <div class="sheet-table">
-                            <span class="sheet-table-name">Melee Attack Notes</span>
-                            <div class="sheet-table-row">
-                                <span class="sheet-table-data sheet-left"><textarea title="@{melee-attack-notes}" name="attr_melee-attack-notes" placeholder="Put notes about context-sensitive Melee Attack bonuses here."></textarea></span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="sheet-table-data sheet-center">
-                        <div class="sheet-table">
-                            <span class="sheet-table-name">Ranged Attack Notes</span>
-                            <div class="sheet-table-row">
-                                <span class="sheet-table-data sheet-left"><textarea title="@{ranged-attack-notes}" name="attr_ranged-attack-notes" placeholder="Put notes about context-sensitive Ranged Attack bonuses here."></textarea></span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="sheet-table-data sheet-center">
-                        <div class="sheet-table">
-                            <span class="sheet-table-name">CMB Notes</span>
-                            <div class="sheet-table-row">
-                                <span class="sheet-table-data sheet-left"><textarea title="@{CMB-notes}" name="attr_CMB-notes" placeholder="Put notes about context-sensitive CMB bonuses here."></textarea></span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="sheet-table-data sheet-center">
-                        <div class="sheet-table">
-                            <span class="sheet-table-name">Attack Notes</span>
-                            <div class="sheet-table-row">
-                                <span class="sheet-table-data sheet-left"><textarea title="@{attack-notes}" name="attr_attack-notes" placeholder="Put notes about context-sensitive Attack bonuses here."></textarea></span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <input type="hidden" name="attr_var_melee_notes" value="{{melee_notes=@{melee-attack-notes}}}"/>
-            <input type="hidden" name="attr_var_ranged_notes" value="{{ranged_notes=@{ranged-attack-notes}}}"/>
-            <input type="hidden" name="attr_var_CMB_notes" value="{{CMB_notes=@{CMB-notes}}}"/>
-            <input type="hidden" name="attr_var_attack_notes" value="{{attack_notes=@{attack-notes}}}"/>
-        </div>
-        <br/>
-    </div>
-    <div>
-        <b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
-        <div class="sheet-sect">
-            <div class="sheet-table">
-                <span class="sheet-table-name">Preset Attack Buttons</span>
-                <div class="sheet-table-row">
-                    <span class="sheet-table-header">0</span>
-                    <span class="sheet-table-header">1</span>
-                    <span class="sheet-table-header">2</span>
-                    <span class="sheet-table-header">3</span>
-                    <span class="sheet-table-header">4</span>
-                    <span class="sheet-table-header">5</span>
-                    <span class="sheet-table-header">6</span>
-                    <span class="sheet-table-header">7</span>
-                    <span class="sheet-table-header">8</span>
-                    <span class="sheet-table-header">9</span>
-                    <span class="sheet-table-header">10</span>
-                    <span class="sheet-table-header">11</span>
-                    <span class="sheet-table-header">12</span>
-                    <span class="sheet-table-header">13</span>
-                    <span class="sheet-table-header">14</span>
-                    <span class="sheet-table-header">15</span>
-                    <span class="sheet-table-header">16</span>
-                    <span class="sheet-table-header">17</span>
-                    <span class="sheet-table-header">18</span>
-                    <span class="sheet-table-header">19</span>
-                    <span class="sheet-table-header">20</span>
-                    <span class="sheet-table-header">21</span>
-                    <span class="sheet-table-header">22</span>
-                    <span class="sheet-table-header">23</span>
-                    <span class="sheet-table-header">24</span>
-                    <span class="sheet-table-header">25</span>
-                    <span class="sheet-table-header">26</span>
-                </div>
-                <div class="sheet-table-row">
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_0_Attack" title="%{selected|repeating_weapon_0_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_0_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_0_crit-target} + [[ (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_0_damage-dice-num}d@{repeating_weapon_0_damage-die} + [[ (@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_0_damage-dice-num} ]] * ([[ @{repeating_weapon_0_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_0_damage-die} + [[ ([[ (@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability}) ]] * (@{repeating_weapon_0_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_0_type}}} {{description=@{repeating_weapon_0_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_1_Attack" title="%{selected|repeating_weapon_1_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_1_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_1_crit-target} + [[ (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_1_damage-dice-num}d@{repeating_weapon_1_damage-die} + [[ (@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_1_damage-dice-num} ]] * ([[ @{repeating_weapon_1_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_1_damage-die} + [[ ([[ (@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability}) ]] * (@{repeating_weapon_1_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_1_type}}} {{description=@{repeating_weapon_1_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_2_Attack" title="%{selected|repeating_weapon_2_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_2_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_2_crit-target} + [[ (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_2_damage-dice-num}d@{repeating_weapon_2_damage-die} + [[ (@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_2_damage-dice-num} ]] * ([[ @{repeating_weapon_2_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_2_damage-die} + [[ ([[ (@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability}) ]] * (@{repeating_weapon_2_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_2_type}}} {{description=@{repeating_weapon_2_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_3_Attack" title="%{selected|repeating_weapon_3_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_3_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_3_crit-target} + [[ (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_3_damage-dice-num}d@{repeating_weapon_3_damage-die} + [[ (@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_3_damage-dice-num} ]] * ([[ @{repeating_weapon_3_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_3_damage-die} + [[ ([[ (@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability}) ]] * (@{repeating_weapon_3_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_3_type}}} {{description=@{repeating_weapon_3_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_4_Attack" title="%{selected|repeating_weapon_4_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_4_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_4_crit-target} + [[ (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_4_damage-dice-num}d@{repeating_weapon_4_damage-die} + [[ (@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_4_damage-dice-num} ]] * ([[ @{repeating_weapon_4_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_4_damage-die} + [[ ([[ (@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability}) ]] * (@{repeating_weapon_4_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_4_type}}} {{description=@{repeating_weapon_4_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_5_Attack" title="%{selected|repeating_weapon_5_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_5_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_5_crit-target} + [[ (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_5_damage-dice-num}d@{repeating_weapon_5_damage-die} + [[ (@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_5_damage-dice-num} ]] * ([[ @{repeating_weapon_5_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_5_damage-die} + [[ ([[ (@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability}) ]] * (@{repeating_weapon_5_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_5_type}}} {{description=@{repeating_weapon_5_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_6_Attack" title="%{selected|repeating_weapon_6_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_6_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_6_crit-target} + [[ (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_6_damage-dice-num}d@{repeating_weapon_6_damage-die} + [[ (@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_6_damage-dice-num} ]] * ([[ @{repeating_weapon_6_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_6_damage-die} + [[ ([[ (@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability}) ]] * (@{repeating_weapon_6_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_6_type}}} {{description=@{repeating_weapon_6_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_7_Attack" title="%{selected|repeating_weapon_7_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_7_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_7_crit-target} + [[ (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_7_damage-dice-num}d@{repeating_weapon_7_damage-die} + [[ (@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_7_damage-dice-num} ]] * ([[ @{repeating_weapon_7_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_7_damage-die} + [[ ([[ (@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability}) ]] * (@{repeating_weapon_7_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_7_type}}} {{description=@{repeating_weapon_7_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_8_Attack" title="%{selected|repeating_weapon_8_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_8_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_8_crit-target} + [[ (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_8_damage-dice-num}d@{repeating_weapon_8_damage-die} + [[ (@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_8_damage-dice-num} ]] * ([[ @{repeating_weapon_8_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_8_damage-die} + [[ ([[ (@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability}) ]] * (@{repeating_weapon_8_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_8_type}}} {{description=@{repeating_weapon_8_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_9_Attack" title="%{selected|repeating_weapon_9_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_9_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_9_crit-target} + [[ (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_9_damage-dice-num}d@{repeating_weapon_9_damage-die} + [[ (@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_9_damage-dice-num} ]] * ([[ @{repeating_weapon_9_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_9_damage-die} + [[ ([[ (@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability}) ]] * (@{repeating_weapon_9_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_9_type}}} {{description=@{repeating_weapon_9_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_10_Attack" title="%{selected|repeating_weapon_10_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_10_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_10_crit-target} + [[ (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_10_damage-dice-num}d@{repeating_weapon_10_damage-die} + [[ (@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_10_damage-dice-num} ]] * ([[ @{repeating_weapon_10_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_10_damage-die} + [[ ([[ (@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability}) ]] * (@{repeating_weapon_10_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_10_type}}} {{description=@{repeating_weapon_10_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_11_Attack" title="%{selected|repeating_weapon_11_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_11_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_11_crit-target} + [[ (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_11_damage-dice-num}d@{repeating_weapon_11_damage-die} + [[ (@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_11_damage-dice-num} ]] * ([[ @{repeating_weapon_11_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_11_damage-die} + [[ ([[ (@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability}) ]] * (@{repeating_weapon_11_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_11_type}}} {{description=@{repeating_weapon_11_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_12_Attack" title="%{selected|repeating_weapon_12_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_12_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_12_crit-target} + [[ (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_12_damage-dice-num}d@{repeating_weapon_12_damage-die} + [[ (@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_12_damage-dice-num} ]] * ([[ @{repeating_weapon_12_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_12_damage-die} + [[ ([[ (@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability}) ]] * (@{repeating_weapon_12_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_12_type}}} {{description=@{repeating_weapon_12_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_13_Attack" title="%{selected|repeating_weapon_13_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_13_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_13_crit-target} + [[ (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_13_damage-dice-num}d@{repeating_weapon_13_damage-die} + [[ (@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_13_damage-dice-num} ]] * ([[ @{repeating_weapon_13_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_13_damage-die} + [[ ([[ (@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability}) ]] * (@{repeating_weapon_13_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_13_type}}} {{description=@{repeating_weapon_13_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_14_Attack" title="%{selected|repeating_weapon_14_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_14_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_14_crit-target} + [[ (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_14_damage-dice-num}d@{repeating_weapon_14_damage-die} + [[ (@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_14_damage-dice-num} ]] * ([[ @{repeating_weapon_14_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_14_damage-die} + [[ ([[ (@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability}) ]] * (@{repeating_weapon_14_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_14_type}}} {{description=@{repeating_weapon_14_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_15_Attack" title="%{selected|repeating_weapon_15_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_15_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_15_crit-target} + [[ (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_15_damage-dice-num}d@{repeating_weapon_15_damage-die} + [[ (@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_15_damage-dice-num} ]] * ([[ @{repeating_weapon_15_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_15_damage-die} + [[ ([[ (@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability}) ]] * (@{repeating_weapon_15_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_15_type}}} {{description=@{repeating_weapon_15_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_16_Attack" title="%{selected|repeating_weapon_16_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_16_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_16_crit-target} + [[ (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_16_damage-dice-num}d@{repeating_weapon_16_damage-die} + [[ (@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_16_damage-dice-num} ]] * ([[ @{repeating_weapon_16_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_16_damage-die} + [[ ([[ (@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability}) ]] * (@{repeating_weapon_16_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_16_type}}} {{description=@{repeating_weapon_16_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_17_Attack" title="%{selected|repeating_weapon_17_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_17_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_17_crit-target} + [[ (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_17_damage-dice-num}d@{repeating_weapon_17_damage-die} + [[ (@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_17_damage-dice-num} ]] * ([[ @{repeating_weapon_17_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_17_damage-die} + [[ ([[ (@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability}) ]] * (@{repeating_weapon_17_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_17_type}}} {{description=@{repeating_weapon_17_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_18_Attack" title="%{selected|repeating_weapon_18_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_18_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_18_crit-target} + [[ (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_18_damage-dice-num}d@{repeating_weapon_18_damage-die} + [[ (@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_18_damage-dice-num} ]] * ([[ @{repeating_weapon_18_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_18_damage-die} + [[ ([[ (@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability}) ]] * (@{repeating_weapon_18_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_18_type}}} {{description=@{repeating_weapon_18_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_19_Attack" title="%{selected|repeating_weapon_19_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_19_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_19_crit-target} + [[ (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_19_damage-dice-num}d@{repeating_weapon_19_damage-die} + [[ (@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_19_damage-dice-num} ]] * ([[ @{repeating_weapon_19_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_19_damage-die} + [[ ([[ (@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability}) ]] * (@{repeating_weapon_19_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_19_type}}} {{description=@{repeating_weapon_19_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_20_Attack" title="%{selected|repeating_weapon_20_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_20_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_20_crit-target} + [[ (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_20_damage-dice-num}d@{repeating_weapon_20_damage-die} + [[ (@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_20_damage-dice-num} ]] * ([[ @{repeating_weapon_20_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_20_damage-die} + [[ ([[ (@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability}) ]] * (@{repeating_weapon_20_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_20_type}}} {{description=@{repeating_weapon_20_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_21_Attack" title="%{selected|repeating_weapon_21_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_21_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_21_crit-target} + [[ (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_21_damage-dice-num}d@{repeating_weapon_21_damage-die} + [[ (@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_21_damage-dice-num} ]] * ([[ @{repeating_weapon_21_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_21_damage-die} + [[ ([[ (@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability}) ]] * (@{repeating_weapon_21_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_21_type}}} {{description=@{repeating_weapon_21_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_22_Attack" title="%{selected|repeating_weapon_22_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_22_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_22_crit-target} + [[ (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_22_damage-dice-num}d@{repeating_weapon_22_damage-die} + [[ (@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_22_damage-dice-num} ]] * ([[ @{repeating_weapon_22_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_22_damage-die} + [[ ([[ (@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability}) ]] * (@{repeating_weapon_22_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_22_type}}} {{description=@{repeating_weapon_22_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_23_Attack" title="%{selected|repeating_weapon_23_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_23_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_23_crit-target} + [[ (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_23_damage-dice-num}d@{repeating_weapon_23_damage-die} + [[ (@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_23_damage-dice-num} ]] * ([[ @{repeating_weapon_23_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_23_damage-die} + [[ ([[ (@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability}) ]] * (@{repeating_weapon_23_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_23_type}}} {{description=@{repeating_weapon_23_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_24_Attack" title="%{selected|repeating_weapon_24_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_24_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_24_crit-target} + [[ (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_24_damage-dice-num}d@{repeating_weapon_24_damage-die} + [[ (@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_24_damage-dice-num} ]] * ([[ @{repeating_weapon_24_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_24_damage-die} + [[ ([[ (@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability}) ]] * (@{repeating_weapon_24_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_24_type}}} {{description=@{repeating_weapon_24_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_25_Attack" title="%{selected|repeating_weapon_25_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_25_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_25_crit-target} + [[ (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_25_damage-dice-num}d@{repeating_weapon_25_damage-die} + [[ (@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_25_damage-dice-num} ]] * ([[ @{repeating_weapon_25_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_25_damage-die} + [[ ([[ (@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability}) ]] * (@{repeating_weapon_25_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_25_type}}} {{description=@{repeating_weapon_25_notes}}} @{macro_options}"></button></span>
-                    <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_26_Attack" title="%{selected|repeating_weapon_26_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_26_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_26_crit-target} + [[ (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency}) ]]  ]]}} {{damage=[[ @{repeating_weapon_26_damage-dice-num}d@{repeating_weapon_26_damage-die} + [[ (@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability}) ]]  ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency}) ]]  ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_26_damage-dice-num} ]] * ([[ @{repeating_weapon_26_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_26_damage-die} + [[ ([[ (@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability}) ]] * (@{repeating_weapon_26_crit-multiplier} - 1)) ]]  ]]}} {{type=@{repeating_weapon_26_type}}} {{description=@{repeating_weapon_26_notes}}} @{macro_options}"></button></span>
-                </div>
-            </div>
-            <div class="sheet-table" style="margin-top: 0.5em;">
-                <div class="sheet-table-row sheet-table-header">
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><b title="Include these additional notes on all preset button attacks.">Include notes?</b></span>
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_melee_notes" value="@{var_melee_notes}" title="@{toggle_melee_notes}"/><b title="Include Melee attack notes"> Melee Notes</b></label></span>
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_ranged_notes" value="@{var_ranged_notes}" title="@{toggle_ranged_notes}"/><b title="Include Ranged attack notes"> Ranged Notes</b></label></span>
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_CMB_notes" value="@{var_CMB_notes}" title="@{toggle_CMB_notes}"/><b title="Include CMB notes"> CMB Notes</b></label></span>
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{toggle_attack_notes}"/><b title="Include Attack notes"> Attack Notes</b></label></span>
-                </div>
-            </div>
-            <input type="hidden" name="attr_macro_options" value="@{toggle_melee_notes} @{toggle_ranged_notes} @{toggle_CMB_notes} @{toggle_attack_notes}"/>
-        </div>
-        <br>
-        <div class="sheet-table sheet-sect">
-            <span class="sheet-table-name">Attacks</span>
-        </div>
-        <div class="sheet-sect">
-            <fieldset class="repeating_weapon">
-                <div class="sheet-table">
-                    <div class="sheet-table-row">
-                        <span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" min="0" name="attr_enhance" title="@{repeating_weapon_X_enhance}"><br>Enhance</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="checkbox" name="attr_masterwork" title="@{repeating_weapon_X_masterwork}" value="1"><br>Mwk</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_name" title="@{repeating_weapon_X_name}" placeholder="Name"><br>Name</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_attack" title="@{repeating_weapon_X_attack}" placeholder="Attack Modifiers"><br>Attack Mods</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-ability-value}" type="number" name="attr_attk-CMB-ability-value" value="@{attk-CMB-ability}" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-size}" type="number" name="attr_attk-CMB-size" value="(@{size} * -1)" disabled></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-CMB-temp}" type="number" name="attr_attk-CMB-temp" value="0"></span>
+				<span class="sheet-table-data sheet-center">+</span>
+				<span class="sheet-table-data sheet-center"><input title="@{attk-penalty}" type="number" name="attr_attk-penalty" value="0" max="0"></span>
+			</div>
+		</div>
+		<br>
+	</div>
+	<div>
+		<b>Attack Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-notes-show}" name="attr_attack-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-table sheet-sect">
+			<div class="sheet-table">
+				<div class="sheet-table-row">
+					<div class="sheet-table-data sheet-center">
+						<div class="sheet-table">
+							<span class="sheet-table-name">Melee Attack Notes</span>
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-left"><textarea title="@{melee-attack-notes}" name="attr_melee-attack-notes" placeholder="Put notes about context-sensitive Melee Attack bonuses here."></textarea></span>
+							</div>
+						</div>
+					</div>
+					<div class="sheet-table-data sheet-center">
+						<div class="sheet-table">
+							<span class="sheet-table-name">Ranged Attack Notes</span>
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-left"><textarea title="@{ranged-attack-notes}" name="attr_ranged-attack-notes" placeholder="Put notes about context-sensitive Ranged Attack bonuses here."></textarea></span>
+							</div>
+						</div>
+					</div>
+					<div class="sheet-table-data sheet-center">
+						<div class="sheet-table">
+							<span class="sheet-table-name">CMB Notes</span>
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-left"><textarea title="@{CMB-notes}" name="attr_CMB-notes" placeholder="Put notes about context-sensitive CMB bonuses here."></textarea></span>
+							</div>
+						</div>
+					</div>
+					<div class="sheet-table-data sheet-center">
+						<div class="sheet-table">
+							<span class="sheet-table-name">Attack Notes</span>
+							<div class="sheet-table-row">
+								<span class="sheet-table-data sheet-left"><textarea title="@{attack-notes}" name="attr_attack-notes" placeholder="Put notes about context-sensitive Attack bonuses here."></textarea></span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<input type="hidden" name="attr_var_melee_notes" value="{{melee_notes=@{melee-attack-notes}}}"/>
+			<input type="hidden" name="attr_var_ranged_notes" value="{{ranged_notes=@{ranged-attack-notes}}}"/>
+			<input type="hidden" name="attr_var_CMB_notes" value="{{CMB_notes=@{CMB-notes}}}"/>
+			<input type="hidden" name="attr_var_attack_notes" value="{{attack_notes=@{attack-notes}}}"/>
+		</div>
+		<br/>
+	</div>
+	<div>
+		<b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
+		<div class="sheet-sect">
+			<div class="sheet-table">
+				<span class="sheet-table-name">Pre-set Attack Buttons</span>
+				<div class="sheet-table-row">
+					<span class="sheet-table-header">0</span>
+					<span class="sheet-table-header">1</span>
+					<span class="sheet-table-header">2</span>
+					<span class="sheet-table-header">3</span>
+					<span class="sheet-table-header">4</span>
+					<span class="sheet-table-header">5</span>
+					<span class="sheet-table-header">6</span>
+					<span class="sheet-table-header">7</span>
+					<span class="sheet-table-header">8</span>
+					<span class="sheet-table-header">9</span>
+					<span class="sheet-table-header">10</span>
+					<span class="sheet-table-header">11</span>
+					<span class="sheet-table-header">12</span>
+					<span class="sheet-table-header">13</span>
+					<span class="sheet-table-header">14</span>
+					<span class="sheet-table-header">15</span>
+					<span class="sheet-table-header">16</span>
+					<span class="sheet-table-header">17</span>
+					<span class="sheet-table-header">18</span>
+					<span class="sheet-table-header">19</span>
+					<span class="sheet-table-header">20</span>
+					<span class="sheet-table-header">21</span>
+					<span class="sheet-table-header">22</span>
+					<span class="sheet-table-header">23</span>
+					<span class="sheet-table-header">24</span>
+					<span class="sheet-table-header">25</span>
+					<span class="sheet-table-header">26</span>
+				</div>
+				<div class="sheet-table-row">
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_0_Attack" title="%{selected|repeating_weapon_0_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_0_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_0_crit-target} + [[ (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_0_damage-dice-num}d@{repeating_weapon_0_damage-die} + [[ (@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_0_proficiency} + (((@{repeating_weapon_0_enhance} + @{repeating_weapon_0_masterwork}) + abs(@{repeating_weapon_0_enhance} - @{repeating_weapon_0_masterwork})) / 2) + @{repeating_weapon_0_attack} + @{repeating_weapon_0_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_0_damage-dice-num} ]] * ([[ @{repeating_weapon_0_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_0_damage-die} + [[ ([[ (@{repeating_weapon_0_enhance} + @{repeating_weapon_0_damage} + @{repeating_weapon_0_damage-ability}) ]] * (@{repeating_weapon_0_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_0_type}}} {{description=@{repeating_weapon_0_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_1_Attack" title="%{selected|repeating_weapon_1_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_1_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_1_crit-target} + [[ (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_1_damage-dice-num}d@{repeating_weapon_1_damage-die} + [[ (@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_1_proficiency} + (((@{repeating_weapon_1_enhance} + @{repeating_weapon_1_masterwork}) + abs(@{repeating_weapon_1_enhance} - @{repeating_weapon_1_masterwork})) / 2) + @{repeating_weapon_1_attack} + @{repeating_weapon_1_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_1_damage-dice-num} ]] * ([[ @{repeating_weapon_1_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_1_damage-die} + [[ ([[ (@{repeating_weapon_1_enhance} + @{repeating_weapon_1_damage} + @{repeating_weapon_1_damage-ability}) ]] * (@{repeating_weapon_1_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_1_type}}} {{description=@{repeating_weapon_1_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_2_Attack" title="%{selected|repeating_weapon_2_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_2_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_2_crit-target} + [[ (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_2_damage-dice-num}d@{repeating_weapon_2_damage-die} + [[ (@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_2_proficiency} + (((@{repeating_weapon_2_enhance} + @{repeating_weapon_2_masterwork}) + abs(@{repeating_weapon_2_enhance} - @{repeating_weapon_2_masterwork})) / 2) + @{repeating_weapon_2_attack} + @{repeating_weapon_2_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_2_damage-dice-num} ]] * ([[ @{repeating_weapon_2_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_2_damage-die} + [[ ([[ (@{repeating_weapon_2_enhance} + @{repeating_weapon_2_damage} + @{repeating_weapon_2_damage-ability}) ]] * (@{repeating_weapon_2_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_2_type}}} {{description=@{repeating_weapon_2_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_3_Attack" title="%{selected|repeating_weapon_3_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_3_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_3_crit-target} + [[ (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_3_damage-dice-num}d@{repeating_weapon_3_damage-die} + [[ (@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_3_proficiency} + (((@{repeating_weapon_3_enhance} + @{repeating_weapon_3_masterwork}) + abs(@{repeating_weapon_3_enhance} - @{repeating_weapon_3_masterwork})) / 2) + @{repeating_weapon_3_attack} + @{repeating_weapon_3_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_3_damage-dice-num} ]] * ([[ @{repeating_weapon_3_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_3_damage-die} + [[ ([[ (@{repeating_weapon_3_enhance} + @{repeating_weapon_3_damage} + @{repeating_weapon_3_damage-ability}) ]] * (@{repeating_weapon_3_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_3_type}}} {{description=@{repeating_weapon_3_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_4_Attack" title="%{selected|repeating_weapon_4_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_4_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_4_crit-target} + [[ (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_4_damage-dice-num}d@{repeating_weapon_4_damage-die} + [[ (@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_4_proficiency} + (((@{repeating_weapon_4_enhance} + @{repeating_weapon_4_masterwork}) + abs(@{repeating_weapon_4_enhance} - @{repeating_weapon_4_masterwork})) / 2) + @{repeating_weapon_4_attack} + @{repeating_weapon_4_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_4_damage-dice-num} ]] * ([[ @{repeating_weapon_4_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_4_damage-die} + [[ ([[ (@{repeating_weapon_4_enhance} + @{repeating_weapon_4_damage} + @{repeating_weapon_4_damage-ability}) ]] * (@{repeating_weapon_4_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_4_type}}} {{description=@{repeating_weapon_4_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_5_Attack" title="%{selected|repeating_weapon_5_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_5_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_5_crit-target} + [[ (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_5_damage-dice-num}d@{repeating_weapon_5_damage-die} + [[ (@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_5_proficiency} + (((@{repeating_weapon_5_enhance} + @{repeating_weapon_5_masterwork}) + abs(@{repeating_weapon_5_enhance} - @{repeating_weapon_5_masterwork})) / 2) + @{repeating_weapon_5_attack} + @{repeating_weapon_5_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_5_damage-dice-num} ]] * ([[ @{repeating_weapon_5_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_5_damage-die} + [[ ([[ (@{repeating_weapon_5_enhance} + @{repeating_weapon_5_damage} + @{repeating_weapon_5_damage-ability}) ]] * (@{repeating_weapon_5_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_5_type}}} {{description=@{repeating_weapon_5_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_6_Attack" title="%{selected|repeating_weapon_6_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_6_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_6_crit-target} + [[ (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_6_damage-dice-num}d@{repeating_weapon_6_damage-die} + [[ (@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_6_proficiency} + (((@{repeating_weapon_6_enhance} + @{repeating_weapon_6_masterwork}) + abs(@{repeating_weapon_6_enhance} - @{repeating_weapon_6_masterwork})) / 2) + @{repeating_weapon_6_attack} + @{repeating_weapon_6_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_6_damage-dice-num} ]] * ([[ @{repeating_weapon_6_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_6_damage-die} + [[ ([[ (@{repeating_weapon_6_enhance} + @{repeating_weapon_6_damage} + @{repeating_weapon_6_damage-ability}) ]] * (@{repeating_weapon_6_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_6_type}}} {{description=@{repeating_weapon_6_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_7_Attack" title="%{selected|repeating_weapon_7_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_7_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_7_crit-target} + [[ (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_7_damage-dice-num}d@{repeating_weapon_7_damage-die} + [[ (@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_7_proficiency} + (((@{repeating_weapon_7_enhance} + @{repeating_weapon_7_masterwork}) + abs(@{repeating_weapon_7_enhance} - @{repeating_weapon_7_masterwork})) / 2) + @{repeating_weapon_7_attack} + @{repeating_weapon_7_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_7_damage-dice-num} ]] * ([[ @{repeating_weapon_7_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_7_damage-die} + [[ ([[ (@{repeating_weapon_7_enhance} + @{repeating_weapon_7_damage} + @{repeating_weapon_7_damage-ability}) ]] * (@{repeating_weapon_7_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_7_type}}} {{description=@{repeating_weapon_7_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_8_Attack" title="%{selected|repeating_weapon_8_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_8_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_8_crit-target} + [[ (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_8_damage-dice-num}d@{repeating_weapon_8_damage-die} + [[ (@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_8_proficiency} + (((@{repeating_weapon_8_enhance} + @{repeating_weapon_8_masterwork}) + abs(@{repeating_weapon_8_enhance} - @{repeating_weapon_8_masterwork})) / 2) + @{repeating_weapon_8_attack} + @{repeating_weapon_8_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_8_damage-dice-num} ]] * ([[ @{repeating_weapon_8_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_8_damage-die} + [[ ([[ (@{repeating_weapon_8_enhance} + @{repeating_weapon_8_damage} + @{repeating_weapon_8_damage-ability}) ]] * (@{repeating_weapon_8_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_8_type}}} {{description=@{repeating_weapon_8_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_9_Attack" title="%{selected|repeating_weapon_9_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_9_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_9_crit-target} + [[ (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_9_damage-dice-num}d@{repeating_weapon_9_damage-die} + [[ (@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_9_proficiency} + (((@{repeating_weapon_9_enhance} + @{repeating_weapon_9_masterwork}) + abs(@{repeating_weapon_9_enhance} - @{repeating_weapon_9_masterwork})) / 2) + @{repeating_weapon_9_attack} + @{repeating_weapon_9_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_9_damage-dice-num} ]] * ([[ @{repeating_weapon_9_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_9_damage-die} + [[ ([[ (@{repeating_weapon_9_enhance} + @{repeating_weapon_9_damage} + @{repeating_weapon_9_damage-ability}) ]] * (@{repeating_weapon_9_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_9_type}}} {{description=@{repeating_weapon_9_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_10_Attack" title="%{selected|repeating_weapon_10_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_10_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_10_crit-target} + [[ (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_10_damage-dice-num}d@{repeating_weapon_10_damage-die} + [[ (@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_10_proficiency} + (((@{repeating_weapon_10_enhance} + @{repeating_weapon_10_masterwork}) + abs(@{repeating_weapon_10_enhance} - @{repeating_weapon_10_masterwork})) / 2) + @{repeating_weapon_10_attack} + @{repeating_weapon_10_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_10_damage-dice-num} ]] * ([[ @{repeating_weapon_10_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_10_damage-die} + [[ ([[ (@{repeating_weapon_10_enhance} + @{repeating_weapon_10_damage} + @{repeating_weapon_10_damage-ability}) ]] * (@{repeating_weapon_10_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_10_type}}} {{description=@{repeating_weapon_10_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_11_Attack" title="%{selected|repeating_weapon_11_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_11_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_11_crit-target} + [[ (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_11_damage-dice-num}d@{repeating_weapon_11_damage-die} + [[ (@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_11_proficiency} + (((@{repeating_weapon_11_enhance} + @{repeating_weapon_11_masterwork}) + abs(@{repeating_weapon_11_enhance} - @{repeating_weapon_11_masterwork})) / 2) + @{repeating_weapon_11_attack} + @{repeating_weapon_11_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_11_damage-dice-num} ]] * ([[ @{repeating_weapon_11_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_11_damage-die} + [[ ([[ (@{repeating_weapon_11_enhance} + @{repeating_weapon_11_damage} + @{repeating_weapon_11_damage-ability}) ]] * (@{repeating_weapon_11_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_11_type}}} {{description=@{repeating_weapon_11_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_12_Attack" title="%{selected|repeating_weapon_12_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_12_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_12_crit-target} + [[ (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_12_damage-dice-num}d@{repeating_weapon_12_damage-die} + [[ (@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_12_proficiency} + (((@{repeating_weapon_12_enhance} + @{repeating_weapon_12_masterwork}) + abs(@{repeating_weapon_12_enhance} - @{repeating_weapon_12_masterwork})) / 2) + @{repeating_weapon_12_attack} + @{repeating_weapon_12_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_12_damage-dice-num} ]] * ([[ @{repeating_weapon_12_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_12_damage-die} + [[ ([[ (@{repeating_weapon_12_enhance} + @{repeating_weapon_12_damage} + @{repeating_weapon_12_damage-ability}) ]] * (@{repeating_weapon_12_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_12_type}}} {{description=@{repeating_weapon_12_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_13_Attack" title="%{selected|repeating_weapon_13_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_13_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_13_crit-target} + [[ (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_13_damage-dice-num}d@{repeating_weapon_13_damage-die} + [[ (@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_13_proficiency} + (((@{repeating_weapon_13_enhance} + @{repeating_weapon_13_masterwork}) + abs(@{repeating_weapon_13_enhance} - @{repeating_weapon_13_masterwork})) / 2) + @{repeating_weapon_13_attack} + @{repeating_weapon_13_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_13_damage-dice-num} ]] * ([[ @{repeating_weapon_13_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_13_damage-die} + [[ ([[ (@{repeating_weapon_13_enhance} + @{repeating_weapon_13_damage} + @{repeating_weapon_13_damage-ability}) ]] * (@{repeating_weapon_13_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_13_type}}} {{description=@{repeating_weapon_13_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_14_Attack" title="%{selected|repeating_weapon_14_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_14_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_14_crit-target} + [[ (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_14_damage-dice-num}d@{repeating_weapon_14_damage-die} + [[ (@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_14_proficiency} + (((@{repeating_weapon_14_enhance} + @{repeating_weapon_14_masterwork}) + abs(@{repeating_weapon_14_enhance} - @{repeating_weapon_14_masterwork})) / 2) + @{repeating_weapon_14_attack} + @{repeating_weapon_14_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_14_damage-dice-num} ]] * ([[ @{repeating_weapon_14_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_14_damage-die} + [[ ([[ (@{repeating_weapon_14_enhance} + @{repeating_weapon_14_damage} + @{repeating_weapon_14_damage-ability}) ]] * (@{repeating_weapon_14_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_14_type}}} {{description=@{repeating_weapon_14_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_15_Attack" title="%{selected|repeating_weapon_15_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_15_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_15_crit-target} + [[ (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_15_damage-dice-num}d@{repeating_weapon_15_damage-die} + [[ (@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_15_proficiency} + (((@{repeating_weapon_15_enhance} + @{repeating_weapon_15_masterwork}) + abs(@{repeating_weapon_15_enhance} - @{repeating_weapon_15_masterwork})) / 2) + @{repeating_weapon_15_attack} + @{repeating_weapon_15_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_15_damage-dice-num} ]] * ([[ @{repeating_weapon_15_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_15_damage-die} + [[ ([[ (@{repeating_weapon_15_enhance} + @{repeating_weapon_15_damage} + @{repeating_weapon_15_damage-ability}) ]] * (@{repeating_weapon_15_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_15_type}}} {{description=@{repeating_weapon_15_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_16_Attack" title="%{selected|repeating_weapon_16_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_16_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_16_crit-target} + [[ (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_16_damage-dice-num}d@{repeating_weapon_16_damage-die} + [[ (@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_16_proficiency} + (((@{repeating_weapon_16_enhance} + @{repeating_weapon_16_masterwork}) + abs(@{repeating_weapon_16_enhance} - @{repeating_weapon_16_masterwork})) / 2) + @{repeating_weapon_16_attack} + @{repeating_weapon_16_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_16_damage-dice-num} ]] * ([[ @{repeating_weapon_16_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_16_damage-die} + [[ ([[ (@{repeating_weapon_16_enhance} + @{repeating_weapon_16_damage} + @{repeating_weapon_16_damage-ability}) ]] * (@{repeating_weapon_16_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_16_type}}} {{description=@{repeating_weapon_16_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_17_Attack" title="%{selected|repeating_weapon_17_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_17_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_17_crit-target} + [[ (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_17_damage-dice-num}d@{repeating_weapon_17_damage-die} + [[ (@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_17_proficiency} + (((@{repeating_weapon_17_enhance} + @{repeating_weapon_17_masterwork}) + abs(@{repeating_weapon_17_enhance} - @{repeating_weapon_17_masterwork})) / 2) + @{repeating_weapon_17_attack} + @{repeating_weapon_17_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_17_damage-dice-num} ]] * ([[ @{repeating_weapon_17_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_17_damage-die} + [[ ([[ (@{repeating_weapon_17_enhance} + @{repeating_weapon_17_damage} + @{repeating_weapon_17_damage-ability}) ]] * (@{repeating_weapon_17_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_17_type}}} {{description=@{repeating_weapon_17_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_18_Attack" title="%{selected|repeating_weapon_18_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_18_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_18_crit-target} + [[ (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_18_damage-dice-num}d@{repeating_weapon_18_damage-die} + [[ (@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_18_proficiency} + (((@{repeating_weapon_18_enhance} + @{repeating_weapon_18_masterwork}) + abs(@{repeating_weapon_18_enhance} - @{repeating_weapon_18_masterwork})) / 2) + @{repeating_weapon_18_attack} + @{repeating_weapon_18_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_18_damage-dice-num} ]] * ([[ @{repeating_weapon_18_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_18_damage-die} + [[ ([[ (@{repeating_weapon_18_enhance} + @{repeating_weapon_18_damage} + @{repeating_weapon_18_damage-ability}) ]] * (@{repeating_weapon_18_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_18_type}}} {{description=@{repeating_weapon_18_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_19_Attack" title="%{selected|repeating_weapon_19_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_19_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_19_crit-target} + [[ (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_19_damage-dice-num}d@{repeating_weapon_19_damage-die} + [[ (@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_19_proficiency} + (((@{repeating_weapon_19_enhance} + @{repeating_weapon_19_masterwork}) + abs(@{repeating_weapon_19_enhance} - @{repeating_weapon_19_masterwork})) / 2) + @{repeating_weapon_19_attack} + @{repeating_weapon_19_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_19_damage-dice-num} ]] * ([[ @{repeating_weapon_19_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_19_damage-die} + [[ ([[ (@{repeating_weapon_19_enhance} + @{repeating_weapon_19_damage} + @{repeating_weapon_19_damage-ability}) ]] * (@{repeating_weapon_19_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_19_type}}} {{description=@{repeating_weapon_19_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_20_Attack" title="%{selected|repeating_weapon_20_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_20_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_20_crit-target} + [[ (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_20_damage-dice-num}d@{repeating_weapon_20_damage-die} + [[ (@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_20_proficiency} + (((@{repeating_weapon_20_enhance} + @{repeating_weapon_20_masterwork}) + abs(@{repeating_weapon_20_enhance} - @{repeating_weapon_20_masterwork})) / 2) + @{repeating_weapon_20_attack} + @{repeating_weapon_20_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_20_damage-dice-num} ]] * ([[ @{repeating_weapon_20_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_20_damage-die} + [[ ([[ (@{repeating_weapon_20_enhance} + @{repeating_weapon_20_damage} + @{repeating_weapon_20_damage-ability}) ]] * (@{repeating_weapon_20_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_20_type}}} {{description=@{repeating_weapon_20_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_21_Attack" title="%{selected|repeating_weapon_21_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_21_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_21_crit-target} + [[ (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_21_damage-dice-num}d@{repeating_weapon_21_damage-die} + [[ (@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_21_proficiency} + (((@{repeating_weapon_21_enhance} + @{repeating_weapon_21_masterwork}) + abs(@{repeating_weapon_21_enhance} - @{repeating_weapon_21_masterwork})) / 2) + @{repeating_weapon_21_attack} + @{repeating_weapon_21_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_21_damage-dice-num} ]] * ([[ @{repeating_weapon_21_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_21_damage-die} + [[ ([[ (@{repeating_weapon_21_enhance} + @{repeating_weapon_21_damage} + @{repeating_weapon_21_damage-ability}) ]] * (@{repeating_weapon_21_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_21_type}}} {{description=@{repeating_weapon_21_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_22_Attack" title="%{selected|repeating_weapon_22_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_22_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_22_crit-target} + [[ (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_22_damage-dice-num}d@{repeating_weapon_22_damage-die} + [[ (@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_22_proficiency} + (((@{repeating_weapon_22_enhance} + @{repeating_weapon_22_masterwork}) + abs(@{repeating_weapon_22_enhance} - @{repeating_weapon_22_masterwork})) / 2) + @{repeating_weapon_22_attack} + @{repeating_weapon_22_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_22_damage-dice-num} ]] * ([[ @{repeating_weapon_22_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_22_damage-die} + [[ ([[ (@{repeating_weapon_22_enhance} + @{repeating_weapon_22_damage} + @{repeating_weapon_22_damage-ability}) ]] * (@{repeating_weapon_22_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_22_type}}} {{description=@{repeating_weapon_22_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_23_Attack" title="%{selected|repeating_weapon_23_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_23_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_23_crit-target} + [[ (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_23_damage-dice-num}d@{repeating_weapon_23_damage-die} + [[ (@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_23_proficiency} + (((@{repeating_weapon_23_enhance} + @{repeating_weapon_23_masterwork}) + abs(@{repeating_weapon_23_enhance} - @{repeating_weapon_23_masterwork})) / 2) + @{repeating_weapon_23_attack} + @{repeating_weapon_23_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_23_damage-dice-num} ]] * ([[ @{repeating_weapon_23_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_23_damage-die} + [[ ([[ (@{repeating_weapon_23_enhance} + @{repeating_weapon_23_damage} + @{repeating_weapon_23_damage-ability}) ]] * (@{repeating_weapon_23_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_23_type}}} {{description=@{repeating_weapon_23_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_24_Attack" title="%{selected|repeating_weapon_24_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_24_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_24_crit-target} + [[ (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_24_damage-dice-num}d@{repeating_weapon_24_damage-die} + [[ (@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_24_proficiency} + (((@{repeating_weapon_24_enhance} + @{repeating_weapon_24_masterwork}) + abs(@{repeating_weapon_24_enhance} - @{repeating_weapon_24_masterwork})) / 2) + @{repeating_weapon_24_attack} + @{repeating_weapon_24_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_24_damage-dice-num} ]] * ([[ @{repeating_weapon_24_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_24_damage-die} + [[ ([[ (@{repeating_weapon_24_enhance} + @{repeating_weapon_24_damage} + @{repeating_weapon_24_damage-ability}) ]] * (@{repeating_weapon_24_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_24_type}}} {{description=@{repeating_weapon_24_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_25_Attack" title="%{selected|repeating_weapon_25_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_25_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_25_crit-target} + [[ (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_25_damage-dice-num}d@{repeating_weapon_25_damage-die} + [[ (@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_25_proficiency} + (((@{repeating_weapon_25_enhance} + @{repeating_weapon_25_masterwork}) + abs(@{repeating_weapon_25_enhance} - @{repeating_weapon_25_masterwork})) / 2) + @{repeating_weapon_25_attack} + @{repeating_weapon_25_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_25_damage-dice-num} ]] * ([[ @{repeating_weapon_25_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_25_damage-die} + [[ ([[ (@{repeating_weapon_25_enhance} + @{repeating_weapon_25_damage} + @{repeating_weapon_25_damage-ability}) ]] * (@{repeating_weapon_25_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_25_type}}} {{description=@{repeating_weapon_25_notes}}} @{macro_options}"></button></span>
+					<span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_weapon_26_Attack" title="%{selected|repeating_weapon_26_Attack}" value="&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_weapon_26_name}}} {{attack=[[ 1d20cs>@{repeating_weapon_26_crit-target} + [[ (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency}) ]] ]]}} {{damage=[[ @{repeating_weapon_26_damage-dice-num}d@{repeating_weapon_26_damage-die} + [[ (@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability}) ]] ]]}} {{crit_confirm=[[ 1d20 + [[ (@{repeating_weapon_26_proficiency} + (((@{repeating_weapon_26_enhance} + @{repeating_weapon_26_masterwork}) + abs(@{repeating_weapon_26_enhance} - @{repeating_weapon_26_masterwork})) / 2) + @{repeating_weapon_26_attack} + @{repeating_weapon_26_attack-type} + @{armor-proficiency}) ]] ]]}} {{crit_damage=[[ [[ ([[ @{repeating_weapon_26_damage-dice-num} ]] * ([[ @{repeating_weapon_26_crit-multiplier} ]] - 1)) ]]d@{repeating_weapon_26_damage-die} + [[ ([[ (@{repeating_weapon_26_enhance} + @{repeating_weapon_26_damage} + @{repeating_weapon_26_damage-ability}) ]] * (@{repeating_weapon_26_crit-multiplier} - 1)) ]] ]]}} {{type=@{repeating_weapon_26_type}}} {{description=@{repeating_weapon_26_notes}}} @{macro_options}"></button></span>
+				</div>
+			</div>
+		<div>
+		<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+		<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span> 			
+			<div class="sheet-table sheet-options" style="margin-top: 0.5em;">
+				<div class="sheet-table-row sheet-table-header">
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><b title="Include these additional notes on all pre-set button attacks.">Include notes?</b></span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_melee_notes" value="@{var_melee_notes}" title="@{toggle_melee_notes}"/><b title="Include Melee attack notes"> Melee Notes</b></label></span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_ranged_notes" value="@{var_ranged_notes}" title="@{toggle_ranged_notes}"/><b title="Include Ranged attack notes"> Ranged Notes</b></label></span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_CMB_notes" value="@{var_CMB_notes}" title="@{toggle_CMB_notes}"/><b title="Include CMB notes"> CMB Notes</b></label></span>
+					<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{toggle_attack_notes}"/><b title="Include Attack notes"> Attack Notes</b></label></span>
+				</div>
+			</div>
+			<input type="hidden" name="attr_macro_options" value="@{toggle_melee_notes} @{toggle_ranged_notes} @{toggle_CMB_notes} @{toggle_attack_notes}"/>
+		</div>
+		</div>
+		<br>
+		<div class="sheet-table sheet-sect">
+			<span class="sheet-table-name">Attacks</span>
+		</div>
+		<div class="sheet-sect">
+			<fieldset class="repeating_weapon">
+				<div class="sheet-table">
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" min="0" name="attr_enhance" title="@{repeating_weapon_X_enhance}"><br>Enhance</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="checkbox" name="attr_masterwork" title="@{repeating_weapon_X_masterwork}" value="1"><br>Mwk</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_name" title="@{repeating_weapon_X_name}" placeholder="Name"><br>Name</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_attack" title="@{repeating_weapon_X_attack}" placeholder="Attack Modifiers"><br>Attack Mods</span>
                         <span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
                             <select title="@{repeating_weapon_X_attack-type}" name="attr_attack-type">
-                                <option value="0" selected>None</option>
-                                <option value="@{attk-melee}">Melee</option>
-                                <option value="@{attk-ranged}">Ranged</option>
+	                            <option value="0" selected>None</option>
+	                            <option value="@{attk-melee}">Melee</option>
+	                            <option value="@{attk-ranged}">Ranged</option>
+					    <option value="@{CMB}">CMB</option>
                             </select>
                             <br>Attack Type
                         </span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-attack" title="@{repeating_weapon_X_total-attack}" value="(@{proficiency} + (((@{enhance} + [[ @{masterwork} ]]) + abs(@{enhance} - [[ @{masterwork} ]])) / 2) + [[ @{attack} ]] + [[ @{attack-type} ]] + [[ @{armor-proficiency} ]])" disabled><br>ATK</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_X_damage-dice-num}" min="0"><br>Dice</span>
-                        <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">d</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-die" title="@{repeating_weapon_X_damage-die}" min="0"><br>Die</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_damage" title="@{repeating_weapon_X_damage}" placeholder="Damage Modifiers"><br>Damage Mods</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-attack" title="@{repeating_weapon_X_total-attack}" value="(@{proficiency} + (((@{enhance} + [[ @{masterwork} ]]) + abs(@{enhance} - [[ @{masterwork} ]])) / 2) + [[ @{attack} ]] + [[ @{attack-type} ]] + [[ @{armor-proficiency} ]])" disabled><br>ATK</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_X_damage-dice-num}" min="0"><br>Dice</span>
+						<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;">d</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_damage-die" title="@{repeating_weapon_X_damage-die}" min="0"><br>Die</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_damage" title="@{repeating_weapon_X_damage}" placeholder="Damage Modifiers"><br>Damage Mods</span>
                         <span class="sheet-table-data sheet-center" style="width:15%;">
                             <select title="@{repeating_weapon_X_damage-ability}" name="attr_damage-ability">
-                                <option value="0 - [[ @{condition-sickened} ]]" selected>None</option>
-                                <option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
-                                <option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
-                                <option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
-                                <option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
-                                <option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
-                                <option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
-                                <option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
-                                <option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
-                                <option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
-                                <option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
-                                <option value="@{WIS-mod} - [[ @{condition-sickened} ]]">WIS</option>
-                                <option value="@{CHA-mod} - [[ @{condition-sickened} ]]">CHA</option>
-                                <option value="floor(1.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1.5x STR</option>
-                                <option value="floor(1.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1.5x DEX</option>
-                                <option value="floor(1.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1.5x CON</option>
-                                <option value="floor(1.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1.5x INT</option>
-                                <option value="floor(1.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1.5x WIS</option>
-                                <option value="floor(1.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1.5x CHA</option>
-                                <option value="floor(2 * @{STR-mod}) - [[ @{condition-sickened} ]]">2x STR</option>
-                                <option value="floor(2 * @{DEX-mod}) - [[ @{condition-sickened} ]]">2x DEX</option>
-                                <option value="floor(2 * @{CON-mod}) - [[ @{condition-sickened} ]]">2x CON</option>
-                                <option value="floor(2 * @{INT-mod}) - [[ @{condition-sickened} ]]">2x INT</option>
-                                <option value="floor(2 * @{WIS-mod}) - [[ @{condition-sickened} ]]">2x WIS</option>
-                                <option value="floor(2 * @{CHA-mod}) - [[ @{condition-sickened} ]]">2x CHA</option>
+	                            <option value="0 - [[ @{condition-sickened} ]]" selected>None</option>
+	                            <option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
+	                            <option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
+	                            <option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
+	                            <option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
+	                            <option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
+	                            <option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
+	                            <option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
+	                            <option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
+	                            <option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
+	                            <option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
+	                            <option value="@{WIS-mod} - [[ @{condition-sickened} ]]">WIS</option>
+	                            <option value="@{CHA-mod} - [[ @{condition-sickened} ]]">CHA</option>
+	                            <option value="floor(1.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1.5x STR</option>
+	                            <option value="floor(1.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1.5x DEX</option>
+	                            <option value="floor(1.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1.5x CON</option>
+	                            <option value="floor(1.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1.5x INT</option>
+	                            <option value="floor(1.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1.5x WIS</option>
+	                            <option value="floor(1.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1.5x CHA</option>
+	                            <option value="floor(2 * @{STR-mod}) - [[ @{condition-sickened} ]]">2x STR</option>
+	                            <option value="floor(2 * @{DEX-mod}) - [[ @{condition-sickened} ]]">2x DEX</option>
+	                            <option value="floor(2 * @{CON-mod}) - [[ @{condition-sickened} ]]">2x CON</option>
+	                            <option value="floor(2 * @{INT-mod}) - [[ @{condition-sickened} ]]">2x INT</option>
+	                            <option value="floor(2 * @{WIS-mod}) - [[ @{condition-sickened} ]]">2x WIS</option>
+	                            <option value="floor(2 * @{CHA-mod}) - [[ @{condition-sickened} ]]">2x CHA</option>
                             </select>
                             <br>Damage Ability
                         </span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-damage" title="@{repeating_weapon_X_total-damage}" value="(@{enhance} + [[ @{damage} ]] + [[ @{damage-ability} ]])" disabled><br>DMG</span>
-                    </div>
-                </div>
-                <div class="sheet-table">
-                    <div class="sheet-table-row">
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-target" title="@{repeating_weapon_X_crit-target}" min="0" max="20"><br>Crit</span>
-                        <span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;"><b>/x</b></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_X_crit-multiplier}" min="0"><br>Multiplier</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_range" title="@{repeating_weapon_X_range}" value="0" min="0"><br>Range</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_type" title="@{repeating_weapon_X_type}" placeholder="Damage Type"><br>Damage Type</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_weight" title="@{repeating_weapon_X_weight}" value="0" step="any" min="0"><br>Weight</span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_ammo" title="@{repeating_weapon_X_ammo}" value="0"><br>Ammo</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_total-damage" title="@{repeating_weapon_X_total-damage}" value="(@{enhance} + [[ @{damage} ]] + [[ @{damage-ability} ]])" disabled><br>DMG</span>
+					</div>
+				</div>
+				<div class="sheet-table">
+					<div class="sheet-table-row">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-target" title="@{repeating_weapon_X_crit-target}" min="0" max="20"><br>Crit</span>
+						<span class="sheet-table-data sheet-center" style="vertical-align:middle;font-size:150%;width:2%;"><b>/x</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_X_crit-multiplier}" min="0"><br>Multiplier</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_range" title="@{repeating_weapon_X_range}" value="0" min="0"><br>Range</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input type="text" name="attr_type" title="@{repeating_weapon_X_type}" placeholder="Damage Type"><br>Damage Type</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_weight" title="@{repeating_weapon_X_weight}" value="0" step="any" min="0"><br>Weight</span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input type="number" name="attr_ammo" title="@{repeating_weapon_X_ammo}" value="0"><br>Ammo</span>
                         <span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
                             <select title="@{repeating_weapon_X_proficiency}" name="attr_proficiency">
-                                <option value="0">Yes</option>
-                                <option value="-4" selected>No</option>
+	                            <option value="0">Yes</option>
+	                            <option value="-4" selected>No</option>
                             </select>
                             <br>Proficiency
                         </span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:48%;"><input type="text" name="attr_notes" title="@{repeating_weapon_X_notes}" placeholder="Weapon Notes"><br>Notes</span>
-                    </div>
-                </div>
-                <input type="hidden" name="attr_var_melee_notes" value="{{melee_notes=@{melee-attack-notes}}}"/>
-                <input type="hidden" name="attr_var_ranged_notes" value="{{ranged_notes=@{ranged-attack-notes}}}"/>
-                <input type="hidden" name="attr_var_CMB_notes" value="{{CMB_notes=@{CMB-notes}}}"/>
-                <input type="hidden" name="attr_var_attack_notes" value="{{attack_notes=@{attack-notes}}}"/>
-                <div class="sheet-table">
-                    <div class="sheet-table-row sheet-table-header">
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><b title="Include these additional notes with this attack roll.">Include notes?</b></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_melee_notes" value="@{var_melee_notes}" title="@{repeating_weapon_X_toggle_melee_notes}"/><b title="Include Melee attack notes"> Melee Notes</b></label></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_ranged_notes" value="@{var_ranged_notes}" title="@{repeating_weapon_X_toggle_ranged_notes}"/><b title="Include Ranged attack notes"> Ranged Notes</b></label></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_CMB_notes" value="@{var_CMB_notes}" title="@{repeating_weapon_X_toggle_CMB_notes}"/><b title="Include CMB notes"> CMB Notes</b></label></span>
-                        <span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{repeating_weapon_X_toggle_attack_notes}"/><b title="Include Attack notes"> Attack Notes</b></label></span>
-                    </div>
-                </div>
-                <input type="hidden" name="attr_macro_options" value="@{toggle_melee_notes} @{toggle_ranged_notes} @{toggle_CMB_notes} @{toggle_attack_notes}"/>
-                <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                <textarea class="sheet-macro-text" title="@{repeating_weapon_X_macro-text}" name="attr_macro-text">&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{name}}} {{attack=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} ]] ]]}} {{damage=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm=[[ 1d20 + [[ @{total-attack} ]]  ]]}} {{crit_damage=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]]  ]]}} {{type=@{type}}} {{description=@{notes}}} @{macro_options}</textarea>
-                <hr>
-            </fieldset>
-        </div>
-    </div>
-    <br>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:48%;"><input type="text" name="attr_notes" title="@{repeating_weapon_X_notes}" placeholder="Weapon Notes"><br>Notes</span>
+					</div>
+				</div>
+				<b>Iterative Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<div class="sheet-table sheet-sect sheet-iterative_attack_section">
+					<span class="sheet-table-name">Iterative Attacks</span>
+					<div class="sheet-table-row">
+						<span class="sheet-table-header" style="width: 180px;">Include Attack?</span>
+						<span class="sheet-table-header">Attack Mod</span>
+						<span class="sheet-table-header">Macro</span>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack2" title="@{repeating_weapon_X_toggle_iterative_attack2}" value="@{var_iterative_attack2_macro}"/>
+	                            <b title="Include a second attack to your weapon?">Include a 2nd attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack2_value" title="@{repeating_weapon_X_iterative_attack2_value}" value="-5" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack2_macro" title="@{repeating_weapon_X_var_iterative_attack2_macro}" value="{{attack2=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack2_value} ]] ]]}} {{damage2=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm2=[[ 1d20 + [[ @{total-attack} + @{iterative_attack2_value} ]] ]]}} {{crit_damage2=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+		                </span>
+						<input type="hidden" name="attr_var_iterative_attack2" value="{{attack2=@{iterative_attack2_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack3" title="@{repeating_weapon_X_toggle_iterative_attack3}" value="@{var_iterative_attack3_macro}"/>
+	                            <b title="Include a third attack to your weapon?">Include a 3rd attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center sheet-small-label">
+							<input type="number" name="attr_iterative_attack3_value" title="@{repeating_weapon_X_iterative_attack3_value}" value="-10" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center sheet-small-label">
+                            <input type="text" name="attr_var_iterative_attack3_macro" title="@{repeating_weapon_X_var_iterative_attack3_macro}" value="{{attack3=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack3_value} ]] ]]}} {{damage3=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm3=[[ 1d20 + [[ @{total-attack} + @{iterative_attack3_value} ]] ]]}} {{crit_damage3=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+		                </span>
+						<input type="hidden" name="attr_var_iterative_attack3" value="{{attack3=@{iterative_attack3_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack4" title="@{repeating_weapon_X_toggle_iterative_attack4}" value="@{var_iterative_attack4_macro}"/>
+	                            <b title="Include a fourth attack to your weapon?">Include a 4th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack4_value" title="@{repeating_weapon_X_iterative_attack4_value}" value="-15" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack4_macro" title="@{repeating_weapon_X_var_iterative_attack4_macro}" value="{{attack4=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack4_value} ]] ]]}} {{damage4=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm4=[[ 1d20 + [[ @{total-attack} + @{iterative_attack4_value} ]] ]]}} {{crit_damage4=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack4" value="{{attack4=@{iterative_attack4_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack5" title="@{repeating_weapon_X_toggle_iterative_attack5}" value="@{var_iterative_attack5_macro}"/>
+	                            <b title="Include a fifth attack to your weapon?">Include a 5th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack5_value" title="@{repeating_weapon_X_iterative_attack5_value}" value="-20" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack5_macro" title="@{repeating_weapon_X_var_iterative_attack5_macro}" value="{{attack5=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack5_value} ]] ]]}} {{damage5=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm5=[[ 1d20 + [[ @{total-attack} + @{iterative_attack5_value} ]] ]]}} {{crit_damage5=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack5" value="{{attack5=@{iterative_attack5_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack6" title="@{repeating_weapon_X_toggle_iterative_attack6}" value="@{var_iterative_attack6_macro}"/>
+	                            <b title="Include a sixth attack to your weapon?">Include a 6th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack6_value" title="@{repeating_weapon_X_iterative_attack6_value}" value="-25" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack6_macro" title="@{repeating_weapon_X_var_iterative_attack6_macro}" value="{{attack6=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack6_value} ]] ]]}} {{damage6=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm6=[[ 1d20 + [[ @{total-attack} + @{iterative_attack6_value} ]] ]]}} {{crit_damage6=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack6" value="{{attack6=@{iterative_attack6_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack7" title="@{repeating_weapon_X_toggle_iterative_attack7}" value="@{var_iterative_attack7_macro}"/>
+	                            <b title="Include a seventh attack to your weapon?">Include a 7th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack7_value" title="@{repeating_weapon_X_iterative_attack7_value}" value="-30" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack7_macro" title="@{repeating_weapon_X_var_iterative_attack7_macro}" value="{{attack7=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack7_value} ]] ]]}} {{damage7=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm7=[[ 1d20 + [[ @{total-attack} + @{iterative_attack7_value} ]] ]]}} {{crit_damage7=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack7" value="{{attack7=@{iterative_attack7_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack8" title="@{repeating_weapon_X_toggle_iterative_attack8}" value="@{var_iterative_attack8_macro}"/>
+	                            <b title="Include an eighth attack to your weapon?">Include an 8th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack8_value" title="@{repeating_weapon_X_iterative_attack8_value}" value="-35" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack8_macro" title="@{repeating_weapon_X_var_iterative_attack8_macro}" value="{{attack8=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack8_value} ]] ]]}} {{damage8=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm8=[[ 1d20 + [[ @{total-attack} + @{iterative_attack8_value} ]] ]]}} {{crit_damage8=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack8" value="{{attack8=@{iterative_attack8_macro}}}"/>
+					</div>
+				</div>
+				<input type="hidden" name="attr_iterative_attacks" value="@{toggle_iterative_attack2} @{toggle_iterative_attack3} @{toggle_iterative_attack4} @{toggle_iterative_attack5} @{toggle_iterative_attack6} @{toggle_iterative_attack7} @{toggle_iterative_attack8}"/>
+			<div>
+				<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>    
+				<input type="hidden" name="attr_var_melee_notes" value="{{melee_notes=@{melee-attack-notes}}}"/>
+				<input type="hidden" name="attr_var_ranged_notes" value="{{ranged_notes=@{ranged-attack-notes}}}"/>
+				<input type="hidden" name="attr_var_CMB_notes" value="{{CMB_notes=@{CMB-notes}}}"/>
+				<input type="hidden" name="attr_var_attack_notes" value="{{attack_notes=@{attack-notes}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><b title="Include these additional notes with this attack roll.">Include notes?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_melee_notes" value="@{var_melee_notes}" title="@{repeating_weapon_X_toggle_melee_notes}"/><b title="Include Melee attack notes"> Melee Notes</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_ranged_notes" value="@{var_ranged_notes}" title="@{repeating_weapon_X_toggle_ranged_notes}"/><b title="Include Ranged attack notes"> Ranged Notes</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_CMB_notes" value="@{var_CMB_notes}" title="@{repeating_weapon_X_toggle_CMB_notes}"/><b title="Include CMB notes"> CMB Notes</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label" style="width:20%;"><label><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{repeating_weapon_X_toggle_attack_notes}"/><b title="Include Attack notes"> Attack Notes</b></label></span>
+					</div>
+				</div>
+			</div>
+				<input type="hidden" name="attr_macro_options" value="@{toggle_melee_notes} @{toggle_ranged_notes} @{toggle_CMB_notes} @{toggle_attack_notes}"/>
+				<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<textarea class="sheet-macro-text" title="@{repeating_weapon_X_macro-text}" name="attr_macro-text">&{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{name}}} {{attack=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} ]] ]]}} {{damage=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm=[[ 1d20 + [[ @{total-attack} ]] ]]}} {{crit_damage=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}} {{type=@{type}}} {{description=@{notes}}} <strong>@{iterative_attacks}</strong> @{macro_options}</textarea>
+				<hr>
+			</fieldset>
+		</div>
+	</div>
+	<br>
 </div>
 <div class="sheet-section sheet-section-skills">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
@@ -1367,7 +1526,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-acp}" type="number" name="attr_Acrobatics-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-misc}" type="number" name="attr_Acrobatics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-macro}" type="text" name="attr_Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{Acrobatics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-macro}" type="text" name="attr_Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{Acrobatics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Bluff-Check}" type="roll" value="@{Bluff-macro}" name="roll_Bluff-Check"></button></span>
@@ -1401,7 +1560,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Bluff-misc}" type="number" name="attr_Bluff-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Bluff-macro}" type="text" name="attr_Bluff-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[ 1d20 + [[ @{Bluff} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Bluff-macro}" type="text" name="attr_Bluff-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[ 1d20 + [[ @{Bluff} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Climb-Check}" type="roll" value="@{Climb-macro}" name="roll_Climb-Check"></button></span>
@@ -1435,7 +1594,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Climb-acp}" type="number" name="attr_Climb-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Climb-misc}" type="number" name="attr_Climb-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Climb-macro}" type="text" name="attr_Climb-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Climb}} {{Check=[[ 1d20 + [[ @{Climb} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Climb-macro}" type="text" name="attr_Climb-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Climb}} {{Check=[[ 1d20 + [[ @{Climb} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Diplomacy-Check}" type="roll" value="@{Diplomacy-macro}" name="roll_Diplomacy-Check"></button></span>
@@ -1469,7 +1628,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-misc}" type="number" name="attr_Diplomacy-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-macro}" type="text" name="attr_Diplomacy-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Diplomacy}} {{Check=[[ 1d20 + [[ @{Diplomacy} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-macro}" type="text" name="attr_Diplomacy-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Diplomacy}} {{Check=[[ 1d20 + [[ @{Diplomacy} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disable-Device-Check}" type="roll" value="@{Disable-Device-macro}" name="roll_Disable-Device-Check"></button></span>
@@ -1503,7 +1662,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-acp}" type="number" name="attr_Disable-Device-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-misc}" type="number" name="attr_Disable-Device-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-macro}" type="text" name="attr_Disable-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disable-Device}} {{Check=[[ 1d20 + [[ @{Disable-Device} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-macro}" type="text" name="attr_Disable-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disable-Device}} {{Check=[[ 1d20 + [[ @{Disable-Device} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disguise-Check}" type="roll" value="@{Disguise-macro}" name="roll_Disguise-Check"></button></span>
@@ -1537,7 +1696,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Disguise-misc}" type="number" name="attr_Disguise-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Disguise-macro}" type="text" name="attr_Disguise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disguise}} {{Check=[[ 1d20 + [[ @{Disguise} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Disguise-macro}" type="text" name="attr_Disguise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disguise}} {{Check=[[ 1d20 + [[ @{Disguise} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Escape-Artist-Check}" type="roll" value="@{Escape-Artist-macro}" name="roll_Escape-Artist-Check"></button></span>
@@ -1571,7 +1730,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-acp}" type="number" name="attr_Escape-Artist-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-misc}" type="number" name="attr_Escape-Artist-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-macro}" type="text" name="attr_Escape-Artist-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Escape-Artist}} {{Check=[[ 1d20 + [[ @{Escape-Artist} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-macro}" type="text" name="attr_Escape-Artist-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Escape-Artist}} {{Check=[[ 1d20 + [[ @{Escape-Artist} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Fly-Check}" type="roll" value="@{Fly-macro}" name="roll_Fly-Check"></button></span>
@@ -1605,7 +1764,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Fly-acp}" type="number" name="attr_Fly-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Fly-misc}" type="number" name="attr_Fly-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Fly-macro}" type="text" name="attr_Fly-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fly}} {{Check=[[ 1d20 + [[ @{Fly} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Fly-macro}" type="text" name="attr_Fly-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fly}} {{Check=[[ 1d20 + [[ @{Fly} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Heal-Check}" type="roll" value="@{Heal-macro}" name="roll_Heal-Check"></button></span>
@@ -1639,7 +1798,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Heal-misc}" type="number" name="attr_Heal-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Heal-macro}" type="text" name="attr_Heal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Heal}} {{Check=[[ 1d20 + [[ @{Heal} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Heal-macro}" type="text" name="attr_Heal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Heal}} {{Check=[[ 1d20 + [[ @{Heal} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Intimidate-Check}" type="roll" value="@{Intimidate-macro}" name="roll_Intimidate-Check"></button></span>
@@ -1673,7 +1832,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Intimidate-misc}" type="number" name="attr_Intimidate-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Intimidate-macro}" type="text" name="attr_Intimidate-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intimidate}} {{Check=[[ 1d20 + [[ @{Intimidate} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Intimidate-macro}" type="text" name="attr_Intimidate-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intimidate}} {{Check=[[ 1d20 + [[ @{Intimidate} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Arcana-Check}" type="roll" value="@{Knowledge-Arcana-macro}" name="roll_Knowledge-Arcana-Check"></button></span>
@@ -1707,7 +1866,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-misc}" type="number" name="attr_Knowledge-Arcana-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-macro}" type="text" name="attr_Knowledge-Arcana-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Arcana}} {{Check=[[ 1d20 + [[ @{Knowledge-Arcana} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-macro}" type="text" name="attr_Knowledge-Arcana-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Arcana}} {{Check=[[ 1d20 + [[ @{Knowledge-Arcana} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Dungeoneering-Check}" type="roll" value="@{Knowledge-Dungeoneering-macro}" name="roll_Knowledge-Dungeoneering-Check"></button></span>
@@ -1741,7 +1900,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-misc}" type="number" name="attr_Knowledge-Dungeoneering-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-macro}" type="text" name="attr_Knowledge-Dungeoneering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Dungeoneering}} {{Check=[[ 1d20 + [[ @{Knowledge-Dungeoneering} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-macro}" type="text" name="attr_Knowledge-Dungeoneering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Dungeoneering}} {{Check=[[ 1d20 + [[ @{Knowledge-Dungeoneering} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Local-Check}" type="roll" value="@{Knowledge-Local-macro}" name="roll_Knowledge-Local-Check"></button></span>
@@ -1775,7 +1934,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-misc}" type="number" name="attr_Knowledge-Local-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-macro}" type="text" name="attr_Knowledge-Local-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Local}} {{Check=[[ 1d20 + [[ @{Knowledge-Local} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-macro}" type="text" name="attr_Knowledge-Local-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Local}} {{Check=[[ 1d20 + [[ @{Knowledge-Local} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nature-Check}" type="roll" value="@{Knowledge-Nature-macro}" name="roll_Knowledge-Nature-Check"></button></span>
@@ -1809,7 +1968,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-misc}" type="number" name="attr_Knowledge-Nature-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-macro}" type="text" name="attr_Knowledge-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nature}} {{Check=[[ 1d20 + [[ @{Knowledge-Nature} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-macro}" type="text" name="attr_Knowledge-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nature}} {{Check=[[ 1d20 + [[ @{Knowledge-Nature} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Planes-Check}" type="roll" value="@{Knowledge-Planes-macro}" name="roll_Knowledge-Planes-Check"></button></span>
@@ -1843,7 +2002,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-misc}" type="number" name="attr_Knowledge-Planes-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-macro}" type="text" name="attr_Knowledge-Planes-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Planes}} {{Check=[[ 1d20 + [[ @{Knowledge-Planes} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-macro}" type="text" name="attr_Knowledge-Planes-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Planes}} {{Check=[[ 1d20 + [[ @{Knowledge-Planes} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Religion-Check}" type="roll" value="@{Knowledge-Religion-macro}" name="roll_Knowledge-Religion-Check"></button></span>
@@ -1877,7 +2036,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-misc}" type="number" name="attr_Knowledge-Religion-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-macro}" type="text" name="attr_Knowledge-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Religion}} {{Check=[[ 1d20 + [[ @{Knowledge-Religion} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-macro}" type="text" name="attr_Knowledge-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Religion}} {{Check=[[ 1d20 + [[ @{Knowledge-Religion} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perception-Check}" type="roll" value="@{Perception-macro}" name="roll_Perception-Check"></button></span>
@@ -1911,7 +2070,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perception-macro}" type="text" name="attr_Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{Perception} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perception-macro}" type="text" name="attr_Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{Perception} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Ride-Check}" type="roll" value="@{Ride-macro}" name="roll_Ride-Check"></button></span>
@@ -1945,7 +2104,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Ride-acp}" type="number" name="attr_Ride-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Ride-misc}" type="number" name="attr_Ride-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Ride-macro}" type="text" name="attr_Ride-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ride}} {{Check=[[ 1d20 + [[ @{Ride} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Ride-macro}" type="text" name="attr_Ride-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ride}} {{Check=[[ 1d20 + [[ @{Ride} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sense-Motive-Check}" type="roll" value="@{Sense-Motive-macro}" name="roll_Sense-Motive-Check"></button></span>
@@ -1979,7 +2138,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-misc}" type="number" name="attr_Sense-Motive-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-macro}" type="text" name="attr_Sense-Motive-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sense-Motive}} {{Check=[[ 1d20 + [[ @{Sense-Motive} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-macro}" type="text" name="attr_Sense-Motive-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sense-Motive}} {{Check=[[ 1d20 + [[ @{Sense-Motive} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spellcraft-Check}" type="roll" value="@{Spellcraft-macro}" name="roll_Spellcraft-Check"></button></span>
@@ -2013,7 +2172,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-misc}" type="number" name="attr_Spellcraft-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-macro}" type="text" name="attr_Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{Spellcraft} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-macro}" type="text" name="attr_Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{Spellcraft} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Stealth-Check}" type="roll" value="@{Stealth-macro}" name="roll_Stealth-Check"></button></span>
@@ -2047,7 +2206,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Stealth-acp}" type="number" name="attr_Stealth-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Stealth-misc}" type="number" name="attr_Stealth-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Stealth-macro}" type="text" name="attr_Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{Stealth} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Stealth-macro}" type="text" name="attr_Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{Stealth} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Survival-Check}" type="roll" value="@{Survival-macro}" name="roll_Survival-Check"></button></span>
@@ -2081,7 +2240,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Survival-misc}" type="number" name="attr_Survival-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Survival-macro}" type="text" name="attr_Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{Survival} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Survival-macro}" type="text" name="attr_Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{Survival} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Swim-Check}" type="roll" value="@{Swim-macro}" name="roll_Swim-Check"></button></span>
@@ -2115,7 +2274,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Swim-acp}" type="number" name="attr_Swim-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Swim-misc}" type="number" name="attr_Swim-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Swim-macro}" type="text" name="attr_Swim-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Swim}} {{Check=[[ 1d20 + [[ @{Swim} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Swim-macro}" type="text" name="attr_Swim-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Swim}} {{Check=[[ 1d20 + [[ @{Swim} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Use-Magic-Device-Check}" type="roll" value="@{Use-Magic-Device-macro}" name="roll_Use-Magic-Device-Check"></button></span>
@@ -2149,7 +2308,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-misc}" type="number" name="attr_Use-Magic-Device-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-macro}" type="text" name="attr_Use-Magic-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Use-Magic-Device}} {{Check=[[ 1d20 + [[ @{Use-Magic-Device} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-macro}" type="text" name="attr_Use-Magic-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Use-Magic-Device}} {{Check=[[ 1d20 + [[ @{Use-Magic-Device} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-0-Check}" type="roll" value="@{Misc-Skill-0-macro}" name="roll_Misc-Skill-0-Check"></button></span>
@@ -2184,7 +2343,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-acp}" type="checkbox" name="attr_Misc-Skill-0-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-macro}" type="text" name="attr_Misc-Skill-0-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-0-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-0} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-macro}" type="text" name="attr_Misc-Skill-0-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-0-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-0} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-1-Check}" type="roll" value="@{Misc-Skill-1-macro}" name="roll_Misc-Skill-1-Check"></button></span>
@@ -2219,7 +2378,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-acp}" type="checkbox" name="attr_Misc-Skill-1-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-macro}" type="text" name="attr_Misc-Skill-1-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-1-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-1} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-macro}" type="text" name="attr_Misc-Skill-1-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-1-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-1} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-2-Check}" type="roll" value="@{Misc-Skill-2-macro}" name="roll_Misc-Skill-2-Check"></button></span>
@@ -2254,7 +2413,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-acp}" type="checkbox" name="attr_Misc-Skill-2-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-misc}" type="number" name="attr_Misc-Skill-2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-macro}" type="text" name="attr_Misc-Skill-2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-2-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-macro}" type="text" name="attr_Misc-Skill-2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-2-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-2} ]] ]]}}"></span>
                     </div>
                 </div>
                 <div class="sheet-table sheet-center sheet-sect">
@@ -2322,7 +2481,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Appraise-macro}" type="text" name="attr_Appraise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Appraise}} {{Check=[[ 1d20 + [[ @{Appraise} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Appraise-macro}" type="text" name="attr_Appraise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Appraise}} {{Check=[[ 1d20 + [[ @{Appraise} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Artistry-Check}" type="roll" value="@{Artistry-macro}" name="roll_Artistry-Check"></button></span>
@@ -2356,7 +2515,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Artistry-misc}" type="number" name="attr_Artistry-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Artistry-macro}" type="text" name="attr_Artistry-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry (@{Artistry-name})}} {{Check=[[ 1d20 + [[ @{Artistry} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Artistry-macro}" type="text" name="attr_Artistry-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry (@{Artistry-name})}} {{Check=[[ 1d20 + [[ @{Artistry} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft-Check}" type="roll" value="@{Craft-macro}" name="roll_Craft-Check"></button></span>
@@ -2390,7 +2549,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft-macro}" type="text" name="attr_Craft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft-name})}} {{Check=[[ 1d20 + [[ @{Craft} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft-macro}" type="text" name="attr_Craft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft-name})}} {{Check=[[ 1d20 + [[ @{Craft} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft2-Check}" type="roll" value="@{Craft2-macro}" name="roll_Craft2-Check"></button></span>
@@ -2424,7 +2583,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft2-macro}" type="text" name="attr_Craft2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft2-name})}} {{Check=[[ 1d20 + [[ @{Craft2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft2-macro}" type="text" name="attr_Craft2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft2-name})}} {{Check=[[ 1d20 + [[ @{Craft2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft3-Check}" type="roll" value="@{Craft3-macro}" name="roll_Craft3-Check"></button></span>
@@ -2458,7 +2617,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3-misc}" type="number" name="attr_Craft3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft3-macro}" type="text" name="attr_Craft3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft3-name})}} {{Check=[[ 1d20 + [[ @{Craft3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft3-macro}" type="text" name="attr_Craft3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft3-name})}} {{Check=[[ 1d20 + [[ @{Craft3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Handle-Animal-Check}" type="roll" value="@{Handle-Animal-macro}" name="roll_Handle-Animal-Check"></button></span>
@@ -2492,7 +2651,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-misc}" type="number" name="attr_Handle-Animal-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-macro}" type="text" name="attr_Handle-Animal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Handle-Animal}} {{Check=[[ 1d20 + [[ @{Handle-Animal} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-macro}" type="text" name="attr_Handle-Animal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Handle-Animal}} {{Check=[[ 1d20 + [[ @{Handle-Animal} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Engineering-Check}" type="roll" value="@{Knowledge-Engineering-macro}" name="roll_Knowledge-Engineering-Check"></button></span>
@@ -2526,7 +2685,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-misc}" type="number" name="attr_Knowledge-Engineering-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-macro}" type="text" name="attr_Knowledge-Engineering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Engineering}} {{Check=[[ 1d20 + [[ @{Knowledge-Engineering} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-macro}" type="text" name="attr_Knowledge-Engineering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Engineering}} {{Check=[[ 1d20 + [[ @{Knowledge-Engineering} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Geography-Check}" type="roll" value="@{Knowledge-Geography-macro}" name="roll_Knowledge-Geography-Check"></button></span>
@@ -2560,7 +2719,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-misc}" type="number" name="attr_Knowledge-Geography-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-macro}" type="text" name="attr_Knowledge-Geography-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Geography}} {{Check=[[ 1d20 + [[ @{Knowledge-Geography} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-macro}" type="text" name="attr_Knowledge-Geography-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Geography}} {{Check=[[ 1d20 + [[ @{Knowledge-Geography} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-History-Check}" type="roll" value="@{Knowledge-History-macro}" name="roll_Knowledge-History-Check"></button></span>
@@ -2594,7 +2753,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-misc}" type="number" name="attr_Knowledge-History-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-macro}" type="text" name="attr_Knowledge-History-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-History}} {{Check=[[ 1d20 + [[ @{Knowledge-History} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-macro}" type="text" name="attr_Knowledge-History-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-History}} {{Check=[[ 1d20 + [[ @{Knowledge-History} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nobility-Check}" type="roll" value="@{Knowledge-Nobility-macro}" name="roll_Knowledge-Nobility-Check"></button></span>
@@ -2628,7 +2787,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-macro}" type="text" name="attr_Knowledge-Nobility-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nobility}} {{Check=[[ 1d20 + [[ @{Knowledge-Nobility} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-macro}" type="text" name="attr_Knowledge-Nobility-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nobility}} {{Check=[[ 1d20 + [[ @{Knowledge-Nobility} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Linguistics-Check}" type="roll" value="@{Linguistics-macro}" name="roll_Linguistics-Check"></button></span>
@@ -2662,7 +2821,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Linguistics-macro}" type="text" name="attr_Linguistics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Linguistics}} {{Check=[[ 1d20 + [[ @{Linguistics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Linguistics-macro}" type="text" name="attr_Linguistics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Linguistics}} {{Check=[[ 1d20 + [[ @{Linguistics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Lore-Check}" type="roll" value="@{Lore-macro}" name="roll_Lore-Check"></button></span>
@@ -2696,7 +2855,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Lore-misc}" type="number" name="attr_Lore-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Lore-macro}" type="text" name="attr_Lore-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore (@{Lore-name})}} {{Check=[[ 1d20 + [[ @{Lore} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Lore-macro}" type="text" name="attr_Lore-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore (@{Lore-name})}} {{Check=[[ 1d20 + [[ @{Lore} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform-Check}" type="roll" value="@{Perform-macro}" name="roll_Perform-Check"></button></span>
@@ -2730,7 +2889,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform-macro}" type="text" name="attr_Perform-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform-name})}} {{Check=[[ 1d20 + [[ @{Perform} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform-macro}" type="text" name="attr_Perform-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform-name})}} {{Check=[[ 1d20 + [[ @{Perform} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform2-Check}" type="roll" value="@{Perform2-macro}" name="roll_Perform2-Check"></button></span>
@@ -2764,7 +2923,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2-misc}" type="number" name="attr_Perform2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform2-macro}" type="text" name="attr_Perform2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform2-name})}} {{Check=[[ 1d20 + [[ @{Perform2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform2-macro}" type="text" name="attr_Perform2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform2-name})}} {{Check=[[ 1d20 + [[ @{Perform2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform3-Check}" type="roll" value="@{Perform3-macro}" name="roll_Perform3-Check"></button></span>
@@ -2798,7 +2957,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform3-macro}" type="text" name="attr_Perform3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform3-name})}} {{Check=[[ 1d20 + [[ @{Perform3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform3-macro}" type="text" name="attr_Perform3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform3-name})}} {{Check=[[ 1d20 + [[ @{Perform3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession-Check}" type="roll" value="@{Profession-macro}" name="roll_Profession-Check"></button></span>
@@ -2832,7 +2991,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession-macro}" type="text" name="attr_Profession-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession-name})}} {{Check=[[ 1d20 + [[ @{Profession} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession-macro}" type="text" name="attr_Profession-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession-name})}} {{Check=[[ 1d20 + [[ @{Profession} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession2-Check}" type="roll" value="@{Profession2-macro}" name="roll_Profession2-Check"></button></span>
@@ -2866,7 +3025,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2-misc}" type="number" name="attr_Profession2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession2-macro}" type="text" name="attr_Profession2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession2-name})}} {{Check=[[ 1d20 + [[ @{Profession2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession2-macro}" type="text" name="attr_Profession2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession2-name})}} {{Check=[[ 1d20 + [[ @{Profession2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession3-Check}" type="roll" value="@{Profession3-macro}" name="roll_Profession3-Check"></button></span>
@@ -2900,7 +3059,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession3-macro}" type="text" name="attr_Profession3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession3-name})}} {{Check=[[ 1d20 + [[ @{Profession3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession3-macro}" type="text" name="attr_Profession3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession3-name})}} {{Check=[[ 1d20 + [[ @{Profession3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sleight-of-Hand-Check}" type="roll" value="@{Sleight-of-Hand-macro}" name="roll_Sleight-of-Hand-Check"></button></span>
@@ -2934,7 +3093,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-acp}" type="number" name="attr_Sleight-of-Hand-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-misc}" type="number" name="attr_Sleight-of-Hand-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-macro}" type="text" name="attr_Sleight-of-Hand-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sleight-of-Hand}} {{Check=[[ 1d20 + [[ @{Sleight-of-Hand} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-macro}" type="text" name="attr_Sleight-of-Hand-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sleight-of-Hand}} {{Check=[[ 1d20 + [[ @{Sleight-of-Hand} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-3-Check}" type="roll" value="@{Misc-Skill-3-macro}" name="roll_Misc-Skill-3-Check"></button></span>
@@ -2969,7 +3128,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-acp}" type="checkbox" name="attr_Misc-Skill-3-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-macro}" type="text" name="attr_Misc-Skill-3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-3-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-macro}" type="text" name="attr_Misc-Skill-3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-3-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-4-Check}" type="roll" value="@{Misc-Skill-4-macro}" name="roll_Misc-Skill-4-Check"></button></span>
@@ -3004,7 +3163,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-acp}" type="checkbox" name="attr_Misc-Skill-4-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-macro}" type="text" name="attr_Misc-Skill-4-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-4-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-4} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-macro}" type="text" name="attr_Misc-Skill-4-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-4-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-4} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-5-Check}" type="roll" value="@{Misc-Skill-5-macro}" name="roll_Misc-Skill-5-Check"></button></span>
@@ -3040,7 +3199,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-acp}" type="checkbox" name="attr_Misc-Skill-5-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-misc}" type="number" name="attr_Misc-Skill-5-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-macro}" type="text" name="attr_Misc-Skill-5-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-5-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-5} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-macro}" type="text" name="attr_Misc-Skill-5-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-5-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-5} ]] ]]}}"></span>
                     </div>
                 </div>
                 <div class="sheet-table sheet-center sheet-sect">
@@ -3128,7 +3287,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Acrobatics-acp}" type="number" name="attr_CS-Acrobatics-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Acrobatics-misc}" type="number" name="attr_CS-Acrobatics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Acrobatics-macro}" type="text" name="attr_CS-Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{CS-Acrobatics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Acrobatics-macro}" type="text" name="attr_CS-Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{CS-Acrobatics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Athletics-Check}" type="roll" value="@{CS-Athletics-macro}" name="roll_Athletics-Check"></button></span>
@@ -3162,7 +3321,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Athletics-acp}" type="number" name="attr_CS-Athletics-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Athletics-misc}" type="number" name="attr_CS-Athletics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Athletics-macro}" type="text" name="attr_CS-Athletics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Athletics}} {{Check=[[ 1d20 + [[ @{CS-Athletics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Athletics-macro}" type="text" name="attr_CS-Athletics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Athletics}} {{Check=[[ 1d20 + [[ @{CS-Athletics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Finesse-Check}" type="roll" value="@{CS-Finesse-macro}" name="roll_Finesse-Check"></button></span>
@@ -3196,7 +3355,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Finesse-acp}" type="number" name="attr_CS-Finesse-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Finesse-misc}" type="number" name="attr_CS-Finesse-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Finesse-macro}" type="text" name="attr_CS-Finesse-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Finesse}} {{Check=[[ 1d20 + [[ @{CS-Finesse} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Finesse-macro}" type="text" name="attr_CS-Finesse-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Finesse}} {{Check=[[ 1d20 + [[ @{CS-Finesse} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Influence-Check}" type="roll" value="@{CS-Influence-macro}" name="roll_Influence-Check"></button></span>
@@ -3230,7 +3389,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Influence-misc}" type="number" name="attr_CS-Influence-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Influence-macro}" type="text" name="attr_CS-Influence-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Influence}} {{Check=[[ 1d20 + [[ @{CS-Influence} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Influence-macro}" type="text" name="attr_CS-Influence-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Influence}} {{Check=[[ 1d20 + [[ @{CS-Influence} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Nature-Check}" type="roll" value="@{CS-Nature-macro}" name="roll_Nature-Check"></button></span>
@@ -3264,7 +3423,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Nature-misc}" type="number" name="attr_CS-Nature-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Nature-macro}" type="text" name="attr_CS-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Nature}} {{Check=[[ 1d20 + [[ @{CS-Nature} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Nature-macro}" type="text" name="attr_CS-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Nature}} {{Check=[[ 1d20 + [[ @{CS-Nature} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Perception-Check}" type="roll" value="@{CS-Perception-macro}" name="roll_Perception-Check"></button></span>
@@ -3298,7 +3457,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Perception-misc}" type="number" name="attr_CS-Perception-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Perception-macro}" type="text" name="attr_CS-Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{CS-Perception} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Perception-macro}" type="text" name="attr_CS-Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{CS-Perception} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Performance-Check}" type="roll" value="@{CS-Performance-macro}" name="roll_Performance-Check"></button></span>
@@ -3332,7 +3491,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Performance-misc}" type="number" name="attr_CS-Performance-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Performance-macro}" type="text" name="attr_CS-Performance-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Performance}} {{Check=[[ 1d20 + [[ @{CS-Performance} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Performance-macro}" type="text" name="attr_CS-Performance-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Performance}} {{Check=[[ 1d20 + [[ @{CS-Performance} ]] ]]}}"></span>
 
                     </div>
                     <div class="sheet-table-row">
@@ -3367,7 +3526,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Religion-misc}" type="number" name="attr_CS-Religion-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Religion-macro}" type="text" name="attr_CS-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Religion}} {{Check=[[ 1d20 + [[ @{CS-Religion} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Religion-macro}" type="text" name="attr_CS-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Religion}} {{Check=[[ 1d20 + [[ @{CS-Religion} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Society-Check}" type="roll" value="@{CS-Society-macro}" name="roll_Society-Check"></button></span>
@@ -3401,7 +3560,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Society-misc}" type="number" name="attr_CS-Society-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Society-macro}" type="text" name="attr_CS-Society-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Society}} {{Check=[[ 1d20 + [[ @{CS-Society} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Society-macro}" type="text" name="attr_CS-Society-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Society}} {{Check=[[ 1d20 + [[ @{CS-Society} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Spellcraft-Check}" type="roll" value="@{CS-Spellcraft-macro}" name="roll_Spellcraft-Check"></button></span>
@@ -3435,7 +3594,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Spellcraft-acp}" type="number" name="attr_CS-Spellcraft-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Spellcraft-misc}" type="number" name="attr_CS-Spellcraft-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Spellcraft-macro}" type="text" name="attr_CS-Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{CS-Spellcraft} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Spellcraft-macro}" type="text" name="attr_CS-Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{CS-Spellcraft} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Stealth-Check}" type="roll" value="@{CS-Stealth-macro}" name="roll_Stealth-Check"></button></span>
@@ -3469,7 +3628,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Stealth-acp}" type="number" name="attr_CS-Stealth-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Stealth-misc}" type="number" name="attr_CS-Stealth-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Stealth-macro}" type="text" name="attr_CS-Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{CS-Stealth} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Stealth-macro}" type="text" name="attr_CS-Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{CS-Stealth} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|CS-Survival-Check}" type="roll" value="@{CS-Survival-macro}" name="roll_Survival-Check"></button></span>
@@ -3503,7 +3662,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{CS-Survival-misc}" type="number" name="attr_CS-Survival-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{CS-Survival-macro}" type="text" name="attr_CS-Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{CS-Survival} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{CS-Survival-macro}" type="text" name="attr_CS-Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{CS-Survival} ]] ]]}}"></span>
                     </div>
                 </div>
                 <div class="sheet-table sheet-center sheet-sect">
@@ -3571,7 +3730,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-acp}" type="number" name="attr_Acrobatics-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-misc}" type="number" name="attr_Acrobatics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-macro}" type="text" name="attr_Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{Acrobatics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Acrobatics-macro}" type="text" name="attr_Acrobatics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Acrobatics}} {{Check=[[ 1d20 + [[ @{Acrobatics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Appraise-Check}" type="roll" value="@{Appraise-macro}" name="roll_Appraise-Check"></button></span>
@@ -3605,7 +3764,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Appraise-misc}" type="number" name="attr_Appraise-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Appraise-macro}" type="text" name="attr_Appraise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Appraise}} {{Check=[[ 1d20 + [[ @{Appraise} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Appraise-macro}" type="text" name="attr_Appraise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Appraise}} {{Check=[[ 1d20 + [[ @{Appraise} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Artistry-Check}" type="roll" value="@{Artistry-macro}" name="roll_Artistry-Check"></button></span>
@@ -3639,7 +3798,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Artistry-misc}" type="number" name="attr_Artistry-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Artistry-macro}" type="text" name="attr_Artistry-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry (@{Artistry-name})}} {{Check=[[ 1d20 + [[ @{Artistry} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Artistry-macro}" type="text" name="attr_Artistry-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Artistry (@{Artistry-name})}} {{Check=[[ 1d20 + [[ @{Artistry} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Bluff-Check}" type="roll" value="@{Bluff-macro}" name="roll_Bluff-Check"></button></span>
@@ -3673,7 +3832,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Bluff-misc}" type="number" name="attr_Bluff-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Bluff-macro}" type="text" name="attr_Bluff-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[ 1d20 + [[ @{Bluff} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Bluff-macro}" type="text" name="attr_Bluff-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Bluff}} {{Check=[[ 1d20 + [[ @{Bluff} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Climb-Check}" type="roll" value="@{Climb-macro}" name="roll_Climb-Check"></button></span>
@@ -3707,7 +3866,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Climb-acp}" type="number" name="attr_Climb-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Climb-misc}" type="number" name="attr_Climb-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Climb-macro}" type="text" name="attr_Climb-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Climb}} {{Check=[[ 1d20 + [[ @{Climb} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Climb-macro}" type="text" name="attr_Climb-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Climb}} {{Check=[[ 1d20 + [[ @{Climb} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft-Check}" type="roll" value="@{Craft-macro}" name="roll_Craft-Check"></button></span>
@@ -3741,7 +3900,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft-macro}" type="text" name="attr_Craft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft-name})}} {{Check=[[ 1d20 + [[ @{Craft} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft-macro}" type="text" name="attr_Craft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft-name})}} {{Check=[[ 1d20 + [[ @{Craft} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft2-Check}" type="roll" value="@{Craft2-macro}" name="roll_Craft2-Check"></button></span>
@@ -3775,7 +3934,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft2-macro}" type="text" name="attr_Craft2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft2-name})}} {{Check=[[ 1d20 + [[ @{Craft2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft2-macro}" type="text" name="attr_Craft2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft2-name})}} {{Check=[[ 1d20 + [[ @{Craft2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft3-Check}" type="roll" value="@{Craft3-macro}" name="roll_Craft3-Check"></button></span>
@@ -3809,7 +3968,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3-misc}" type="number" name="attr_Craft3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Craft3-macro}" type="text" name="attr_Craft3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft3-name})}} {{Check=[[ 1d20 + [[ @{Craft3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Craft3-macro}" type="text" name="attr_Craft3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Craft (@{Craft3-name})}} {{Check=[[ 1d20 + [[ @{Craft3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Diplomacy-Check}" type="roll" value="@{Diplomacy-macro}" name="roll_Diplomacy-Check"></button></span>
@@ -3843,7 +4002,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-misc}" type="number" name="attr_Diplomacy-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-macro}" type="text" name="attr_Diplomacy-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Diplomacy}} {{Check=[[ 1d20 + [[ @{Diplomacy} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Diplomacy-macro}" type="text" name="attr_Diplomacy-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Diplomacy}} {{Check=[[ 1d20 + [[ @{Diplomacy} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disable-Device-Check}" type="roll" value="@{Disable-Device-macro}" name="roll_Disable-Device-Check"></button></span>
@@ -3877,7 +4036,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-acp}" type="number" name="attr_Disable-Device-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-misc}" type="number" name="attr_Disable-Device-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-macro}" type="text" name="attr_Disable-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disable-Device}} {{Check=[[ 1d20 + [[ @{Disable-Device} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Disable-Device-macro}" type="text" name="attr_Disable-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disable-Device}} {{Check=[[ 1d20 + [[ @{Disable-Device} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Disguise-Check}" type="roll" value="@{Disguise-macro}" name="roll_Disguise-Check"></button></span>
@@ -3911,7 +4070,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Disguise-misc}" type="number" name="attr_Disguise-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Disguise-macro}" type="text" name="attr_Disguise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disguise}} {{Check=[[ 1d20 + [[ @{Disguise} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Disguise-macro}" type="text" name="attr_Disguise-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Disguise}} {{Check=[[ 1d20 + [[ @{Disguise} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Escape-Artist-Check}" type="roll" value="@{Escape-Artist-macro}" name="roll_Escape-Artist-Check"></button></span>
@@ -3945,7 +4104,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-acp}" type="number" name="attr_Escape-Artist-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-misc}" type="number" name="attr_Escape-Artist-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-macro}" type="text" name="attr_Escape-Artist-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Escape-Artist}} {{Check=[[ 1d20 + [[ @{Escape-Artist} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Escape-Artist-macro}" type="text" name="attr_Escape-Artist-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Escape-Artist}} {{Check=[[ 1d20 + [[ @{Escape-Artist} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Fly-Check}" type="roll" value="@{Fly-macro}" name="roll_Fly-Check"></button></span>
@@ -3979,7 +4138,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Fly-acp}" type="number" name="attr_Fly-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Fly-misc}" type="number" name="attr_Fly-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Fly-macro}" type="text" name="attr_Fly-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fly}} {{Check=[[ 1d20 + [[ @{Fly} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Fly-macro}" type="text" name="attr_Fly-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Fly}} {{Check=[[ 1d20 + [[ @{Fly} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Handle-Animal-Check}" type="roll" value="@{Handle-Animal-macro}" name="roll_Handle-Animal-Check"></button></span>
@@ -4013,7 +4172,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-misc}" type="number" name="attr_Handle-Animal-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-macro}" type="text" name="attr_Handle-Animal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Handle-Animal}} {{Check=[[ 1d20 + [[ @{Handle-Animal} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Handle-Animal-macro}" type="text" name="attr_Handle-Animal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Handle-Animal}} {{Check=[[ 1d20 + [[ @{Handle-Animal} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Heal-Check}" type="roll" value="@{Heal-macro}" name="roll_Heal-Check"></button></span>
@@ -4047,7 +4206,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Heal-misc}" type="number" name="attr_Heal-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Heal-macro}" type="text" name="attr_Heal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Heal}} {{Check=[[ 1d20 + [[ @{Heal} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Heal-macro}" type="text" name="attr_Heal-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Heal}} {{Check=[[ 1d20 + [[ @{Heal} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Intimidate-Check}" type="roll" value="@{Intimidate-macro}" name="roll_Intimidate-Check"></button></span>
@@ -4081,7 +4240,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Intimidate-misc}" type="number" name="attr_Intimidate-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Intimidate-macro}" type="text" name="attr_Intimidate-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intimidate}} {{Check=[[ 1d20 + [[ @{Intimidate} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Intimidate-macro}" type="text" name="attr_Intimidate-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intimidate}} {{Check=[[ 1d20 + [[ @{Intimidate} ]] ]]}}"></span>
                     </div>
 
                     <div class="sheet-table-row">
@@ -4116,7 +4275,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-misc}" type="number" name="attr_Knowledge-Arcana-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-macro}" type="text" name="attr_Knowledge-Arcana-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Arcana}} {{Check=[[ 1d20 + [[ @{Knowledge-Arcana} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Arcana-macro}" type="text" name="attr_Knowledge-Arcana-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Arcana}} {{Check=[[ 1d20 + [[ @{Knowledge-Arcana} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Dungeoneering-Check}" type="roll" value="@{Knowledge-Dungeoneering-macro}" name="roll_Knowledge-Dungeoneering-Check"></button></span>
@@ -4150,7 +4309,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-misc}" type="number" name="attr_Knowledge-Dungeoneering-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-macro}" type="text" name="attr_Knowledge-Dungeoneering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Dungeoneering}} {{Check=[[ 1d20 + [[ @{Knowledge-Dungeoneering} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Dungeoneering-macro}" type="text" name="attr_Knowledge-Dungeoneering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Dungeoneering}} {{Check=[[ 1d20 + [[ @{Knowledge-Dungeoneering} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Engineering-Check}" type="roll" value="@{Knowledge-Engineering-macro}" name="roll_Knowledge-Engineering-Check"></button></span>
@@ -4184,7 +4343,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-misc}" type="number" name="attr_Knowledge-Engineering-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-macro}" type="text" name="attr_Knowledge-Engineering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Engineering}} {{Check=[[ 1d20 + [[ @{Knowledge-Engineering} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Engineering-macro}" type="text" name="attr_Knowledge-Engineering-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Engineering}} {{Check=[[ 1d20 + [[ @{Knowledge-Engineering} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Geography-Check}" type="roll" value="@{Knowledge-Geography-macro}" name="roll_Knowledge-Geography-Check"></button></span>
@@ -4218,7 +4377,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-misc}" type="number" name="attr_Knowledge-Geography-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-macro}" type="text" name="attr_Knowledge-Geography-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Geography}} {{Check=[[ 1d20 + [[ @{Knowledge-Geography} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Geography-macro}" type="text" name="attr_Knowledge-Geography-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Geography}} {{Check=[[ 1d20 + [[ @{Knowledge-Geography} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-History-Check}" type="roll" value="@{Knowledge-History-macro}" name="roll_Knowledge-History-Check"></button></span>
@@ -4252,7 +4411,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-misc}" type="number" name="attr_Knowledge-History-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-macro}" type="text" name="attr_Knowledge-History-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-History}} {{Check=[[ 1d20 + [[ @{Knowledge-History} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-History-macro}" type="text" name="attr_Knowledge-History-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-History}} {{Check=[[ 1d20 + [[ @{Knowledge-History} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Local-Check}" type="roll" value="@{Knowledge-Local-macro}" name="roll_Knowledge-Local-Check"></button></span>
@@ -4286,7 +4445,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-misc}" type="number" name="attr_Knowledge-Local-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-macro}" type="text" name="attr_Knowledge-Local-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Local}} {{Check=[[ 1d20 + [[ @{Knowledge-Local} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Local-macro}" type="text" name="attr_Knowledge-Local-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Local}} {{Check=[[ 1d20 + [[ @{Knowledge-Local} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nature-Check}" type="roll" value="@{Knowledge-Nature-macro}" name="roll_Knowledge-Nature-Check"></button></span>
@@ -4320,7 +4479,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-misc}" type="number" name="attr_Knowledge-Nature-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-macro}" type="text" name="attr_Knowledge-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nature}} {{Check=[[ 1d20 + [[ @{Knowledge-Nature} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nature-macro}" type="text" name="attr_Knowledge-Nature-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nature}} {{Check=[[ 1d20 + [[ @{Knowledge-Nature} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Nobility-Check}" type="roll" value="@{Knowledge-Nobility-macro}" name="roll_Knowledge-Nobility-Check"></button></span>
@@ -4354,7 +4513,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-misc}" type="number" name="attr_Knowledge-Nobility-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-macro}" type="text" name="attr_Knowledge-Nobility-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nobility}} {{Check=[[ 1d20 + [[ @{Knowledge-Nobility} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Nobility-macro}" type="text" name="attr_Knowledge-Nobility-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Nobility}} {{Check=[[ 1d20 + [[ @{Knowledge-Nobility} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Planes-Check}" type="roll" value="@{Knowledge-Planes-macro}" name="roll_Knowledge-Planes-Check"></button></span>
@@ -4388,7 +4547,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-misc}" type="number" name="attr_Knowledge-Planes-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-macro}" type="text" name="attr_Knowledge-Planes-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Planes}} {{Check=[[ 1d20 + [[ @{Knowledge-Planes} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Planes-macro}" type="text" name="attr_Knowledge-Planes-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Planes}} {{Check=[[ 1d20 + [[ @{Knowledge-Planes} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Knowledge-Religion-Check}" type="roll" value="@{Knowledge-Religion-macro}" name="roll_Knowledge-Religion-Check"></button></span>
@@ -4422,7 +4581,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-misc}" type="number" name="attr_Knowledge-Religion-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-macro}" type="text" name="attr_Knowledge-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Religion}} {{Check=[[ 1d20 + [[ @{Knowledge-Religion} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Knowledge-Religion-macro}" type="text" name="attr_Knowledge-Religion-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Knowledge-Religion}} {{Check=[[ 1d20 + [[ @{Knowledge-Religion} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Linguistics-Check}" type="roll" value="@{Linguistics-macro}" name="roll_Linguistics-Check"></button></span>
@@ -4456,7 +4615,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Linguistics-misc}" type="number" name="attr_Linguistics-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Linguistics-macro}" type="text" name="attr_Linguistics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Linguistics}} {{Check=[[ 1d20 + [[ @{Linguistics} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Linguistics-macro}" type="text" name="attr_Linguistics-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Linguistics}} {{Check=[[ 1d20 + [[ @{Linguistics} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Lore-Check}" type="roll" value="@{Lore-macro}" name="roll_Lore-Check"></button></span>
@@ -4490,7 +4649,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Lore-misc}" type="number" name="attr_Lore-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Lore-macro}" type="text" name="attr_Lore-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore (@{Lore-name})}} {{Check=[[ 1d20 + [[ @{Lore} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Lore-macro}" type="text" name="attr_Lore-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Lore (@{Lore-name})}} {{Check=[[ 1d20 + [[ @{Lore} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perception-Check}" type="roll" value="@{Perception-macro}" name="roll_Perception-Check"></button></span>
@@ -4524,7 +4683,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perception-macro}" type="text" name="attr_Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{Perception} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perception-macro}" type="text" name="attr_Perception-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perception}} {{Check=[[ 1d20 + [[ @{Perception} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform-Check}" type="roll" value="@{Perform-macro}" name="roll_Perform-Check"></button></span>
@@ -4558,7 +4717,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform-macro}" type="text" name="attr_Perform-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform-name})}} {{Check=[[ 1d20 + [[ @{Perform} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform-macro}" type="text" name="attr_Perform-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform-name})}} {{Check=[[ 1d20 + [[ @{Perform} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform2-Check}" type="roll" value="@{Perform2-macro}" name="roll_Perform2-Check"></button></span>
@@ -4592,7 +4751,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2-misc}" type="number" name="attr_Perform2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform2-macro}" type="text" name="attr_Perform2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform2-name})}} {{Check=[[ 1d20 + [[ @{Perform2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform2-macro}" type="text" name="attr_Perform2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform2-name})}} {{Check=[[ 1d20 + [[ @{Perform2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform3-Check}" type="roll" value="@{Perform3-macro}" name="roll_Perform3-Check"></button></span>
@@ -4626,7 +4785,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Perform3-macro}" type="text" name="attr_Perform3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform3-name})}} {{Check=[[ 1d20 + [[ @{Perform3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Perform3-macro}" type="text" name="attr_Perform3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Perform (@{Perform3-name})}} {{Check=[[ 1d20 + [[ @{Perform3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession-Check}" type="roll" value="@{Profession-macro}" name="roll_Profession-Check"></button></span>
@@ -4660,7 +4819,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession-macro}" type="text" name="attr_Profession-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession-name})}} {{Check=[[ 1d20 + [[ @{Profession} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession-macro}" type="text" name="attr_Profession-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession-name})}} {{Check=[[ 1d20 + [[ @{Profession} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession2-Check}" type="roll" value="@{Profession2-macro}" name="roll_Profession2-Check"></button></span>
@@ -4694,7 +4853,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2-misc}" type="number" name="attr_Profession2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession2-macro}" type="text" name="attr_Profession2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession2-name})}} {{Check=[[ 1d20 + [[ @{Profession2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession2-macro}" type="text" name="attr_Profession2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession2-name})}} {{Check=[[ 1d20 + [[ @{Profession2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession3-Check}" type="roll" value="@{Profession3-macro}" name="roll_Profession3-Check"></button></span>
@@ -4728,7 +4887,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Profession3-macro}" type="text" name="attr_Profession3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession3-name})}} {{Check=[[ 1d20 + [[ @{Profession3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Profession3-macro}" type="text" name="attr_Profession3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Profession (@{Profession3-name})}} {{Check=[[ 1d20 + [[ @{Profession3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Ride-Check}" type="roll" value="@{Ride-macro}" name="roll_Ride-Check"></button></span>
@@ -4762,7 +4921,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Ride-acp}" type="number" name="attr_Ride-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Ride-misc}" type="number" name="attr_Ride-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Ride-macro}" type="text" name="attr_Ride-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ride}} {{Check=[[ 1d20 + [[ @{Ride} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Ride-macro}" type="text" name="attr_Ride-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Ride}} {{Check=[[ 1d20 + [[ @{Ride} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sense-Motive-Check}" type="roll" value="@{Sense-Motive-macro}" name="roll_Sense-Motive-Check"></button></span>
@@ -4796,7 +4955,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-misc}" type="number" name="attr_Sense-Motive-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-macro}" type="text" name="attr_Sense-Motive-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sense-Motive}} {{Check=[[ 1d20 + [[ @{Sense-Motive} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Sense-Motive-macro}" type="text" name="attr_Sense-Motive-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sense-Motive}} {{Check=[[ 1d20 + [[ @{Sense-Motive} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Sleight-of-Hand-Check}" type="roll" value="@{Sleight-of-Hand-macro}" name="roll_Sleight-of-Hand-Check"></button></span>
@@ -4830,7 +4989,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-acp}" type="number" name="attr_Sleight-of-Hand-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-misc}" type="number" name="attr_Sleight-of-Hand-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-macro}" type="text" name="attr_Sleight-of-Hand-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sleight-of-Hand}} {{Check=[[ 1d20 + [[ @{Sleight-of-Hand} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Sleight-of-Hand-macro}" type="text" name="attr_Sleight-of-Hand-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Sleight-of-Hand}} {{Check=[[ 1d20 + [[ @{Sleight-of-Hand} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spellcraft-Check}" type="roll" value="@{Spellcraft-macro}" name="roll_Spellcraft-Check"></button></span>
@@ -4864,7 +5023,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-misc}" type="number" name="attr_Spellcraft-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-macro}" type="text" name="attr_Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{Spellcraft} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Spellcraft-macro}" type="text" name="attr_Spellcraft-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Spellcraft}} {{Check=[[ 1d20 + [[ @{Spellcraft} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Stealth-Check}" type="roll" value="@{Stealth-macro}" name="roll_Stealth-Check"></button></span>
@@ -4898,7 +5057,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Stealth-acp}" type="number" name="attr_Stealth-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Stealth-misc}" type="number" name="attr_Stealth-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Stealth-macro}" type="text" name="attr_Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{Stealth} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Stealth-macro}" type="text" name="attr_Stealth-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Stealth}} {{Check=[[ 1d20 + [[ @{Stealth} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Survival-Check}" type="roll" value="@{Survival-macro}" name="roll_Survival-Check"></button></span>
@@ -4932,7 +5091,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Survival-misc}" type="number" name="attr_Survival-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Survival-macro}" type="text" name="attr_Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{Survival} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Survival-macro}" type="text" name="attr_Survival-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{Survival} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Swim-Check}" type="roll" value="@{Swim-macro}" name="roll_Swim-Check"></button></span>
@@ -4966,7 +5125,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Swim-acp}" type="number" name="attr_Swim-acp" value="@{acp}" disabled></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Swim-misc}" type="number" name="attr_Swim-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Swim-macro}" type="text" name="attr_Swim-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Swim}} {{Check=[[ 1d20 + [[ @{Swim} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Swim-macro}" type="text" name="attr_Swim-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Swim}} {{Check=[[ 1d20 + [[ @{Swim} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Use-Magic-Device-Check}" type="roll" value="@{Use-Magic-Device-macro}" name="roll_Use-Magic-Device-Check"></button></span>
@@ -5000,7 +5159,7 @@
                         <span class="sheet-table-data sheet-center"><b>N/A</b></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-misc}" type="number" name="attr_Use-Magic-Device-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-macro}" type="text" name="attr_Use-Magic-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Use-Magic-Device}} {{Check=[[ 1d20 + [[ @{Use-Magic-Device} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-macro}" type="text" name="attr_Use-Magic-Device-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Use-Magic-Device}} {{Check=[[ 1d20 + [[ @{Use-Magic-Device} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-0-Check}" type="roll" value="@{Misc-Skill-0-macro}" name="roll_Misc-Skill-0-Check"></button></span>
@@ -5035,7 +5194,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-acp}" type="checkbox" name="attr_Misc-Skill-0-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-macro}" type="text" name="attr_Misc-Skill-0-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-0-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-0} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-macro}" type="text" name="attr_Misc-Skill-0-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-0-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-0} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-1-Check}" type="roll" value="@{Misc-Skill-1-macro}" name="roll_Misc-Skill-1-Check"></button></span>
@@ -5070,7 +5229,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-acp}" type="checkbox" name="attr_Misc-Skill-1-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-macro}" type="text" name="attr_Misc-Skill-1-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-1-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-1} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-macro}" type="text" name="attr_Misc-Skill-1-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-1-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-1} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-2-Check}" type="roll" value="@{Misc-Skill-2-macro}" name="roll_Misc-Skill-2-Check"></button></span>
@@ -5105,7 +5264,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-acp}" type="checkbox" name="attr_Misc-Skill-2-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-misc}" type="number" name="attr_Misc-Skill-2-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-macro}" type="text" name="attr_Misc-Skill-2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-2-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-2} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-macro}" type="text" name="attr_Misc-Skill-2-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-2-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-2} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-3-Check}" type="roll" value="@{Misc-Skill-3-macro}" name="roll_Misc-Skill-3-Check"></button></span>
@@ -5140,7 +5299,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-acp}" type="checkbox" name="attr_Misc-Skill-3-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-macro}" type="text" name="attr_Misc-Skill-3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-3-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-3} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-macro}" type="text" name="attr_Misc-Skill-3-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-3-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-3} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-4-Check}" type="roll" value="@{Misc-Skill-4-macro}" name="roll_Misc-Skill-4-Check"></button></span>
@@ -5175,7 +5334,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-acp}" type="checkbox" name="attr_Misc-Skill-4-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-macro}" type="text" name="attr_Misc-Skill-4-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-4-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-4} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-macro}" type="text" name="attr_Misc-Skill-4-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-4-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-4} ]] ]]}}"></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-5-Check}" type="roll" value="@{Misc-Skill-5-macro}" name="roll_Misc-Skill-5-Check"></button></span>
@@ -5211,7 +5370,7 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-acp}" type="checkbox" name="attr_Misc-Skill-5-acp" value="@{acp}"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-misc}" type="number" name="attr_Misc-Skill-5-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-macro}" type="text" name="attr_Misc-Skill-5-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-5-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-5} ]]  ]]}}"></span>
+                        <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-macro}" type="text" name="attr_Misc-Skill-5-macro" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{Misc-Skill-5-name}}} {{Check=[[ 1d20 + [[ @{Misc-Skill-5} ]] ]]}}"></span>
                     </div>
                 </div>
                 <br/>
@@ -5657,13 +5816,13 @@
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-left"><input title="@{spellclass-0-name}" type="text" name="attr_spellclass-0-name" placeholder="Class Name"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-0-CL-Check}" type="roll" name="roll_Spell-Class-0-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-0-name} @{spellclass-0-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-0-level} ]]   ]]}}">CL Check</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-0-CL-Check}" type="roll" name="roll_Spell-Class-0-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-0-name} @{spellclass-0-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-0-level} ]] ]]}}">CL Check</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-total}" type="number" name="attr_spellclass-0-level-total" value="(@{spellclass-0-level} + [[ @{spellclass-0-level-misc} ]] - [[ @{condition-Wounds} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level}" type="number" name="attr_spellclass-0-level" value="0"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-0-level-misc}" type="number" name="attr_spellclass-0-level-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-0-name} [[ @{spellclass-0-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]]  ]]}}">Concentration</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-0-name} [[ @{spellclass-0-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]] ]]}}">Concentration</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-0-level} + [[ @{Concentration-0-ability} ]] + [[ @{Concentration-0-misc} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center">
@@ -5854,13 +6013,13 @@
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-left"><input title="@{spellclass-1-name}" type="text" name="attr_spellclass-1-name" placeholder="Class Name"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-1-CL-Check}" type="roll" name="roll_Spell-Class-1-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-1-name} @{spellclass-1-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-1-level} ]]  ]]}}">CL Check</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-1-CL-Check}" type="roll" name="roll_Spell-Class-1-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-1-name} @{spellclass-1-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-1-level} ]] ]]}}">CL Check</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-total}" type="number" name="attr_spellclass-1-level-total" value="(@{spellclass-1-level} + [[ @{spellclass-1-level-misc} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level}" type="number" name="attr_spellclass-1-level" value="0"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-1-level-misc}" type="number" name="attr_spellclass-1-level-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-1}" name="roll_Concentration-Check-1" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-1-name} [[ @{spellclass-1-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-1} ]]  ]]}}">Concentration</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-1}" name="roll_Concentration-Check-1" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-1-name} [[ @{spellclass-1-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-1} ]] ]]}}">Concentration</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Concentration-1}" type="number" name="attr_Concentration-1" value="(@{spellclass-1-level} + [[ @{Concentration-1-ability} ]] + [[ @{Concentration-1-misc} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center">
@@ -6051,13 +6210,13 @@
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-left"><input title="@{spellclass-2-name}" type="text" name="attr_spellclass-2-name" placeholder="Class Name"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-2-CL-Check}" type="roll" name="roll_Spell-Class-2-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-2-name} @{spellclass-2-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-2-level} ]]  ]]}}">CL Check</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Spell-Class-2-CL-Check}" type="roll" name="roll_Spell-Class-2-CL-Check" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CL Check}} {{Class=**@{spellclass-2-name} @{spellclass-2-level}**}} {{Check=[[ 1d20 + [[ @{spellclass-2-level} ]] ]]}}">CL Check</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-2-level-total}" type="number" name="attr_spellclass-2-level-total" value="(@{spellclass-2-level} + [[ @{spellclass-2-level-misc} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-2-level}" type="number" name="attr_spellclass-2-level" value="0"></span>
                         <span class="sheet-table-data sheet-center">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{spellclass-2-level-misc}" type="number" name="attr_spellclass-2-level-misc" value="0"></span>
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-2}" name="roll_Concentration-Check-2" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-2-name} [[ @{spellclass-2-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-2} ]]  ]]}}">Concentration</button></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Concentration-Check-2}" name="roll_Concentration-Check-2" type="roll" value="&{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Concentration Check}} {{Class=@{spellclass-2-name} [[ @{spellclass-2-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-2} ]] ]]}}">Concentration</button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Concentration-2}" type="number" name="attr_Concentration-2" value="(@{spellclass-2-level} + [[ @{Concentration-2-ability} ]] + [[ @{Concentration-2-misc} ]])" disabled></span>
                         <span class="sheet-table-data sheet-center">=</span>
                         <span class="sheet-table-data sheet-center">
@@ -6317,7 +6476,7 @@
                         <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_25_Cast" title="%{selected|repeating_lvl-0-spells_25_Cast}" value="&{template:pf_spell} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_lvl-0-spells_25_name}}} {{school=@{repeating_lvl-0-spells_25_school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{repeating_lvl-0-spells_25_cast-time}}} {{components=@{repeating_lvl-0-spells_25_components}}} {{range=@{repeating_lvl-0-spells_25_range}}} {{target=@{repeating_lvl-0-spells_25_targets}}} {{duration=@{repeating_lvl-0-spells_25_duration}}} {{saving_throw=@{repeating_lvl-0-spells_25_save}}} {{dc=[[ @{spellclass-0-level-0-savedc} + [[ @{repeating_lvl-0-spells_25_DC-mod} ]] ]]}} {{sr=@{repeating_lvl-0-spells_25_sr}}} {{spell_description=@{repeating_lvl-0-spells_25_description}}}"></button></span>
                         <span class="sheet-table-data sheet-center"><button type="roll" name="roll_repeating_lvl-0-spells_26_Cast" title="%{selected|repeating_lvl-0-spells_26_Cast}" value="&{template:pf_spell} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{repeating_lvl-0-spells_26_name}}} {{school=@{repeating_lvl-0-spells_26_school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{repeating_lvl-0-spells_26_cast-time}}} {{components=@{repeating_lvl-0-spells_26_components}}} {{range=@{repeating_lvl-0-spells_26_range}}} {{target=@{repeating_lvl-0-spells_26_targets}}} {{duration=@{repeating_lvl-0-spells_26_duration}}} {{saving_throw=@{repeating_lvl-0-spells_26_save}}} {{dc=[[ @{spellclass-0-level-0-savedc} + [[ @{repeating_lvl-0-spells_26_DC-mod} ]] ]]}} {{sr=@{repeating_lvl-0-spells_26_sr}}} {{spell_description=@{repeating_lvl-0-spells_26_description}}}"></button></span>
                     </div>
-                </div>
+                </div>		    
                 <br>
                 <div class="sheet-sect">
                     <div class="sheet-table">
@@ -6328,11 +6487,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-0-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-0-spells_X_spell_level}" type="number" value="0" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6340,7 +6511,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-0-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-0-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6352,11 +6523,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-0-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-0-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-0-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-0-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-0-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-0-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-0-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-0-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-0-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-0-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-0-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-0-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-0-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-0-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-0-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-0-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-0-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-0-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-0-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-0-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>			
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6432,11 +6645,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-1-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-1-spells_X_spell_level}" type="number" value="1" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6444,7 +6669,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-1-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-1-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6456,11 +6681,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-1-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-1-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-1-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-1-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-1-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-1-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-1-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-1-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-1-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-1-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-1-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-1-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-1-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-1-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-1-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-1-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-1-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-1-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-1-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-1-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6536,11 +6803,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-2-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-2-spells_X_spell_level}" type="number" value="2" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6548,7 +6827,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-2-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-2-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6560,11 +6839,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-2-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-2-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-2-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-2-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-2-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-2-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-2-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-2-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-2-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-2-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-2-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-2-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-2-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-2-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-2-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-2-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-2-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-2-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-2-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-2-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6640,11 +6961,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-3-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-3-spells_X_spell_level}" type="number" value="3" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6652,7 +6985,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-3-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-3-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6664,11 +6997,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-3-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-3-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-3-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-3-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-3-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-3-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-3-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-3-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-3-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-3-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-3-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-3-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-3-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-3-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-3-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-3-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-3-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-3-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-3-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-3-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>			
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6744,11 +7119,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-4-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-4-spells_X_spell_level}" type="number" value="4" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6756,7 +7143,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-4-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-4-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6768,11 +7155,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-4-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-4-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-4-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-4-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-4-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-4-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-4-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-4-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-4-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-4-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-4-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-4-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-4-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-4-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-4-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-4-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-4-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-4-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-4-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-4-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6848,11 +7277,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-5-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-5-spells_X_spell_level}" type="number" value="5" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6860,7 +7301,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-5-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-5-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6872,11 +7313,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-5-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-5-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-5-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-5-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-5-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-5-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-5-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-5-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-5-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-5-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-5-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-5-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-5-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-5-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-5-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-5-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-5-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-5-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-5-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-5-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>			
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -6952,11 +7435,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-6-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-6-spells_X_spell_level}" type="number" value="6" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -6964,7 +7459,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-6-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-6-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -6976,11 +7471,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-6-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-6-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-6-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-6-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-6-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-6-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-6-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-6-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-6-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-6-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-6-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-6-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-6-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-6-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-6-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-6-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-6-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-6-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-6-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-6-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -7056,11 +7593,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-7-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-7-spells_X_spell_level}" type="number" value="7" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -7068,7 +7617,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-7-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-7-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -7080,11 +7629,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-7-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-7-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-7-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-7-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-7-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-7-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-7-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-7-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-7-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-7-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-7-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-7-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-7-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-7-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-7-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-7-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-7-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-7-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-7-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-7-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -7157,14 +7748,26 @@
                     </div>
                     <fieldset class="repeating_lvl-8-spells">
                         <div class="sheet-table">
-                            <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" name="roll_Cast" value="@{macro-text}"></button></span>
+                            <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-8-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-8-spells_X_spell_level}" type="number" value="8" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -7172,7 +7775,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-8-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-8-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -7184,11 +7787,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-8-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-8-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-8-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-8-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-8-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-8-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-8-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-8-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-8-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-8-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-8-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-8-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-8-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-8-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-8-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-8-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-8-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-8-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-8-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-8-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -7264,11 +7909,23 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" value="@{macro-text}"></button></span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_used}" type="number" name="attr_used" value="0" placeholder="Number Prepared"><br>Prepped</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_name}" type="text" value="N/A" name="attr_name" placeholder="Spell Name"><br>Name</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">
+					  <select title="@{repeating_lvl-9-spells_X_spellclass}" name="attr_spellclass">
+						<option value="" selected>N/A</option>
+                                    <option value="@{spellclass-0-name}">Class 0</option>
+                                    <option value="@{spellclass-1-name}">Class 1</option>
+                                    <option value="@{spellclass-2-name}">Class 2</option>
+                                </select>
+					  <br>Class
+				    </span>
+				    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_lvl-9-spells_X_spell_level}" type="number" value="9" name="attr_spell_level" disabled><br>Level</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_school}" type="text" value="N/A" name="attr_school" placeholder="Spell School [descriptor]"><br>School</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_cast-time}" type="text" value="N/A" name="attr_cast-time" placeholder="Casting Time"><br>Casting Time</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_DC-mod}" type="number" value="0" name="attr_DC-mod" placeholder="DC Mod"> <br>DC Mod</span>
                         </div>
                         <div class="sheet-table">
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+				    <span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_components}" type="text" value="N/A" name="attr_components" placeholder="Components"><br>Components</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_range}" type="text" value="N/A" name="attr_range" placeholder="Range"><br>Range</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_targets}" type="text" value="N/A" name="attr_targets" placeholder="Targets/Area"><br>Targets/Area</span>
@@ -7276,7 +7933,7 @@
                             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{repeating_lvl-9-spells_X_save}" type="text" value="N/A" name="attr_save" placeholder="Save Effect"><br>Save Effect</span>
                             <span class="sheet-table-data sheet-center sheet-small-label">
                                 <select title="@{repeating_lvl-9-spells_X_sr}" name="attr_sr">
-                                    <option value="" selected>Select SR</option>
+                                    <option value="" selected>N/A</option>
                                     <option value="Yes">Yes</option>
                                     <option value="No">No</option>
                                     <option value="Yes (Harmless)">Yes (Harmless)</option>
@@ -7288,11 +7945,53 @@
                         <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-desc-show" title="@{repeating_lvl-9-spells_X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
                         <textarea class="sheet-desc" title="@{repeating_lvl-9-spells_X_description}" name="attr_description"></textarea>
-                        <br>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_lvl-9-spells_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
-                        <textarea class="sheet-macro-text" title="@{repeating_lvl-9-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{school=@{school}}} {{level=@{spellclass-0-name} [[ @{spellclass-0-level-total} ]]}} {{casting_time=@{cast-time}}} {{components=@{components}}} {{range=@{range}}} {{target=@{targets}}} {{duration=@{duration}}} {{saving_throw=@{save}}} {{dc=[[ @{spellclass-0-level-9-savedc} + [[ @{DC-mod} ]] ]]}} {{sr=@{sr}}} {{spell_description=@{description}}}</textarea>
-                        <hr>
+				<textarea class="sheet-macro-text" title="@{repeating_lvl-9-spells_X_macro-text}" name="attr_macro-text">&{template:pf_spell} {{name=@{name}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} @{spell_options}</textarea>
+				<br>
+                        <b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+                        <input type="checkbox" class="sheet-options-show" title="@{repeating_lvl-9-spells_X_options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>				
+				<input type="hidden" name="attr_var_level_notes" value="{{level=@{spellclass} @{spell_level}}}"/>
+				<input type="hidden" name="attr_var_school_notes" value="{{school=@{school}}}"/>
+				<input type="hidden" name="attr_var_casting_time_notes" value="{{casting_time=@{cast-time}}}"/>
+				<input type="hidden" name="attr_var_dc_notes" value="{{dc=[[ @{spellclass-0-level-9-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc1_notes" value="{{dc1=[[ @{spellclass-1-level-9-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_dc2_notes" value="{{dc2=[[ @{spellclass-2-level-9-savedc} + [[ @{DC-mod} ]] ]]}}"/>
+				<input type="hidden" name="attr_var_components_notes" value="{{components=@{components}}}"/>
+				<input type="hidden" name="attr_var_range_notes" value="{{range=@{range}}}"/>
+				<input type="hidden" name="attr_var_targets_notes" value="{{targets=@{targets}}}"/>
+				<input type="hidden" name="attr_var_duration_notes" value="{{duration=@{duration}}}"/>
+				<input type="hidden" name="attr_var_saving_throw_notes" value="{{saving_throw=@{save}}}"/>
+				<input type="hidden" name="attr_var_sr_notes" value="{{sr=@{sr}}}"/>
+				<input type="hidden" name="attr_var_description_notes" value="{{description=@{description}}}"/>
+				<div class="sheet-table sheet-options">
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these attributes with this spell roll?">Include info?</b></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_school_notes" value="@{var_school_notes}" title="@{repeating_lvl-9-spells_X_school_notes}" checked/><b title="Include School">School</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_level_notes" value="@{var_level_notes}" title="@{repeating_lvl-9-spells_X_level_notes}" checked/><b title="Include Class/Level">Level</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_casting_time_notes" value="@{var_casting_time_notes}" title="@{repeating_lvl-9-spells_X_casting_time_notes}" checked/><b title="Include Casting Time">Casting Time</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_components_notes" value="@{var_components_notes}" title="@{repeating_lvl-9-spells_X_components_notes}" checked/><b title="Include Components">Components</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_range_notes" value="@{var_range_notes}" title="@{repeating_lvl-9-spells_X_range_notes}" checked/><b title="Include Range">Range</b></label></span>
+					</div>
+					<div class="sheet-table-row sheet-table-header">
+						<span class="sheet-table-data sheet-center sheet-small-label" style="padding-left:10px;"><label><input type="checkbox" name="attr_toggle_targets_notes" value="@{var_targets_notes}" title="@{repeating_lvl-9-spells_X_targets_notes}" checked/><b title="Include Targets/Area">Target</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_duration_notes" value="@{var_duration_notes}" title="@{repeating_lvl-9-spells_X_duration_notes}" checked/><b title="Include Duration">Duration</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_saving_throw_notes" value="@{var_saving_throw_notes}" title="@{repeating_lvl-9-spells_X_saving_throw_notes}" checked/><b title="Include Saving Throw">Saving Throw</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><b style="float: left; padding-top:4px; padding-right:4px;" title="Include DC">DC</b>
+						<select name="attr_toggle_dc_notes" style="width:50%; float:left; height:1.85em; margin-bottom: 2px;">
+							<option name="attr_toggle_dc_notes" value="" title="Do not Include Difficulty Check" /><b>None</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc_notes}" title="Include Difficulty Check Spell Class 0" checked /><b>DC</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc1_notes}" title="Include Difficulty Check Spell Class 1" /><b>DC1</b>
+							<option name="attr_toggle_dc_notes" value="@{var_dc2_notes}" title="Include Difficulty Check Spell Class 2" /><b>DC2</b>
+						</select>
+						</label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_sr_notes" value="@{var_sr_notes}" title="@{repeating_lvl-9-spells_X_sr_notes}" checked/><b title="Include Spell Resistance">SR</b></label></span>
+						<span class="sheet-table-data sheet-center sheet-small-label"><label><input type="checkbox" name="attr_toggle_description_notes" value="@{var_description_notes}" title="@{repeating_lvl-9-spells_X_description_notes}" checked/><b title="Include Description">Description</b></label></span>
+					</div>
+				</div>
+				<input type="hidden" name="attr_spell_options" value="@{toggle_level_notes} @{toggle_school_notes} @{toggle_casting_time_notes} @{toggle_dc_notes} @{toggle_components_notes} @{toggle_range_notes} @{toggle_targets_notes} @{toggle_duration_notes} @{toggle_saving_throw_notes} @{toggle_sr_notes} @{toggle_description_notes}"/>				
+				<hr>				
                     </fieldset>
                 </div>
             </div>
@@ -7775,6 +8474,123 @@
                                 <span class="sheet-table-data sheet-center sheet-small-label" style="width:48%;"><input type="text" name="attr_notes" title="@{repeating_weapon_X_notes}" placeholder="Attack Notes"><br>Notes</span>
                             </div>
                         </div>
+				<b>Iterative Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+				<div class="sheet-table sheet-sect sheet-iterative_attack_section">
+					<span class="sheet-table-name">Iterative Attacks</span>
+					<div class="sheet-table-row">
+						<span class="sheet-table-header" style="width: 180px;">Include Attack?</span>
+						<span class="sheet-table-header">Attack Mod</span>
+						<span class="sheet-table-header">Macro</span>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack2" title="@{repeating_weapon_X_toggle_iterative_attack2}" value="@{var_iterative_attack2_macro}"/>
+	                            <b title="Include a second attack to your weapon?">Include a 2nd attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack2_value" title="@{repeating_weapon_X_iterative_attack2_value}" value="-5" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack2_macro" title="@{repeating_weapon_X_var_iterative_attack2_macro}" value="{{attack2=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack2_value} ]] ]] }} {{damage2=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm2=[[ 1d20 + [[ @{total-attack} + @{iterative_attack2_value} ]] ]] }} {{crit_damage2=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+		                </span>
+						<input type="hidden" name="attr_var_iterative_attack2" value="{{attack2=@{iterative_attack2_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack3" title="@{repeating_weapon_X_toggle_iterative_attack3}" value="@{var_iterative_attack3_macro}"/>
+	                            <b title="Include a third attack to your weapon?">Include a 3rd attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center sheet-small-label">
+							<input type="number" name="attr_iterative_attack3_value" title="@{repeating_weapon_X_iterative_attack3_value}" value="-10" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center sheet-small-label">
+                            <input type="text" name="attr_var_iterative_attack3_macro" title="@{repeating_weapon_X_var_iterative_attack3_macro}" value="{{attack3=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack3_value} ]] ]] }} {{damage3=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm3=[[ 1d20 + [[ @{total-attack} + @{iterative_attack3_value} ]] ]] }} {{crit_damage3=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+		                </span>
+						<input type="hidden" name="attr_var_iterative_attack3" value="{{attack3=@{iterative_attack3_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack4" title="@{repeating_weapon_X_toggle_iterative_attack4}" value="@{var_iterative_attack4_macro}"/>
+	                            <b title="Include a fourth attack to your weapon?">Include a 4th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack4_value" title="@{repeating_weapon_X_iterative_attack4_value}" value="-15" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack4_macro" title="@{repeating_weapon_X_var_iterative_attack4_macro}" value="{{attack4=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack4_value} ]] ]] }} {{damage4=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm4=[[ 1d20 + [[ @{total-attack} + @{iterative_attack4_value} ]] ]] }} {{crit_damage4=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack4" value="{{attack4=@{iterative_attack4_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack5" title="@{repeating_weapon_X_toggle_iterative_attack5}" value="@{var_iterative_attack5_macro}"/>
+	                            <b title="Include a fifth attack to your weapon?">Include a 5th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack5_value" title="@{repeating_weapon_X_iterative_attack5_value}" value="-20" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack5_macro" title="@{repeating_weapon_X_var_iterative_attack5_macro}" value="{{attack5=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack5_value} ]] ]] }} {{damage5=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm5=[[ 1d20 + [[ @{total-attack} + @{iterative_attack5_value} ]] ]] }} {{crit_damage5=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack5" value="{{attack5=@{iterative_attack5_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack6" title="@{repeating_weapon_X_toggle_iterative_attack6}" value="@{var_iterative_attack6_macro}"/>
+	                            <b title="Include a sixth attack to your weapon?">Include a 6th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack6_value" title="@{repeating_weapon_X_iterative_attack6_value}" value="-25" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack6_macro" title="@{repeating_weapon_X_var_iterative_attack6_macro}" value="{{attack6=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack6_value} ]] ]] }} {{damage6=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm6=[[ 1d20 + [[ @{total-attack} + @{iterative_attack6_value} ]] ]] }} {{crit_damage6=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack6" value="{{attack6=@{iterative_attack6_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack7" title="@{repeating_weapon_X_toggle_iterative_attack7}" value="@{var_iterative_attack7_macro}"/>
+	                            <b title="Include a seventh attack to your weapon?">Include a 7th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack7_value" title="@{repeating_weapon_X_iterative_attack7_value}" value="-30" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack7_macro" title="@{repeating_weapon_X_var_iterative_attack7_macro}" value="{{attack7=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack7_value} ]] ]] }} {{damage7=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]] }} {{crit_confirm7=[[ 1d20 + [[ @{total-attack} + @{iterative_attack7_value} ]] ]] }} {{crit_damage7=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]] }}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack7" value="{{attack7=@{iterative_attack7_macro}}}"/>
+					</div>
+					<div class="sheet-table-row">
+                        <span class="sheet-table-data sheet-center">
+                            <label>
+	                            <input type="checkbox" name="attr_toggle_iterative_attack8" title="@{repeating_weapon_X_toggle_iterative_attack8}" value="@{var_iterative_attack8_macro}"/>
+	                            <b title="Include an eighth attack to your weapon?">Include an 8th attack?</b>
+                            </label>
+                        </span>
+						<span class="sheet-table-data sheet-center">
+							<input type="number" name="attr_iterative_attack8_value" title="@{repeating_weapon_X_iterative_attack8_value}" value="-35" max="0"/>
+						</span>
+		                <span class="sheet-table-data sheet-center">
+                            <input type="text" name="attr_var_iterative_attack8_macro" title="@{repeating_weapon_X_var_iterative_attack8_macro}" value="{{attack8=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} + @{iterative_attack8_value} ]] ]]}} {{damage8=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm8=[[ 1d20 + [[ @{total-attack} + @{iterative_attack8_value} ]] ]]}} {{crit_damage8=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}}" />
+						</span>
+						<input type="hidden" name="attr_var_iterative_attack8" value="{{attack8=@{iterative_attack8_macro}}}"/>
+					</div>
+				</div>
+				<input type="hidden" name="attr_iterative_attacks" value="@{toggle_iterative_attack2} @{toggle_iterative_attack3} @{toggle_iterative_attack4} @{toggle_iterative_attack5} @{toggle_iterative_attack6} @{toggle_iterative_attack7} @{toggle_iterative_attack8}"/>
+				<br>
                         <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
                         <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
                         <textarea class="sheet-macro-text" title="@{repeating_weapon_X_macro-text}" name="attr_macro-text">/w gm &{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=@{name}}} {{attack=[[ 1d20cs>@{crit-target} + [[ @{total-attack} ]] ]]}} {{damage=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm=[[ 1d20 + [[ @{total-attack} ]] ]]}} {{crit_damage=[[ (@{damage-dice-num} * (@{crit-multiplier} - 1))d@{damage-die} + (@{total-damage} * (@{crit-multiplier} - 1)) ]]}} {{type=@{type}}} {{description=@{notes}}}</textarea>
@@ -8069,18 +8885,18 @@
         <input type="checkbox" class="sheet-sect-show" title="@{npc-statistics-show}" name="attr_npc-statistics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" checked/><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom"/>
         <div style="text-align:left;" class="sheet-sect">
-            <span class="sheet-table-data sheet-center"><input title="@{STR-base}" type="number" name="attr_STR-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-STR-Check}" type="roll" name="roll_NPC-STR-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Strength}} {{Check=[[ 1d20 + [[ @{STR-mod} + @{condition-drained} - @{condition-Wounds} - [[ @{condition-fatigued} ]] ]]  ]]}}">Str</button></span>
-            <span class="sheet-table-data sheet-center"><input title="@{DEX-base}" type="number" name="attr_DEX-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-DEX-Check}" type="roll" name="roll_NPC-DEX-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Dexterity}} {{Check=[[ 1d20 + [[ @{DEX-mod} + @{condition-drained} - @{condition-Wounds} - [[ @{condition-entangled} ]] - [[ @{condition-grappled} ]] - [[ @{condition-fatigued} ]] ]]  ]]}}">Dex</button></span>
-            <span class="sheet-table-data sheet-center"><input title="@{CON-base}" type="number" name="attr_CON-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CON-Check}" type="roll" name="roll_NPC-CON-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Constitution}} {{Check=[[ 1d20 + [[ @{CON-mod} + @{condition-drained} - @{condition-Wounds} ]]  ]]}}">Con</button></span>
-            <span class="sheet-table-data sheet-center"><input title="@{INT-base}" type="number" name="attr_INT-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-INT-Check}" type="roll" name="roll_NPC-INT-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intellegence}} {{Check=[[ 1d20 + [[ @{INT-mod} + @{condition-drained} - @{condition-Wounds} ]]  ]]}}">Int</button></span>
-            <span class="sheet-table-data sheet-center"><input title="@{WIS-base}" type="number" name="attr_WIS-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-WIS-Check}" type="roll" name="roll_NPC-WIS-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Wisdom}} {{Check=[[ 1d20 + [[ @{WIS-mod} + @{condition-drained} - @{condition-Wounds} ]]  ]]}}">Wis</button></span>
-            <span class="sheet-table-data sheet-center"><input title="@{CHA-base}" type="number" name="attr_CHA-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CHA-Check}" type="roll" name="roll_NPC-CHA-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Charisma}} {{Check=[[ 1d20 + [[ @{CHA-mod} + @{condition-drained} - @{condition-Wounds} ]]  ]]}}">Cha</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{STR-base}" type="number" name="attr_STR-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-STR-Check}" type="roll" name="roll_NPC-STR-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Strength}} {{Check=[[ 1d20 + [[ @{STR-mod} + @{condition-drained} - @{condition-Wounds} - [[ @{condition-fatigued} ]] ]] ]]}}">Str</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{DEX-base}" type="number" name="attr_DEX-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-DEX-Check}" type="roll" name="roll_NPC-DEX-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Dexterity}} {{Check=[[ 1d20 + [[ @{DEX-mod} + @{condition-drained} - @{condition-Wounds} - [[ @{condition-entangled} ]] - [[ @{condition-grappled} ]] - [[ @{condition-fatigued} ]] ]] ]]}}">Dex</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{CON-base}" type="number" name="attr_CON-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CON-Check}" type="roll" name="roll_NPC-CON-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Constitution}} {{Check=[[ 1d20 + [[ @{CON-mod} + @{condition-drained} - @{condition-Wounds} ]] ]]}}">Con</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{INT-base}" type="number" name="attr_INT-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-INT-Check}" type="roll" name="roll_NPC-INT-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Intellegence}} {{Check=[[ 1d20 + [[ @{INT-mod} + @{condition-drained} - @{condition-Wounds} ]] ]]}}">Int</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{WIS-base}" type="number" name="attr_WIS-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-WIS-Check}" type="roll" name="roll_NPC-WIS-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Wisdom}} {{Check=[[ 1d20 + [[ @{WIS-mod} + @{condition-drained} - @{condition-Wounds} ]] ]]}}">Wis</button></span>
+            <span class="sheet-table-data sheet-center"><input title="@{CHA-base}" type="number" name="attr_CHA-base" value="10"><br><button style="font-size:100%;" title="%{selected|NPC-CHA-Check}" type="roll" name="roll_NPC-CHA-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Charisma}} {{Check=[[ 1d20 + [[ @{CHA-mod} + @{condition-drained} - @{condition-Wounds} ]] ]]}}">Cha</button></span>
             <br>
             <div class="sheet-table">
                 <div class="sheet-table-row">
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{class-0-bab}" type="number" name="attr_class-0-bab" value="0"><br>BAB</span>
                     <span class="sheet-table-data sheet-center" ><b>&nbsp;</b></span>
-                    <span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled><br><button style="font-size:100%;" type="roll" title="NPC-CMB-Check" name="roll_NPC-CMB-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]]  ]]}}">CMB</button></span>
+                    <span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="(@{bab} + @{attk-CMB-ability} + @{attk-CMB-size} + @{attk-CMB-misc} + @{attk-CMB-temp} - @{condition-dazzled} - @{condition-entangled} - @{condition-grappled} - @{condition-fear} - @{condition-sickened} + @{condition-invisible} + @{condition-drained} - @{condition-Wounds})" disabled><br><button style="font-size:100%;" type="roll" title="NPC-CMB-Check" name="roll_NPC-CMB-Check" value="/w gm &{template:pf_generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]] ]]}}">CMB</button></span>
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0"><br>Misc</span>
                     <span class="sheet-table-data sheet-center" ><b>&nbsp;</b></span>
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{CMD}" type="number" name="attr_CMD" value="(10 + @{bab} + @{STR-mod} + @{DEX-mod} + @{CMD-size} + @{AC-dodge} + @{AC-deflect} + @{CMD-misc} + @{CMD-temp} + @{AC-penalty} + @{condition-drained})" disabled><br>CMD</span>
@@ -8470,11 +9286,11 @@
     <br>
 </div>
 <div style="text-align:center;">
-    Sheet created by Samuel Marino for Roll20.net, Maintained by Vince, Samuel Terrazas and Nibrodooh | Last updated: <i>2015.06.04</i>
+    Sheet created by Samuel Marino for Roll20.net, Maintained by Vince, Samuel Terrazas and Nibrodooh | Last updated: <i>2015.06.21</i>
     <br>
     Have questions or feedback? <a href="https://app.roll20.net/forum/post/1915585/pathfinder-sheet-thread-4-life-after-sam" target="_blank">This thread can help: https://app.roll20.net/forum/post/1915585/pathfinder-sheet-thread-4-life-after-sam</a>
 </div>
-
+<div class="sheet-section sheet-section-roll_templates">
 <!-- Roll Templates -->
 <!-- Spell Roll Templates -->
 <rolltemplate class="sheet-rolltemplate-pf_spell">
@@ -8490,14 +9306,23 @@
             {{^name_link}}{{name}}{{/name_link}}
             {{/name}}
         </td></tr>
-
-        {{#school}}<tr><td colspan="2"><span class="sheet-tcat">School</span> {{school}}; {{#level}}<span class="tcat">Level</span> {{level}}{{/level}}</td></tr>{{/school}}
+       <tr>
+	  <td colspan="2">
+	  {{#school}}<span class="sheet-tcat">School</span> {{school}};{{/school}}<br>
+	  {{#level}}<span class="sheet-tcat">Level</span> {{level}}{{/level}}
+	  </td>
+	  </tr>
         {{#casting_time}}<tr><td colspan="2"><span class="sheet-tcat">Casting Time</span> {{casting_time}}</td></tr>{{/casting_time}}
         {{#components}}<tr><td colspan="2"><span class="sheet-tcat">Components</span> {{components}}</td></tr>{{/components}}
         {{#range}}<tr><td colspan="2"><span class="sheet-tcat">Range</span> {{range}}</td></tr>{{/range}}
         {{#target}}<tr><td colspan="2"><span class="sheet-tcat">Effects/Target</span> {{target}}</td></tr>{{/target}}
         {{#duration}}<tr><td colspan="2"><span class="sheet-tcat">Duration</span> {{duration}}</td></tr>{{/duration}}
-        {{#saving_throw}}<tr><td colspan="2"><span class="sheet-tcat">Saving Throw</span> {{saving_throw}} {{#dc}}**DC** {{dc}}{{/dc}}</td></tr>{{/saving_throw}}
+	  <tr><td colspan="2">
+	  {{#saving_throw}}<span class="sheet-tcat">Saving Throw</span> {{saving_throw}}{{/saving_throw}}
+	  {{#dc}}<span class="sheet-tcat" title="DC Spell Class 0"> DC</span>{{dc}}{{/dc}}
+	  {{#dc1}}<span class="sheet-tcat" title="DC Spell Class 1"> DC</span>{{dc1}}{{/dc1}}
+	  {{#dc2}}<span class="sheet-tcat" title="DC Spell Class 2"> DC</span>{{dc2}}{{/dc2}}
+	  </td></tr>
         {{#sr}}<tr><td colspan="2"><span class="sheet-tcat">Spell Resistance</span> {{sr}}</td></tr>{{/sr}}
 
         {{#attack}}
@@ -8539,17 +9364,224 @@
         {{/crit_damage2}}
         {{/attack2}}
 
-        {{#allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
+        {{#allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc dc1 dc2 sr description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
         <tr><td colspan="2"><b>{{key}}</b> {{value}}</td></tr>
-        {{/allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc sr spell_description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
-        {{#spell_description}}<tr><td colspan="2">{{spell_description}}</td></tr>{{/spell_description}}
+        {{/allprops() character_name character_id name_link school level casting_time components range target duration saving_throw dc dc1 dc2 sr description attack damage crit_confirm crit_damage attack2 damage2 crit_confirm2 crit_damage2}}
+        
+	  {{#description}}<tr><td colspan="2">{{description}}</td></tr>{{/description}}
     </table>
 </rolltemplate>
 
 <!-- Attack Roll Templates -->
 <rolltemplate class="sheet-rolltemplate-pf_attack">
+	<table>
+		<tr><td colspan="2" class="sheet-header">
+			{{#character_name}}
+			{{#character_id}}[{{character_name}}](http://journal.roll20.net/character/{{character_id}}){{/character_id}}
+			{{^character_id}}{{character_name}}{{/character_id}}
+			{{#name}}:{{/name}}
+			{{/character_name}}
+			{{#name}}
+			{{#name_link}}[{{name}}]({{name_link}}){{/name_link}}
+			{{^name_link}}{{name}}{{/name_link}}
+			{{/name}}
+		</td></tr>
+		
+		{{#attack}}
+		<tr><td>Attack</td><td>{{attack}}</td></tr>
+		{{#crit_confirm}}
+		{{#rollWasCrit() attack}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm}}</td></tr>
+		{{/rollWasCrit() attack}}
+		{{/crit_confirm}}
+		{{#damage}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage}}</td></tr>
+		{{/damage}}
+		{{#crit_damage}}
+		{{#rollWasCrit() attack}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage}}</td></tr>
+		{{/rollWasCrit() attack}}
+		{{/crit_damage}}
+		{{/attack}}
+		{{^attack}}
+		{{#damage}}
+		<tr><td>Damage</td><td>{{damage}}</td></tr>
+		{{/damage}}
+		{{/attack}}
+		
+		{{#attack2}}
+		<tr><td>Attack 2</td><td>{{attack2}}</td></tr>
+		{{#crit_confirm2}}
+		{{#rollWasCrit() attack2}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm2}}</td></tr>
+		{{/rollWasCrit() attack2}}
+		{{/crit_confirm2}}
+		{{#damage2}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage2}}</td></tr>
+		{{/damage2}}
+		{{#crit_damage2}}
+		{{#rollWasCrit() attack2}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage2}}</td></tr>
+		{{/rollWasCrit() attack2}}
+		{{/crit_damage2}}
+		{{/attack2}}
+		{{^attack2}}
+		{{#damage2}}
+		<tr><td>Damage</td><td>{{damage2}}</td></tr>
+		{{/damage2}}
+		{{/attack2}}
+		
+		{{#attack3}}
+		<tr><td>Attack 3</td><td>{{attack3}}</td></tr>
+		{{#crit_confirm3}}
+		{{#rollWasCrit() attack3}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm3}}</td></tr>
+		{{/rollWasCrit() attack3}}
+		{{/crit_confirm3}}
+		{{#damage3}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage3}}</td></tr>
+		{{/damage3}}
+		{{#crit_damage3}}
+		{{#rollWasCrit() attack3}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage3}}</td></tr>
+		{{/rollWasCrit() attack3}}
+		{{/crit_damage3}}
+		{{/attack3}}
+		{{^attack3}}
+		{{#damage3}}
+		<tr><td>Damage</td><td>{{damage3}}</td></tr>
+		{{/damage3}}
+		{{/attack3}}
+		
+		{{#attack4}}
+		<tr><td>Attack 4</td><td>{{attack4}}</td></tr>
+		{{#crit_confirm4}}
+		{{#rollWasCrit() attack4}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm4}}</td></tr>
+		{{/rollWasCrit() attack4}}
+		{{/crit_confirm4}}
+		{{#damage4}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage4}}</td></tr>
+		{{/damage4}}
+		{{#crit_damage4}}
+		{{#rollWasCrit() attack4}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage4}}</td></tr>
+		{{/rollWasCrit() attack4}}
+		{{/crit_damage4}}
+		{{/attack4}}
+		{{^attack4}}
+		{{#damage4}}
+		<tr><td>Damage</td><td>{{damage4}}</td></tr>
+		{{/damage4}}
+		{{/attack4}}
+		
+		{{#attack5}}
+		<tr><td>Attack 5</td><td>{{attack5}}</td></tr>
+		{{#crit_confirm5}}
+		{{#rollWasCrit() attack5}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm5}}</td></tr>
+		{{/rollWasCrit() attack5}}
+		{{/crit_confirm5}}
+		{{#damage5}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage5}}</td></tr>
+		{{/damage5}}
+		{{#crit_damage5}}
+		{{#rollWasCrit() attack5}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage5}}</td></tr>
+		{{/rollWasCrit() attack5}}
+		{{/crit_damage5}}
+		{{/attack5}}
+		{{^attack5}}
+		{{#damage5}}
+		<tr><td>Damage</td><td>{{damage5}}</td></tr>
+		{{/damage5}}
+		{{/attack5}}
+		
+		{{#attack6}}
+		<tr><td>Attack 6</td><td>{{attack6}}</td></tr>
+		{{#crit_confirm6}}
+		{{#rollWasCrit() attack6}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm6}}</td></tr>
+		{{/rollWasCrit() attack6}}
+		{{/crit_confirm6}}
+		{{#damage6}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage6}}</td></tr>
+		{{/damage6}}
+		{{#crit_damage6}}
+		{{#rollWasCrit() attack6}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage6}}</td></tr>
+		{{/rollWasCrit() attack6}}
+		{{/crit_damage6}}
+		{{/attack6}}
+		{{^attack6}}
+		{{#damage6}}
+		<tr><td>Damage</td><td>{{damage6}}</td></tr>
+		{{/damage6}}
+		{{/attack6}}
+		
+		{{#attack7}}
+		<tr><td>Attack 7</td><td>{{attack7}}</td></tr>
+		{{#crit_confirm7}}
+		{{#rollWasCrit() attack7}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm7}}</td></tr>
+		{{/rollWasCrit() attack7}}
+		{{/crit_confirm7}}
+		{{#damage7}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage7}}</td></tr>
+		{{/damage7}}
+		{{#crit_damage7}}
+		{{#rollWasCrit() attack7}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage7}}</td></tr>
+		{{/rollWasCrit() attack7}}
+		{{/crit_damage7}}
+		{{/attack7}}
+		{{^attack7}}
+		{{#damage7}}
+		<tr><td>Damage</td><td>{{damage7}}</td></tr>
+		{{/damage7}}
+		{{/attack7}}
+		
+		{{#attack8}}
+		<tr><td>Attack 8</td><td>{{attack8}}</td></tr>
+		{{#crit_confirm8}}
+		{{#rollWasCrit() attack8}}
+		<tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm8}}</td></tr>
+		{{/rollWasCrit() attack8}}
+		{{/crit_confirm8}}
+		{{#damage8}}
+		<tr><td style="text-indent:0.5em">Damage</td><td>{{damage8}}</td></tr>
+		{{/damage8}}
+		{{#crit_damage8}}
+		{{#rollWasCrit() attack8}}
+		<tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage8}}</td></tr>
+		{{/rollWasCrit() attack8}}
+		{{/crit_damage8}}
+		{{/attack8}}
+		{{^attack8}}
+		{{#damage8}}
+		<tr><td>Damage</td><td>{{damage8}}</td></tr>
+		{{/damage8}}
+		{{/attack8}}
+		
+		{{#melee_notes}}<tr><td colspan="2">Melee Notes: <span style="font-weight:normal; font-size:13px;">{{melee_notes}}</span></td></tr>{{/melee_notes}}
+		{{#ranged_notes}}<tr><td colspan="2">Ranged Notes: <span style="font-weight:normal; font-size:13px;">{{ranged_notes}}</span></td></tr>{{/ranged_notes}}
+		{{#CMB_notes}}<tr><td colspan="2">CMB Notes: <span style="font-weight:normal; font-size:13px;">{{CMB_notes}}</span></td></tr>{{/CMB_notes}}
+		{{#attack_notes}}<tr><td colspan="2">Attack Notes: <span style="font-weight:normal; font-size:13px;">{{attack_notes}}</span></td></tr>{{/attack_notes}}
+		
+		{{#allprops() character_name character_id name_link attack damage crit_confirm crit_damage description attack2 damage2 crit_confirm2 crit_damage2 attack3 damage3 crit_confirm3 crit_damage3 attack4 damage4 crit_confirm4 crit_damage4 attack5 damage5 crit_confirm5 crit_damage5 attack6 damage6 crit_confirm6 crit_damage6 attack7 damage7 crit_confirm7 crit_damage7 attack8 damage8 crit_confirm8 crit_damage8 melee_notes ranged_notes CMB_notes attack_notes}}
+		<tr><td>{{key}}</td><td>{{value}}</td></tr>
+		{{/allprops() character_name character_id name_link attack damage crit_confirm crit_damage description attack2 damage2 crit_confirm2 crit_damage2 attack3 damage3 crit_confirm3 crit_damage3 attack4 damage4 crit_confirm4 crit_damage4 attack5 damage5 crit_confirm5 crit_damage5 attack6 damage6 crit_confirm6 crit_damage6 attack7 damage7 crit_confirm7 crit_damage7 attack8 damage8 crit_confirm8 crit_damage8 melee_notes ranged_notes CMB_notes attack_notes}}
+		
+		{{#description}}
+		<tr><td colspan="2" style="font-weight:normal; text-align: center"><p>{{description}}</p></td></tr>
+		{{/description}}
+	</table>
+</rolltemplate>
+
+<!-- Defense Roll Templates -->
+<rolltemplate class="sheet-rolltemplate-pf_defense">
     <table>
-        <tr><td colspan="2" class="sheet-header">
+		<tr><td colspan="2" class="sheet-header">
             {{#character_name}}
             {{#character_id}}[{{character_name}}](http://journal.roll20.net/character/{{character_id}}){{/character_id}}
             {{^character_id}}{{character_name}}{{/character_id}}
@@ -8559,68 +9591,21 @@
             {{#name_link}}[{{name}}]({{name_link}}){{/name_link}}
             {{^name_link}}{{name}}{{/name_link}}
             {{/name}}
-        </td></tr>
-
-        {{#attack}}
-        <tr><td>Attack</td><td>{{attack}}</td></tr>
-        {{#crit_confirm}}
-        {{#rollWasCrit() attack}}
-        <tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm}}</td></tr>
-        {{/rollWasCrit() attack}}
-        {{/crit_confirm}}
-        {{#damage}}
-        <tr><td style="text-indent:0.5em">Damage</td><td>{{damage}}</td></tr>
-        {{/damage}}
-        {{#crit_damage}}
-        {{#rollWasCrit() attack}}
-        <tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage}}</td></tr>
-        {{/rollWasCrit() attack}}
-        {{/crit_damage}}
-        {{/attack}}
-        {{^attack}}
-        {{#damage}}
-        <tr><td>Damage</td><td>{{damage}}</td></tr>
-        {{/damage}}
-        {{/attack}}
-
-        {{#attack2}}
-        <tr><td>Attack 2</td><td>{{attack2}}</td></tr>
-        {{#crit_confirm2}}
-        {{#rollWasCrit() attack2}}
-        <tr><td style="text-indent:0.5em">Crit Confirm</td><td>{{crit_confirm2}}</td></tr>
-        {{/rollWasCrit() attack2}}
-        {{/crit_confirm2}}
-        {{#damage2}}
-        <tr><td style="text-indent:0.5em">Damage</td><td>{{damage2}}</td></tr>
-        {{/damage2}}
-        {{#crit_damage2}}
-        {{#rollWasCrit() attack2}}
-        <tr><td style="text-indent:0.5em">Crit Damage</td><td><b>+</b>{{crit_damage2}}</td></tr>
-        {{/rollWasCrit() attack2}}
-        {{/crit_damage2}}
-        {{/attack2}}
-
-        {{#melee_notes}}
-        <tr><td colspan="2">Melee Notes: <span style="font-weight:normal; font-size:13px;">{{melee_notes}}</span></td></tr>
-        {{/melee_notes}}
-        {{#ranged_notes}}
-        <tr><td colspan="2">Ranged Notes: <span style="font-weight:normal; font-size:13px;">{{ranged_notes}}</span></td></tr>
-        {{/ranged_notes}}
-        {{#CMB_notes}}
-        <tr><td colspan="2">CMB Notes: <span style="font-weight:normal; font-size:13px;">{{CMB_notes}}</span></td></tr>
-        {{/CMB_notes}}
-        {{#attack_notes}}
-        <tr><td colspan="2">Attack Notes: <span style="font-weight:normal; font-size:13px;">{{attack_notes}}</span></td></tr>
-        {{/attack_notes}}
-
-        {{#allprops() character_name character_id name_link attack damage crit_confirm crit_damage description attack2 damage2 crit_confirm2 crit_damage2 melee_notes ranged_notes CMB_notes attack_notes}}
-        <tr><td>{{key}}</td><td>{{value}}</td></tr>
-        {{/allprops() character_name character_id name_link attack damage crit_confirm crit_damage description attack2 damage2 crit_confirm2 crit_damage2 melee_notes ranged_notes CMB_notes attack_notes}}
-
-        {{#description}}
-        <tr><td colspan="2" style="font-weight:normal; text-align: center"><p>{{description}}</p></td></tr>
-        {{/description}}
-    </table>
+		</td></tr>
+		{{#allprops() character_name character_id name_link dr_notes resistances_notes immunities_notes weaknesses_notes sr_notes armor_notes save_notes cmd_notes defense_notes}}
+		<tr><td>{{key}}</td><td>{{value}}</td></tr>
+		{{/allprops() character_name character_id name_link dr_notes resistances_notes immunities_notes weaknesses_notes sr_notes armor_notes save_notes cmd_notes defense_notes}}
+		
+		{{#dr_notes}}<tr><td>DR:</td><td>{{dr_notes}}</td></tr>{{/dr_notes}}
+		{{#resistances_notes}}<tr><td>Resistances:</td><td>{{resistances_notes}}</td></tr>{{/resistances_notes}}
+		{{#immunities_notes}}<tr><td>Immunities:</td><td>{{immunities_notes}}</td></tr>{{/immunities_notes}}
+		{{#weaknesses_notes}}<tr><td>Weaknesses:</td><td>{{weaknesses_notes}}</td></tr>{{/weaknesses_notes}}
+		{{#sr_notes}}<tr><td>SR:</td><td>{{sr_notes}}</td></tr>{{/sr_notes}}
+		{{#armor_notes}}<tr><td colspan="2">Armor Notes: <span style="font-weight:normal; font-size:13px;">{{armor_notes}}</span></td></tr>{{/armor_notes}}
+		{{#save_notes}}<tr><td colspan="2">Save Notes: <span style="font-weight:normal; font-size:13px;">{{save_notes}}</span></td></tr>{{/save_notes}}
+		{{#cmd_notes}}<tr><td colspan="2">CMD Notes: <span style="font-weight:normal; font-size:13px;">{{cmd_notes}}</span></td></tr>{{/cmd_notes}}
+		{{#defense_notes}}<tr><td colspan="2">Defense Notes: <span style="font-weight:normal; font-size:13px;">{{defense_notes}}</span></td></tr>{{/defense_notes}}
+	</table>
 </rolltemplate>
 
 <!-- Generic Roll Templates -->
@@ -8639,7 +9624,8 @@
         </td></tr>
         {{#allprops() character_name character_id name_link}}
         <tr><td>{{key}}</td><td>{{value}}</td></tr>
-        {{/allprops() character_name character_id name_link}}
+	  {{/allprops() character_name character_id name_link}}
+	  
     </table>
 </rolltemplate>
 
@@ -8662,3 +9648,4 @@
         {{/allprops() character_name character_id name_link}}
     </table>
 </rolltemplate>
+</div>


### PR DESCRIPTION
- added toggles for Saving Throws to include DR, Resistances, Immunities, Weaknesses, SR,
Armor notes, Save Notes, CMD Notes, Defense Notes.
-   added toggles for all Spell attributes (repeating items only for now) will add global toggles for Spell button bar
-   placed all toggles in an Options[hide/show] directly under their applicable section.
-   added iterative attacks to the NPC section.  NPC attacks are linked to the Attacks tab, so if you want NPC attacks whispered, you need to add "/w gm" at the beginning of the macro text.
Might add a toggle to whisper all attacks which would be good for NPC's.
-  added CMB as an attack-type option. 
-  added spellclass selector (attr_spellclass) to spells to show the proper spellclass of the spell in output. This was previously showing spellclass-0 only.
-  added (attr_spell_level) to show proper spell's level in output. This was previously showing the caster's level.    
-     added toggle option for DC spell class 0,1,2 (repeating items only for now...)