### PR TITLE
fix hit location values in Dark Heresy 1e and Rogue Trader

### DIFF
--- a/Dark_Heresy/DarkHeresy.html
+++ b/Dark_Heresy/DarkHeresy.html
@@ -547,13 +547,13 @@
 <label>Head</label> <input name="attr_Headarmourvalue" type="text"> <label>(1-10) Type</label> <input name="attr_Headarmourtype" type="text">
 </div><br>
 <div class="sheet-quickborder sheet-armourblock">
-<label>Left Arm</label> <input name="attr_LeftArmarmourvalue" type="text"> <label>(11-20) Type</label> <input name="attr_LeftArmarmourtype" type="text">
+<label>Left Arm</label> <input name="attr_LeftArmarmourvalue" type="text"> <label>(21-30) Type</label> <input name="attr_LeftArmarmourtype" type="text">
 </div>
 <div class="sheet-quickborder sheet-armourblock">
 <label>Body</label> <input name="attr_Bodyarmourvalue" type="text"> <label>(31-70) Type</label> <input name="attr_Bodyarmourtype" type="text">
 </div>
 <div class="sheet-quickborder sheet-armourblock">
-<label>Right Arm</label> <input name="attr_RightArmarmourvalue" type="text"> <label>(31-30) Type</label> <input name="attr_RightArmarmourtype" type="text">
+<label>Right Arm</label> <input name="attr_RightArmarmourvalue" type="text"> <label>(11-20) Type</label> <input name="attr_RightArmarmourtype" type="text">
 </div>
 <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
 <label>Left Leg</label> <input name="attr_LeftLegarmourvalue" type="text"> <label>(71-85) Type</label> <input name="attr_LeftLegarmourtype" type="text">

--- a/Rogue_Trader/RogueTrader.html
+++ b/Rogue_Trader/RogueTrader.html
@@ -478,7 +478,7 @@
         <div class="sheet-quickborder sheet-armourblock">
            	<label>Left Arm</label>
 			<input type="text" name="attr_leftarmarmourvalue" />
-            <label>(11-20) Type</label>
+            <label>(21-30) Type</label>
             <input type="text" name="attr_leftarmarmourtype" />         
         </div>
        	<div class="sheet-quickborder sheet-armourblock">
@@ -491,7 +491,7 @@
         <div class="sheet-quickborder sheet-armourblock">
            	<label>Right Arm</label>
 			<input type="text" name="attr_rightarmarmourvalue" />
-            <label>(31-30) Type</label>
+            <label>(11-20) Type</label>
             <input type="text" name="attr_rightarmarmourtype" />         
         </div>              
         <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">


### PR DESCRIPTION
The numbers in the paper doll are not correct. I suspect this is true of (at least) Deathwatch and the other 40K systems, but I don't have the sourcebooks for them.