### PR TITLE
Updating Kobolds Ate My Baby HTML and sheet.json

### DIFF
--- a/Kobolds Ate My Baby/Kobolds Ate My Baby.html
+++ b/Kobolds Ate My Baby/Kobolds Ate My Baby.html
@@ -238,7 +238,7 @@
 </div>
 <!-- Information Footer -->
 <div class="sheet-col sheet-grey">
-    <span class="sheet-inverted">WWW.KOBOLDSATEMYBABY.COM - &copy; 2005 - 9TH LEVEL GAMES - ART BY JOHN KOVALIC - ( Sheet Version 0.1 )</span>
+    <span class="sheet-inverted">WWW.KOBOLDSATEMYBABY.COM - &copy; 2005 - 9TH LEVEL GAMES - ART BY JOHN KOVALIC - ( Sheet Version 0.2 )</span>
 </div>
 <div class="sheet-col sheet-grey">
     <span class="sheet-inverted">Additional Information on the Roll20 Wiki: </span><button class="sheet-KAMBroll" type="roll" value="&{template:KAMB} {{name=Wiki Information }} {{subheader=at the Following Link }} {{Link:= [Kobolds Ate My Baby Wiki](https://wiki.roll20.net/Kobolds_Ate_My_Baby_Character_Sheet)}} }}" name="roll_Wiki"  /> Wiki Link</button>

--- a/Kobolds Ate My Baby/Kobolds Ate My Baby.html
+++ b/Kobolds Ate My Baby/Kobolds Ate My Baby.html
@@ -240,6 +240,9 @@
 <div class="sheet-col sheet-grey">
     <span class="sheet-inverted">WWW.KOBOLDSATEMYBABY.COM - &copy; 2005 - 9TH LEVEL GAMES - ART BY JOHN KOVALIC - ( Sheet Version 0.1 )</span>
 </div>
+<div class="sheet-col sheet-grey">
+    <span class="sheet-inverted">Additional Information on the Roll20 Wiki: </span><button class="sheet-KAMBroll" type="roll" value="&{template:KAMB} {{name=Wiki Information }} {{subheader=at the Following Link }} {{Link:= [Kobolds Ate My Baby Wiki](https://wiki.roll20.net/Kobolds_Ate_My_Baby_Character_Sheet)}} }}" name="roll_Wiki"  /> Wiki Link</button>
+</div>
 
 <!-- KAMB Rolltemplate -->
 <rolltemplate class="sheet-rolltemplate-KAMB">

--- a/Kobolds Ate My Baby/sheet.json
+++ b/Kobolds Ate My Baby/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Wesley L. (Wes on Roll20.net)",
 	"roll20userid": "405463",
 	"preview": "Kobolds_Ate_My_Baby.png",
-	"instructions": "**Super Deluxx Edition**\r\r As Decreed by King Torg&trade; *(All Hail King Torg!)* there is now a character sheet for Kobolds Ate My Baby!\r\rComplete with Kobold Horrible Death Record&trade; and Lots of Random Tables!!"
+	"instructions": "**Super Deluxx Edition**\r\r As Decreed by King Torg&trade; *(All Hail King Torg!)* there is now a character sheet for Kobolds Ate My Baby!\r\rComplete with Kobold Horrible Death Record&trade; and Lots of Random Tables!!\r\rMore information on the Roll20 Wiki: https://wiki.roll20.net/Kobolds_Ate_My_Baby_Character_Sheet\r\rVersion 0.2"
 }


### PR DESCRIPTION
Added Link to Roll20 Wiki Kobolds Ate My Baby Character Sheet wiki page and changed Version Number in HTML.
Updated sheet.json to Include Link to Kobolds Ate My Baby Character Sheet Wiki page on Roll20 wiki and show sheet version number in the Character Sheet Description.