### PR TITLE
Stars Without Number -- Ship Sheet Implementation

### DIFF
--- a/Stars_Without_Number/ReadMe.md
+++ b/Stars_Without_Number/ReadMe.md
@@ -4,6 +4,21 @@ This sheet is created for use in Stars Without Number on Roll20. Based on the ch
 
 ### Changelog
 
+#### 0.0.7
+
+* Add ship character sheet tab
+
+#### 0.0.6
+
+* Roll buttons for all the listed skills
+* Roll buttons for all saves
+* Auto-sets the Max Strain to Unaltered CON
+* Boxes to store each Attribute's bonus value
+* A Box to store your current AC (to allow target-macros + for easy reference)
+* A button for rolling initiative. If you have your token selected, it will automatically add it to the turn tracker.
+* A section just below the Core Stats sheet for the above initiative macro/roll button (and any future buttons that might be useful)
+* Buttons for rolling attacks based on weapons in the weapon section, as well as a generic attack roll button.
+
 #### 0.0.5
 
 * Fixed Skill rows not aligning.
@@ -32,3 +47,4 @@ This sheet is created for use in Stars Without Number on Roll20. Based on the ch
 Report any problems, suggestions or features by sending a private message on Roll20 or submitting an issue on Github.
 
 [Kevin the Barbarian](https://app.roll20.net/users/565104/kevin-the-barbarian) on Roll20
+[Joe Fredette](https://app.roll20.net/users/161749/joe-f) on Roll20

--- a/Stars_Without_Number/ReadMe.md
+++ b/Stars_Without_Number/ReadMe.md
@@ -6,6 +6,7 @@ This sheet is created for use in Stars Without Number on Roll20. Based on the ch
 
 #### 0.0.7
 
+* Add support for multiple tabs
 * Add ship character sheet tab
 
 #### 0.0.6

--- a/Stars_Without_Number/Stars_Without_Number.css
+++ b/Stars_Without_Number/Stars_Without_Number.css
@@ -266,3 +266,7 @@ div.sheet-tab-input
 .sheet-tab-ship .sheet-ship-repeating-headers .sheet-6colrow input {
   width: 100%;
 }
+
+.sheet-tab-ship .sheet-ship-other-notes {
+  width: 98%;
+}

--- a/Stars_Without_Number/Stars_Without_Number.css
+++ b/Stars_Without_Number/Stars_Without_Number.css
@@ -244,3 +244,25 @@ div.sheet-tab-input
   margin: 1px;
   padding: 0;
 }
+
+.sheet-tab-ship .sheet-ship-repeating-headers {
+  width: 100%;
+}
+
+.sheet-tab-ship .sheet-ship-weapons .sheet-6colrow {
+  width: 100%;
+}
+
+.sheet-tab-ship .sheet-ship-repeating-headers .sheet-3colrow div {
+  width: 27%;
+  margin: 0;
+}
+
+.sheet-tab-ship .sheet-ship-repeating-headers .sheet-6colrow div {
+  width: 15%;
+  margin: 0;
+}
+
+.sheet-tab-ship .sheet-ship-repeating-headers .sheet-6colrow input {
+  width: 100%;
+}

--- a/Stars_Without_Number/Stars_Without_Number.css
+++ b/Stars_Without_Number/Stars_Without_Number.css
@@ -1,151 +1,223 @@
-.charsheet {
-    background-color: white;
-}
-.charsheet .sheet-wrapper h1, .charsheet .sheet-wrapper h3 {
-    margin: 0 auto;
-    border: 2px solid #000000;
-    background-color: #848482;
-    text-align: center;
-    color: #ffffff;
-    font-size: 15pt;
-}
-.charsheet .sheet-wrapper .sheet-logo {
-    width: 100%;
-}
-.charsheet .sheet-wrapper .sheet-logo img {
-    display: block;
-    margin: auto;
-}
-.charsheet .sheet-wrapper .sheet-swn-min {
-    font-size: 10px;
-}
-.charsheet .sheet-wrapper h3 {
-    margin-top: 10px;
-    margin-bottom: 10px;
-    text-align: left;
-    font-size: 15px;
+div.sheet-tab-content { display: none; }
+
+input.sheet-tab-character:checked ~ div.sheet-tab-character,
+input.sheet-tab-ship:checked ~ div.sheet-tab-ship,
+{
+  display: block;
 }
 
-    /* Rows */
+input.sheet-tab
+{
+  width: 150px;
+  height: 20px;
+  position: relative;
+  left: 6px;
+  margin: -1.5px;
+  cursor: pointer;
+  z-index: 1;
+}
+
+input.sheet-tab::before
+{
+  content: attr(title);
+
+  border: solid 1px #a8a8a8;
+  border-bottom-color: black;
+  text-align: center;
+  display: inline-block;
+
+  background: #bbb;
+
+  width: 150px;
+  height: 20px;
+  font-size: 18px;
+}
+
+input.sheet-tab:checked::before
+{
+  background: #fff;
+  border-bottom-color: #fff;
+}
+
+input.sheet-tab:not(:first-child)::before
+{
+  border-left: none;
+}
+
+
+input.sheet-tab-input:checked::before
+{
+  background: #dcdcdc;
+  background: -moz-linear-gradient(to top, #fcecec, #f8c8c8, #fcecec);
+  background: -webkit-linear-gradient(to top, #fcecec, #f8c8c8, #fcecec);
+  background: -ms-linear-gradient(to top, #fcecec, #f8c8c8, #fcecec);
+  background: -o-linear-gradient(to top, #fcecec, #f8c8c8, #fcecec);
+  background: linear-gradient(to top, #fcecec, #f8c8c8, #fcecec);
+  border-bottom-color: #fcecec;
+}
+
+div.sheet-tab-content
+{
+  border: 1px solid #a8a8a8;
+  border-top-color: #000;
+  margin: 2px 0 0 5px;
+  padding: 5px;
+}
+
+div.sheet-tab-input
+{
+  background-color: #fcecec;
+}
+
+
+.charsheet {
+  background-color: white;
+}
+.charsheet .sheet-wrapper h1, .charsheet .sheet-wrapper h3 {
+  margin: 0 auto;
+  border: 2px solid #000000;
+  background-color: #848482;
+  text-align: center;
+  color: #ffffff;
+  font-size: 15pt;
+}
+.charsheet .sheet-wrapper .sheet-logo {
+  width: 100%;
+}
+.charsheet .sheet-wrapper .sheet-logo img {
+  display: block;
+  margin: auto;
+}
+.charsheet .sheet-wrapper .sheet-swn-min {
+  font-size: 10px;
+}
+.charsheet .sheet-wrapper h3 {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  text-align: left;
+  font-size: 15px;
+}
+
+/* Rows */
 .charsheet .sheet-wrapper .sheet-skills .sheet-row,
 .charsheet .sheet-wrapper div.sheet-gear-cyberware,
 .charsheet .sheet-wrapper .sheet-stats div,
 .charsheet .sheet-wrapper .sheet-gear div {
-    min-height: 30px;
+  min-height: 30px;
 }
 .charsheet .sheet-wrapper .sheet-skills {
-    padding-top: 5px;
-    padding-bottom: 5px;
-    margin-bottom: 5px;
-    border: 1px solid #000;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-bottom: 5px;
+  border: 1px solid #000;
 }
 .charsheet .sheet-wrapper .sheet-skills:nth-child(odd) {
-    background-color: #d3d3d3;
+  background-color: #d3d3d3;
 }
 
-    /* Cols */
+/* Cols */
 .sheet-col-whitespace {
-    width: 30px;
+  width: 30px;
 }
 .charsheet .sheet-wrapper .sheet-stats div.sheet-stats-label {
-    width: 90px;
+  width: 90px;
 }
 .charsheet .sheet-wrapper .sheet-stats div.sheet-attribute-label {
-    width: 50px;
+  width: 50px;
 }
 .charsheet .sheet-wrapper .sheet-stats div.sheet-attribute-ext-label {
-    width: 100px;
+  width: 100px;
 }
 .charsheet .sheet-wrapper .sheet-saves .sheet-col {
-    width: 150px;
+  width: 150px;
 }
 .charsheet .sheet-wrapper .sheet-gear div.sheet-gear-name {
-    width: 180px;
+  width: 180px;
 }
 .charsheet .sheet-wrapper .sheet-gear div.sheet-gear-readied {
-    width: 55px;
-    text-align: center;
+  width: 55px;
+  text-align: center;
 }
 .charsheet .sheet-wrapper .sheet-gear div.sheet-gear-encumbrance {
-    width: 100px;
+  width: 100px;
 }
 .charsheet .sheet-wrapper .sheet-weapons .sheet-col {
-    width: 12%;
+  width: 12%;
 }
 .charsheet .sheet-wrapper div.sheet-psionics-level {
-    width: 300px;
+  width: 300px;
 }
 .charsheet .sheet-wrapper div.sheet-psionics-pp {
-    width: 380px;
+  width: 380px;
 }
 .charsheet .sheet-wrapper div.sheet-psionics-pp .sheet-col {
-    width: 50px;
+  width: 50px;
 }
 .charsheet .sheet-wrapper div.sheet-misc-goal,
 .charsheet .sheet-wrapper div.sheet-misc-goal-xp {
-    width: 100px;
+  width: 100px;
 }
 
-    /* Labels */
+/* Labels */
 .charsheet .sheet-wrapper label {
-    font-weight: bold;
+  font-weight: bold;
 }
 .charsheet .sheet-wrapper .sheet-skills label {
-    display: inline;
-    width: 175px;
-    white-space: nowrap;
+  display: inline;
+  width: 175px;
+  white-space: nowrap;
 }
 .charsheet .sheet-wrapper .sheet-skills label.sheet-skill-points-unspent {
-    background: #000000;
-    color: #ffffff;
+  background: #000000;
+  color: #ffffff;
 }
 
-    /* Input fields */
+/* Input fields */
 .charsheet .sheet-wrapper textarea {
-    resize: none;
+  resize: none;
 }
 .charsheet .sheet-wrapper .sheet-stats input {
-    width: 243px;
+  width: 243px;
 }
 .charsheet .sheet-wrapper .sheet-stats input.sheet-stats-half {
-    width: 75px;
+  width: 75px;
 }
 .charsheet .sheet-wrapper .sheet-skills input {
-    width: 50px;
+  width: 50px;
 }
 .charsheet .sheet-wrapper input.sheet-skills-custom {
-    display: inline;
-    width: 150px;
+  display: inline;
+  width: 150px;
 }
 .charsheet .sheet-wrapper input.sheet-gear-credits {
-    width: 100px;
+  width: 100px;
 }
 .charsheet .sheet-wrapper .sheet-gear-cyberware input {
-    width: 340px;
+  width: 340px;
 }
 .charsheet .sheet-wrapper .sheet-gear-other textarea {
-    width: 330px;
-    min-height: 164px;
+  width: 330px;
+  min-height: 164px;
 }
 .charsheet .sheet-wrapper .sheet-weapons .sheet-col input {
-    width: 90%;
+  width: 90%;
 }
 .charsheet .sheet-wrapper .sheet-psionics-discipline input {
-    width: 340px;
+  width: 340px;
 }
 .charsheet .sheet-wrapper .sheet-psionics-discipline-level input {
-    width: 50px;
+  width: 50px;
 }
 .charsheet .sheet-wrapper .sheet-psionics-power input,
 .charsheet .sheet-wrapper .sheet-psionics-mastered input {
-    width: 340px;
+  width: 340px;
 }
 .charsheet .sheet-wrapper .sheet-psionics-pp input {
-    width: 50px;
+  width: 50px;
 }
 .charsheet .sheet-wrapper .sheet-misc-goal input {
-    width: 400px;
+  width: 400px;
 }
 .charsheet .sheet-wrapper .sheet-misc-goal-xp input {
-    width: 100px;
+  width: 100px;
 }

--- a/Stars_Without_Number/Stars_Without_Number.css
+++ b/Stars_Without_Number/Stars_Without_Number.css
@@ -1,3 +1,4 @@
+/* tab styles */
 div.sheet-tab-content { display: none; }
 
 input.sheet-tab-character:checked ~ div.sheet-tab-character,
@@ -44,7 +45,6 @@ input.sheet-tab:not(:first-child)::before
   border-left: none;
 }
 
-
 input.sheet-tab-input:checked::before
 {
   background: #dcdcdc;
@@ -69,7 +69,7 @@ div.sheet-tab-input
   background-color: #fcecec;
 }
 
-
+/* character sheet styles */
 .charsheet {
   background-color: white;
 }
@@ -111,6 +111,11 @@ div.sheet-tab-input
   margin-bottom: 5px;
   border: 1px solid #000;
 }
+
+.charsheet .sheet-wrapper .sheet-stat-bonus {
+  width: 40px;
+}
+
 .charsheet .sheet-wrapper .sheet-skills:nth-child(odd) {
   background-color: #d3d3d3;
 }
@@ -220,4 +225,22 @@ div.sheet-tab-input
 }
 .charsheet .sheet-wrapper .sheet-misc-goal-xp input {
   width: 100px;
+}
+
+/* ship sheet styles */
+
+.sheet-tab-ship .sheet-stats .sheet-col .sheet-stats-ship-min-max .sheet-stats-ship-value {
+  width: 50px;
+  margin: 0;
+}
+
+.sheet-tab-ship .sheet-stats .sheet-col .sheet-stats-ship-min-max .sheet-stats-ship-value input {
+  width: 50px;
+  margin: 0;
+}
+
+.sheet-tab-ship .sheet-stats .sheet-col .sheet-stats-ship-min-max .sheet-stats-label-separator {
+  width: 5px;
+  margin: 1px;
+  padding: 0;
 }

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -1,114 +1,135 @@
-<div class="sheet-wrapper">
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab-character" value="1" title="Character" checked="checked" />
+<input type="radio" name="attr_tab" class="sheet-tab sheet-tab-ship" value="2" title="Ship" />
+
+<div class="sheet-tab-content sheet-tab-ship">
+  <div class="sheet-wrapper">
     <div class="sheet-row">
-        <div class="sheet-col sheet-logo">
-            <img src="http://i.imgur.com/3U3Ibb7.png" alt="Stars Without Number">
-        </div>
+      <div class="sheet-col sheet-logo">
+        <img src="http://i.imgur.com/3U3Ibb7.png" alt="Stars Without Number">
+      </div>
     </div>
     <div class="sheet-row">
       <div class="sheet-col sheet-swn-min">Version 0.0.7</div>
     </div>
     <h3>Core Stats</h3>
     <div class="sheet-row sheet-stats">
-        <div class="sheet-col">
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_name">Name</label></div>
-                <div class="sheet-col"><input type="text" name="attr_name"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_gender">Gender</label></div>
-                <div class="sheet-col"><input type="text" name="attr_gender"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_class">Class</label></div>
-                <div class="sheet-col"><input type="text" name="attr_class"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_level">Level</label></div>
-                <div class="sheet-col"><input type="number" min="1" name="attr_level"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_xp">XP</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_xp" class="sheet-stats-half"></div>
-                <div class="sheet-col"><label for="attr_xp_max">XP Next Level</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_xp_max" class="sheet-stats-half"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_homeworld">Homeworld</label></div>
-                <div class="sheet-col"><input type="text" name="attr_homeworld"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_background">Background</label></div>
-                <div class="sheet-col"><input type="text" name="attr_background"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_training">Training</label></div>
-                <div class="sheet-col"><input type="text" name="attr_training"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-stats-label"><label for="attr_faction">Faction</label></div>
-                <div class="sheet-col"><input type="text" name="attr_faction"></div>
-            </div>
+      lorem ipsum dolor sit amet
+    </div>
+  </div>
+</div>
+
+<div class="sheet-tab-content sheet-tab-character">
+  <div class="sheet-wrapper">
+    <div class="sheet-row">
+      <div class="sheet-col sheet-logo">
+        <img src="http://i.imgur.com/3U3Ibb7.png" alt="Stars Without Number">
+      </div>
+    </div>
+    <div class="sheet-row">
+      <div class="sheet-col sheet-swn-min">Version 0.0.7</div>
+    </div>
+    <h3>Core Stats</h3>
+    <div class="sheet-row sheet-stats">
+      <div class="sheet-col">
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_name">Name</label></div>
+          <div class="sheet-col"><input type="text" name="attr_name"></div>
         </div>
-        <div class="sheet-col" class="sheet-col-whitespace">&nbsp;</div>
-        <div class="sheet-col">
-            <div class="sheet-row">
-                Modifiers: 18 [+2] | 14-17 [+1] | 8-13 [+0] | 4-7 [-1] | 3 [-2]
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-label"><label for="attr_str">STR</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_str" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_strBonus" value="@{Str}" class="sheet-stats-half">
-                </div>
-                <div class="sheet-col sheet-attribute-label"><label for="attr_int">INT</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_int" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_intBonus" value="" class="sheet-stats-half">
-                </div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-label"><label for="attr_dex">DEX</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_dex" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_dexBonus" value="" class="sheet-stats-half">
-                </div>
-                <div class="sheet-col sheet-attribute-label"><label for="attr_wis">WIS</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_wis" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_wisBonus" value="" class="sheet-stats-half">
-                </div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-label"><label for="attr_con">CON</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_con" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_conBonus" value="" class="sheet-stats-half">
-                </div>
-                <div class="sheet-col sheet-attribute-label"><label for="attr_cha">CHA</label></div>
-                <div class="sheet-col">
-                    <input type="number" min="3" name="attr_cha" class="sheet-stats-half">
-                    <input type="number" min="-2" max="2" name="attr_chaBonus" value="" class="sheet-stats-half">
-                </div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain">System Strain</label></div>
-                <div class="sheet-col"><input type="number" name="attr_strain" class="sheet-stats-half"></div>
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain_max">Max Strain</label></div>
-                <div class="sheet-col"><input type="number" disabled="true" value="@{Con}" name="attr_strain_max" class="sheet-stats-half"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_hp">Hit Points</label></div>
-                <div class="sheet-col"><input type="number" name="attr_hp" class="sheet-stats-half"></div>
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain_max">Max HP</label></div>
-                <div class="sheet-col"><input type="number" name="attr_hp_max" class="sheet-stats-half"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_attack_bonus">Attack Bonus</label></div>
-                <div class="sheet-col"><input type="number" name="attr_attack_bonus" class="sheet-stats-half"></div>
-                <div class="sheet-col sheet-attribute-ext-label"><label for="attr_AC">AC</label></div>
-                <div class="sheet-col"><input type="number" name="attr_AC" class="sheet-stats-half"></div>
-            </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_gender">Gender</label></div>
+          <div class="sheet-col"><input type="text" name="attr_gender"></div>
         </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_class">Class</label></div>
+          <div class="sheet-col"><input type="text" name="attr_class"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_level">Level</label></div>
+          <div class="sheet-col"><input type="number" min="1" name="attr_level"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_xp">XP</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_xp" class="sheet-stats-half"></div>
+          <div class="sheet-col"><label for="attr_xp_max">XP Next Level</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_xp_max" class="sheet-stats-half"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_homeworld">Homeworld</label></div>
+          <div class="sheet-col"><input type="text" name="attr_homeworld"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_background">Background</label></div>
+          <div class="sheet-col"><input type="text" name="attr_background"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_training">Training</label></div>
+          <div class="sheet-col"><input type="text" name="attr_training"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_faction">Faction</label></div>
+          <div class="sheet-col"><input type="text" name="attr_faction"></div>
+        </div>
+      </div>
+      <div class="sheet-col" class="sheet-col-whitespace">&nbsp;</div>
+      <div class="sheet-col">
+        <div class="sheet-row">
+          Modifiers: 18 [+2] | 14-17 [+1] | 8-13 [+0] | 4-7 [-1] | 3 [-2]
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-label"><label for="attr_str">STR</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_str" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_strBonus" value="@{Str}" class="sheet-stats-half">
+          </div>
+          <div class="sheet-col sheet-attribute-label"><label for="attr_int">INT</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_int" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_intBonus" value="" class="sheet-stats-half">
+          </div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-label"><label for="attr_dex">DEX</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_dex" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_dexBonus" value="" class="sheet-stats-half">
+          </div>
+          <div class="sheet-col sheet-attribute-label"><label for="attr_wis">WIS</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_wis" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_wisBonus" value="" class="sheet-stats-half">
+          </div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-label"><label for="attr_con">CON</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_con" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_conBonus" value="" class="sheet-stats-half">
+          </div>
+          <div class="sheet-col sheet-attribute-label"><label for="attr_cha">CHA</label></div>
+          <div class="sheet-col">
+            <input type="number" min="3" name="attr_cha" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_chaBonus" value="" class="sheet-stats-half">
+          </div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain">System Strain</label></div>
+          <div class="sheet-col"><input type="number" name="attr_strain" class="sheet-stats-half"></div>
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain_max">Max Strain</label></div>
+          <div class="sheet-col"><input type="number" disabled="true" value="@{Con}" name="attr_strain_max" class="sheet-stats-half"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_hp">Hit Points</label></div>
+          <div class="sheet-col"><input type="number" name="attr_hp" class="sheet-stats-half"></div>
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_strain_max">Max HP</label></div>
+          <div class="sheet-col"><input type="number" name="attr_hp_max" class="sheet-stats-half"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_attack_bonus">Attack Bonus</label></div>
+          <div class="sheet-col"><input type="number" name="attr_attack_bonus" class="sheet-stats-half"></div>
+          <div class="sheet-col sheet-attribute-ext-label"><label for="attr_AC">AC</label></div>
+          <div class="sheet-col"><input type="number" name="attr_AC" class="sheet-stats-half"></div>
+        </div>
+      </div>
     </div>
     <h3>Common Rolls:</h3>
     <div class="sheet-5colrow">
@@ -123,803 +144,804 @@
     </div>
     <h3>Saving Throws</h3>
     <div class="sheet-5colrow sheet-saves">
-        <div class="sheet-col">
-          <label for="attr_save_physical">Physical Save</label>
-        </div>
-        <div class="sheet-col">
-          <label for="attr_save_mental">Mental Save</label>
-        </div>
-        <div class="sheet-col">
-          <label for="attr_save_evasion">Evasion Save</label>
-        </div>
-        <div class="sheet-col">
-          <label for="attr_save_tech">Tech Save</label>
-        </div>
-        <div class="sheet-col">
-          <label for="attr_save_luck">Luck Save</label>
-        </div>
+      <div class="sheet-col">
+        <label for="attr_save_physical">Physical Save</label>
+      </div>
+      <div class="sheet-col">
+        <label for="attr_save_mental">Mental Save</label>
+      </div>
+      <div class="sheet-col">
+        <label for="attr_save_evasion">Evasion Save</label>
+      </div>
+      <div class="sheet-col">
+        <label for="attr_save_tech">Tech Save</label>
+      </div>
+      <div class="sheet-col">
+        <label for="attr_save_luck">Luck Save</label>
+      </div>
     </div>
     <div class="sheet-5colrow sheet-saves">
-        <div class="sheet-col">
-          <input type="number" min="0" name="attr_save_physical" class="sheet-stats-save">
-          <button name="roll_save_physical" type="roll" value="/roll 1d20>@{save_physical} Physical Save"></button>
-        </div>
-        <div class="sheet-col">
-          <input type="number" min="0" name="attr_save_mental" class="sheet-stats-save">
-          <button name="roll_save_mental" type="roll" value="/roll 1d20>@{save_mental} Mental Save"></button>
-        </div>
-        <div class="sheet-col">
-          <input type="number" min="0" name="attr_save_evasion" class="sheet-stats-save">
-          <button name="roll_save_evasion" type="roll" value="/roll 1d20>@{save_evasion} Evasion Save"></button>
-        </div>
-        <div class="sheet-col">
-          <input type="number" min="0" name="attr_save_tech" class="sheet-stats-save">
-          <button name="roll_save_tech" type="roll" value="/roll 1d20>@{save_tech} Tech Save"></button>
-        </div>
-        <div class="sheet-col">
-          <input type="number" min="0" name="attr_save_luck" class="sheet-stats-save">
-          <button name="roll_save_luck" type="roll" value="/roll 1d20>@{save_luck} Luck Save"></button>
-        </div>
+      <div class="sheet-col">
+        <input type="number" min="0" name="attr_save_physical" class="sheet-stats-save">
+        <button name="roll_save_physical" type="roll" value="/roll 1d20>@{save_physical} Physical Save"></button>
+      </div>
+      <div class="sheet-col">
+        <input type="number" min="0" name="attr_save_mental" class="sheet-stats-save">
+        <button name="roll_save_mental" type="roll" value="/roll 1d20>@{save_mental} Mental Save"></button>
+      </div>
+      <div class="sheet-col">
+        <input type="number" min="0" name="attr_save_evasion" class="sheet-stats-save">
+        <button name="roll_save_evasion" type="roll" value="/roll 1d20>@{save_evasion} Evasion Save"></button>
+      </div>
+      <div class="sheet-col">
+        <input type="number" min="0" name="attr_save_tech" class="sheet-stats-save">
+        <button name="roll_save_tech" type="roll" value="/roll 1d20>@{save_tech} Tech Save"></button>
+      </div>
+      <div class="sheet-col">
+        <input type="number" min="0" name="attr_save_luck" class="sheet-stats-save">
+        <button name="roll_save_luck" type="roll" value="/roll 1d20>@{save_luck} Luck Save"></button>
+      </div>
     </div>
     <h3>Skills</h3>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_artist">Artist</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" min="-1" value="-1" name="attr_skill_artist">
-                    <button name="roll_skill_artist" type="roll" value="/me skill checking **Artist**: [[2d6 + @{skill_artist} + ?{Stat Bonus|0} + ?{Assisted?|0}]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_artist">Artist</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" min="-1" value="-1" name="attr_skill_artist">
+            <button name="roll_skill_artist" type="roll" value="/me skill checking **Artist**: [[2d6 + @{skill_artist} + ?{Stat Bonus|0} + ?{Assisted?|0}]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_navigation">Navigation</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" min="-1" value="-1" name="attr_skill_navigation">
-                    <button name="roll_skill_navigation" type="roll" value="/me skill checking **Navigation**: [[ 2d6+@{skill_navigation} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_navigation">Navigation</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" min="-1" value="-1" name="attr_skill_navigation">
+            <button name="roll_skill_navigation" type="roll" value="/me skill checking **Navigation**: [[ 2d6+@{skill_navigation} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_athletics">Athletics</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_athletics">
-                    <button name="roll_skill_athletics" type="roll" value="/me skill checking **Athletics**: [[ 2d6+@{skill_athletics} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_athletics">Athletics</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_athletics">
+            <button name="roll_skill_athletics" type="roll" value="/me skill checking **Athletics**: [[ 2d6+@{skill_athletics} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_perception">Perception</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_perception">
-                    <button name="roll_skill_perception" type="roll" value="/me skill checking **Perception**: [[ 2d6+@{skill_perception} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_perception">Perception</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_perception">
+            <button name="roll_skill_perception" type="roll" value="/me skill checking **Perception**: [[ 2d6+@{skill_perception} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_bureaucracy">Bureaucracy</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_bureaucracy">
-                    <button name="roll_skill_bureaucracy" type="roll" value="/me skill checking **Bureaucracy**: [[ 2d6+@{skill_bureaucracy} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_bureaucracy">Bureaucracy</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_bureaucracy">
+            <button name="roll_skill_bureaucracy" type="roll" value="/me skill checking **Bureaucracy**: [[ 2d6+@{skill_bureaucracy} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_persuade">Persuade</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_persuade">
-                    <button name="roll_skill_persuade" type="roll" value="/me skill checking **Persuade**: [[ 2d6+@{skill_persuade} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_persuade">Persuade</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_persuade">
+            <button name="roll_skill_persuade" type="roll" value="/me skill checking **Persuade**: [[ 2d6+@{skill_persuade} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_business">Business</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_business">
-                    <button name="roll_skill_business" type="roll" value="/me skill checking **Business**: [[ 2d6+@{skill_business} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_business">Business</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_business">
+            <button name="roll_skill_business" type="roll" value="/me skill checking **Business**: [[ 2d6+@{skill_business} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_profession">Profession/</label><input type="text" name="attr_profession_type" class="sheet-skills-custom">
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_profession">
-                    <button name="roll_skill_profession" type="roll" value="/me skill checking **Profession**: [[ 2d6+@{skill_profession} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_profession">Profession/</label><input type="text" name="attr_profession_type" class="sheet-skills-custom">
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_profession">
+            <button name="roll_skill_profession" type="roll" value="/me skill checking **Profession**: [[ 2d6+@{skill_profession} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_energy">Combat/Energy Weapons</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_combat_energy">
-                    <button name="roll_skill_combat_energy" type="roll" value="/me skill checking **Combat_energy**: [[ 2d6+@{skill_combat_energy} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_energy">Combat/Energy Weapons</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_combat_energy">
+            <button name="roll_skill_combat_energy" type="roll" value="/me skill checking **Combat_energy**: [[ 2d6+@{skill_combat_energy} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_religion">Religion</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_religion">
-                    <button name="roll_skill_religion" type="roll" value="/me skill checking **Religion**: [[ 2d6+@{skill_religion} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_religion">Religion</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_religion">
+            <button name="roll_skill_religion" type="roll" value="/me skill checking **Religion**: [[ 2d6+@{skill_religion} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_gunnery">Combat/Gunnery</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_combat_gunnery">
-                    <button name="roll_skill_combat_gunnery" type="roll" value="/me skill checking **Combat_gunnery**: [[ 2d6+@{skill_combat_gunnery} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_gunnery">Combat/Gunnery</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_combat_gunnery">
+            <button name="roll_skill_combat_gunnery" type="roll" value="/me skill checking **Combat_gunnery**: [[ 2d6+@{skill_combat_gunnery} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_science">Science</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_science">
-                    <button name="roll_skill_science" type="roll" value="/me skill checking **Science**: [[ 2d6+@{skill_science} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_science">Science</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_science">
+            <button name="roll_skill_science" type="roll" value="/me skill checking **Science**: [[ 2d6+@{skill_science} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_primitive">Combat/Primitive Weapons</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_primitive">
-                    <button name="roll_skill_primitive" type="roll" value="/me skill checking **Primitive**: [[ 2d6+@{skill_primitive} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_primitive">Combat/Primitive Weapons</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_primitive">
+            <button name="roll_skill_primitive" type="roll" value="/me skill checking **Primitive**: [[ 2d6+@{skill_primitive} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_security">Security</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_security">
-                    <button name="roll_skill_security" type="roll" value="/me skill checking **Security**: [[ 2d6+@{skill_security} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_security">Security</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_security">
+            <button name="roll_skill_security" type="roll" value="/me skill checking **Security**: [[ 2d6+@{skill_security} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_projectile">Combat/Projectile Weapons</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_projectile">
-                    <button name="roll_skill_projectile" type="roll" value="/me skill checking **Projectile**: [[ 2d6+@{skill_projectile} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_projectile">Combat/Projectile Weapons</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_projectile">
+            <button name="roll_skill_projectile" type="roll" value="/me skill checking **Projectile**: [[ 2d6+@{skill_projectile} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_stealth">Stealth</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_stealth">
-                    <button name="roll_skill_stealth" type="roll" value="/me skill checking **Stealth**: [[ 2d6+@{skill_stealth} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_stealth">Stealth</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_stealth">
+            <button name="roll_skill_stealth" type="roll" value="/me skill checking **Stealth**: [[ 2d6+@{skill_stealth} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_psitech">Combat/Psitech</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_psitech">
-                    <button name="roll_skill_psitech" type="roll" value="/me skill checking **Psitech**: [[ 2d6+@{skill_psitech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_psitech">Combat/Psitech</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_psitech">
+            <button name="roll_skill_psitech" type="roll" value="/me skill checking **Psitech**: [[ 2d6+@{skill_psitech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_steward">Steward</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_steward">
-                    <button name="roll_skill_steward" type="roll" value="/me skill checking **Steward**: [[ 2d6+@{skill_steward} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_steward">Steward</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_steward">
+            <button name="roll_skill_steward" type="roll" value="/me skill checking **Steward**: [[ 2d6+@{skill_steward} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_combat_unarmed">Combat/Unarmed</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_unarmed">
-                    <button name="roll_skill_unarmed" type="roll" value="/me skill checking **Unarmed**: [[ 2d6+@{skill_unarmed} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_combat_unarmed">Combat/Unarmed</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_unarmed">
+            <button name="roll_skill_unarmed" type="roll" value="/me skill checking **Unarmed**: [[ 2d6+@{skill_unarmed} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_survival">Survival</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_survival">
-                    <button name="roll_skill_survival" type="roll" value="/me skill checking **Survival**: [[ 2d6+@{skill_survival} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_survival">Survival</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_survival">
+            <button name="roll_skill_survival" type="roll" value="/me skill checking **Survival**: [[ 2d6+@{skill_survival} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_computer">Computer</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_computer">
-                    <button name="roll_skill_computer" type="roll" value="/me skill checking **Computer**: [[ 2d6+@{skill_computer} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_computer">Computer</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_computer">
+            <button name="roll_skill_computer" type="roll" value="/me skill checking **Computer**: [[ 2d6+@{skill_computer} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tactics">Tactics</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tactics">
-                    <button name="roll_skill_tactics" type="roll" value="/me skill checking **Tactics**: [[ 2d6+@{skill_tactics} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tactics">Tactics</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tactics">
+            <button name="roll_skill_tactics" type="roll" value="/me skill checking **Tactics**: [[ 2d6+@{skill_tactics} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_culture_alien">Culture/Alien/</label><input type="text" name="attr_culture_alien_type" class="sheet-skills-custom">
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_alien">
-                    <button name="roll_skill_culture_alien" type="roll" value="/me skill checking **Culture/Alien**: [[ 2d6+@{skill_culture_alien} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_culture_alien">Culture/Alien/</label><input type="text" name="attr_culture_alien_type" class="sheet-skills-custom">
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_alien">
+            <button name="roll_skill_culture_alien" type="roll" value="/me skill checking **Culture/Alien**: [[ 2d6+@{skill_culture_alien} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_astronautic">Tech/Astronautic</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_astronautic">
-                    <button name="roll_skill_tech_astronautic" type="roll" value="/me skill checking **Tech/Astronautic**: [[ 2d6+@{skill_tech_astronautic} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"> </button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_astronautic">Tech/Astronautic</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_astronautic">
+            <button name="roll_skill_tech_astronautic" type="roll" value="/me skill checking **Tech/Astronautic**: [[ 2d6+@{skill_tech_astronautic} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"> </button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_crivalue="-1" minal">Culture/Criminal</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_criminal">
-                    <button name="roll_skill_culture_criminal" type="roll" value="/me skill checking **Culture/Criminal**: [[ 2d6+@{skill_culture_criminal} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"> </button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_crivalue="-1" minal">Culture/Criminal</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_criminal">
+            <button name="roll_skill_culture_criminal" type="roll" value="/me skill checking **Culture/Criminal**: [[ 2d6+@{skill_culture_criminal} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"> </button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_maltech">Tech/Maltech</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_maltech">
-                    <button name="roll_skill_tech_maltech" type="roll" value="/me skill checking **Tech/Maltech**: [[ 2d6+@{skill_tech_maltech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_maltech">Tech/Maltech</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_maltech">
+            <button name="roll_skill_tech_maltech" type="roll" value="/me skill checking **Tech/Maltech**: [[ 2d6+@{skill_tech_maltech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_spacer">Culture/Spacer</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_spacer">
-                    <button name="roll_skill_culture_spacer" type="roll" value="/me skill checking **Culture/Spacer**: [[ 2d6+@{skill_culture_spacer} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_spacer">Culture/Spacer</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_spacer">
+            <button name="roll_skill_culture_spacer" type="roll" value="/me skill checking **Culture/Spacer**: [[ 2d6+@{skill_culture_spacer} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_medical">Tech/Medical</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_medical">
-                    <button name="roll_skill_tech_medical" type="roll" value="/me skill checking **Tech/Medical**: [[ 2d6+@{skill_tech_medical} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_medical">Tech/Medical</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_medical">
+            <button name="roll_skill_tech_medical" type="roll" value="/me skill checking **Tech/Medical**: [[ 2d6+@{skill_tech_medical} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_traveller">Culture/Traveller</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_traveller">
-                    <button name="roll_skill_culture_traveller" type="roll" value="/me skill checking **Culture/Traveller**: [[ 2d6+@{skill_culture_traveller} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_traveller">Culture/Traveller</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_traveller">
+            <button name="roll_skill_culture_traveller" type="roll" value="/me skill checking **Culture/Traveller**: [[ 2d6+@{skill_culture_traveller} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_postech">Tech/Postech</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_postech">
-                    <button name="roll_skill_tech_postech" type="roll" value="/me skill checking **Tech/Postech**: [[ 2d6+@{skill_tech_postech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_postech">Tech/Postech</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_postech">
+            <button name="roll_skill_tech_postech" type="roll" value="/me skill checking **Tech/Postech**: [[ 2d6+@{skill_tech_postech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_one">Culture/</label><input type="text" name="attr_skill_culture_one_value" class="sheet-skills-custom">
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_one">
-                    <button name="roll_skill_culture_one" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_one} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_one">Culture/</label><input type="text" name="attr_skill_culture_one_value" class="sheet-skills-custom">
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_one">
+            <button name="roll_skill_culture_one" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_one} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_pretech">Tech/Pretech</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_pretech">
-                    <button name="roll_skill_tech_pretech" type="roll" value="/me skill checking **Tech/Pretech**: [[ 2d6+@{skill_tech_pretech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_pretech">Tech/Pretech</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_pretech">
+            <button name="roll_skill_tech_pretech" type="roll" value="/me skill checking **Tech/Pretech**: [[ 2d6+@{skill_tech_pretech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_two">Culture/</label><input type="text" name="attr_skill_culture_two_value" class="sheet-skills-custom">
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_two">
-                    <button name="roll_skill_culture_two" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_two} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_two">Culture/</label><input type="text" name="attr_skill_culture_two_value" class="sheet-skills-custom">
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_two">
+            <button name="roll_skill_culture_two" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_two} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_tech_psitech">Tech/Psitech</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_tech_psitech">
-                    <button name="roll_skill_tech_psitech" type="roll" value="/me skill checking **Tech/Psitech**: [[ 2d6+@{skill_tech_psitech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_tech_psitech">Tech/Psitech</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_tech_psitech">
+            <button name="roll_skill_tech_psitech" type="roll" value="/me skill checking **Tech/Psitech**: [[ 2d6+@{skill_tech_psitech} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_culture_three">Culture/</label><input type="text" name="attr_skill_culture_three_value" class="sheet-skills-custom">
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_culture_three">
-                    <button name="roll_skill_culture_three" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_three} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_culture_three">Culture/</label><input type="text" name="attr_skill_culture_three_value" class="sheet-skills-custom">
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_culture_three">
+            <button name="roll_skill_culture_three" type="roll" value="/me skill checking **Culture**: [[ 2d6+@{skill_culture_three} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_vehicle_air">Vehicle/Air</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_vehicle_air">
-                    <button name="roll_skill_vehicle_air" type="roll" value="/me skill checking **Vehicle/Air**: [[ 2d6+@{skill_vehicle_air} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_vehicle_air">Vehicle/Air</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_vehicle_air">
+            <button name="roll_skill_vehicle_air" type="roll" value="/me skill checking **Vehicle/Air**: [[ 2d6+@{skill_vehicle_air} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_exosuit">Exosuit</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_exosuit">
-                    <button name="roll_skill_exosuit" type="roll" value="/me skill checking **Exosuit**: [[ 2d6+@{skill_exosuit} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_exosuit">Exosuit</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_exosuit">
+            <button name="roll_skill_exosuit" type="roll" value="/me skill checking **Exosuit**: [[ 2d6+@{skill_exosuit} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_vehicle_grav">Vehicle/Grav</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_vehicle_grav">
-                    <button name="roll_skill_vehicle_grav" type="roll" value="/me skill checking **Vehicle_grav**: [[ 2d6+@{skill_vehicle_grav} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_vehicle_grav">Vehicle/Grav</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_vehicle_grav">
+            <button name="roll_skill_vehicle_grav" type="roll" value="/me skill checking **Vehicle_grav**: [[ 2d6+@{skill_vehicle_grav} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_gambling">Gambling</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_gambling">
-                    <button name="roll_skill_gambling" type="roll" value="/me skill checking **Gambling**: [[ 2d6+@{skill_gambling} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_gambling">Gambling</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_gambling">
+            <button name="roll_skill_gambling" type="roll" value="/me skill checking **Gambling**: [[ 2d6+@{skill_gambling} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_vehicle_land">Vehicle/Land</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_vehicle_land">
-                    <button name="roll_skill_vehicle_land" type="roll" value="/me skill checking **Vehicle_land**: [[ 2d6+@{skill_vehicle_land} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_vehicle_land">Vehicle/Land</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_vehicle_land">
+            <button name="roll_skill_vehicle_land" type="roll" value="/me skill checking **Vehicle_land**: [[ 2d6+@{skill_vehicle_land} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_history">History</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_history">
-                    <button name="roll_skill_history" type="roll" value="/me skill checking **History**: [[ 2d6+@{skill_history} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_history">History</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_history">
+            <button name="roll_skill_history" type="roll" value="/me skill checking **History**: [[ 2d6+@{skill_history} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_vehicle_space">Vehicle/Space</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_vehicle_space">
-                    <button name="roll_skill_vehicle_space" type="roll" value="/me skill checking **Vehicle_space**: [[ 2d6+@{skill_vehicle_space} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_vehicle_space">Vehicle/Space</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_vehicle_space">
+            <button name="roll_skill_vehicle_space" type="roll" value="/me skill checking **Vehicle_space**: [[ 2d6+@{skill_vehicle_space} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_instructor">Instructor</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_instructor">
-                    <button name="roll_skill_instructor" type="roll" value="/me skill checking **Instructor**: [[ 2d6+@{skill_instructor} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_instructor">Instructor</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_instructor">
+            <button name="roll_skill_instructor" type="roll" value="/me skill checking **Instructor**: [[ 2d6+@{skill_instructor} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_vehicle_water">Vehicle/Water</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_vehicle_water">
-                    <button name="roll_skill_vehicle_water" type="roll" value="/me skill checking **Vehicle_water**: [[ 2d6+@{skill_vehicle_water} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_vehicle_water">Vehicle/Water</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_vehicle_water">
+            <button name="roll_skill_vehicle_water" type="roll" value="/me skill checking **Vehicle_water**: [[ 2d6+@{skill_vehicle_water} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_language">Language</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_language">
-                    <button name="roll_skill_language" type="roll" value="/me skill checking **Language**: [[ 2d6+@{skill_language} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_language">Language</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_language">
+            <button name="roll_skill_language" type="roll" value="/me skill checking **Language**: [[ 2d6+@{skill_language} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    &nbsp;
-                </div>
-                <div class="sheet-col">
-                    &nbsp;
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+          &nbsp;
+          </div>
+          <div class="sheet-col">
+          &nbsp;
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-2colrow sheet-skills">
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_leadership">Leadership</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" value="-1" min="-1" name="attr_skill_leadership">
-                    <button name="roll_skill_leadership" type="roll" value="/me skill checking **Leadership**: [[ 2d6+@{skill_leadership} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
-                </div>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_leadership">Leadership</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" value="-1" min="-1" name="attr_skill_leadership">
+            <button name="roll_skill_leadership" type="roll" value="/me skill checking **Leadership**: [[ 2d6+@{skill_leadership} + ?{Stat Bonus|0} + ?{Assisted?|0} ]]"></button>
+          </div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <label for="attr_skill_points" class="sheet-skill-points-unspent">Unspent Skill Points</label>
-                </div>
-                <div class="sheet-col">
-                    <input type="number" min="-1" name="attr_skill_points">
-                </div>
-            </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <label for="attr_skill_points" class="sheet-skill-points-unspent">Unspent Skill Points</label>
+          </div>
+          <div class="sheet-col">
+            <input type="number" min="-1" name="attr_skill_points">
+          </div>
         </div>
+      </div>
     </div>
     <div class="sheet-row">
-        Cost to raise by 1: Class Skill = New Level +1, Other = New level + 2
+    Cost to raise by 1: Class Skill = New Level +1, Other = New level + 2
     </div>
     <h3>Gear</h3>
     <div class="sheet-row">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-gear-credits">
-                <div class="sheet-col"><label for="attr_credits">Credits</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_credits" class="sheet-gear-credits"></div>
-                <div class="sheet-col"><label for="attr_credits_owed">Credits Owed</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_credits_owed" class="sheet-gear-credits"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col"><label>Cyberware</label></div>
-            </div>
-            <div class="sheet-row sheet-gear-cyberware">
-                <div class="sheet-col"><input type="text" name="attr_cyberware_1"></div>
-            </div>
-            <div class="sheet-row sheet-gear-cyberware">
-                <div class="sheet-col"><input type="text" name="attr_cyberware_2"></div>
-            </div>
-            <div class="sheet-row sheet-gear-cyberware">
-                <div class="sheet-col"><input type="text" name="attr_cyberware_3"></div>
-            </div>
-            <div class="sheet-row sheet-gear-cyberware">
-                <div class="sheet-col"><input type="text" name="attr_cyberware_4"></div>
-            </div>
-            <div class="sheet-row">
-                <div class="sheet-col"><label>Other Equipment</label></div>
-            </div>
-            <div class="sheet-row sheet-gear-other">
-                <textarea name="attr_gear_other"></textarea>
-            </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-gear-credits">
+          <div class="sheet-col"><label for="attr_credits">Credits</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_credits" class="sheet-gear-credits"></div>
+          <div class="sheet-col"><label for="attr_credits_owed">Credits Owed</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_credits_owed" class="sheet-gear-credits"></div>
         </div>
-        <div class="sheet-col" class="sheet-col-whitespace">&nbsp;</div>
-        <div class="sheet-col sheet-gear">
-            <div class="sheet-3colrow">
-                <div class="sheet-col sheet-gear-name"><label>Gear</label></div>
-                <div class="sheet-col sheet-gear-readied"><label>Readied</label></div>
-                <div class="sheet-col sheet-gear-encumbrance"><label>Encumbrance</label></div>
-            </div>
-            <fieldset class="repeating_gear">
-                <div class="sheet-3colrow">
-                    <div class="sheet-col sheet-gear-name"><input type="text" name="attr_gear_name"></div>
-                    <div class="sheet-col sheet-gear-readied"><input type="checkbox" name="attr_gear_readied" value="0"></div>
-                    <div class="sheet-col sheet-gear-encumbrance"><input type="number" min="0" name="attr_gear_encumbrance"></div>
-                </div>
-            </fieldset>
+        <div class="sheet-row">
+          <div class="sheet-col"><label>Cyberware</label></div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-weapons sheet-7colrow">
-                <div class="sheet-col sheet-gear-weapon"><label>Weapon</label></div>
-                <div class="sheet-col sheet-gear-weapon-attack"><label>Attack Bonus</label></div>
-                <div class="sheet-col sheet-gear-weapon-damage"><label>Damage</label></div>
-                <div class="sheet-col sheet-gear-weapon-range"><label>Range</label></div>
-                <div class="sheet-col sheet-gear-weapon-ammo"><label>Ammo</label></div>
-                <div class="sheet-col sheet-gear-weapon-roll-to-hit"><label for="roll_weapon_attack">To Hit</label></div>
-                <div class="sheet-col sheet-gear-weapon-roll-damage"><label for="roll_weapon_damage">Damage</label></div>
-            </div>
-            <fieldset class="repeating_weapons">
-                <div class="sheet-weapons sheet-7colrow">
-                    <div class="sheet-col sheet-gear-weapon"><input type="text" name="attr_weapon_name"></div>
-                    <div class="sheet-col sheet-gear-weapon-attack"><input type="text" name="attr_weapon_attack"></div>
-                    <div class="sheet-col sheet-gear-weapon-damage"><input type="text" name="attr_weapon_damage"></div>
-                    <div class="sheet-col sheet-gear-weapon-range"><input type="text" name="attr_weapon_range"></div>
-                    <div class="sheet-col sheet-gear-weapon-ammo"><input type="number" min="0" name="attr_weapon_ammo"></div>
-                    <div class="sheet-col">
-                      <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+@{target|AC}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
-                    </div>
-                    <div class="sheet-col">
-                      <button type="roll" name="roll_weapon_damage" value="/me rolls damage with @{weapon_name}: [[@{weapon_damage}]]" ></button>
-                    </div>
-                </div>
-            </fieldset>
+        <div class="sheet-row sheet-gear-cyberware">
+          <div class="sheet-col"><input type="text" name="attr_cyberware_1"></div>
         </div>
+        <div class="sheet-row sheet-gear-cyberware">
+          <div class="sheet-col"><input type="text" name="attr_cyberware_2"></div>
+        </div>
+        <div class="sheet-row sheet-gear-cyberware">
+          <div class="sheet-col"><input type="text" name="attr_cyberware_3"></div>
+        </div>
+        <div class="sheet-row sheet-gear-cyberware">
+          <div class="sheet-col"><input type="text" name="attr_cyberware_4"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col"><label>Other Equipment</label></div>
+        </div>
+        <div class="sheet-row sheet-gear-other">
+          <textarea name="attr_gear_other"></textarea>
+        </div>
+      </div>
+      <div class="sheet-col" class="sheet-col-whitespace">&nbsp;</div>
+      <div class="sheet-col sheet-gear">
+        <div class="sheet-3colrow">
+          <div class="sheet-col sheet-gear-name"><label>Gear</label></div>
+          <div class="sheet-col sheet-gear-readied"><label>Readied</label></div>
+          <div class="sheet-col sheet-gear-encumbrance"><label>Encumbrance</label></div>
+        </div>
+        <fieldset class="repeating_gear">
+          <div class="sheet-3colrow">
+            <div class="sheet-col sheet-gear-name"><input type="text" name="attr_gear_name"></div>
+            <div class="sheet-col sheet-gear-readied"><input type="checkbox" name="attr_gear_readied" value="0"></div>
+            <div class="sheet-col sheet-gear-encumbrance"><input type="number" min="0" name="attr_gear_encumbrance"></div>
+          </div>
+        </fieldset>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-weapons sheet-7colrow">
+          <div class="sheet-col sheet-gear-weapon"><label>Weapon</label></div>
+          <div class="sheet-col sheet-gear-weapon-attack"><label>Attack Bonus</label></div>
+          <div class="sheet-col sheet-gear-weapon-damage"><label>Damage</label></div>
+          <div class="sheet-col sheet-gear-weapon-range"><label>Range</label></div>
+          <div class="sheet-col sheet-gear-weapon-ammo"><label>Ammo</label></div>
+          <div class="sheet-col sheet-gear-weapon-roll-to-hit"><label for="roll_weapon_attack">To Hit</label></div>
+          <div class="sheet-col sheet-gear-weapon-roll-damage"><label for="roll_weapon_damage">Damage</label></div>
+        </div>
+        <fieldset class="repeating_weapons">
+          <div class="sheet-weapons sheet-7colrow">
+            <div class="sheet-col sheet-gear-weapon"><input type="text" name="attr_weapon_name"></div>
+            <div class="sheet-col sheet-gear-weapon-attack"><input type="text" name="attr_weapon_attack"></div>
+            <div class="sheet-col sheet-gear-weapon-damage"><input type="text" name="attr_weapon_damage"></div>
+            <div class="sheet-col sheet-gear-weapon-range"><input type="text" name="attr_weapon_range"></div>
+            <div class="sheet-col sheet-gear-weapon-ammo"><input type="number" min="0" name="attr_weapon_ammo"></div>
+            <div class="sheet-col">
+              <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+@{target|AC}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
+            </div>
+            <div class="sheet-col">
+              <button type="roll" name="roll_weapon_damage" value="/me rolls damage with @{weapon_name}: [[@{weapon_damage}]]" ></button>
+            </div>
+          </div>
+        </fieldset>
+      </div>
     </div>
     <h3>Psionics</h3>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><label>Psionic Disciplines</label></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><label>Level</label></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><label>Psionic Disciplines</label></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><label>Level</label></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_1"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_1"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_1"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_1"></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_2"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_2"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_2"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_2"></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_3"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_3"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_3"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_3"></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_4"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_4"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_4"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_4"></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_5"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_5"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_5"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_5"></div>
+      </div>
     </div>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_6"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_6"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-discipline"><input type="text" name="attr_psionics_discipline_6"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-level"><input type="number" min="0" name="attr_psionics_level_6"></div>
+      </div>
     </div>
     <br>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-power"><label>Psionic Powers Mastered</label></div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-power"><label>Psionic Powers Mastered</label></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-4colrow sheet-psionics-pp">
+          <div class="sheet-col"><label>PP</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_psionics_pp"></div>
+          <div class="sheet-col"><label>Max PP</label></div>
+          <div class="sheet-col"><input type="number" min="0" name="attr_psionics_pp_max"></div>
         </div>
-        <div class="sheet-col">
-            <div class="sheet-4colrow sheet-psionics-pp">
-                <div class="sheet-col"><label>PP</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_psionics_pp"></div>
-                <div class="sheet-col"><label>Max PP</label></div>
-                <div class="sheet-col"><input type="number" min="0" name="attr_psionics_pp_max"></div>
-            </div>
-        </div>
+      </div>
     </div>
     <div class="sheet-colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_1"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_2"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_3"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_4"></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_5"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_6"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_7"></div>
-            <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_8"></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_1"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_2"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_3"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_4"></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_5"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_6"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_7"></div>
+        <div class="sheet-row sheet-psionics-mastered"><input type="text" name="attr_psionics_mastered_8"></div>
+      </div>
     </div>
     <h3>Miscellaneous</h3>
     <div class="sheet-2colrow">
-        <div class="sheet-col">
-            <div class="sheet-row sheet-misc-goal"><label>Current Goals</label></div>
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-row sheet-misc-goal-xp"><label>XP</label></div>
-        </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-misc-goal"><label>Current Goals</label></div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row sheet-misc-goal-xp"><label>XP</label></div>
+      </div>
     </div>
     <fieldset class="repeating_goals">
-        <div class="sheet-2colrow">
-            <div class="sheet-col">
-                <div class="sheet-row sheet-misc-goal"><input type="text" name="attr_misc_goal"></div>
-            </div>
-            <div class="sheet-col">
-                <div class="sheet-row sheet-misc-goal-xp"><input type="number" min="0" name="attr_misc_goal_xp"></div>
-            </div>
+      <div class="sheet-2colrow">
+        <div class="sheet-col">
+          <div class="sheet-row sheet-misc-goal"><input type="text" name="attr_misc_goal"></div>
         </div>
+        <div class="sheet-col">
+          <div class="sheet-row sheet-misc-goal-xp"><input type="number" min="0" name="attr_misc_goal_xp"></div>
+        </div>
+      </div>
     </fieldset>
     <div class="sheet-row">
-        <label for="attr_notes">Notes</label>
+      <label for="attr_notes">Notes</label>
     </div>
     <div class="sheet-row">
-        <textarea name="attr_notes"></textarea>
+      <textarea name="attr_notes"></textarea>
     </div>
+  </div>
 </div>

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -112,53 +112,53 @@
       </div>
     </div>
     <h3>Weapons</h3>
-    <div class="sheet-col">
+    <div class="sheet-col sheet-ship-repeating-headers">
       <div class="sheet-ship-weapons sheet-6colrow">
-        <div class="sheet-col sheet-ship-weapon"><label>Name</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label for="attr_ship_weapon_name">Name</label></div>
         <div class="sheet-col sheet-ship-weapon"><label>Attack Bonus</label></div>
         <div class="sheet-col sheet-ship-weapon"><label>Damage</label></div>
         <div class="sheet-col sheet-ship-weapon"><label>Ammo</label></div>
         <div class="sheet-col sheet-ship-weapon"><label>Special Effects</label></div>
-        <div class="sheet-col sheet-ship-weapon"><label>Broken?</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label class="sheet-ship-item-halfsize">Broken?</label></div>
       </div>
-      <fieldset class="repeating_weapons">
-        <div class="sheet-weapons sheet-6colrow">
+      <fieldset class="repeating_weapons repeating repeating-ship-weapons">
+        <div class="sheet-ship-weapons sheet-6colrow">
           <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_name"></div>
-          <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_ab"></div>
+          <div class="sheet-col sheet-ship-weapon"><input class="sheet-ship-item-halfsize" type="number" name="attr_ship_weapon_ab"></div>
           <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_damage"></div>
-          <div class="sheet-col sheet-ship-weapon"><input type="number" min="0" name="attr_ship_weapon_ammo"></div>
-          <div class="sheet-col sheet-ship-weapon"><input type="number" min="0" name="attr_ship_weapon_special_effects"></div>
-          <div class="sheet-col sheet-ship-weapon"><input type="checkbox" min="0" name="attr_ship_weapon_broken"></div>
+          <div class="sheet-col sheet-ship-weapon"><input class="sheet-ship-item-halfsize" type="number" min="0" name="attr_ship_weapon_ammo"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="text" min="0" name="attr_ship_weapon_special_effects"></div>
+          <div class="sheet-col sheet-ship-weapon"><input class="sheet-ship-item-halfsize" type="checkbox" min="0" name="attr_ship_weapon_broken"></div>
         </div>
       </fieldset>
     </div>
     <h3>Defenses</h3>
-    <div class="sheet-col">
+    <div class="sheet-col sheet-ship-repeating-headers">
       <div class="sheet-ship-weapons sheet-3colrow">
         <div class="sheet-col sheet-ship-defense"><label>Name</label></div>
         <div class="sheet-col sheet-ship-defense"><label>Special Effects</label></div>
-        <div class="sheet-col sheet-ship-defense"><label>Broken?</label></div>
+        <div class="sheet-col sheet-ship-defense"><label class="sheet-ship-item-halfsize">Broken?</label></div>
       </div>
-      <fieldset class="repeating_weapons">
-        <div class="sheet-weapons sheet-3colrow">
+      <fieldset class="repeating_weapons repeating repeating-ship-defenses">
+        <div class="sheet-ship-weapons sheet-3colrow">
           <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_name"></div>
           <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_special_effects"></div>
-          <div class="sheet-col sheet-ship-defense"><input type="checkbox" name="attr_ship_defense_broken"></div>
+          <div class="sheet-col sheet-ship-defense"><input class="sheet-ship-item-halfsize" type="checkbox" name="attr_ship_defense_broken"></div>
         </div>
       </fieldset>
     </div>
     <h3>Fittings</h3>
-    <div class="sheet-col">
+    <div class="sheet-col sheet-ship-repeating-headers">
       <div class="sheet-ship-weapons sheet-3colrow">
         <div class="sheet-col sheet-ship-fitting"><label>Name</label></div>
         <div class="sheet-col sheet-ship-fitting"><label>Special Effects</label></div>
-        <div class="sheet-col sheet-ship-fitting"><label>Broken?</label></div>
+        <div class="sheet-col sheet-ship-fitting"><label class="sheet-ship-item-halfsize">Broken?</label></div>
       </div>
-      <fieldset class="repeating_weapons">
-        <div class="sheet-weapons sheet-3colrow">
+      <fieldset class="repeating_weapons repeating repeating-ship-fittings">
+        <div class="sheet-ship-weapons sheet-3colrow">
           <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_name"></div>
           <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_special_effects"></div>
-          <div class="sheet-col sheet-ship-fitting"><input type="checkbox" name="attr_ship_fitting_broken"></div>
+          <div class="sheet-col sheet-ship-fitting"><input class="sheet-ship-item-halfsize" type="checkbox" name="attr_ship_fitting_broken"></div>
         </div>
       </fieldset>
     </div>

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -12,8 +12,159 @@
       <div class="sheet-col sheet-swn-min">Version 0.0.7</div>
     </div>
     <h3>Core Stats</h3>
-    <div class="sheet-row sheet-stats">
-      lorem ipsum dolor sit amet
+    <div class="sheet-2colrow sheet-stats">
+      <div class="sheet-col">
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_name">Name</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_name"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_hulltype"> Hull Type </label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_hulltype"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_speed"> Speed </label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_speed"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_ac">Armor Class</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_ac"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_armor">Armor</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_armor"></div>
+        </div>
+        <div class="sheet-row sheet-stats-ship-min-max">
+          <div class="sheet-col sheet-stats-label">
+            <label for="attr_ship_crew_min">Crew Min/Max</label>
+          </div>
+          <div class="sheet-col sheet-stats-ship-value">
+            <input type="text" name="attr_ship_crew_min">
+          </div>
+          <div class="sheet-col sheet-stats-label sheet-stats-label-separator">
+            <label for="attr_ship_crew_max">/</label>
+          </div>
+          <div class="sheet-col sheet-stats-ship-value">
+            <input type="text" name="attr_ship_crew_max">
+          </div>
+        </div>
+        <div class="sheet-row sheet-stats-ship-min-max">
+          <div class="sheet-col sheet-stats-label">
+            <label for="attr_ship_hp_min">Hit Points</label>
+          </div>
+          <div class="sheet-col sheet-stats-ship-value">
+            <input type="text" name="attr_ship_hp_min">
+          </div>
+          <div class="sheet-col sheet-stats-label sheet-stats-label-separator">
+            <label for="attr_ship_hp_max">/</label>
+          </div>
+          <div class="sheet-col sheet-stats-ship-value">
+            <input type="text" name="attr_ship_hp_max">
+          </div>
+        </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row">
+          <textarea name="attr_ship_notes"></textarea>
+        </div>
+      </div>
+    </div>
+    <div class="sheet-2colrow sheet-stats">
+      <div class="sheet-col">
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_free_power">Free Power</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_free_power"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_free_mass">Free Mass</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_free_mass"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_free_hardpoints">Free Hardpoints</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_free_hardpoints"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_cargo_tonnage">Cargo Tonnage</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_cargo_tonnage"></div>
+        </div>
+      </div>
+      <div class="sheet-col">
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_current_crew">Current Crew</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_current_crew"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_operating_cost">Operating Cost</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_operating_cost"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_maintenance_cost">Maintenance Cost</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_maintenance_cost"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_last_maintenance_cost">Last Maintenance Date</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_last_maintenance_cost"></div>
+        </div>
+        <div class="sheet-row">
+          <div class="sheet-col sheet-stats-label"><label for="attr_ship_home_port">Home Port</label></div>
+          <div class="sheet-col"><input type="text" name="attr_ship_home_port"></div>
+        </div>
+      </div>
+    </div>
+    <h3>Weapons</h3>
+    <div class="sheet-col">
+      <div class="sheet-ship-weapons sheet-6colrow">
+        <div class="sheet-col sheet-ship-weapon"><label>Name</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label>Attack Bonus</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label>Damage</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label>Ammo</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label>Special Effects</label></div>
+        <div class="sheet-col sheet-ship-weapon"><label>Broken?</label></div>
+      </div>
+      <fieldset class="repeating_weapons">
+        <div class="sheet-weapons sheet-6colrow">
+          <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_name"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_ab"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="text" name="attr_ship_weapon_damage"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="number" min="0" name="attr_ship_weapon_ammo"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="number" min="0" name="attr_ship_weapon_special_effects"></div>
+          <div class="sheet-col sheet-ship-weapon"><input type="checkbox" min="0" name="attr_ship_weapon_broken"></div>
+        </div>
+      </fieldset>
+    </div>
+    <h3>Defenses</h3>
+    <div class="sheet-col">
+      <div class="sheet-ship-weapons sheet-3colrow">
+        <div class="sheet-col sheet-ship-defense"><label>Name</label></div>
+        <div class="sheet-col sheet-ship-defense"><label>Special Effects</label></div>
+        <div class="sheet-col sheet-ship-defense"><label>Broken?</label></div>
+      </div>
+      <fieldset class="repeating_weapons">
+        <div class="sheet-weapons sheet-3colrow">
+          <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_name"></div>
+          <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_special_effects"></div>
+          <div class="sheet-col sheet-ship-defense"><input type="checkbox" name="attr_ship_defense_broken"></div>
+        </div>
+      </fieldset>
+    </div>
+    <h3>Fittings</h3>
+    <div class="sheet-col">
+      <div class="sheet-ship-weapons sheet-3colrow">
+        <div class="sheet-col sheet-ship-fitting"><label>Name</label></div>
+        <div class="sheet-col sheet-ship-fitting"><label>Special Effects</label></div>
+        <div class="sheet-col sheet-ship-fitting"><label>Broken?</label></div>
+      </div>
+      <fieldset class="repeating_weapons">
+        <div class="sheet-weapons sheet-3colrow">
+          <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_name"></div>
+          <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_special_effects"></div>
+          <div class="sheet-col sheet-ship-fitting"><input type="checkbox" name="attr_ship_fitting_broken"></div>
+        </div>
+      </fieldset>
+    </div>
+    <h3>Other Notes</h3>
+    <div class="sheet-col sheet-ship-other-notes">
+      <textarea name="attr_ship_other_notes"></textarea>
     </div>
   </div>
 </div>
@@ -79,36 +230,36 @@
           <div class="sheet-col sheet-attribute-label"><label for="attr_str">STR</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_str" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_strBonus" value="@{Str}" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_strBonus" value="@{Str}" class="sheet-stats-half sheet-stat-bonus">
           </div>
           <div class="sheet-col sheet-attribute-label"><label for="attr_int">INT</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_int" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_intBonus" value="" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_intBonus" value="" class="sheet-stats-half sheet-stat-bonus">
           </div>
         </div>
         <div class="sheet-row">
           <div class="sheet-col sheet-attribute-label"><label for="attr_dex">DEX</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_dex" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_dexBonus" value="" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_dexBonus" value="" class="sheet-stats-half sheet-stat-bonus">
           </div>
           <div class="sheet-col sheet-attribute-label"><label for="attr_wis">WIS</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_wis" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_wisBonus" value="" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_wisBonus" value="" class="sheet-stats-half sheet-stat-bonus">
           </div>
         </div>
         <div class="sheet-row">
           <div class="sheet-col sheet-attribute-label"><label for="attr_con">CON</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_con" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_conBonus" value="" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_conBonus" value="" class="sheet-stats-half sheet-stat-bonus">
           </div>
           <div class="sheet-col sheet-attribute-label"><label for="attr_cha">CHA</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_cha" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_chaBonus" value="" class="sheet-stats-half">
+            <input type="number" min="-2" max="2" name="attr_chaBonus" value="" class="sheet-stats-half sheet-stat-bonus">
           </div>
         </div>
         <div class="sheet-row">

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -50,7 +50,7 @@
         <div class="sheet-row">
           <div class="sheet-col sheet-stats-label"><label for="attr_xp">XP</label></div>
           <div class="sheet-col"><input type="number" min="0" name="attr_xp" class="sheet-stats-half"></div>
-          <div class="sheet-col"><label for="attr_xp_max">XP Next Level</label></div>
+          <div class="sheet-col"><label for="attr_xp_max">Next Level</label></div>
           <div class="sheet-col"><input type="number" min="0" name="attr_xp_max" class="sheet-stats-half"></div>
         </div>
         <div class="sheet-row">

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -5,7 +5,7 @@
         </div>
     </div>
     <div class="sheet-row">
-        <div class="sheet-col sheet-swn-min">Version 0.0.6</div>
+      <div class="sheet-col sheet-swn-min">Version 0.0.7</div>
     </div>
     <h3>Core Stats</h3>
     <div class="sheet-row sheet-stats">

--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -290,7 +290,7 @@
       </div>
       <div class="sheet-col">
         <label for="roll_basic_attack">Basic Attack Roll</label>
-        <button type="roll" name="roll_basic_attack" value="/me rolls an attack: [[{1d20+ @{target|AC} + @{attack_bonus} + ?{Combat Skill Bonus|0} + ?{Attribute Modifier|0}}]]" ></button>
+        <button type="roll" name="roll_basic_attack" value="/me rolls an attack: [[{1d20+ ?{AC|0} + @{attack_bonus} + ?{Combat Skill Bonus|0} + ?{Attribute Modifier|0}}]]" ></button>
       </div>
     </div>
     <h3>Saving Throws</h3>
@@ -960,7 +960,7 @@
       <div class="sheet-col">
         <div class="sheet-weapons sheet-7colrow">
           <div class="sheet-col sheet-gear-weapon"><label>Weapon</label></div>
-          <div class="sheet-col sheet-gear-weapon-attack"><label>Attack Bonus</label></div>
+          <div class="sheet-col sheet-gear-weapon-attack"><label>Weapon AB</label></div>
           <div class="sheet-col sheet-gear-weapon-damage"><label>Damage</label></div>
           <div class="sheet-col sheet-gear-weapon-range"><label>Range</label></div>
           <div class="sheet-col sheet-gear-weapon-ammo"><label>Ammo</label></div>
@@ -970,12 +970,12 @@
         <fieldset class="repeating_weapons">
           <div class="sheet-weapons sheet-7colrow">
             <div class="sheet-col sheet-gear-weapon"><input type="text" name="attr_weapon_name"></div>
-            <div class="sheet-col sheet-gear-weapon-attack"><input type="text" name="attr_weapon_attack"></div>
+            <div class="sheet-col sheet-gear-weapon-attack"><input type="number" value="0" name="attr_weapon_attack"></div>
             <div class="sheet-col sheet-gear-weapon-damage"><input type="text" name="attr_weapon_damage"></div>
             <div class="sheet-col sheet-gear-weapon-range"><input type="text" name="attr_weapon_range"></div>
             <div class="sheet-col sheet-gear-weapon-ammo"><input type="number" min="0" name="attr_weapon_ammo"></div>
             <div class="sheet-col">
-              <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+@{target|AC}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
+              <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+?{AC|0}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
             </div>
             <div class="sheet-col">
               <button type="roll" name="roll_weapon_damage" value="/me rolls damage with @{weapon_name}: [[@{weapon_damage}]]" ></button>

--- a/Stars_Without_Number/sheet.json
+++ b/Stars_Without_Number/sheet.json
@@ -1,8 +1,8 @@
 {
     "html": "Stars_Without_Number.html",
     "css": "Stars_Without_Number.css",
-    "authors": "kevin the barbarian (@kevinsearle)",
-    "roll20userid": "565104",
+    "authors": ["kevin the barbarian (@kevinsearle)", "Joe Fredette (@jfredett)"],
+    "roll20userid": "565104, 161749",
     "preview": "Stars_Without_Number.png",
-    "instructions": "Created by kevin the barbarian (proton.mule@gmail.com) for use in Stars Without Number in Roll20. Based on the character sheet design by OneSevenDesign at http://www.onesevendesign.com/swn_charsheets_oneseven.pdf.\r\r\r"
+    "instructions": "Created by kevin the barbarian (proton.mule@gmail.com) for use in Stars Without Number in Roll20. Based on the character sheet design by OneSevenDesign at http://www.onesevendesign.com/swn_charsheets_oneseven.pdf. Additional work by jfredett (jfredett at gmail dot com) adding roll buttons, the ship sheet, and other miscellanea\r\r\r"
 }


### PR DESCRIPTION
I won't claim it's the best in the world, but it'll do.

In this PR:

* a multi-tab implementation
* a tab with a basic implementation of ship character sheets. Including:
    - All basic data (Name, Hull Type, AC, Armor, Crew Min/Max, HP, etc)
    - A section for additional notes
    - Repeating fields for Weapons, Defenses, and Fittings.
    - A second section for more notes (you can never have enough space for arbitrary notes)
* an updated changelog + sheet.json (I forgot to update it last time)

What it doesn't contain:

* Roll macros for any of the ship stuff (that would require some way of syncing the ship between character's, so you could use the right gunnery stat, etc). Fortunately, there isn't a great deal needed there besides damage; so it could be done.
* Great CSS. The repeating fields don't break with convention, and remain divs-full-of-divs. I think tables might make more sense for rigid layouts like these. I might refactor them when I go into refactoring the culture/profession/etc sections into repeating fields. I did the best I could, but I'm no CSS wizard.

Paging @kevinsearle -- What do you think about converting to tables for layout? I spent a fair while getting all the divs to line up, and they still aren't great.

Next up will be roll templates, I think.
