### PR TITLE
Updated HTML and CSS

### DIFF
--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -4,7 +4,7 @@
 .charsheet .sheet-wrapper table, .charsheet .sheet-wrapper caption, .charsheet .sheet-wrapper tbody, .charsheet .sheet-wrapper tfoot, .charsheet .sheet-wrapper thead, .charsheet .sheet-wrapper tr, .charsheet .sheet-wrapper th, .charsheet .sheet-wrapper td {
     margin: 0;
     padding: 0;
-	border: 0;
+    border: 0;
 	font-size: 100%;
 	font: inherit;
 	color: #404040;
@@ -445,11 +445,11 @@
 }
 
 .charsheet .sheet-wrapper .sheet-power-card input[type="radio"] {
-	width: 28px;
+	width: 20px;
 	display: inline-block;
 }
 .charsheet .sheet-wrapper .sheet-power-card input[type="radio"] + label{
-	width: 25%;
+	width: 19%;
 	display: inline-block;
 }
 
@@ -461,6 +461,9 @@
 }
 .sheet-colgrey:checked ~ .sheet-headcolor {
     background-color: gray;
+}
+.sheet-colorange:checked ~ .sheet-headcolor {
+    background-color: orange;
 }
 
 .charsheet .sheet-wrapper .sheet-headcolor {
@@ -655,4 +658,125 @@
 
 .charsheet .sheet-wrapper input[type="checkbox"].sheet-power-card-toggle:checked + label{
     background-color: #333;
+}
+
+/* Power Roll Template */
+.sheet-rolltemplate-dnd4epower table {
+    width: 98%;
+    padding: 2px;
+    border: 1px solid;
+    background-color: #ffffff;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-emote {
+    color: #000000;
+    padding-left: 5px;
+    padding-bottom: 5px;
+    line-height: 1em;
+	font-size: 1em;
+    font-style: italic;
+    text-align: left;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-power-header {
+	color: #ffffff;
+    padding-left: 5px;
+	line-height: 1.6em;
+	font-size: 1.2em;
+    text-align: left;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-atwill {
+    background-color: #3a7042;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-encounter {
+    background-color: #7d0824;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-daily {
+    background-color: #333333;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-item {
+    background-color: #E6B800;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-other {
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-ability {
+    background-color: #483D8B;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-skill {
+    background-color: #3A5ECA;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-monster {
+	background-color: -webkit-linear-gradient(left, darkgreen , chartreuse); /* For Safari 5.1 to 6.0 */
+    background-color: -o-linear-gradient(right, darkgreen, chartreuse); /* For Opera 11.1 to 12.0 */
+    background-color: -moz-linear-gradient(right, darkgreen, chartreuse); /* For Firefox 3.6 to 15 */
+    background-color: linear-gradient(to right, darkgreen , chartreuse); /* Standard syntax (must be last) */
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-subheader-alignright {
+    color: #ffffff;
+    padding-left: 5px;
+	line-height: 1em;
+	font-size: 1em;
+    text-align: right;
+}
+
+/* Odd Row Background (Hex Value #D9D1C7) */
+.sheet-rolltemplate-dnd4epower tr:nth-of-type(odd) {
+    background: -webkit-linear-gradient(left,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Safari 5.1-6*/
+    background: -o-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Opera 11.1-12*/
+    background: -moz-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Fx 3.6-15*/
+    background: linear-gradient(to right, rgba(217, 209, 199,1), rgba(217, 209, 199,0.25)); /*Standard*/
+}
+
+
+.sheet-rolltemplate-dnd4epower td {
+    color: #000000;
+    padding-left: 5px;
+	line-height: 1em;
+	font-size: 1em;
+    text-align: left;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-td-critical {
+    color: #3FB315;
+    line-height: 1.1em;
+    font-size: 1.1em;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-td-red {
+    color: #B31515;
+}
+
+.sheet-rolltemplate-dnd4epower .sheet-template-bold {
+    font-weight: bold;
+}
+
+.sheet-rolltemplate-dnd4epower .inlinerollresult  {
+    background-color: transparent;
+    border: none;
+}
+ 
+.sheet-rolltemplate-dnd4epower .inlinerollresult.fullcrit {
+    color: #3FB315;
+    border: none;
+}
+ 
+.sheet-rolltemplate-dnd4epower .inlinerollresult.fullfail {
+	color: #B31515;
+    border: none;
+}
+ 
+.sheet-rolltemplate-dnd4epower .inlinerollresult.importantroll {
+	color: #4A57ED;
+    border: none;
 }

--- a/D&D_4E/D&D_4E.html
+++ b/D&D_4E/D&D_4E.html
@@ -22,14 +22,7 @@
             <label>Size</label>
         </div>
         <div class="sheet-baseinfo sheet-number"><input type="text" name="attr_age" /><label>Age</label></div>
-        <div class="sheet-baseinfo sheet-short">
-            <select name="attr_gender">
-                    <option value="Male">Male</option>
-                    <option value="Female">Female</option>
-                    <option value="Other">Other</option>
-            </select>
-            <label>Gender</label>
-        </div>
+        <div class="sheet-baseinfo sheet-short"><input type="text" name="attr_gender" /><label>Gender</label></div>
         <div class="sheet-baseinfo sheet-short"><input type="text" name="attr_height" /><label>Height</label></div>
         <div class="sheet-baseinfo sheet-short"><input type="text" name="attr_weight" /><label>Weight</label></div>
         <div class="sheet-baseinfo"><input type="text" name="attr_alignment" /><label>Alignment</label></div>
@@ -49,7 +42,7 @@
     
         <!-- Left --> <!-- Hit Points, Movement, Action Points, Ability Scores, and Senses -->
         <div class="sheet-col">
-        	<!-- Hit Points -->
+            <!-- Hit Points -->
 			<div class="sheet-toggle-container">
 				<input type="checkbox" class="sheet-toggle">
 				<label class="sheet-headtwo">Hit Points</label>
@@ -174,7 +167,7 @@
 							<input type="text" name="attr_strength-mod" value="floor((@{strength}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-strength-roll-text} [[1d20 + @{strength-mod-level}]] (Strength Check)' name='strength-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-strength-roll-text}}} {{name=Strength Ability Check}} {{class=@{character_name}}} {{type=Using Strength}} {{ability=[[1d20 + [[@{strength-mod}]] [STR Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='strength-Check'>
 								<input type="text" name="attr_strength-mod-level" value="@{strength-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -191,7 +184,7 @@
 							<input type="text" name="attr_constitution-mod" value="floor((@{constitution}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-constitution-roll-text} [[1d20 + @{constitution-mod-level}]] (Constitution Check)' name='constitution-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-constitution-roll-text}}} {{name=Constitution Ability Check}} {{class=@{character_name}}} {{type=Using Constitution}} {{ability=[[1d20 + [[@{constitution-mod}]] [CON Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='constitution-Check'>
 								<input type="text" name="attr_constitution-mod-level" value="@{constitution-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -208,7 +201,7 @@
 							<input type="text" name="attr_dexterity-mod" value="floor((@{dexterity}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-dexterity-roll-text} [[1d20 + @{dexterity-mod-level}]] (Dexterity Check)' name='dexterity-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-dexterity-roll-text}}} {{name=Dexterity Ability Check}} {{class=@{character_name}}} {{type=Using Dexterity}} {{ability=[[1d20 + [[@{dexterity-mod}]] [DEX Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='dexterity-Check'>
 								<input type="text" name="attr_dexterity-mod-level" value="@{dexterity-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -225,7 +218,7 @@
 							<input type="text" name="attr_intelligence-mod" value="floor((@{intelligence}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-intelligence-roll-text} [[1d20 + @{intelligence-mod-level}]] (Intelligence Check)' name='intelligence-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-intelligence-roll-text}}} {{name=Intelligence Ability Check}} {{class=@{character_name}}} {{type=Using Intelligence}} {{ability=[[1d20 + [[@{intelligence-mod}]] [INT Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='intelligence-Check'>
 								<input type="text" name="attr_intelligence-mod-level" value="@{intelligence-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -242,7 +235,7 @@
 							<input type="text" name="attr_wisdom-mod" value="floor((@{wisdom}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-wisdom-roll-text} [[1d20 + @{wisdom-mod-level}]] (Wisdom Check)' name='wisdom-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-wisdom-roll-text}}} {{name=Wisdom Ability Check}} {{class=@{character_name}}} {{type=Using Wisdom}} {{ability=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='wisdom-Check'>
 								<input type="text" name="attr_wisdom-mod-level" value="@{wisdom-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -259,7 +252,7 @@
 							<input type="text" name="attr_charisma-mod" value="floor((@{charisma}-10)/2)" disabled = "true"/>
 						</div>
 						<div class="sheet-item sheet-small sheet-black">
-							<button class="sheet-hidden-roll" type='roll' value='@{ability-charisma-roll-text} [[1d20 + @{charisma-mod-level}]] (Charisma Check)' name='charisma-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{ability-charisma-roll-text}}} {{name=Charisma Ability Check}} {{class=@{character_name}}} {{type=Using Charisma }} {{ability=[[1d20 + [[@{charisma-mod}]] [CHA Mod] + [[@{halflevel}]] [Half Level] ]]}}" name='charisma-Check'>
 								<input type="text" name="attr_charisma-mod-level" value="@{charisma-mod}+@{halflevel}" disabled = "true"/>
 							</button>
 						</div>
@@ -603,7 +596,7 @@
 					<!-- Initiative -->
 					<div class="sheet-row">
 						<div class="sheet-item sheet-small sheet-halfblack">
-							<button class="sheet-hidden-roll" type='roll' value='@{initiative-roll-text} [[1d20 + @{initiative} &{tracker}]] (Initiative)' name='initiativeCheck' title="Please select your token!">
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{other=1}} {{emote=@{initiative-roll-text}}} {{name=Initiative Check}} {{class=@{selected|token_name}}} {{initiative=[[1d20 + [[@{init-highest}]] [Selected Mod] + [[@{halflevel}]] [Half Level] + [[@{init-feat}]] [Feat Bonus] + [[@{init-item}]] [Item Bonus] + [[@{init-misc}]] [Misc Bonus] + [[ [[@{initiative}]]*@{init-tie}]] [Tie Breaker] &{tracker}]]}}" name='initiativeCheck' title="Please select your token!">
                                 <input type="text" name="attr_initiative" value="@{init-dexterity}+@{init-feat}+@{init-item}+@{init-misc}" disabled = "true"/>
                             </button>
 						</div>
@@ -660,7 +653,7 @@
 					<!-- Acrobatics -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-acrobatics-roll-text} [[1d20 + @{acrobatics}]] (Acrobatics)' name='acrobatics-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-acrobatics-roll-text}}} {{name=Acrobatics}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{dexterity-mod}]] [DEX Mod] + [[@{halflevel}]] [Half Level] + [[@{acrobatics-trained}*5)]] [Trained] + [[@{acrobatics-pen}]] [Armor Penalty] + [[@{acrobatics-misc}]] [Misc] ]]}}" name='acrobatics-Check'>
 								<input type="text" name="attr_acrobatics" value="(@{dexterity-mod-level}+@{acrobatics-trained}*5)+@{acrobatics-pen}+@{acrobatics-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -683,7 +676,7 @@
 					<!-- Arcana -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-arcana-roll-text} [[1d20 + @{arcana}]] (Arcana)' name='arcana-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-arcana-roll-text}}} {{name=Arcana}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{intelligence-mod}]] [INT Mod] + [[@{halflevel}]] [Half Level] + [[@{arcana-trained}*5)]] [Trained] + [[@{arcana-pen}]] [Armor Penalty] + [[@{arcana-misc}]] [Misc] ]]}}" name='arcana-Check'>
 								<input type="text" name="attr_arcana" value="(@{intelligence-mod-level}+@{arcana-trained}*5)+@{arcana-pen}+@{arcana-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -706,7 +699,7 @@
 					<!-- Athletics -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-athletics-roll-text} [[1d20 + @{athletics}]] (Athletics)' name='athletics-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-athletics-roll-text}}} {{name=Athletics}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{strength-mod}]] [STR Mod] + [[@{halflevel}]] [Half Level] + [[@{athletics-trained}*5)]] [Trained] + [[@{athletics-pen}]] [Armor Penalty] + [[@{athletics-misc}]] [Misc] ]]}}" name='athletics-Check'>
 								<input type="text" name="attr_athletics" value="(@{strength-mod-level}+@{athletics-trained}*5)+@{athletics-pen}+@{athletics-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -729,7 +722,7 @@
 					<!-- Bluff -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-bluff-roll-text} [[1d20 + @{bluff}]] (Bluff)' name='bluff-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-bluff-roll-text}}} {{name=Bluff}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{charisma-mod}]] [CHA Mod] + [[@{halflevel}]] [Half Level] + [[@{bluff-trained}*5)]] [Trained] + [[@{bluff-pen}]] [Armor Penalty] + [[@{bluff-misc}]] [Misc] ]]}}" name='bluff-Check'>
 								<input type="text" name="attr_bluff" value="(@{charisma-mod-level}+@{bluff-trained}*5)+@{bluff-pen}+@{bluff-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -752,7 +745,7 @@
 					<!-- Diplomacy -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-diplomacy-roll-text} [[1d20 + @{diplomacy}]] (Diplomacy)' name='diplomacy-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-diplomacy-roll-text}}} {{name=Diplomacy}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{charisma-mod}]] [CHA Mod] + [[@{halflevel}]] [Half Level] + [[@{diplomacy-trained}*5)]] [Trained] + [[@{diplomacy-pen}]] [Armor Penalty] + [[@{diplomacy-misc}]] [Misc] ]]}}" name='diplomacy-Check'>
 								<input type="text" name="attr_diplomacy" value="(@{charisma-mod-level}+@{diplomacy-trained}*5)+@{diplomacy-pen}+@{diplomacy-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -775,7 +768,7 @@
 					<!-- Dungeoneering -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-dungeoneering-roll-text} [[1d20 + @{dungeoneering}]] (Dungeoneering)' name='dungeoneering-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-dungeoneering-roll-text}}} {{name=Dungeoneering}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] + [[@{dungeoneering-trained}*5)]] [Trained] + [[@{dungeoneering-pen}]] [Armor Penalty] + [[@{dungeoneering-misc}]] [Misc] ]]}}" name='dungeoneering-Check'>
 								<input type="text" name="attr_dungeoneering" value="(@{wisdom-mod-level}+@{dungeoneering-trained}*5)+@{dungeoneering-pen}+@{dungeoneering-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -798,7 +791,7 @@
 					<!-- Endurance -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-endurance-roll-text} [[1d20 + @{endurance}]] (Endurance)' name='endurance-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-endurance-roll-text}}} {{name=Endurance}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{constitution-mod}]] [CON Mod] + [[@{halflevel}]] [Half Level] + [[@{endurance-trained}*5)]] [Trained] + [[@{endurance-pen}]] [Armor Penalty] + [[@{endurance-misc}]] [Misc] ]]}}" name='endurance-Check'>
 								<input type="text" name="attr_endurance" value="(@{constitution-mod-level}+@{endurance-trained}*5)+@{endurance-pen}+@{endurance-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -821,7 +814,7 @@
 					<!-- Heal -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-heal-roll-text} [[1d20 + @{heal}]] (Heal)' name='heal-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-heal-roll-text}}} {{name=Heal}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] + [[@{heal-trained}*5)]] [Trained] + [[@{heal-pen}]] [Armor Penalty] + [[@{heal-misc}]] [Misc] ]]}}" name='heal-Check'>
 								<input type="text" name="attr_heal" value="(@{wisdom-mod-level}+@{heal-trained}*5)+@{heal-pen}+@{heal-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -844,7 +837,7 @@
 					<!-- History -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-history-roll-text} [[1d20 + @{history}]] (History)' name='history-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-history-roll-text}}} {{name=History}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{intelligence-mod}]] [INT Mod] + [[@{halflevel}]] [Half Level] + [[@{history-trained}*5)]] [Trained] + [[@{history-pen}]] [Armor Penalty] + [[@{history-misc}]] [Misc] ]]}}" name='history-Check'>
 								<input type="text" name="attr_history" value="(@{intelligence-mod-level}+@{history-trained}*5)+@{history-pen}+@{history-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -867,7 +860,7 @@
 					<!-- Insight -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-insight-roll-text} [[1d20 + @{insight}]] (Insight)' name='insight-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-insight-roll-text}}} {{name=Insight}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] + [[@{insight-trained}*5)]] [Trained] + [[@{insight-pen}]] [Armor Penalty] + [[@{insight-misc}]] [Misc] ]]}}" name='insight-Check'>
 								<input type="text" name="attr_insight" value="(@{wisdom-mod-level}+@{insight-trained}*5)+@{insight-pen}+@{insight-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -890,7 +883,7 @@
 					<!-- Intimidate -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-intimidate-roll-text} [[1d20 + @{intimidate}]] (Intimidate)' name='intimidate-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-intimidate-roll-text}}} {{name=Intimidate}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{charisma-mod}]] [CHA Mod] + [[@{halflevel}]] [Half Level] + [[@{intimidate-trained}*5)]] [Trained] + [[@{intimidate-pen}]] [Armor Penalty] + [[@{intimidate-misc}]] [Misc] ]]}}" name='intimidate-Check'>
 								<input type="text" name="attr_intimidate" value="(@{charisma-mod-level}+@{intimidate-trained}*5)+@{intimidate-pen}+@{intimidate-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -913,7 +906,7 @@
 					<!-- Nature -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-nature-roll-text} [[1d20 + @{nature}]] (Nature)' name='nature-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-nature-roll-text}}} {{name=Nature}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] + [[@{nature-trained}*5)]] [Trained] + [[@{nature-pen}]] [Armor Penalty] + [[@{nature-misc}]] [Misc] ]]}}" name='nature-Check'>
 								<input type="text" name="attr_nature" value="(@{wisdom-mod-level}+@{nature-trained}*5)+@{nature-pen}+@{nature-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -936,7 +929,7 @@
 					<!-- Perception -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-perception-roll-text} [[1d20 + @{perception}]] (Perception)' name='perception-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-perception-roll-text}}} {{name=Perception}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{wisdom-mod}]] [WIS Mod] + [[@{halflevel}]] [Half Level] + [[@{perception-trained}*5)]] [Trained] + [[@{perception-pen}]] [Armor Penalty] + [[@{perception-misc}]] [Misc] ]]}}" name='perception-Check'>
 								<input type="text" name="attr_perception" value="(@{wisdom-mod-level}+@{perception-trained}*5)+@{perception-pen}+@{perception-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -959,7 +952,7 @@
 					<!-- Religion -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-religion-roll-text} [[1d20 + @{religion}]] (Religion)' name='religion-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-religion-roll-text}}} {{name=Religion}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{intelligence-mod}]] [INT Mod] + [[@{halflevel}]] [Half Level] + [[@{religion-trained}*5)]] [Trained] + [[@{religion-pen}]] [Armor Penalty] + [[@{religion-misc}]] [Misc] ]]}}" name='religion-Check'>
 								<input type="text" name="attr_religion" value="(@{intelligence-mod-level}+@{religion-trained}*5)+@{religion-pen}+@{religion-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -982,7 +975,7 @@
 					<!-- Stealth -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-stealth-roll-text} [[1d20 + @{stealth}]] (Stealth)' name='stealth-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-stealth-roll-text}}} {{name=Stealth}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{dexterity-mod}]] [DEX Mod] + [[@{halflevel}]] [Half Level] + [[@{stealth-trained}*5)]] [Trained] + [[@{stealth-pen}]] [Armor Penalty] + [[@{stealth-misc}]] [Misc] ]]}}" name='stealth-Check'>
 								<input type="text" name="attr_stealth" value="(@{dexterity-mod-level}+@{stealth-trained}*5)+@{stealth-pen}+@{stealth-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -1005,7 +998,7 @@
 					<!-- Streetwise -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-streetwise-roll-text} [[1d20 + @{streetwise}]] (Streetwise)' name='streetwise-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-streetwise-roll-text}}} {{name=Streetwise}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{charisma-mod}]] [CHA Mod] + [[@{halflevel}]] [Half Level] + [[@{streetwise-trained}*5)]] [Trained] + [[@{streetwise-pen}]] [Armor Penalty] + [[@{streetwise-misc}]] [Misc] ]]}}" name='streetwise-Check'>
 								<input type="text" name="attr_streetwise" value="(@{charisma-mod-level}+@{streetwise-trained}*5)+@{streetwise-pen}+@{streetwise-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -1029,7 +1022,7 @@
 					<!-- Thievery -->
 					<div class="sheet-row sheet-alternative">
 						<div class="sheet-item sheet-tiny">
-							<button class="sheet-hidden-roll" type='roll' value='@{skill-thievery-roll-text} [[1d20 + @{thievery}]] (Thievery)' name='thievery-Check'>
+							<button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{emote=@{skill-thievery-roll-text}}} {{name=Thievery}} {{class=@{character_name}}} {{type=Skill Check}} {{skill=[[1d20 + [[@{dexterity-mod}]] [DEX Mod] + [[@{halflevel}]] [Half Level] + [[@{thievery-trained}*5)]] [Trained] + [[@{thievery-pen}]] [Armor Penalty] + [[@{thievery-misc}]] [Misc] ]]}}" name='thievery-Check'>
 								<input type="text" name="attr_thievery" value="(@{dexterity-mod-level}+@{thievery-trained}*5)+@{thievery-pen}+@{thievery-misc}" disabled = "true"/>
 							</button>
 						</div>
@@ -1145,6 +1138,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>						
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1164,6 +1160,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-1-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-1-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-1-attack" value="@{weapon-1-prof}+@{weapon-1-enh}+@{weapon-1-attack-class}+@{weapon-1-attack-feat}+@{weapon-1-attack-misc}" disabled="true"/>
@@ -1250,6 +1249,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1269,6 +1271,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-2-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-2-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-2-attack" value="@{weapon-2-prof}+@{weapon-2-enh}+@{weapon-2-attack-class}+@{weapon-2-attack-feat}+@{weapon-2-attack-misc}" disabled="true"/>
@@ -1355,6 +1360,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1374,6 +1382,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-3-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-3-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-3-attack" value="@{weapon-3-prof}+@{weapon-3-enh}+@{weapon-3-attack-class}+@{weapon-3-attack-feat}+@{weapon-3-attack-misc}" disabled="true"/>
@@ -1460,6 +1471,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1479,6 +1493,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-4-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-4-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-4-attack" value="@{weapon-4-prof}+@{weapon-4-enh}+@{weapon-4-attack-class}+@{weapon-4-attack-feat}+@{weapon-4-attack-misc}" disabled="true"/>
@@ -1565,6 +1582,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1584,6 +1604,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-5-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-5-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-5-attack" value="@{weapon-5-prof}+@{weapon-5-enh}+@{weapon-5-attack-class}+@{weapon-5-attack-feat}+@{weapon-5-attack-misc}" disabled="true"/>
@@ -1670,6 +1693,9 @@
 						<div class="sheet-item sheet-tiny">
 							<label>Misc Damage Bonus</label> 
 						</div>
+						<div class="sheet-item sheet-puny">
+							<label>Per Plus Die Size</label> 
+						</div>
 					</div>
                     <div class="sheet-row">
 						<div class="sheet-item sheet-tiny">
@@ -1689,6 +1715,9 @@
 						</div>
 						<div class="sheet-item sheet-tiny sheet-center">
 							<input type="text" name="attr_weapon-6-damage-misc" value="0"/>
+						</div>
+						<div class="sheet-item sheet-puny sheet-center">
+							<input type="text" name="attr_weapon-6-per-plus" value="0"/>
 						</div>
 					</div>
                     <input type="hidden" name="attr_weapon-6-attack" value="@{weapon-6-prof}+@{weapon-6-enh}+@{weapon-6-attack-class}+@{weapon-6-attack-feat}+@{weapon-6-attack-misc}" disabled="true"/>
@@ -2108,6 +2137,7 @@ Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-1-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-1-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-1-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-1-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -2308,6 +2338,7 @@ Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-2-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-2-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-2-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-2-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -2508,6 +2539,7 @@ Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-3-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-3-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-3-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-3-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -2708,6 +2740,7 @@ Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-4-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-4-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-4-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-4-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -2908,6 +2941,7 @@ Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-5-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-5-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-5-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-5-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -3108,6 +3142,7 @@ Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-6-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-6-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-6-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-6-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -3308,6 +3343,7 @@ Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-7-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-7-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-7-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-7-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -3508,6 +3544,7 @@ Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-8-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-8-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-8-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-8-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -3708,6 +3745,7 @@ Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-9-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-9-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-9-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-9-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -3908,6 +3946,7 @@ Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-10-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-10-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-10-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-10-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -4108,6 +4147,7 @@ Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-11-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-11-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-11-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-11-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -4308,6 +4348,7 @@ Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-12-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-12-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-12-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-12-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -4508,6 +4549,7 @@ Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-13-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-13-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-13-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-13-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -4708,6 +4750,7 @@ Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-14-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-14-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-14-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-14-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -4908,6 +4951,7 @@ Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-15-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-15-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-15-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-15-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -5108,6 +5152,7 @@ Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-16-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-16-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-16-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-16-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -5308,6 +5353,7 @@ Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-17-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-17-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-17-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-17-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -5508,6 +5554,7 @@ Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-18-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-18-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-18-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-18-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -5708,6 +5755,7 @@ Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-19-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-19-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-19-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-19-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -5908,6 +5956,7 @@ Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-20-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-20-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-20-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-20-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -6108,6 +6157,7 @@ Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-21-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-21-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-21-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-21-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -6308,6 +6358,7 @@ Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-22-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-22-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-22-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-22-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -6508,6 +6559,7 @@ Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-23-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-23-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-23-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-23-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -6708,6 +6760,7 @@ Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-24-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-24-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-24-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-24-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -6908,6 +6961,7 @@ Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-25-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-25-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-25-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-25-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -7108,6 +7162,7 @@ Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-26-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-26-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-26-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-26-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -7308,6 +7363,7 @@ Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-27-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-27-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-27-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-27-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -7508,6 +7564,7 @@ Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-28-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-28-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-28-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-28-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -7708,6 +7765,7 @@ Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-29-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-29-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-29-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-29-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -7908,6 +7966,7 @@ Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-30-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-30-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-30-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-30-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -8108,6 +8167,7 @@ Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-31-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-31-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-31-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-31-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -8308,6 +8368,7 @@ Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-32-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-32-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-32-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-32-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -8508,6 +8569,7 @@ Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-33-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-33-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-33-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-33-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -8708,6 +8770,7 @@ Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-34-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-34-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-34-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-34-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -8908,6 +8971,7 @@ Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-35-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-35-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-35-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-35-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -9108,6 +9172,7 @@ Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-36-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-36-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-36-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-36-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -9308,6 +9373,7 @@ Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-37-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-37-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-37-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-37-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -9508,6 +9574,7 @@ Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-38-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-38-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-38-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-38-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -9708,6 +9775,7 @@ Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-39-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-39-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-39-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-39-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -9908,6 +9976,7 @@ Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-40-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-40-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-40-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-40-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -10108,6 +10177,7 @@ Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-41-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-41-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-41-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-41-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -10308,6 +10378,7 @@ Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-42-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-42-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-42-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-42-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -10508,6 +10579,7 @@ Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-43-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-43-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-43-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-43-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -10708,6 +10780,7 @@ Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-44-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-44-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-44-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-44-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -10908,6 +10981,7 @@ Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-45-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-45-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-45-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-45-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -11108,6 +11182,7 @@ Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-46-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-46-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-46-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-46-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -11308,6 +11383,7 @@ Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-47-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-47-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-47-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-47-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -11508,6 +11584,7 @@ Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-48-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-48-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-48-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-48-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -11708,6 +11785,7 @@ Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-49-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-49-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-49-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-49-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -11908,6 +11986,7 @@ Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-50-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-50-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-50-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+                        <input type="radio" name="attr_power-50-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -12108,6 +12187,7 @@ Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-51-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-51-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-51-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-51-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -12308,6 +12388,7 @@ Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-52-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-52-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-52-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-52-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -12508,6 +12589,7 @@ Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-53-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-53-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-53-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-53-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -12708,6 +12790,7 @@ Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-54-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-54-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-54-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-54-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -12908,6 +12991,7 @@ Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-55-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-55-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-55-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-55-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -13108,6 +13192,7 @@ Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-56-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-56-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-56-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-56-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -13308,6 +13393,7 @@ Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-57-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-57-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-57-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-57-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -13508,6 +13594,7 @@ Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-58-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-58-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-58-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-58-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -13708,6 +13795,7 @@ Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-59-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-59-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-59-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-59-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -13908,6 +13996,7 @@ Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-60-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-60-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-60-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-60-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -14108,6 +14197,7 @@ Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-61-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-61-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-61-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-61-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -14308,6 +14398,7 @@ Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-62-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-62-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-62-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-62-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -14508,6 +14599,7 @@ Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-63-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-63-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-63-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-63-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -14708,6 +14800,7 @@ Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-64-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-64-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-64-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-64-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -14908,6 +15001,7 @@ Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-65-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-65-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-65-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-65-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -15108,6 +15202,7 @@ Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-66-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-66-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-66-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-66-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -15308,6 +15403,7 @@ Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-67-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-67-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-67-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-67-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -15508,6 +15604,7 @@ Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-68-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-68-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-68-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-68-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -15708,6 +15805,7 @@ Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-69-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-69-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-69-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-69-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -15908,6 +16006,7 @@ Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-70-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-70-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-70-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-70-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -16108,6 +16207,7 @@ Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-71-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-71-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-71-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-71-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -16308,6 +16408,7 @@ Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-72-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-72-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-72-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-72-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -16508,6 +16609,7 @@ Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-73-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-73-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-73-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-73-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -16708,6 +16810,7 @@ Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-74-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-74-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-74-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-74-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -16908,6 +17011,7 @@ Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-75-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-75-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-75-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-75-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -17108,6 +17212,7 @@ Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-76-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-76-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-76-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-76-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -17308,6 +17413,7 @@ Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-77-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-77-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-77-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-77-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -17508,6 +17614,7 @@ Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-78-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-78-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-78-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-78-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -17708,6 +17815,7 @@ Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-79-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-79-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-79-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-79-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -17908,6 +18016,7 @@ Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-80-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-80-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-80-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-80-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -18108,6 +18217,7 @@ Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-81-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-81-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-81-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-81-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -18308,6 +18418,7 @@ Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-82-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-82-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-82-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-82-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -18508,6 +18619,7 @@ Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-83-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-83-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-83-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-83-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -18708,6 +18820,7 @@ Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-84-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-84-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-84-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-84-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -18908,6 +19021,7 @@ Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-85-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-85-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-85-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-85-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -19108,6 +19222,7 @@ Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-86-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-86-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-86-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-86-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -19308,6 +19423,7 @@ Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-87-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-87-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-87-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-87-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -19508,6 +19624,7 @@ Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-88-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-88-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-88-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-88-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -19708,6 +19825,7 @@ Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-89-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-89-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-89-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-89-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -19908,6 +20026,7 @@ Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-90-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-90-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-90-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-90-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -20108,6 +20227,7 @@ Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-91-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-91-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-91-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-91-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -20308,6 +20428,7 @@ Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-92-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-92-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-92-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-92-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -20508,6 +20629,7 @@ Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-93-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-93-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-93-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-93-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -20708,6 +20830,7 @@ Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-94-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-94-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-94-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-94-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -20908,6 +21031,7 @@ Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-95-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-95-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-95-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-95-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -21108,6 +21232,7 @@ Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-96-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-96-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-96-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-96-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -21308,6 +21433,7 @@ Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-97-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-97-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-97-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-97-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -21508,6 +21634,7 @@ Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-98-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-98-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-98-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-98-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -21708,6 +21835,7 @@ Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-99-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-99-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-99-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-99-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -21908,6 +22036,7 @@ Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
                         <input type="radio" name="attr_power-100-useage" value="At-Will" class="sheet-colgreen" checked/><label>At-Will</label>
                         <input type="radio" name="attr_power-100-useage" value="Encounter" class="sheet-colred" /><label>Encounter</label>
                         <input type="radio" name="attr_power-100-useage" value="Daily" class="sheet-colgrey" /><label>Daily</label>
+						<input type="radio" name="attr_power-100-useage" value="Item" class="sheet-colorange" /><label>Item</label>
                         <div class="sheet-headcolor"></div>
                         <div class="sheet-bodyfix"></div>
                         <div class="sheet-statblock">
@@ -22097,6 +22226,163 @@ Abilities are "-[ability]-Check" (replacing the [ability] with the relevant abil
 An example of an Initiative check for the character bob would be "%{bob|-initiativeCheck}" without the quotes.</textarea>
             </div>
 		</div>
+		<!-- Roll Template Information -->
+		<div class="sheet-toggle-container sheet-tab-powers">
+			<input type="checkbox" class="sheet-toggle" checked>
+			<label class="sheet-headtwo sheet-tab-powers">Roll Template Information</label>
+			<div class="sheet-statblock">
+                <div class="sheet-header">
+                    <div class="sheet-item sheet-huge">
+                        <label>Melee Basic Roll Template Example</label>
+                    </div>
+                </div>
+                <textarea class="sheet-text-large">&{template:dnd4epower} {{atwill=1 }} {{emote=I resort to the simple attack learned when I first picked up a melee weapon. }} {{name=Basic Melee }} {{level=Basic Attack }} {{type=At-Will }} {{keywords=Weapon }} {{action=Standard }} {{range=Melee Weapon }} {{target=One Creature }} {{attack=[[1d20+3 [strength] ]] vs. **AC** }} {{damage=[[1d6+3 [strength] ]] damage. }} {{critical=[[0d0+6+3 [strength] ]] damage. }} {{special=I can use an unarmed attack as a weapon to make a melee basic attack. }}</textarea>
+                <div class="sheet-header">
+                    <div class="sheet-item sheet-huge">
+                        <label>List of {{propertynames}} for Roll Template</label>
+                    </div>
+                </div>
+                <textarea class="sheet-text-large">{{emote}}
+{{atwill}} (Green)
+{{encounter}} (Red)
+{{daily}} (Grey)
+{{item}} (Gold)
+{{other}} (Black)
+{{ability}} (Purple)
+{{skill}} (Blue)
+{{name}}
+{{class}}
+{{level}}
+{{type}} {{keywords}}
+{{attacktechnique}}
+{{action}} {{range}}
+{{requirement}}
+{{trigger}}
+{{beforespecial}}
+{{beforeeffect}}
+{{target}}
+{{primarytarget}}
+{{attackweaponmod}}
+{{attack}}
+{{multiattacktoggle=[[?{Number of Attacks|2}]]}}
+{{multiattack2}}
+{{multiattack3}}
+{{multiattack4}}
+{{multiattack5}}
+{{multiattack6}}
+{{multiattack7}}
+{{multiattack8}}
+{{multiattack9}}
+{{multiattack10}}
+{{multiattack11}}
+{{multiattack12}}
+{{multiattack13}}
+{{multiattack14}}
+{{multiattack15}}
+{{multiattack16}}
+{{multiattack17}}
+{{multiattack18}}
+{{multiattack19}}
+{{multiattack20}}
+{{damage}}
+{{critical}}
+{{hitweaponmod}}
+{{hiteffect}}
+{{hitaftereffect}}
+{{effectweaponmod}}
+{{secondaryrange}}
+{{secondarytarget}}
+{{secondaryattack}}
+{{secondarydamage}}
+{{secondarycritical}}
+{{secondaryhiteffect}}
+{{tertiaryrange}}
+{{tertiarytarget}}
+{{tertiaryattack}}
+{{tertiarydamage}}
+{{tertiarycritical}}
+{{tertiaryhiteffect}}
+{{augmenttoggle=[[?{Augment|0}]]}}
+{{augment1range}}
+{{augment1target}}
+{{augment1attack}}
+{{augment1multitoggle=[[?{Number of Attacks|2}]]}}
+{{augment1multiattack2}}
+{{augment1multiattack3}}
+{{augment1multiattack4}}
+{{augment1multiattack5}}
+{{augment1multiattack6}}
+{{augment1multiattack7}}
+{{augment1multiattack8}}
+{{augment1multiattack9}}
+{{augment1damage}}
+{{augment1critical}}
+{{augment1hiteffect}}
+{{augment2range}}
+{{augment2target}}
+{{augment2attack}}
+{{augment2multitoggle=[[?{Number of Attacks|2}]]}}
+{{augment2multiattack2}}
+{{augment2multiattack3}}
+{{augment2multiattack4}}
+{{augment2multiattack5}}
+{{augment2multiattack6}}
+{{augment2multiattack7}}
+{{augment2multiattack8}}
+{{augment2multiattack9}}
+{{augment2damage}}
+{{augment2critical}}
+{{augment2hiteffect}}
+{{augment4range}}
+{{augment4target}}
+{{augment4attack}}
+{{augment4multitoggle=[[?{Number of Attacks|2}]]}}
+{{augment4multiattack2}}
+{{augment4multiattack3}}
+{{augment4multiattack4}}
+{{augment4multiattack5}}
+{{augment4multiattack6}}
+{{augment4multiattack7}}
+{{augment4multiattack8}}
+{{augment4multiattack9}}
+{{augment4damage}}
+{{augment4critical}}
+{{augment4hiteffect}}
+{{augment6range}}
+{{augment6target}}
+{{augment6attack}}
+{{augment6multitoggle=[[?{Number of Attacks|2}]]}}
+{{augment6multiattack2}}
+{{augment6multiattack3}}
+{{augment6multiattack4}}
+{{augment6multiattack5}}
+{{augment6multiattack6}}
+{{augment6multiattack7}}
+{{augment6multiattack8}}
+{{augment6multiattack9}}
+{{augment6damage}}
+{{augment6critical}}
+{{augment6hiteffect}}
+{{classmodifier}}
+{{miss}}
+{{effect}}
+{{firstfailedsave}}
+{{secondfailedsave}}
+{{eachfailedsave}}
+{{aftereffect}}
+{{sustainminor}}
+{{sustainstandard}}
+{{movetechnique}}
+{{mttype}} {{mtrange}}
+{{mttarget}}
+{{mteffect}}
+{{special}}
+{{initiative}}
+{{ability}}
+{{skill}}
+{{key}} {{value}}</textarea>
+            </div>
+		</div>
     </div>
 	
 	<!-- Feats -->
@@ -22172,15 +22458,26 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
 									</select>
 								</div>
 							</div>
+							<div class="sheet-row">
+								<div class="sheet-item sheet-large">
+									<label>Use Initiative Tie Break</label>
+								</div>
+								<div class="sheet-item sheet-med">
+									<select name="attr_init-tie">
+                                        <option value="0" selected="selected">No, Do NOT Use</option>
+                                        <option value="0.01">Yes, Use</option>
+									</select>
+								</div>
+							</div>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Initiative Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_initiative-roll-text">/me readies for battle.</textarea>
+							<textarea name="attr_initiative-roll-text">**@{character_name}** readies for battle.</textarea>
 						</div>
 						<div class="sheet-statblock">
-							<label class="sheet-headtwo">Defence</label>
+							<label class="sheet-headtwo">Defense</label>
 							<div class="sheet-row">
 								<div class="sheet-item sheet-large">
 									<label>AC Ability</label>
@@ -22189,10 +22486,11 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
 									<select name="attr_ac-highest">
                                         <option value="@{strength-mod}">Strength</option>
                                         <option value="@{constitution-mod}">Constitution</option>
-                                        <option value="@{dexterity-mod}" selected="selected">Dexterity</option>
+                                        <option value="@{dexterity-mod}">Dexterity</option>
                                         <option value="@{intelligence-mod}">Intelligence</option>
                                         <option value="@{wisdom-mod}">Wisdom</option>
                                         <option value="@{charisma-mod}">Charisma</option>
+                                        <option value="0" selected="selected">None</option>
 									</select>
 								</div>
 							</div>
@@ -22249,37 +22547,37 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
 									<label>Strength Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-strength-roll-text">/me .</textarea>
+							<textarea name="attr_ability-strength-roll-text">**@{character_name}** uses Strength.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Constitution Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-constitution-roll-text">/me .</textarea>
+							<textarea name="attr_ability-constitution-roll-text">**@{character_name}** uses Constitution.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Dexterity Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-dexterity-roll-text">/me .</textarea>
+							<textarea name="attr_ability-dexterity-roll-text">**@{character_name}** uses Dexterity.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Intelligence Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-intelligence-roll-text">/me .</textarea>
+							<textarea name="attr_ability-intelligence-roll-text">**@{character_name}** uses Intelligence.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Wisdom Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-wisdom-roll-text">/me .</textarea>
+							<textarea name="attr_ability-wisdom-roll-text">**@{character_name}** uses Wisdom.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Charisma Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_ability-charisma-roll-text">/me .</textarea>
+							<textarea name="attr_ability-charisma-roll-text">**@{character_name}** uses Charisma.</textarea>
 						</div>
 					</div>
 					<div class="sheet-col">
@@ -22290,103 +22588,103 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
 									<label>Acrobatics Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-acrobatics-roll-text">/me tries something acrobatic.</textarea>
+							<textarea name="attr_skill-acrobatics-roll-text">**@{character_name}** tries something acrobatic.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Arcana Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-arcana-roll-text">/me tries something magical.</textarea>
+							<textarea name="attr_skill-arcana-roll-text">**@{character_name}** tries something magical.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Athletics Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-athletics-roll-text">/me tries something athletic.</textarea>
+							<textarea name="attr_skill-athletics-roll-text">**@{character_name}** tries something athletic.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Bluff Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-bluff-roll-text">/me lies.</textarea>
+							<textarea name="attr_skill-bluff-roll-text">**@{character_name}** lies.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Diplomacy Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-diplomacy-roll-text">/me is diplomatic.</textarea>
+							<textarea name="attr_skill-diplomacy-roll-text">**@{character_name}** is diplomatic.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Dungeoneering Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-dungeoneering-roll-text">/me .</textarea>
+							<textarea name="attr_skill-dungeoneering-roll-text">**@{character_name}** figures something out.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Endurance Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-endurance-roll-text">/me tries to endure.</textarea>
+							<textarea name="attr_skill-endurance-roll-text">**@{character_name}** tries to endure.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Heal Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-heal-roll-text">/me .</textarea>
+							<textarea name="attr_skill-heal-roll-text">**@{character_name}** .</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>History Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-history-roll-text">/me .</textarea>
+							<textarea name="attr_skill-history-roll-text">**@{character_name}** remembers something.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Insight Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-insight-roll-text">/me .</textarea>
+							<textarea name="attr_skill-insight-roll-text">**@{character_name}** is insightful.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Intimidate Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-intimidate-roll-text">/me tries to act scary.</textarea>
+							<textarea name="attr_skill-intimidate-roll-text">**@{character_name}** tries to act scary.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Nature Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-nature-roll-text">/me tries something natural.</textarea>
+							<textarea name="attr_skill-nature-roll-text">**@{character_name}** tries something natural.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Perception Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-perception-roll-text">/me looks around.</textarea>
+							<textarea name="attr_skill-perception-roll-text">**@{character_name}** looks around.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Religion Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-religion-roll-text">/me prays.</textarea>
+							<textarea name="attr_skill-religion-roll-text">**@{character_name}** prays.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Stealth Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-stealth-roll-text">/me hides.</textarea>
+							<textarea name="attr_skill-stealth-roll-text">**@{character_name}** hides.</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Streetwise Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-streetwise-roll-text">/me .</textarea>
+							<textarea name="attr_skill-streetwise-roll-text">**@{character_name}** .</textarea>
 							<div class="sheet-header">
 								<div class="sheet-item sheet-huge">
 									<label>Thievery Roll Text</label> 
 								</div>
 							</div>
-							<textarea name="attr_skill-thievery-roll-text">/me .</textarea>
+							<textarea name="attr_skill-thievery-roll-text">**@{character_name}** .</textarea>
 						</div>
 					</div>
 				</div>
@@ -22396,8 +22694,658 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
     <footer class="sheet-statblock">
         <div class="sheet-header">
             <div class="sheet-item sheet-huge">
-                <label>version: 1.0</label> 
+                <button class="sheet-hidden-roll" type='roll' value="&{template:dnd4epower} {{other=yes}}{{name=More Information}} {{**Link:**=[Roll20 Wiki: DnD4e Character Sheet](https://wiki.roll20.net/DnD4e_Character_Sheet)}}" name='wiki-link'>
+					<input type="text" name="attr_wiki-link" value="Version 2.0 - More Information" disabled = "true"/>
             </div>
         </div>
     </footer>
 </div>
+<!-- Roll Template for D&D4e Character Sheet -->
+<rolltemplate class="sheet-rolltemplate-dnd4epower">
+  <table>
+    <caption class="sheet-emote">{{emote}}</caption>
+        <tr><th class="sheet-power-header{{#atwill}} sheet-atwill{{/atwill}}{{#encounter}} sheet-encounter{{/encounter}}{{#daily}} sheet-daily{{/daily}}{{#item}} sheet-item{{/item}}{{#other}} sheet-other{{/other}}{{#ability}} sheet-ability{{/ability}}{{#skill}} sheet-skill{{/skill}}{{#monster}} sheet-monster{{/monster}}">{{name}}</th></tr>
+        <tr><th class="sheet-subheader-alignright{{#atwill}} sheet-atwill{{/atwill}}{{#encounter}} sheet-encounter{{/encounter}}{{#daily}} sheet-daily{{/daily}}{{#item}} sheet-item{{/item}}{{#other}} sheet-other{{/other}}{{#ability}} sheet-ability{{/ability}}{{#skill}} sheet-skill{{/skill}}{{#monster}} sheet-monster{{/monster}}">{{class}} {{level}}</th></tr>
+	{{#type}}    
+		<tr><td><span class="sheet-template-bold">
+    		{{type}} {{keywords}}
+        </span></td></tr>
+	{{/type}}
+	{{#attacktechnique}}
+    	<tr><td><span class="sheet-template-bold">
+			Attack Technique: </span>{{attacktechnique}}
+        </td></tr>
+	{{/attacktechnique}}
+	{{#action}}
+		<tr><td><span class="sheet-template-bold">
+			{{action}} {{range}}
+		</span></td></tr>
+	{{/action}}
+	{{#requirement}}
+		<tr><td><span class="sheet-template-bold">
+			Requirement: </span>{{requirement}}
+        </td></tr>
+	{{/requirement}}
+	{{#trigger}}
+		<tr><td><span class="sheet-template-bold">
+			Trigger: </span>{{trigger}}
+        </td></tr>
+	{{/trigger}}
+	{{#beforespecial}}
+		<tr><td><span class="sheet-template-bold">
+			Special: </span>{{beforespecial}}
+        </td></tr>
+	{{/beforespecial}}
+	{{#beforeeffect}}
+		<tr><td><span class="sheet-template-bold">
+			Effect: </span>{{beforeeffect}}
+        </td></tr>
+	{{/beforeeffect}}
+	{{#target}}
+		<tr><td><span class="sheet-template-bold">
+			Target: </span>{{target}}
+        </td></tr>
+	{{/target}}
+	{{#primarytarget}}
+		<tr><td><span class="sheet-template-bold sheet-td-red">
+			Primary Attack</span>
+		</td></tr>
+		<tr><td><span class="sheet-template-bold">
+			Target: </span>{{primarytarget}}
+		</td></tr>
+	{{/primarytarget}}
+	{{#attackweaponmod}}
+		<tr><td><span class="sheet-template-bold">
+			Weapon: </span>{{attackweaponmod}}
+		</td></tr>
+	{{/attackweaponmod}}
+	{{#attack}}
+        <tr><td><span class="sheet-template-bold">
+			Attack: </span>{{attack}} 
+		</td></tr>
+	{{/attack}}
+	{{#multiattacktoggle}} <!-- Toggle Formula [[?{Number of Attacks|2}]] -->
+		{{#rollBetween() multiattacktoggle 2 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 2: </span>{{multiattack2}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 2 20}}
+		{{#rollBetween() multiattacktoggle 3 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 3: </span>{{multiattack3}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 3 20}}
+		{{#rollBetween() multiattacktoggle 4 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 4: </span>{{multiattack4}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 4 20}}
+		{{#rollBetween() multiattacktoggle 5 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 5: </span>{{multiattack5}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 5 20}}
+		{{#rollBetween() multiattacktoggle 6 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 6: </span>{{multiattack6}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 6 20}}
+		{{#rollBetween() multiattacktoggle 7 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 7: </span>{{multiattack7}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 7 20}}
+		{{#rollBetween() multiattacktoggle 8 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 8: </span>{{multiattack8}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 8 20}}
+		{{#rollBetween() multiattacktoggle 9 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 9: </span>{{multiattack9}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 9 20}}
+		{{#rollBetween() multiattacktoggle 10 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 10: </span>{{multiattack10}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 10 20}}
+		{{#rollBetween() multiattacktoggle 11 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 11: </span>{{multiattack11}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 11 20}}
+		{{#rollBetween() multiattacktoggle 12 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 12: </span>{{multiattack12}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 12 20}}
+		{{#rollBetween() multiattacktoggle 13 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 13: </span>{{multiattack13}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 13 20}}
+		{{#rollBetween() multiattacktoggle 14 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 14: </span>{{multiattack14}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 14 20}}
+		{{#rollBetween() multiattacktoggle 15 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 15: </span>{{multiattack15}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 15 20}}
+		{{#rollBetween() multiattacktoggle 16 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 16: </span>{{multiattack16}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 16 20}}
+		{{#rollBetween() multiattacktoggle 17 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 17: </span>{{multiattack17}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 17 20}}
+		{{#rollBetween() multiattacktoggle 18 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 18: </span>{{multiattack18}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 18 20}}
+		{{#rollBetween() multiattacktoggle 19 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 19:</span>{{multiattack19}} 
+			</td></tr>
+        {{/rollBetween() multiattacktoggle 19 20}}		
+		{{#rollTotal() multiattacktoggle 20}}
+			<tr><td><span class="sheet-template-bold">
+				Attack 20: </span>{{multiattack20}} 
+			</td></tr>
+        {{/rollTotal() multiattacktoggle 20}}
+	{{/multiattacktoggle}}
+	{{#damage}}
+			<tr><td><span class="sheet-template-bold">
+				Damage: </span>{{damage}}
+			</td></tr>
+	{{/damage}}
+	{{#critical}}
+		{{#rollWasCrit() attack}}
+			<tr><td><span class="sheet-td-critical sheet-template-bold">
+				Critical: </span>{{critical}}
+			</td></tr>    
+		{{/rollWasCrit() attack}}
+	{{/critical}}
+	{{#hitweaponmod}}
+		<tr><td><span class="sheet-template-bold">
+			Weapon: </span>{{hitweaponmod}}
+		</td></tr>
+	{{/hitweaponmod}}
+	{{#hiteffect}}
+		<tr><td><span class="sheet-template-bold">
+			On Hit: </span>{{hiteffect}}
+		</td></tr>
+	{{/hiteffect}}
+	{{#hitaftereffect}}
+		<tr><td><span class="sheet-template-bold">
+			Aftereffect: </span>{{hitaftereffect}}
+		</td></tr>
+	{{/hitaftereffect}}
+	{{#effectweaponmod}}
+		<tr><td><span class="sheet-template-bold">
+			Weapon: </span>{{effectweaponmod}}
+		</td></tr>
+	{{/effectweaponmod}}
+	{{#secondaryattack}}
+		<tr><td><span class="sheet-template-bold sheet-td-red">
+			Secondary Attack</span>
+		</td></tr>
+		{{#secondaryrange}}
+			<tr><td><span class="sheet-template-bold">
+				Range: </span>{{secondaryrange}}
+			</td></tr>
+		{{/secondaryrange}}
+		{{#secondarytarget}}
+			<tr><td><span class="sheet-template-bold">
+				Target: </span>{{secondarytarget}}
+			</td></tr>
+		{{/secondarytarget}}
+        <tr><td><span class="sheet-template-bold">
+			Attack: </span>{{secondaryattack}} 
+		</td></tr>
+		{{#secondarydamage}}
+			<tr><td><span class="sheet-template-bold">
+				Damage: </span>{{secondarydamage}}
+			</td></tr>
+		{{/secondarydamage}}
+		{{#rollWasCrit() secondaryattack}}
+			<tr><td><span class="sheet-template-bold sheet-td-critical">
+				Critical: </span>{{secondarycritical}}
+			</td></tr>
+	    {{/rollWasCrit() secondaryattack}}
+		{{#secondaryhiteffect}}
+			<tr><td><span class="sheet-template-bold">
+				On Hit: </span>{{secondaryhiteffect}}
+			</td></tr>
+		{{/secondaryhiteffect}}
+	{{/secondaryattack}}
+	{{#tertiaryattack}}
+		<tr><td><span class="sheet-template-bold sheet-td-red">
+			Tertiary Attack</span>
+		</td></tr>
+		{{#tertiaryrange}}
+			<tr><td><span class="sheet-template-bold">
+				Range: </span>{{tertiaryrange}}
+			</td></tr>
+		{{/tertiaryrange}}
+		{{#tertiarytarget}}
+			<tr><td><span class="sheet-template-bold">
+				Target: </span>{{tertiarytarget}}
+			</td></tr>
+		{{/tertiarytarget}}
+        <tr><td><span class="sheet-template-bold">
+			Attack: </span>{{tertiaryattack}} 
+		</td></tr>
+		{{#tertiarydamage}}
+			<tr><td><span class="sheet-template-bold">
+				Damage: </span>{{tertiarydamage}}
+			</td></tr>
+		{{/tertiarydamage}}
+		{{#rollWasCrit() tertiaryattack}}
+			<tr><td><span class="sheet-template-bold sheet-td-critical">
+				Critical: </span>{{tertiarycritical}}
+			</td></tr>
+	    {{/rollWasCrit() tertiaryattack}}
+		{{#tertiaryhiteffect}}
+			<tr><td><span class="sheet-template-bold">
+				On Hit: </span>{{tertiaryhiteffect}}
+			</td></tr>
+		{{/tertiaryhiteffect}}
+	{{/tertiaryattack}}
+	{{#augmenttoggle}} <!--Augment Toggle [[?{Augment|0}]] -->
+    	{{#rollTotal() augmenttoggle 1}}
+			<tr><td><span class="sheet-template-bold sheet-td-red">
+				Augment 1</span>
+			</td></tr>
+			{{#augment1range}}
+				<tr><td><span class="sheet-template-bold">
+					Range: </span>{{augment1range}}
+				</td></tr>
+			{{/augment1range}}
+			{{#augment1target}}
+				<tr><td><span class="sheet-template-bold">
+					Target: </span>{{augment1target}}
+				</td></tr>
+			{{/augment1target}}
+			<tr><td><span class="sheet-template-bold">
+				Attack: </span>{{augment1attack}} 
+			</td></tr>
+			{{#augment1multitoggle}} <!-- Toggle Formula [[?{Number of Attacks|2}]] -->
+				{{#rollBetween() augment1multitoggle 2 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 2: </span>{{augment1multiattack2}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 2 9}}
+				{{#rollBetween() augment1multitoggle 3 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 3: </span>{{augment1multiattack3}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 3 9}}
+				{{#rollBetween() augment1multitoggle 4 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 4: </span>{{augment1multiattack4}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 4 9}} 
+				{{#rollBetween() augment1multitoggle 5 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 5: </span>{{augment1multiattack5}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 5 9}}
+				{{#rollBetween() augment1multitoggle 6 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 6: </span>{{augment1multiattack6}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 6 9}}
+				{{#rollBetween() augment1multitoggle 7 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 7: </span>{{augment1multiattack7}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 7 9}}
+				{{#rollBetween() augment1multitoggle 8 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 8: </span>{{augment1multiattack8}} 
+					</td></tr>
+				{{/rollBetween() augment1multitoggle 8 9}}
+				{{#rollTotal() augment1multitoggle 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 9: </span>{{augment1multiattack9}} 
+					</td></tr>
+				{{/rollTotal() augment1multitoggle 9}}
+			{{/augment1multitoggle}}
+			{{#augment1damage}}
+				<tr><td><span class="sheet-template-bold">
+					Damage: </span>{{augment1damage}}
+				</td></tr>
+			{{/augment1damage}}
+			{{#rollWasCrit() augment1attack}}
+				<tr><td><span class="sheet-template-bold sheet-td-critical">
+					Critical: </span>{{augment1critical}}
+				</td></tr>
+			{{/rollWasCrit() augment1attack}}
+			{{#augment1hiteffect}}
+				<tr><td><span class="sheet-template-bold">
+					On Hit: </span>{{augment1hiteffect}}
+				</td></tr>
+			{{/augment1hiteffect}}
+        {{/rollTotal() augmenttoggle 1}}
+		{{#rollTotal() augmenttoggle 2}}
+			<tr><td><span class="sheet-template-bold sheet-td-red">
+				Augment 2</span>
+			</td></tr>
+			{{#augment2range}}
+				<tr><td><span class="sheet-template-bold">
+					Range: </span>{{augment2range}}
+				</td></tr>
+			{{/augment2range}}
+			{{#augment2target}}
+				<tr><td><span class="sheet-template-bold">
+					Target: </span>{{augment2target}}
+				</td></tr>
+			{{/augment2target}}
+			<tr><td><span class="sheet-template-bold">
+				Attack: </span>{{augment2attack}} 
+			</td></tr>
+			{{#augment2multitoggle}} <!-- Toggle Formula [[?{Number of Attacks|2}]] -->
+				{{#rollBetween() augment2multitoggle 2 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 2: </span>{{augment2multiattack2}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 2 9}}
+				{{#rollBetween() augment2multitoggle 3 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 3: </span>{{augment2multiattack3}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 3 9}}
+				{{#rollBetween() augment2multitoggle 4 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 4: </span>{{augment2multiattack4}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 4 9}} 
+				{{#rollBetween() augment2multitoggle 5 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 5: </span>{{augment2multiattack5}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 5 9}}
+				{{#rollBetween() augment2multitoggle 6 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 6: </span>{{augment2multiattack6}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 6 9}}
+				{{#rollBetween() augment2multitoggle 7 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 7: </span>{{augment2multiattack7}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 7 9}}
+				{{#rollBetween() augment2multitoggle 8 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 8: </span>{{augment2multiattack8}} 
+					</td></tr>
+				{{/rollBetween() augment2multitoggle 8 9}}
+				{{#rollTotal() augment2multitoggle 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 9: </span>{{augment2multiattack9}} 
+					</td></tr>
+				{{/rollTotal() augment2multitoggle 9}}
+			{{/augment2multitoggle}}
+			{{#augment2damage}}
+				<tr><td><span class="sheet-template-bold">
+					Damage: </span>{{augment2damage}}
+				</td></tr>
+			{{/augment2damage}}
+			{{#rollWasCrit() augment2attack}}
+				<tr><td><span class="sheet-template-bold sheet-td-critical">
+					Critical: </span>{{augment2critical}}
+				</td></tr>
+			{{/rollWasCrit() augment2attack}}
+			{{#augment2hiteffect}}
+				<tr><td><span class="sheet-template-bold">
+					On Hit: </span>{{augment2hiteffect}}
+				</td></tr>
+			{{/augment2hiteffect}}
+        {{/rollTotal() augmenttoggle 2}}
+		{{#rollTotal() augmenttoggle 4}}
+			<tr><td><span class="sheet-template-bold sheet-td-red">
+				Augment 4</span>
+			</td></tr>
+			{{#augment4range}}
+				<tr><td><span class="sheet-template-bold">
+					Range: </span>{{augment4range}}
+				</td></tr>
+			{{/augment4range}}
+			{{#augment4target}}
+				<tr><td><span class="sheet-template-bold">
+					Target: </span>{{augment4target}}
+				</td></tr>
+			{{/augment4target}}
+			<tr><td><span class="sheet-template-bold">
+				Attack: </span>{{augment4attack}} {{defense}}
+			</td></tr>
+			{{#augment4multitoggle}} <!-- Toggle Formula [[?{Number of Attacks|2}]] -->
+				{{#rollBetween() augment4multitoggle 2 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 2: </span>{{augment4multiattack2}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 2 9}}
+				{{#rollBetween() augment4multitoggle 3 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 3: </span>{{augment4multiattack3}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 3 9}}
+				{{#rollBetween() augment4multitoggle 4 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 4: </span>{{augment4multiattack4}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 4 9}} 
+				{{#rollBetween() augment4multitoggle 5 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 5: </span>{{augment4multiattack5}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 5 9}}
+				{{#rollBetween() augment4multitoggle 6 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 6: </span>{{augment4multiattack6}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 6 9}}
+				{{#rollBetween() augment4multitoggle 7 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 7: </span>{{augment4multiattack7}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 7 9}}
+				{{#rollBetween() augment4multitoggle 8 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 8: </span>{{augment4multiattack8}} 
+					</td></tr>
+				{{/rollBetween() augment4multitoggle 8 9}}
+				{{#rollTotal() augment4multitoggle 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 9: </span>{{augment4multiattack9}} 
+					</td></tr>
+				{{/rollTotal() augment4multitoggle 9}}
+			{{/augment4multitoggle}}
+			{{#augment4damage}}
+				<tr><td><span class="sheet-template-bold">
+					Damage: </span>{{augment4damage}}
+				</td></tr>
+			{{/augment4damage}}
+			{{#rollWasCrit() augment4attack}}
+				<tr><td><span class="sheet-template-bold sheet-td-critical">
+					Critical: </span>{{augment4critical}}
+				</td></tr>
+			{{/rollWasCrit() augment4attack}}
+			{{#augment4hiteffect}}
+				<tr><td><span class="sheet-template-bold">
+					On Hit: </span>{{augment4hiteffect}}
+				</td></tr>
+			{{/augment4hiteffect}}
+        {{/rollTotal() augmenttoggle 4}}
+		{{#rollTotal() augmenttoggle 6}}
+			<tr><td><span class="sheet-template-bold sheet-td-red">
+				Augment 6</span>
+			</td></tr>
+			{{#augment6range}}
+				<tr><td><span class="sheet-template-bold">
+					Range: </span>{{augment6range}}
+				</td></tr>
+			{{/augment6range}}
+			{{#augment6target}}
+				<tr><td><span class="sheet-template-bold">
+					Target: </span>{{augment6target}}
+				</td></tr>
+			{{/augment6target}}
+			<tr><td><span class="sheet-template-bold">
+				Attack: </span>{{augment6attack}} 
+			</td></tr>
+			{{#augment6multitoggle}} <!-- Toggle Formula [[?{Number of Attacks|2}]] -->
+				{{#rollBetween() augment6multitoggle 2 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 2: </span>{{augment6multiattack2}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 2 9}}
+				{{#rollBetween() augment6multitoggle 3 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 3: </span>{{augment6multiattack3}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 3 9}}
+				{{#rollBetween() augment6multitoggle 4 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 4: </span>{{augment6multiattack4}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 4 9}} 
+				{{#rollBetween() augment6multitoggle 5 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 5: </span>{{augment6multiattack5}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 5 9}}
+				{{#rollBetween() augment6multitoggle 6 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 6: </span>{{augment6multiattack6}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 6 9}}
+				{{#rollBetween() augment6multitoggle 7 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 7: </span>{{augment6multiattack7}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 7 9}}
+				{{#rollBetween() augment6multitoggle 8 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 8: </span>{{augment6multiattack8}} 
+					</td></tr>
+				{{/rollBetween() augment6multitoggle 8 9}}
+				{{#rollTotal() augment6multitoggle 9}}
+					<tr><td><span class="sheet-template-bold">
+						Attack 9: </span>{{augment6multiattack9}} 
+					</td></tr>
+				{{/rollTotal() augment6multitoggle 9}}
+			{{/augment6multitoggle}}
+			{{#augment6damage}}
+				<tr><td><span class="sheet-template-bold">
+					Damage: </span>{{augment6damage}}
+				</td></tr>
+			{{/augment6damage}}
+			{{#rollWasCrit() augment6attack}}
+				<tr><td><span class="sheet-template-bold sheet-td-critical">
+					Critical: </span>{{augment6critical}}
+				</td></tr>
+			{{/rollWasCrit() augment6attack}}
+			{{#augment6hiteffect}}
+				<tr><td><span class="template-bold">
+					On Hit: </span>{{augment6hiteffect}}
+				</td></tr>
+			{{/augment6hiteffect}}
+        {{/rollTotal() augmenttoggle 6}}		
+	{{/augmenttoggle}}
+	{{#classmodifier}}
+		<tr><td>
+			{{classmodifier}}
+        </td></tr>
+	{{/classmodifier}}
+	{{#miss}}
+		<tr><td><span class="sheet-template-bold">
+			Miss: </span>{{miss}}
+        </td></tr>
+	{{/miss}}
+	{{#effect}}
+		<tr><td><span class="sheet-template-bold">
+			Effect: </span>{{effect}}
+        </td></tr>
+	{{/effect}}
+	{{#firstfailedsave}}
+		<tr><td><span class="sheet-template-bold">
+			First Failed Save: </span>{{firstfailedsave}}
+        </td></tr>
+	{{/firstfailedsave}}
+	{{#secondfailedsave}}
+		<tr><td><span class="sheet-template-bold">
+			Second Failed Save: </span>{{secondfailedsave}}
+        </td></tr>
+	{{/secondfailedsave}}
+	{{#eachfailedsave}}
+		<tr><td><span class="sheet-template-bold">
+			Each Failed Save: </span>{{eachfailedsave}}
+        </td></tr>
+	{{/eachfailedsave}}
+	{{#aftereffect}}
+		<tr><td><span class="sheet-template-bold">
+			Aftereffect: </span>{{aftereffect}}
+         </td></tr>
+	{{/aftereffect}}
+	{{#sustainminor}}
+		<tr><td><span class="sheet-template-bold">
+			Sustain Minor: </span>{{sustainminor}}
+         </td></tr>
+	{{/sustainminor}}
+	{{#sustainstandard}}
+		<tr><td><span class="sheet-template-bold">
+			Sustain Standard: </span>{{sustainstandard}}
+         </td></tr>
+	{{/sustainstandard}}
+	{{#movetechnique}}
+		<tr><td><span class="sheet-template-bold">
+			Move Technique: </span> {{movetechnique}}
+        </td></tr>
+		<tr><td><span class="sheet-template-bold">
+			{{mttype}} {{mtrange}}</span>
+        </td></tr>
+		{{#mttarget}}
+			<tr><td><span class="sheet-template-bold">
+				Target: </span>{{mttarget}}
+            </td></tr>
+		{{/mttarget}}
+		{{#mteffect}}
+			<tr><td><span class="sheet-template-bold">
+				Effect: </span>{{mteffect}}
+            </td></tr>
+		{{/mteffect}}
+	{{/movetechnique}}
+	{{#special}}
+		<tr><td><span class="sheet-template-bold">
+			Special: </span>{{special}}
+         </td></tr>
+	{{/special}}
+	{{#initiative}}
+		<tr><td><span class="sheet-template-bold">
+			Roll: </span>{{initiative}}
+         </td></tr>
+	{{/initiative}}
+	{{#ability}}
+		<tr><td><span class="sheet-template-bold">
+			Roll: </span>{{ability}}
+         </td></tr>
+	{{/ability}}
+	{{#skill}}
+		<tr><td><span class="sheet-template-bold">
+			Roll: </span>{{skill}}
+         </td></tr>
+	{{/skill}}
+	{{#allprops() atwill encounter daily item other monster emote name class level type keywords attacktechnique action range requirement trigger beforespecial beforeeffect target primarytarget attackweaponmod attack multiattacktoggle multiattack2 multiattack3 multiattack4 multiattack5 multiattack6 multiattack7 multiattack8 multiattack9 multiattack10 multiattack11 multiattack12 multiattack13 multiattack14 multiattack15 multiattack16 multiattack17 multiattack18 multiattack19 multiattack20 damage critical hitweaponmod hiteffect hitaftereffect effectweaponmod secondaryrange secondarytarget secondaryattack secondarydamage secondarycritical secondaryhiteffect tertiaryrange tertiarytarget tertiaryattack tertiarydamage tertiarycritical tertiaryhiteffect augmenttoggle augment1range augment1target augment1attack augment1multitoggle augment1multiattack2 augment1multiattack3 augment1multiattack4 augment1multiattack5 augment1multiattack6 augment1multiattack7 augment1multiattack8 augment1multiattack9 augment1damage augment1critical augment1hiteffect augment2range augment2target augment2attack augment2multitoggle augment2multiattack2 augment2multiattack3 augment2multiattack4 augment2multiattack5 augment2multiattack6 augment2multiattack7 augment2multiattack8 augment2multiattack9 augment2damage augment2critical augment2hiteffect augment4range augment4target augment4attack augment4multitoggle augment4multiattack2 augment4multiattack3 augment4multiattack4 augment4multiattack5 augment4multiattack6 augment4multiattack7 augment4multiattack8 augment4multiattack9 augment4damage augment4critical augment4hiteffect augment6range augment6target augment6attack augment6multitoggle augment6multiattack2 augment6multiattack3 augment6multiattack4 augment6multiattack5 augment6multiattack6 augment6multiattack7 augment6multiattack8 augment6multiattack9 augment6damage augment6critical augment6hiteffect classmodifier miss effect firstfailedsave secondfailedsave eachfailedsave aftereffect sustainminor sustainstandard movetechnique mttype mtrange mttarget mteffect special initiative ability skill}}
+		<tr><td>{{key}} {{value}}</td></tr>
+	{{/allprops() atwill encounter daily item other monster emote name class level type keywords attacktechnique action range requirement trigger beforespecial beforeeffect target primarytarget attackweaponmod attack multiattacktoggle multiattack2 multiattack3 multiattack4 multiattack5 multiattack6 multiattack7 multiattack8 multiattack9 multiattack10 multiattack11 multiattack12 multiattack13 multiattack14 multiattack15 multiattack16 multiattack17 multiattack18 multiattack19 multiattack20 damage critical hitweaponmod hiteffect hitaftereffect effectweaponmod secondaryrange secondarytarget secondaryattack secondarydamage secondarycritical secondaryhiteffect tertiaryrange tertiarytarget tertiaryattack tertiarydamage tertiarycritical tertiaryhiteffect augmenttoggle augment1range augment1target augment1attack augment1multitoggle augment1multiattack2 augment1multiattack3 augment1multiattack4 augment1multiattack5 augment1multiattack6 augment1multiattack7 augment1multiattack8 augment1multiattack9 augment1damage augment1critical augment1hiteffect augment2range augment2target augment2attack augment2multitoggle augment2multiattack2 augment2multiattack3 augment2multiattack4 augment2multiattack5 augment2multiattack6 augment2multiattack7 augment2multiattack8 augment2multiattack9 augment2damage augment2critical augment2hiteffect augment4range augment4target augment4attack augment4multitoggle augment4multiattack2 augment4multiattack3 augment4multiattack4 augment4multiattack5 augment4multiattack6 augment4multiattack7 augment4multiattack8 augment4multiattack9 augment4damage augment4critical augment4hiteffect augment6range augment6target augment6attack augment6multitoggle augment6multiattack2 augment6multiattack3 augment6multiattack4 augment6multiattack5 augment6multiattack6 augment6multiattack7 augment6multiattack8 augment6multiattack9 augment6damage augment6critical augment6hiteffect classmodifier miss effect firstfailedsave secondfailedsave eachfailedsave aftereffect sustainminor sustainstandard movetechnique mttype mtrange mttarget mteffect special initiative ability skill}}
+  </table>
+</rolltemplate>

--- a/D&D_4E/sheet.json
+++ b/D&D_4E/sheet.json
@@ -1,8 +1,8 @@
 {
 	"html": "D&D_4E.html",
 	"css": "D&D_4E.css",
-	"authors": "Alex L., Ville S.",
+	"authors": "Alex L., Ville S., Wesley L. (Wes on Roll20.net)",
 	"preview": "D&D_4E.png",
-    "roll20userid": "71687",
-	"instructions": "# D&D 4E classic character sheet\r## Useful Attributes\r\r* level\r* halflevel\r\r* hp\r* hp-bloodied\r* surge-value\r* surges\r* tmp-hp\r\r* initiative\r* speed\r* action-points\r\r* ac\r* fort\r* ref\r* will\r\r**ability scores**\r\r* strength\r* constitution\r* dexterity\r* intelligence\r* wisdom\r*charisma\r* [ability]-mod\r* [ability]-mod-level *modifier with half level*\r\r* passive-insight\r* passive-perception\r\r**skills**\r\r* acrobatics\r* arcana\r* athletics\r* bluff\r* diplomacy\r* dungeoneering\r* endurance\r* heal\r* history\r* insight\r* intimidate\r* nature\r* perception\r* religion\r* stealth\r* streetwise\r* thievery"
+    "roll20userid": "71687, 405463",
+	"instructions": "# D&D 4E classic character sheet\r## Useful Attributes\r\r* level\r* halflevel\r\r* hp\r* hp-bloodied\r* surge-value\r* surges\r* tmp-hp\r\r* initiative\r* speed\r* action-points\r\r* ac\r* fort\r* ref\r* will\r\r**ability scores**\r\r* strength\r* constitution\r* dexterity\r* intelligence\r* wisdom\r*charisma\r* [ability]-mod\r* [ability]-mod-level *modifier with half level*\r\r* passive-insight\r* passive-perception\r\r**skills**\r\r* acrobatics\r* arcana\r* athletics\r* bluff\r* diplomacy\r* dungeoneering\r* endurance\r* heal\r* history\r* insight\r* intimidate\r* nature\r* perception\r* religion\r* stealth\r* streetwise\r* thievery\r\r More information on the Roll20 Wiki: https://wiki.roll20.net/DnD4e_Character_Sheet"
 }


### PR DESCRIPTION
* Changed Gender Field from a Select Field to a Text Field.
* Added a “None” to the AC Select List in the Settings Tab. The value is set to Zero “0” and is set to selected.
* Added a “Tie Breaker Select in the Settings Tab.
* The Initiative roll was changed to add the bonus value of @{initiative}*@{init-tie}. Multipling the initiative bonus by either 0 or 0.01 depending on the selected value and adding it to the initiative roll.
* Added a Magical Per Plus Die Size to the Weapons in the Inventory Section. Users will be able to call this value into macros for critical damage calculations.
* Added Roll Template information under the Powers in the Powers Tab.
* Changed Emote text in the Settings tab to work with Roll Templates.
* Added Roll Templates to the character sheet.
* Changed the Character Sheet Roll Buttons to use the new Roll Templates
* Changed Version number to 2 and Added a Link to the Wiki in the Footer of the Character Sheet