### PR TITLE
Fix #957 - Attack Rolls not working (SWN)

### DIFF
--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -104,7 +104,7 @@
             </div>
             <div class="sheet-row">
                 <div class="sheet-col sheet-attribute-ext-label"><label for="attr_attack_bonus">Attack Bonus</label></div>
-                <div class="sheet-col"><input type="number" name="attr_attack_bonus" class="sheet-stats-half"></div>
+                <div class="sheet-col"><input type="number" min="0" name="attr_attack_bonus" class="sheet-stats-half"></div>
                 <div class="sheet-col sheet-attribute-ext-label"><label for="attr_AC">AC</label></div>
                 <div class="sheet-col"><input type="number" name="attr_AC" class="sheet-stats-half"></div>
             </div>
@@ -118,7 +118,7 @@
       </div>
       <div class="sheet-col">
         <label for="roll_basic_attack">Basic Attack Roll</label>
-        <button type="roll" name="roll_basic_attack" value="/me rolls an attack: [[{1d20+ @{target|AC} + @{attack_bonus} + ?{Combat Skill Bonus|0} + ?{Attribute Modifier|0}}]]" ></button>
+        <button type="roll" name="roll_basic_attack" value="/me rolls an attack: [[{1d20 + ?{AC|0} + @{attack_bonus} + ?{Combat Skill Bonus|0} + ?{Attribute Modifier|0}}]]" ></button>
       </div>
     </div>
     <h3>Saving Throws</h3>
@@ -787,7 +787,7 @@
         </div>
         <div class="sheet-col">
             <div class="sheet-weapons sheet-7colrow">
-                <div class="sheet-col sheet-gear-weapon"><label>Weapon</label></div>
+                <div class="sheet-col sheet-gear-weapon"><label>Weapon AB</label></div>
                 <div class="sheet-col sheet-gear-weapon-attack"><label>Attack Bonus</label></div>
                 <div class="sheet-col sheet-gear-weapon-damage"><label>Damage</label></div>
                 <div class="sheet-col sheet-gear-weapon-range"><label>Range</label></div>
@@ -798,12 +798,12 @@
             <fieldset class="repeating_weapons">
                 <div class="sheet-weapons sheet-7colrow">
                     <div class="sheet-col sheet-gear-weapon"><input type="text" name="attr_weapon_name"></div>
-                    <div class="sheet-col sheet-gear-weapon-attack"><input type="text" name="attr_weapon_attack"></div>
+                    <div class="sheet-col sheet-gear-weapon-attack"><input type="number" min="0" name="attr_weapon_attack"></div>
                     <div class="sheet-col sheet-gear-weapon-damage"><input type="text" name="attr_weapon_damage"></div>
                     <div class="sheet-col sheet-gear-weapon-range"><input type="text" name="attr_weapon_range"></div>
                     <div class="sheet-col sheet-gear-weapon-ammo"><input type="number" min="0" name="attr_weapon_ammo"></div>
                     <div class="sheet-col">
-                      <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+@{target|AC}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
+                      <button type="roll" name="roll_weapon_to_hit" value="/me rolls to hit with @{weapon_name}: [[1d20+@{weapon_attack}+@{attack_bonus}+?{AC|0}+?{Stat Bonus|0}+?{Other Modifier|0}]]" ></button>
                     </div>
                     <div class="sheet-col">
                       <button type="roll" name="roll_weapon_damage" value="/me rolls damage with @{weapon_name}: [[@{weapon_damage}]]" ></button>


### PR DESCRIPTION
This removes the `@{target|AC}` element, replacing it with a simple query, and adds some defaulting for the weapon AB and regular AB sections. Should resolve the problems people have been experiencing w/ rolls not working (if AB or Weapon AB was empty, then the roll wouldn't work).

Fixes #957