### PR TITLE
D&D3.5 update, cosmetic +

### DIFF
--- a/D&D_3-5/charsheet_3-5.css
+++ b/D&D_3-5/charsheet_3-5.css
@@ -6,6 +6,7 @@
 .sheet-pc-combat-show:not(:checked)~.sheet-pc-combat {display:none;}
 .sheet-pc-charnotes-show:not(:checked)~.sheet-pc-charnotes {display:none;}
 .sheet-pc-saveblock-show:not(:checked)~.sheet-pc-saveblock {display:none;}  
+.sheet-pc-savemacros-show:not(:checked)~.sheet-pc-savemacros {display:none;}  
 .sheet-pc-statblock-show:not(:checked)~.sheet-pc-statblock {display:none;} 
 .sheet-pc-equipment-show:not(:checked)~.sheet-pc-equipment {display:none;} 
 .sheet-pc-acequipment-show:not(:checked)~.sheet-pc-acequipment {display:none;} 

--- a/D&D_3-5/charsheet_3-5.css
+++ b/D&D_3-5/charsheet_3-5.css
@@ -64,21 +64,6 @@
 
 .sheet-pc-rolltemplates-show:not(:checked)~.sheet-pc-rolltemplates {display:none;} 
 
-input.sheet-tab1:checked + span.sheet-tab1,
-input.sheet-tab2:checked + span.sheet-tab2,
-input.sheet-tab3:checked + span.sheet-tab3,
-input.sheet-tab4:checked + span.sheet-tab4,
-input.sheet-tab5:checked + span.sheet-tab5,
-input.sheet-tab6:checked + span.sheet-tab6,
-input.sheet-tab7:checked + span.sheet-tab7,
-input.sheet-tab8:checked + span.sheet-tab8,
-input.sheet-tab9:checked + span.sheet-tab9,
-input.sheet-tab99:checked + span.sheet-tab99,
-input.sheet-tab10:checked + span.sheet-tab10 {
-	background: gray;
-	color: white;
-}
-
 .charsheet label {
     display: inline-block;
     width: 75px;
@@ -435,6 +420,22 @@ input.sheet-tab10:checked ~ div.sheet-tab10,
 input.sheet-tab99:checked ~ div.sheet-tab99
 {
     display: block;
+}
+
+input.sheet-tab1:checked + span.sheet-tab1,
+input.sheet-tab2:checked + span.sheet-tab2,
+input.sheet-tab3:checked + span.sheet-tab3,
+input.sheet-tab4:checked + span.sheet-tab4,
+input.sheet-tab5:checked + span.sheet-tab5,
+input.sheet-tab6:checked + span.sheet-tab6,
+input.sheet-tab7:checked + span.sheet-tab7,
+input.sheet-tab8:checked + span.sheet-tab8,
+input.sheet-tab9:checked + span.sheet-tab9,
+input.sheet-tab10:checked + span.sheet-tab10,
+input.sheet-tab99:checked + span.sheet-tab99
+{
+	background: gray;
+	color: white;
 }
 
 input.sheet-tab

--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -2,7 +2,7 @@
 <!-- by Diana P. -->
 <!-- based on Pathfinder sheets from Barry R., Sam, Brian, and Justin N. -->
 <!-- with lots of help from Toby-->
-<!-- Version 2.6.19 7/28/15 (Tabs, Roll Templates, Inline Rolls, NPC toggle, encumbrance w/ ACP & MaxDex, Trained-Only)-->
+<!-- Version 2.6.20 8/10/15 (Tabs, Roll Templates, Inline Rolls, NPC toggle, encumbrance w/ ACP & MaxDex, Trained-Only)-->
 <input type="radio" class="sheet-switch-pc-show sheet-switch" title="npc-show" name="attr_npc-show" value="1" checked /><span style="text-align: left;">PC &nbsp; &nbsp; &nbsp; &nbsp;</span>
 <input type="radio" class="sheet-switch-npc-show sheet-switch" title="npc-show" name="attr_npc-show" value="2" /><span style="text-align: left;">NPC</span>
 
@@ -275,116 +275,140 @@
 		<div class="sheet-pc-saveblock">
 			<table>
 				<tr>
-					<td>
-						<table>
-							<tr>
-								<td class="sheet-table-data-left">
-									<!--Saving Throws -->
-									<table cellpadding="0" cellspacing="0">
-										<tr><td>
-											<div class="sheet-table-row">
-												<span class="sheet-table-header2">Saving<br>Throws</span>
-												<span class="sheet-table-header2">Total</span>
-												<span class="sheet-table-header2">Base<br>Save</span>
-												<span class="sheet-table-header2">Ability<br>Modifier</span>
-												<span class="sheet-table-header2">Magic<br>Modifier</span>
-												<span class="sheet-table-header2">Misc<br>Modifier</span>
-												<span class="sheet-table-header2">Temp<br>Modifier</span>
-												<span class="sheet-table-header2">Macro</span>
-											</div>
-											<div class="sheet-table-row">
-												<span class="sheet-table-row-name">Fortitude<br><div style="font-size: 0.65em;">(Constitution)</div></span>
-												<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_fortitude" title="fortitude" value="(@{fortitudebase} +@{fortitudeability} +@{fortitudemagicmod} +@{fortitudemiscmod} +@{fortitudetempmod} )" disabled="true"></span>
-												<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_fortitudebase" title="fortitudebase" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudeability" title="fortitudeability" value="floor(@{con}/2-5) " disabled="true"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemagicmod" title="fortitudemagicmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemiscmod" title="fortitudemiscmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudetempmod" title="fortitudetempmod" value="0"></span>
-												<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 50px; height: 20px;" name="attr_fortitudemacro" title="fortitudemacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=braces against the attack}} {{check=Fortitude check:}} {{checkroll=[[1d20 + [[@{fortitude}]] ]] }}</textarea></span>
-												<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_fortitudecheck" title='fortitudecheck' value="@{fortitudemacro}"></button></span>
-											</div>
-											<div class="sheet-table-row">
-												<span class="sheet-table-row-name">Reflex<br><div style="font-size: 0.65em;">(Dexterity)</div></span>
-												<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_reflex" title="reflex" value="(@{reflexbase} +@{reflexability} +@{reflexmagicmod} +@{reflexmiscmod} +@{reflextempmod} )" disabled="true"></span>
-												<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_reflexbase" title="reflexbase" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexability" title="reflexability" value="floor(@{dex}/2-5) " disabled="true"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmagicmod" title="reflexmagicmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmiscmod" title="reflexmiscmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflextempmod" title="reflextempmod" value="0"></span>
-												<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 50px; height: 20px;" name="attr_reflexmacro" title="reflexmacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=tries to dodge}} {{check=Reflex check:}} {{checkroll=[[1d20 + [[@{reflex}]] ]] }}</textarea></span>
-												<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_reflexcheck" title='reflexcheck' value="@{reflexmacro}"></button></span>
-											</div>
-											<div class="sheet-table-row">
-												<span class="sheet-table-row-name">Will<br><div style="font-size: 0.65em;">(Wisdom)</div></span>
-												<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_will" title="will" value="(@{willbase} +@{willability} +@{willmagicmod} +@{willmiscmod} +@{willtempmod} )" disabled="true"></span>
-												<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_willbase" title="willbase" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willability" title="willability" value="floor(@{wis}/2-5) " disabled="true"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmagicmod" title="willmagicmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmiscmod" title="willmiscmod" value="0"></span>
-												<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willtempmod" title="willtempmod" value="0"></span>
-												<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 50px; height: 20px;" name="attr_willmacro" title="willmacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=tries to resist}} {{check=Will check:}} {{checkroll=[[1d20 + [[@{will}]] ]] }}</textarea></span>
-												<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_willcheck" title='willcheck' value="@{willmacro}"></button></span>
-											</div>
-										</td></tr> 
-									</table>
+					<td style="vertical-align:top;">
+						<div class="sheet-table-data-center" style="vertical-align:top;">
+							<table>
+								<tr>
+									<td class="sheet-table-data-left">
+										<!--Saving Throws -->
+										<table cellpadding="0" cellspacing="0">
+											<tr><td style="text-align: left;">
+												<input type="checkbox" class="sheet-pc-savemacros-show sheet-arrow" title="savemacros-show" name="attr_savemacros-show" value="1" /><!--span style="text-align: left;"></span-->
+												<div class="sheet-table-row">
+													<span class="sheet-table-header2">Saving<br>Throws</span>
+													<span class="sheet-table-header2">Total</span>
+													<span class="sheet-table-header2">Base<br>Save</span>
+													<span class="sheet-table-header2">Ability<br>Modifier</span>
+													<span class="sheet-table-header2">Epic Save<br>Bonus</span>
+													<span class="sheet-table-header2">Magic<br>Modifier</span>
+													<span class="sheet-table-header2">Misc<br>Modifier</span>
+													<span class="sheet-table-header2">Temp<br>Modifier</span>
+												</div>
+												<div class="sheet-table-row">
+													<span class="sheet-table-row-name" style="width: 60px;">Fortitude<br><div style="font-size: 0.65em;">(Constitution)</div></span>
+													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_fortitude" title="fortitude" value="(@{fortitudebase} +@{fortitudeability} +@{fortitudeepicsavemod} +@{fortitudemagicmod} +@{fortitudemiscmod} +@{fortitudetempmod} )" disabled="true"></span>
+													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_fortitudebase" title="fortitudebase" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudeability" title="fortitudeability" value="floor(@{con}/2-5) " disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudeepicsavemod" title="fortitudeepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemagicmod" title="fortitudemagicmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemiscmod" title="fortitudemiscmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudetempmod" title="fortitudetempmod" value="0"></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_fortitudecheck" title='fortitudecheck' value="@{fortitudemacro}"></button></span>
+												</div>
+												<div class="sheet-pc-savemacros">
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_fortitudenote" title="fortitudenote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_fortitudemacro" title="fortitudemacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=braces against the attack}} {{check=Fortitude check:}} {{checkroll=[[1d20 + [[@{fortitude}]] ]] }} {{notes=@{fortitudenote} }}</textarea></span>
+												</div>
+												<div class="sheet-table-row" style="font-size: 1em;">
+													<span class="sheet-table-row-name" style="width: 60px;">Reflex<br><div style="font-size: 0.65em;">(Dexterity)</div></span>
+													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_reflex" title="reflex" value="(@{reflexbase} +@{reflexability} +@{reflexepicsavemod} +@{reflexmagicmod} +@{reflexmiscmod} +@{reflextempmod} )" disabled="true"></span>
+													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_reflexbase" title="reflexbase" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexability" title="reflexability" value="floor(@{dex}/2-5) " disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexepicsavemod" title="reflexepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmagicmod" title="reflexmagicmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmiscmod" title="reflexmiscmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflextempmod" title="reflextempmod" value="0"></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_reflexcheck" title='reflexcheck' value="@{reflexmacro}"></button></span>
+												</div>											
+												<div class="sheet-pc-savemacros">
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_reflexnote" title="reflexnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_reflexmacro" title="reflexmacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=tries to dodge}} {{check=Reflex check:}} {{checkroll=[[1d20 + [[@{reflex}]] ]] }} {{notes=@{reflexnote} }}</textarea></span>
+												</div>
+												<div class="sheet-table-row">
+													<span class="sheet-table-row-name" style="width: 60px;">Will<br><div style="font-size: 0.65em;">(Wisdom)</div></span>
+													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_will" title="will" value="(@{willbase} +@{willability} +@{willepicsavemod} +@{willmagicmod} +@{willmiscmod} +@{willtempmod} )" disabled="true"></span>
+													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_willbase" title="willbase" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willability" title="willability" value="floor(@{wis}/2-5) " disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willepicsavemod" title="willepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmagicmod" title="willmagicmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmiscmod" title="willmiscmod" value="0"></span>
+													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willtempmod" title="willtempmod" value="0"></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_willcheck" title='willcheck' value="@{willmacro}"></button></span>
+												</div>											
+												<div class="sheet-pc-savemacros">
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_willnote" title="willnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_willmacro" title="willmacro">&{template:DnD35StdRoll} {{saveflag=true}} {{name=@{character_name} }} {{subtags=tries to resist}} {{check=Will check:}} {{checkroll=[[1d20 + [[@{will}]] ]] }} {{notes=@{willnote} }}</textarea></span>
+												</div>
+												<input type="checkbox" class="sheet-pc-savemacros-show sheet-arrow" title="savemacros-show" name="attr_savemacros-show" value="1" /><span style="text-align: left;">Show Save Macros</span>
+											</td></tr> 
+										</table>
+										<br>
+										<table>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 80px;"><div>Spell Resist</div></td>
+												<td style="text-align: left;"><input class="sheet-inputbox" type="text" name="attr_spellresistance" title="spellresistance" style="height: 24px; width: 50px;"></td>
+												<td> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </td>
+												<td class="sheet-statlabel-big" style="width: 110px;"><div>Arcane Spell Failure</div></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_arcanespellfailure" title="arcanespellfailure" style="height: 24px; width: 50px;"></td>
+											</tr>
+										</table>
 									<br>
-									<table>
-										<tr>
-											<td class="sheet-statlabel-big" style="width: 80px;"><div>Spell Resist</div></td>
-											<td style="text-align: left;"><input class="sheet-inputbox" type="text" name="attr_spellresistance" title="spellresistance" style="height: 24px; width: 50px;"></td>
-											<td> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </td>
-											<td class="sheet-statlabel-big" style="width: 110px;"><div>Arcane Spell Failure</div></td>
-											<td><input class="sheet-inputbox" type="text" name="attr_arcanespellfailure" title="arcanespellfailure" style="height: 24px; width: 50px;"></td>
-										</tr>
-									</table>
-								<br>
-									<table>
-										<tr>
-											<td class="sheet-statlabel-big" style="width: 80px;">Base Attack</td>
-											<td>&nbsp;<input class="sheet-inputbox" type="text" name="attr_bab" title="bab" value="0" style="height: 24px; width: 50px;"></td>
-											<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab2" title="bab2" value="(((@{bab}-5)+abs(@{bab}-5))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
-											<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab3" title="bab3" value="(((@{bab}-10)+abs(@{bab}-10))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
-											<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab4" title="bab4" value="(((@{bab}-15)+abs(@{bab}-15))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
-										</tr>
-										<tr>
-											<td class="sheet-statlabel-big" style="width: 80px;">Grapple</td>
-											<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapple" title="grapple" value="(@{bab}+@{grapplestrmod}+@{specialattacksizemod}+@{grapplemiscmod})" disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Total</div></td>
-											<td>=<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplebab" title="grapplebab" style="height: 24px; width: 50px;" disabled="true" value="@{bab}"><br><div style="font-size: 0.5em;">Base Attack</div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplestrmod" title="grapplestrmod" value="floor(@{str}/2-5) " disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Str mod </div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_specialattacksizemod" title="specialattacksizemod" value="(floor((@{size} + 50) / 58) + floor((@{size} + 50) / 54) + floor((@{size} + 50) / 52) + floor((@{size} + 50) / 51) + floor((@{size} + 50) / 50) + floor((@{size} + 50) / 49) + floor((@{size} + 50) / 47) + floor((@{size} + 50) / 43) -4) * (-4) " disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Size Mod</div></td>
-											<td>+<input class="sheet-inputbox" type="text" name="attr_grapplemiscmod" title="grapplemiscmod" value="0" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Misc Mod</div></td>
-											<td><button type='roll' name='attr_Grapplecheck' title='Grapplecheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name} }} {{attack1=Grapple check:[[1d20 +[[@{grapple}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br></div></td>
-										</tr>
-									</table>
-									<br>
-									<table>
-										<tr>
-											<td class="sheet-statlabel-big" style="width: 50px;">Melee<div style="font-size: 0.65em;">Attack Bonus</div></td>
-											<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_meleeattackbonus" title="meleeattackbonus" style="height: 24px; width: 60px;" value="(@{bab}+@{strmodmab}+@{size}+@{mabmiscmod}+@{mabtempmod})" disabled="true"><br><div style="font-size: 0.5em;">Total<br>&nbsp;</div></td>
-											<td> =<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_babmab" title="babmab" style="height: 24px; width: 40px;" value="@{bab}" disabled="true"><br><div style="font-size: 0.5em;">Base Attack<br>Bonus</div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_strmodmab" title="strmodmab" style="height: 24px; width: 40px;" value="floor(@{str}/2-5) " disabled="true"><br><div style="font-size: 0.5em;">Strength<br>Modifier</div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_sizemodmab" title="sizemodmab" style="height: 24px; width: 40px;" value="@{size}" disabled="true"><br><div style="font-size: 0.5em;">Size<br>Modifier</div></td>
-											<td>+<input class="sheet-inputbox" type="text" name="attr_mabmiscmod" title="mabmiscmod" style="height: 24px; width: 40px;" value="0"><br><div style="font-size: 0.5em;">Misc<br>Modifiers<br></div></td>
-											<td>+<input class="sheet-inputbox" type="text" name="attr_mabtempmod" title="mabtempmod" style="height: 24px; width: 40px;" value="0"><br><div style="font-size: 0.5em;">Temp<br>Modifiers<br></div></td>
-											<td><button type='roll' name='attr_meleeattackcheck' title='meleeattackcheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=makes a melee attack }} {{attack1=hitting AC [[1d20 +[[@{meleeattackbonus}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br>&nbsp;<br></div></td>
-										</tr>
-									</table>
-									<br>
-									<table>
-										<tr>
-											<td class="sheet-statlabel-big" style="width: 50px;">Ranged<div style="font-size: 0.65em;">Attack Bonus</div></td>
-											<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_rangedattackbonus" title="rangedattackbonus" style="height: 24px; width: 60px;" value="(@{bab}+@{dexmodrab}+@{size}+@{rabmiscmod}+@{rabtempmod})" disabled="true"><br><div style="font-size: 0.5em;">Total<br>&nbsp;</div></td>
-											<td> =<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_babrab" title="babrab" style="height: 24px; width: 40px;" value="@{bab}" disabled="true"><br><div style="font-size: 0.5em;">Base Attack<br>Bonus</div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_dexmodrab" title="dexmodrab" style="height: 24px; width: 40px;" value="floor(@{dex}/2-5) " disabled="true"><br><div style="font-size: 0.5em;">Dexterity<br>Modifier</div></td>
-											<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_sizemodrab" title="sizemodrab" style="height: 24px; width: 40px;" value="@{size}" disabled="true"><br><div style="font-size: 0.5em;">Size<br>Modifier</div></td>
-											<td>+<input class="sheet-inputbox" type="text" name="attr_rabmiscmod" title="rabmiscmod" style="height: 24px; width: 40px;" value="0"><br><div style="font-size: 0.5em;">Misc<br>Modifiers<br></div></td>
-											<td>+<input class="sheet-inputbox" type="text" name="attr_rabtempmod" title="rabtempmod" style="height: 24px; width: 40px;" value="0"><br><div style="font-size: 0.5em;">Temp<br>Modifiers<br></div></td>
-											<td><button type='roll' name='attr_rangedattackcheck' title='rangedattackcheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=makes a ranged attack }} {{attack1=hitting AC [[1d20 +[[@{rangedattackbonus}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br>&nbsp;<br></div></td>
-										</tr>
-									</table>
-								</td>
-							</tr>
-						</table>
+										<table>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 80px;">Base Attack</td>
+												<td>&nbsp;<input class="sheet-inputbox" type="text" name="attr_bab" title="bab" value="0" style="height: 24px; width: 50px;"></td>
+												<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab2" title="bab2" value="(((@{bab} -5)+abs(@{bab} -5))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
+												<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab3" title="bab3" value="(((@{bab} -10)+abs(@{bab} -10))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
+												<td>/<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_bab4" title="bab4" value="(((@{bab} -15)+abs(@{bab} -15))/2)" disabled="true" style="height: 24px; width: 50px;"></td>
+											</tr>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 80px;">Grapple</td>
+												<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapple" title="grapple" value="(@{bab} +@{epicattackbonus} +@{grapplestrmod}+@{specialattacksizemod}+@{grapplemiscmod})" disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Total</div></td>
+												<td>=<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplebab" title="grapplebab (Base Attack Bonus + Epic Attack Bonus)" style="height: 24px; width: 50px;" disabled="true" value="@{bab} +@{epicattackbonus} "><br><div style="font-size: 0.5em;">BAB + EAB</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplestrmod" title="grapplestrmod" value="floor(@{str}/2-5) " disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Str mod </div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_specialattacksizemod" title="specialattacksizemod" value="(floor((@{size} + 50) / 58) + floor((@{size} + 50) / 54) + floor((@{size} + 50) / 52) + floor((@{size} + 50) / 51) + floor((@{size} + 50) / 50) + floor((@{size} + 50) / 49) + floor((@{size} + 50) / 47) + floor((@{size} + 50) / 43) -4) * (-4) " disabled="true" style="height: 24px; width: 50px;"><br><div style="font-size: 0.5em;">Size Mod</div></td>
+												<td>+<input class="sheet-inputbox" type="text" name="attr_grapplemiscmod" title="grapplemiscmod" value="0" style="width: 50px;"><br><div style="font-size: 0.5em;">Misc Mod</div></td>
+												<td><button type='roll' name='attr_Grapplecheck' title='Grapplecheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name} }} {{attack1=Grapple check:[[1d20 +[[@{grapple}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br></div></td>
+											</tr>
+										</table>
+										<br>
+										<table>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 50px;">Melee<div style="font-size: 0.65em;">Attack Bonus</div></td>
+												<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_meleeattackbonus" title="meleeattackbonus" value="(@{bab} +@{epicattackbonus} +@{strmodmab}+@{size}+@{mabmiscmod}+@{mabtempmod})" disabled="true"><br><div style="font-size: 0.5em;">Total<br>&nbsp;</div></td>
+												<td> =<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_babmab" title="babmab (Base Attack Bonus + Epic Attack Bonus)" value="@{bab} +@{epicattackbonus} " disabled="true"><br><div style="font-size: 0.5em;">Base AB <br>+ Epic AB</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_strmodmab" title="strmodmab" value="floor(@{str}/2-5) " disabled="true"><br><div style="font-size: 0.5em;">Strength<br>Modifier</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_sizemodmab" title="sizemodmab" value="@{size}" disabled="true"><br><div style="font-size: 0.5em;">Size<br>Modifier</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_mabmiscmod" title="mabmiscmod" value="0"><br><div style="font-size: 0.5em;">Misc<br>Modifiers<br></div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_mabtempmod" title="mabtempmod" value="0"><br><div style="font-size: 0.5em;">Temp<br>Modifiers<br></div></td>
+												<td><button type='roll' name='attr_meleeattackcheck' title='meleeattackcheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=makes a melee attack }} {{attack1=hitting AC [[1d20 +[[@{meleeattackbonus}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br>&nbsp;<br></div></td>
+											</tr>
+										</table>
+										<br>
+										<table>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 50px;">Ranged<div style="font-size: 0.65em;">Attack Bonus</div></td>
+												<td><input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_rangedattackbonus" title="rangedattackbonus" value="(@{bab} +@{epicattackbonus} +@{dexmodrab}+@{size}+@{rabmiscmod}+@{rabtempmod})" disabled="true"><br><div style="font-size: 0.5em;">Total<br>&nbsp;</div></td>
+												<td> =<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_babrab" title="babrab (Base Attack Bonus + Epic Attack Bonus)" value="@{bab} +@{epicattackbonus} " disabled="true"><br><div style="font-size: 0.5em;">Base AB <br>+ Epic AB</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_dexmodrab" title="dexmodrab" value="floor(@{dex}/2-5) " disabled="true"><br><div style="font-size: 0.5em;">Dexterity<br>Modifier</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_sizemodrab" title="sizemodrab" value="@{size}" disabled="true"><br><div style="font-size: 0.5em;">Size<br>Modifier</div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_rabmiscmod" title="rabmiscmod" value="0"><br><div style="font-size: 0.5em;">Misc<br>Modifiers<br></div></td>
+												<td>+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_rabtempmod" title="rabtempmod" value="0"><br><div style="font-size: 0.5em;">Temp<br>Modifiers<br></div></td>
+												<td><button type='roll' name='attr_rangedattackcheck' title='rangedattackcheck' value='&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=makes a ranged attack }} {{attack1=hitting AC [[1d20 +[[@{rangedattackbonus}]] ]]}}'></button><br><div style="font-size: 0.5em;">&nbsp;<br>&nbsp;<br></div></td>
+											</tr>
+										</table>
+										<br>
+										<table>
+											<tr>
+												<td class="sheet-statlabel-big" style="width: 50px;">Epic Levels:</td>
+												<td>Epic Save Bonus: <input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_epicsavebonus" title="epicsavebonus" value="0"></td>
+												<td>Epic Attack Bonus: <input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_epicattackbonus" title="epicattackbonus" value="0"></td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+						</div>
 					</td>
 					<td class="sheet-table-data-left">
 						<div class="sheet-table-data-center" style="vertical-align:top;">
@@ -394,16 +418,16 @@
 										<span class="sheet-table-data-center">Languages<br><textarea rows="2" cols="55" style="width: 380px;" name="attr_languages" title="languages"></textarea></span>
 									</div>
 									<div class="sheet-table-row">
-										<span class="sheet-table-data-center">Racial Abilities<br><textarea rows="3" cols="55" style="width: 380px;" name="attr_racialabilities" title="racialabilities"></textarea></span>
+										<span class="sheet-table-data-center">Racial Abilities<br><textarea rows="4" cols="55" style="width: 380px;" name="attr_racialabilities" title="racialabilities"></textarea></span>
 									</div>
 									<div class="sheet-table-row">
-										<span class="sheet-table-data-center">Class Abilities<br><textarea rows="3" cols="55" style="width: 380px;" name="attr_classabilities" title="classabilities"></textarea></span>
+										<span class="sheet-table-data-center">Class Abilities<br><textarea rows="4" cols="55" style="width: 380px;" name="attr_classabilities" title="classabilities"></textarea></span>
 									</div>
 									<div class="sheet-table-row">
-										<span class="sheet-table-data-center">Feats<br><textarea rows="3" cols="55" style="width: 380px;" name="attr_feats" title="feats"></textarea></span>
+										<span class="sheet-table-data-center">Feats<br><textarea rows="4" cols="55" style="width: 380px;" name="attr_feats" title="feats"></textarea></span>
 									</div>
 									<div class="sheet-table-row">
-										<span class="sheet-table-data-center">Other<br><textarea rows="3" cols="55" style="width: 380px;" name="attr_other" title="other"></textarea></span>
+										<span class="sheet-table-data-center">Other<br><textarea rows="4" cols="55" style="width: 380px;" name="attr_other" title="other"></textarea></span>
 									</div>
 								</div>
 							</div>
@@ -452,7 +476,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon1enh" title="weapon1enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon1focus" title="weapon1focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon1specialize" title="weapon1specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon1critmin" title="weapon1critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon1critmult" title="weapon1critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon1critdamage" title='weapon1critdamage' style="width: 17px;" value="@{character_name}'s @{weapon1name} does [[(@{weapon1critmult})*(@{weapon1damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon1critmin" title="weapon1critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon1critmult" title="weapon1critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon1critdamage" title='weapon1critdamage' style="width: 17px;" value="@{character_name}'s @{weapon1name} does [[(@{weapon1critmult})*(@{weapon1damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon1range" title="weapon1range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon1ammunition" title="weapon1ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon1stat" title="weapon1stat">
@@ -468,14 +492,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon1specialproperties" title="weapon1specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon1attackcalc">1d20cs>@{weapon1critmin} +@{bab}[BAB] +[[@{weapon1stat}]][Ability] +@{size}[size] +@{weapon1enh}[Weapon Enh] +@{weapon1focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon1attackcalc">1d20cs>@{weapon1critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon1stat}]][Ability] +@{size}[size] +@{weapon1enh}[Weapon Enh] +@{weapon1focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon1attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=hitting AC[[@{weapon1attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon1attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon1damage}]] dmg}} {{critdmg1=+[[@{weapon1crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon1attack" text="attack" title='weapon1attack' value="@{weapon1attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon1attack" text="attack" title='weapon1attack' value="@{weapon1attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon1fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon1fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=A1:[[@{weapon1attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon1attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon1damage}]]}} {{critdmg1=+[[@{weapon1crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon1attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon1attackcalc}-5]]}} {{damage2=D2:[[@{weapon1damage}]]}} {{critdmg2=+[[@{weapon1crit}]]}} {{attack3=A3:[[@{weapon1attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon1attackcalc}-10]]}} {{damage3=D3:[[@{weapon1damage}]]}} {{critdmg3=+[[@{weapon1crit}]]}} {{attack4=A4:[[@{weapon1attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon1attackcalc}-15]]}} {{damage4=D4:[[@{weapon1damage}]]}} {{critdmg4=+[[@{weapon1crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon1fullattack" text="Full Attack" title='weapon1fullattack' value="@{weapon1fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll"name="attr_weapon1fullattack" text="Full Attack" title='weapon1fullattack' value="@{weapon1fullattackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon1damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon1crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1crit (Edit this to adjust the critical calculation.)">[[(@{weapon1critmult}-1)]]d6 +[[(@{weapon1critmult}-1)]]*([[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon1damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon1damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon1name} }} {{damage1=does [[@{weapon1damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon1damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon1damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon1name} }} {{damage1=does [[@{weapon1damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon1damageroll" title='weapon1damageroll' style="width: 20px;" value="@{weapon1damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -503,7 +527,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon2enh" title="weapon2enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon2focus" title="weapon2focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon2specialize" title="weapon2specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon2critmin" title="weapon2critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon2critmult" title="weapon2critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon2critdamage" title='weapon2critdamage' style="width: 17px;" value="@{character_name}'s @{weapon2name} does [[(@{weapon2critmult})*(@{weapon2damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon2critmin" title="weapon2critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon2critmult" title="weapon2critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon2critdamage" title='weapon2critdamage' style="width: 17px;" value="@{character_name}'s @{weapon2name} does [[(@{weapon2critmult})*(@{weapon2damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon2range" title="weapon2range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon2ammunition" title="weapon2ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon2stat" title="weapon2stat">
@@ -519,14 +543,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon2specialproperties" title="weapon2specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon2attackcalc">1d20cs>@{weapon2critmin} +@{bab}[BAB] +[[@{weapon2stat}]][Ability] +@{size}[size] +@{weapon2enh}[Weapon Enh] +@{weapon2focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon2attackcalc">1d20cs>@{weapon2critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon2stat}]][Ability] +@{size}[size] +@{weapon2enh}[Weapon Enh] +@{weapon2focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon2attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=hitting AC[[@{weapon2attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon2attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon2damage}]] dmg}} {{critdmg1=+[[@{weapon2crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon2attack" text="attack" title='weapon2attack' value="@{weapon2attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon2fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon2fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=A1:[[@{weapon2attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon2attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon2damage}]]}} {{critdmg1=+[[@{weapon2crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon2attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon2attackcalc}-5]]}} {{damage2=D2:[[@{weapon2damage}]]}} {{critdmg2=+[[@{weapon2crit}]]}} {{attack3=A3:[[@{weapon2attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon2attackcalc}-10]]}} {{damage3=D3:[[@{weapon2damage}]]}} {{critdmg3=+[[@{weapon2crit}]]}} {{attack4=A4:[[@{weapon2attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon2attackcalc}-15]]}} {{damage4=D4:[[@{weapon2damage}]]}} {{critdmg4=+[[@{weapon2crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon2fullattack" text="Full Attack" title='weapon2fullattack' value="@{weapon2fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon2damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon2crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2crit (Edit this to adjust the critical calculation.)">[[(@{weapon2critmult}-1)]]d6 +[[(@{weapon2critmult}-1)]]*([[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon2damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon2damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon2name} }} {{damage1=does [[@{weapon2damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon2damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon2damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon2name} }} {{damage1=does [[@{weapon2damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon2damageroll" title='weapon2damageroll' style="width: 20px;" value="@{weapon2damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -554,7 +578,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon3enh" title="weapon3enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon3focus" title="weapon3focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon3specialize" title="weapon3specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon3critmin" title="weapon3critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon3critmult" title="weapon3critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon3critdamage" title='weapon3critdamage' style="width: 17px;" value="@{character_name}'s @{weapon3name} does [[(@{weapon3critmult})*(@{weapon3damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon3critmin" title="weapon3critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon3critmult" title="weapon3critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon3critdamage" title='weapon3critdamage' style="width: 17px;" value="@{character_name}'s @{weapon3name} does [[(@{weapon3critmult})*(@{weapon3damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon3range" title="weapon3range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon3ammunition" title="weapon3ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon3stat" title="weapon3stat">
@@ -570,14 +594,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon3specialproperties" title="weapon3specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon3attackcalc">1d20cs>@{weapon3critmin} +@{bab}[BAB] +[[@{weapon3stat}]][Ability] +@{size}[size] +@{weapon3enh}[Weapon Enh] +@{weapon3focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon3attackcalc">1d20cs>@{weapon3critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon3stat}]][Ability] +@{size}[size] +@{weapon3enh}[Weapon Enh] +@{weapon3focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon3attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=hitting AC[[@{weapon3attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon3attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon3damage}]] dmg}} {{critdmg1=+[[@{weapon3crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon3attack" text="attack" title='weapon3attack' value="@{weapon3attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon3fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon3fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=A1:[[@{weapon3attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon3attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon3damage}]]}} {{critdmg1=+[[@{weapon3crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon3attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon3attackcalc}-5]]}} {{damage2=D2:[[@{weapon3damage}]]}} {{critdmg2=+[[@{weapon3crit}]]}} {{attack3=A3:[[@{weapon3attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon3attackcalc}-10]]}} {{damage3=D3:[[@{weapon3damage}]]}} {{critdmg3=+[[@{weapon3crit}]]}} {{attack4=A4:[[@{weapon3attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon3attackcalc}-15]]}} {{damage4=D4:[[@{weapon3damage}]]}} {{critdmg4=+[[@{weapon3crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon3fullattack" text="Full Attack" title='weapon3fullattack' value="@{weapon3fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon3damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon3crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3crit (Edit this to adjust the critical calculation.)">[[(@{weapon3critmult}-1)]]d6 +[[(@{weapon3critmult}-1)]]*([[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon3damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon3damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon3name} }} {{damage1=does [[@{weapon3damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon3damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon3damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon3name} }} {{damage1=does [[@{weapon3damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon3damageroll" title='weapon3damageroll' style="width: 20px;" value="@{weapon3damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -605,7 +629,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon4enh" title="weapon4enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon4focus" title="weapon4focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon4specialize" title="weapon4specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon4critmin" title="weapon4critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon4critmult" title="weapon4critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon4critdamage" title='weapon4critdamage' style="width: 17px;" value="@{character_name}'s @{weapon4name} does [[(@{weapon4critmult})*(@{weapon4damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon4critmin" title="weapon4critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon4critmult" title="weapon4critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon4critdamage" title='weapon4critdamage' style="width: 17px;" value="@{character_name}'s @{weapon4name} does [[(@{weapon4critmult})*(@{weapon4damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon4range" title="weapon4range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon4ammunition" title="weapon4ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon4stat" title="weapon4stat">
@@ -621,14 +645,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon4specialproperties" title="weapon4specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon4attackcalc">1d20cs>@{weapon4critmin} +@{bab}[BAB] +[[@{weapon4stat}]][Ability] +@{size}[size] +@{weapon4enh}[Weapon Enh] +@{weapon4focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon4attackcalc">1d20cs>@{weapon4critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon4stat}]][Ability] +@{size}[size] +@{weapon4enh}[Weapon Enh] +@{weapon4focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon4attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=hitting AC[[@{weapon4attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon4attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon4damage}]] dmg}} {{critdmg1=+[[@{weapon4crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon4attack" text="attack" title='weapon4attack' value="@{weapon4attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon4fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon4fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=A1:[[@{weapon4attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon4attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon4damage}]]}} {{critdmg1=+[[@{weapon4crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon4attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon4attackcalc}-5]]}} {{damage2=D2:[[@{weapon4damage}]]}} {{critdmg2=+[[@{weapon4crit}]]}} {{attack3=A3:[[@{weapon4attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon4attackcalc}-10]]}} {{damage3=D3:[[@{weapon4damage}]]}} {{critdmg3=+[[@{weapon4crit}]]}} {{attack4=A4:[[@{weapon4attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon4attackcalc}-15]]}} {{damage4=D4:[[@{weapon4damage}]]}} {{critdmg4=+[[@{weapon4crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon4fullattack" text="Full Attack" title='weapon4fullattack' value="@{weapon4fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon4damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon4crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4crit (Edit this to adjust the critical calculation.)">[[(@{weapon4critmult}-1)]]d6 +[[(@{weapon4critmult}-1)]]*([[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon4damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon4damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon4name} }} {{damage1=does [[@{weapon4damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon4damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon4damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon4name} }} {{damage1=does [[@{weapon4damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon4damageroll" title='weapon4damageroll' style="width: 20px;" value="@{weapon4damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -656,7 +680,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon5enh" title="weapon5enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon5focus" title="weapon5focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon5specialize" title="weapon5specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon5critmin" title="weapon5critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon5critmult" title="weapon5critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon5critdamage" title='weapon5critdamage' style="width: 17px;" value="@{character_name}'s @{weapon5name} does [[(@{weapon5critmult})*(@{weapon5damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon5critmin" title="weapon5critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon5critmult" title="weapon5critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon5critdamage" title='weapon5critdamage' style="width: 17px;" value="@{character_name}'s @{weapon5name} does [[(@{weapon5critmult})*(@{weapon5damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon5range" title="weapon5range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon5ammunition" title="weapon5ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon5stat" title="weapon5stat">
@@ -672,14 +696,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon5specialproperties" title="weapon5specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon5attackcalc">1d20cs>@{weapon5critmin} +@{bab}[BAB] +[[@{weapon5stat}]][Ability] +@{size}[size] +@{weapon5enh}[Weapon Enh] +@{weapon5focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon5attackcalc">1d20cs>@{weapon5critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon5stat}]][Ability] +@{size}[size] +@{weapon5enh}[Weapon Enh] +@{weapon5focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon5attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=hitting AC[[@{weapon5attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon5attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon5damage}]] dmg}} {{critdmg1=+[[@{weapon5crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon5attack" text="attack" title='weapon5attack' value="@{weapon5attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon5fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon5fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=A1:[[@{weapon5attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon5attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon5damage}]]}} {{critdmg1=+[[@{weapon5crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon5attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon5attackcalc}-5]]}} {{damage2=D2:[[@{weapon5damage}]]}} {{critdmg2=+[[@{weapon5crit}]]}} {{attack3=A3:[[@{weapon5attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon5attackcalc}-10]]}} {{damage3=D3:[[@{weapon5damage}]]}} {{critdmg3=+[[@{weapon5crit}]]}} {{attack4=A4:[[@{weapon5attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon5attackcalc}-15]]}} {{damage4=D4:[[@{weapon5damage}]]}} {{critdmg4=+[[@{weapon5crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon5fullattack" text="Full Attack" title='weapon5fullattack' value="@{weapon5fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon5damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon5crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5crit (Edit this to adjust the critical calculation.)">[[(@{weapon5critmult}-1)]]d6 +[[(@{weapon5critmult}-1)]]*([[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon5damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon5damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon5name} }} {{damage1=does [[@{weapon5damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon5damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon5damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon5name} }} {{damage1=does [[@{weapon5damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon5damageroll" title='weapon5damageroll' style="width: 20px;" value="@{weapon5damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -707,7 +731,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon6enh" title="weapon6enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon6focus" title="weapon6focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon6specialize" title="weapon6specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon6critmin" title="weapon6critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon6critmult" title="weapon6critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon6critdamage" title='weapon6critdamage' style="width: 17px;" value="@{character_name}'s @{weapon6name} does [[(@{weapon6critmult})*(@{weapon6damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon6critmin" title="weapon6critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon6critmult" title="weapon6critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon6critdamage" title='weapon6critdamage' style="width: 17px;" value="@{character_name}'s @{weapon6name} does [[(@{weapon6critmult})*(@{weapon6damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon6range" title="weapon6range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon6ammunition" title="weapon6ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon6stat" title="weapon6stat">
@@ -723,14 +747,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon6specialproperties" title="weapon6specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon6attackcalc">1d20cs>@{weapon6critmin} +@{bab}[BAB] +[[@{weapon6stat}]][Ability] +@{size}[size] +@{weapon6enh}[Weapon Enh] +@{weapon6focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon6attackcalc">1d20cs>@{weapon6critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon6stat}]][Ability] +@{size}[size] +@{weapon6enh}[Weapon Enh] +@{weapon6focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon6attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=hitting AC[[@{weapon6attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon6attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon6damage}]] dmg}} {{critdmg1=+[[@{weapon6crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon6attack" text="attack" title='weapon6attack' value="@{weapon6attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon6fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon6fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=A1:[[@{weapon6attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon6attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon6damage}]]}} {{critdmg1=+[[@{weapon6crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon6attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon6attackcalc}-5]]}} {{damage2=D2:[[@{weapon6damage}]]}} {{critdmg2=+[[@{weapon6crit}]]}} {{attack3=A3:[[@{weapon6attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon6attackcalc}-10]]}} {{damage3=D3:[[@{weapon6damage}]]}} {{critdmg3=+[[@{weapon6crit}]]}} {{attack4=A4:[[@{weapon6attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon6attackcalc}-15]]}} {{damage4=D4:[[@{weapon6damage}]]}} {{critdmg4=+[[@{weapon6crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon6fullattack" text="Full Attack" title='weapon6fullattack' value="@{weapon6fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon6damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon6crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6crit (Edit this to adjust the critical calculation.)">[[(@{weapon6critmult}-1)]]d6 +[[(@{weapon6critmult}-1)]]*([[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon6damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon6damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon6name} }} {{damage1=does [[@{weapon6damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon6damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon6damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon6name} }} {{damage1=does [[@{weapon6damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon6damageroll" title='weapon6damageroll' style="width: 20px;" value="@{weapon6damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -758,7 +782,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon7enh" title="weapon7enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon7focus" title="weapon7focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon7specialize" title="weapon7specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon7critmin" title="weapon7critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon7critmult" title="weapon7critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon7critdamage" title='weapon7critdamage' style="width: 17px;" value="@{character_name}'s @{weapon7name} does [[(@{weapon7critmult})*(@{weapon7damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon7critmin" title="weapon7critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon7critmult" title="weapon7critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon7critdamage" title='weapon7critdamage' style="width: 17px;" value="@{character_name}'s @{weapon7name} does [[(@{weapon7critmult})*(@{weapon7damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon7range" title="weapon7range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon7ammunition" title="weapon7ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon7stat" title="weapon7stat">
@@ -774,14 +798,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon7specialproperties" title="weapon7specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon7attackcalc">1d20cs>@{weapon7critmin} +@{bab}[BAB] +[[@{weapon7stat}]][Ability] +@{size}[size] +@{weapon7enh}[Weapon Enh] +@{weapon7focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon7attackcalc">1d20cs>@{weapon7critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon7stat}]][Ability] +@{size}[size] +@{weapon7enh}[Weapon Enh] +@{weapon7focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon7attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=hitting AC[[@{weapon7attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon7attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon7damage}]] dmg}} {{critdmg1=+[[@{weapon7crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon7attack" text="attack" title='weapon7attack' value="@{weapon7attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon7fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon7fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=A1:[[@{weapon7attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon7attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon7damage}]]}} {{critdmg1=+[[@{weapon7crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon7attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon7attackcalc}-5]]}} {{damage2=D2:[[@{weapon7damage}]]}} {{critdmg2=+[[@{weapon7crit}]]}} {{attack3=A3:[[@{weapon7attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon7attackcalc}-10]]}} {{damage3=D3:[[@{weapon7damage}]]}} {{critdmg3=+[[@{weapon7crit}]]}} {{attack4=A4:[[@{weapon7attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon7attackcalc}-15]]}} {{damage4=D4:[[@{weapon7damage}]]}} {{critdmg4=+[[@{weapon7crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon7fullattack" text="Full Attack" title='weapon7fullattack' value="@{weapon7fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon7damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon7crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7crit (Edit this to adjust the critical calculation.)">[[(@{weapon7critmult}-1)]]d6 +[[(@{weapon7critmult}-1)]]*([[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon7damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon7damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon7name} }} {{damage1=does [[@{weapon7damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon7damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon7damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon7name} }} {{damage1=does [[@{weapon7damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon7damageroll" title='weapon7damageroll' style="width: 20px;" value="@{weapon7damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -809,7 +833,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon8enh" title="weapon8enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon8focus" title="weapon8focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon8specialize" title="weapon8specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon8critmin" title="weapon8critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon8critmult" title="weapon8critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon8critdamage" title='weapon8critdamage' style="width: 17px;" value="@{character_name}'s @{weapon8name} does [[(@{weapon8critmult})*(@{weapon8damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon8critmin" title="weapon8critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon8critmult" title="weapon8critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon8critdamage" title='weapon8critdamage' style="width: 17px;" value="@{character_name}'s @{weapon8name} does [[(@{weapon8critmult})*(@{weapon8damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon8range" title="weapon8range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon8ammunition" title="weapon8ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon8stat" title="weapon8stat">
@@ -825,14 +849,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon8specialproperties" title="weapon8specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon8attackcalc">1d20cs>@{weapon8critmin} +@{bab}[BAB] +[[@{weapon8stat}]][Ability] +@{size}[size] +@{weapon8enh}[Weapon Enh] +@{weapon8focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon8attackcalc">1d20cs>@{weapon8critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon8stat}]][Ability] +@{size}[size] +@{weapon8enh}[Weapon Enh] +@{weapon8focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon8attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=hitting AC[[@{weapon8attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon8attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon8damage}]] dmg}} {{critdmg1=+[[@{weapon8crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon8attack" text="attack" title='weapon8attack' value="@{weapon8attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon8fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon8fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=A1:[[@{weapon8attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon8attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon8damage}]]}} {{critdmg1=+[[@{weapon8crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon8attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon8attackcalc}-5]]}} {{damage2=D2:[[@{weapon8damage}]]}} {{critdmg2=+[[@{weapon8crit}]]}} {{attack3=A3:[[@{weapon8attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon8attackcalc}-10]]}} {{damage3=D3:[[@{weapon8damage}]]}} {{critdmg3=+[[@{weapon8crit}]]}} {{attack4=A4:[[@{weapon8attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon8attackcalc}-15]]}} {{damage4=D4:[[@{weapon8damage}]]}} {{critdmg4=+[[@{weapon8crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon8fullattack" text="Full Attack" title='weapon8fullattack' value="@{weapon8fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon8damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon8crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8crit (Edit this to adjust the critical calculation.)">[[(@{weapon8critmult}-1)]]d6 +[[(@{weapon8critmult}-1)]]*([[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon8damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon8damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon8name} }} {{damage1=does [[@{weapon8damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon8damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon8damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon8name} }} {{damage1=does [[@{weapon8damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon8damageroll" title='weapon8damageroll' style="width: 20px;" value="@{weapon8damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -860,7 +884,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon9enh" title="weapon9enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon9focus" title="weapon9focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon9specialize" title="weapon9specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon9critmin" title="weapon9critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon9critmult" title="weapon9critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon9critdamage" title='weapon9critdamage' style="width: 17px;" value="@{character_name}'s @{weapon9name} does [[(@{weapon9critmult})*(@{weapon9damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon9critmin" title="weapon9critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon9critmult" title="weapon9critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon9critdamage" title='weapon9critdamage' style="width: 17px;" value="@{character_name}'s @{weapon9name} does [[(@{weapon9critmult})*(@{weapon9damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon9range" title="weapon9range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon9ammunition" title="weapon9ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon9stat" title="weapon9stat">
@@ -876,14 +900,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon9specialproperties" title="weapon9specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon9attackcalc">1d20cs>@{weapon9critmin} +@{bab}[BAB] +[[@{weapon9stat}]][Ability] +@{size}[size] +@{weapon9enh}[Weapon Enh] +@{weapon9focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon9attackcalc">1d20cs>@{weapon9critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon9stat}]][Ability] +@{size}[size] +@{weapon9enh}[Weapon Enh] +@{weapon9focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon9attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=hitting AC[[@{weapon9attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon9attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon9damage}]] dmg}} {{critdmg1=+[[@{weapon9crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon9attack" text="attack" title='weapon9attack' value="@{weapon9attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon9fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon9fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=A1:[[@{weapon9attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon9attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon9damage}]]}} {{critdmg1=+[[@{weapon9crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon9attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon9attackcalc}-5]]}} {{damage2=D2:[[@{weapon9damage}]]}} {{critdmg2=+[[@{weapon9crit}]]}} {{attack3=A3:[[@{weapon9attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon9attackcalc}-10]]}} {{damage3=D3:[[@{weapon9damage}]]}} {{critdmg3=+[[@{weapon9crit}]]}} {{attack4=A4:[[@{weapon9attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon9attackcalc}-15]]}} {{damage4=D4:[[@{weapon9damage}]]}} {{critdmg4=+[[@{weapon9crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon9fullattack" text="Full Attack" title='weapon9fullattack' value="@{weapon9fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon9damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon9crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9crit (Edit this to adjust the critical calculation.)">[[(@{weapon9critmult}-1)]]d6 +[[(@{weapon9critmult}-1)]]*([[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon9damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon9damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon9name} }} {{damage1=does [[@{weapon9damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon9damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon9damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon9name} }} {{damage1=does [[@{weapon9damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon9damageroll" title='weapon9damageroll' style="width: 20px;" value="@{weapon9damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -911,7 +935,7 @@
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon10enh" title="weapon10enh (affects both attack and damage)" style="height: 24px; width: 44px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon10focus" title="weapon10focus (affects only attack)" style="height: 24px; width: 41px;" value="0"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon10specialize" title="weapon10specialize (affects only damage)" style="height: 24px; width: 41px;" value="0"></td>
-												<td><input class="sheet-inputbox" type="text" name="attr_weapon10critmin" title="weapon10critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon10critmult" title="weapon10critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon10critdamage" title='weapon10critdamage' style="width: 17px;" value="@{character_name}'s @{weapon10name} does [[(@{weapon10critmult})*(@{weapon10damage})]] critical damage"/--></td>
+												<td><input class="sheet-inputbox" type="text" name="attr_weapon10critmin" title="weapon10critmin" style="height: 24px; width: 25px;" value="20">-20/x<input class="sheet-inputbox" type="text" name="attr_weapon10critmult" title="weapon10critmult" style="height: 24px; width: 19px;" value="2"><!--button type="roll" name="attr_weapon10critdamage" title='weapon10critdamage' style="width: 17px;" value="@{character_name}'s @{weapon10name} does [[(@{weapon10critmult})*(@{weapon10damage})]] critical damage"></button--></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon10range" title="weapon10range" style="height: 24px; width: 59px;"></td>
 												<td><input class="sheet-inputbox" type="text" name="attr_weapon10ammunition" title="weapon10ammunition" style="height: 24px; width: 59px;"></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon10stat" title="weapon10stat">
@@ -927,14 +951,14 @@
 												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon10specialproperties" title="weapon10specialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon10attackcalc">1d20cs>@{weapon10critmin} +@{bab}[BAB] +[[@{weapon10stat}]][Ability] +@{size}[size] +@{weapon10enh}[Weapon Enh] +@{weapon10focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon10attackcalc">1d20cs>@{weapon10critmin} +@{bab} +@{epicattackbonus} [BAB] +[[@{weapon10stat}]][Ability] +@{size}[size] +@{weapon10enh}[Weapon Enh] +@{weapon10focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon10attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=hitting AC[[@{weapon10attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon10attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon10damage}]] dmg}} {{critdmg1=+[[@{weapon10crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon10attack" text="attack" title='weapon10attack' value="@{weapon10attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon10fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon10fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=A1:[[@{weapon10attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon10attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon10damage}]]}} {{critdmg1=+[[@{weapon10crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon10attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon10attackcalc}-5]]}} {{damage2=D2:[[@{weapon10damage}]]}} {{critdmg2=+[[@{weapon10crit}]]}} {{attack3=A3:[[@{weapon10attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon10attackcalc}-10]]}} {{damage3=D3:[[@{weapon10damage}]]}} {{critdmg3=+[[@{weapon10crit}]]}} {{attack4=A4:[[@{weapon10attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon10attackcalc}-15]]}} {{damage4=D4:[[@{weapon10damage}]]}} {{critdmg4=+[[@{weapon10crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon10fullattack" text="Full Attack" title='weapon10fullattack' value="@{weapon10fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon10damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon10crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10crit (Edit this to adjust the critical calculation.)">[[(@{weapon10critmult}-1)]]d6 +[[(@{weapon10critmult}-1)]]*([[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon10damagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapon10damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon10name} }} {{damage1=does [[@{weapon10damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon10damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon10damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon10name} }} {{damage1=does [[@{weapon10damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon10damageroll" title='weapon10damageroll' style="width: 20px;" value="@{weapon10damagemacro}"></button></td>
 											</tr>
 										</table>
@@ -974,14 +998,14 @@
 												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weaponspecialproperties">0</textarea></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weaponattackcalc (Edit this to adjust the attack calculation)" name="attr_weaponattackcalc">1d20cs>@{weaponcritmin} +@{bab}[BAB] +[[@{weaponstat}]][Ability] +@{size}[size] +@{weaponenh}[Weapon Enh] +@{weaponfocus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weaponattackcalc (Edit this to adjust the attack calculation)" name="attr_weaponattackcalc">1d20cs>@{weaponcritmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weaponstat}]][Ability] +@{size}[size] +@{weaponenh}[Weapon Enh] +@{weaponfocus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weaponattackmacro (Modify this macro to modify your attack macro)" name="attr_weaponattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weaponname} }} {{attack1=A1:[[@{weaponattackcalc}]]}} {{critconfirm1=Crit!:[[@{weaponattackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapondamage}]]}} {{critdmg1=+[[@{weapondamage}]]}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weaponattack" text="attack" title='weaponattack' value="@{weaponattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weaponfullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weaponfullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weaponname} }} {{attack1=A1:[[@{weaponattackcalc}]]}} {{critconfirm1=Crit!:[[@{weaponattackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapondamage}]]}} {{critdmg1=+[[@{weapondamage}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weaponattackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weaponattackcalc}-5]]}} {{damage2=D2:[[@{weapondamage}]]}} {{critdmg2=+[[@{weapondamage}]]}} {{attack3=A3:[[@{weaponattackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weaponattackcalc}-10]]}} {{damage3=D3:[[@{weapondamage}]]}} {{critdmg3=+[[@{weapondamage}]]}} {{attack4=A4:[[@{weaponattackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weaponattackcalc}-15]]}} {{damage4=D4:[[@{weapondamage}]]}} {{critdmg4=+[[@{weapondamage}]]}} </textarea>
 													<button type="roll"name="attr_weaponfullattack" text="Full Attack" title='weaponfullattack' value="@{weaponfullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapondamage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapondamage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapondamagestat}]][Weapon Dmg Ability] +@{weaponenh}[Weapon Enh] +@{weaponspecialize}[Weapon Specialization] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weaponcrit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weaponcrit (Edit this to adjust the critical calculation.)">[[(@{weaponcritmult}-1)]]d6 +[[(@{weaponcritmult}-1)]]*([[@{weapondamagestat}]][Weapon Dmg Ability] +@{weaponenh}[Weapon Enh] +@{weaponspecialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapondamagemacro" rows="1" cols="45" style="height: 20px; width: 105px;" title="weapondamagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weaponname} }} {{damage1=does [[@{weapondamage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapondamagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapondamagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weaponname} }} {{damage1=does [[@{weapondamage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapondamageroll" title='weapondamageroll' style="width: 20px;" value="@{weapondamagemacro}"></button></td>
 											</tr>
 										</table>
@@ -1648,6 +1672,7 @@
 						<span class="sheet-table-header2">Ranks</span>
 						<span class="sheet-table-header2">Armor<br>Penalty</span>
 						<span class="sheet-table-header2">Misc<br>Mod.</span>
+						<span class="sheet-table-header2">Notes</span>
 						<span class="sheet-table-header2">Macro</span>
 					</div>
 					<div class="sheet-table-row">
@@ -1659,7 +1684,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraiseranks" title="appraiseranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraisemiscmod" title="appraisemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_appraisemacro" title="appraisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Appraise](http://www.dandwiki.com/wiki/SRD:Appraise_Skill ) check:}} {{checkroll=[[1d20 + [[@{appraise}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_appraisenote" title="appraisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_appraisemacro" title="appraisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Appraise](http://www.dandwiki.com/wiki/SRD:Appraise_Skill ) check:}} {{checkroll=[[1d20 + [[@{appraise}]] ]] {{notes=@{appraisenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_appraisecheck" title='appraisecheck' value="@{appraisemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1671,7 +1697,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balanceranks" title="balanceranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancearmorcheckpen" title="balancearmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancemiscmod" title="balancemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_balancemacro" title="balancemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Balance](http://www.dandwiki.com/wiki/SRD:Balance_Skill ) check:}} {{checkroll=[[1d20 + [[@{balance}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_balancenote" title="balancenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_balancemacro" title="balancemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Balance](http://www.dandwiki.com/wiki/SRD:Balance_Skill ) check:}} {{checkroll=[[1d20 + [[@{balance}]] ]] }} {{notes=@{balancenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_balancecheck" title='balancecheck' value="@{balancemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1683,7 +1710,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffranks" title="bluffranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffmiscmod" title="bluffmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_bluffmacro" title="bluffmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Bluff](http://www.dandwiki.com/wiki/SRD:Bluff_Skill ) check:}} {{checkroll=[[1d20 + [[@{bluff}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_bluffnote" title="bluffnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_bluffmacro" title="bluffmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Bluff](http://www.dandwiki.com/wiki/SRD:Bluff_Skill ) check:}} {{checkroll=[[1d20 + [[@{bluff}]] ]] }} {{notes=@{bluffnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_bluffcheck" title='bluffcheck' value="@{bluffmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1699,7 +1727,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbranks" title="climbranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbarmorcheckpen" title="climbarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbmiscmod" title="climbmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_climbmacro" title="climbmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Climb](http://www.dandwiki.com/wiki/SRD:Climb_Skill ) check:}} {{checkroll=[[1d20 + [[@{climb}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_climbnote" title="climbnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_climbmacro" title="climbmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Climb](http://www.dandwiki.com/wiki/SRD:Climb_Skill ) check:}} {{checkroll=[[1d20 + [[@{climb}]] ]] }} {{notes=@{climbnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_climbcheck" title='climbcheck' value="@{climbmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1711,7 +1740,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationranks" title="concentrationranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationmiscmod" title="concentrationmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_concentrationmacro" title="concentrationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Concentration](http://www.dandwiki.com/wiki/SRD:Concentration_Skill ) check:}} {{checkroll=[[1d20 + [[@{concentration}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_concentrationnote" title="concentrationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_concentrationmacro" title="concentrationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Concentration](http://www.dandwiki.com/wiki/SRD:Concentration_Skill ) check:}} {{checkroll=[[1d20 + [[@{concentration}]] ]] }} {{notes=@{concentrationnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_concentrationcheck" title='concentrationcheck' value="@{concentrationmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1723,7 +1753,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1ranks" title="craft1ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1miscmod" title="craft1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_craft1macro" title="craft1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft1name}) check:}} {{checkroll=[[1d20 + [[@{craft1}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft1note" title="craft1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft1macro" title="craft1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft1name}) check:}} {{checkroll=[[1d20 + [[@{craft1}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft1note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft1check" title='craft1check' value="@{craft1macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1735,7 +1766,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2ranks" title="craft2ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2miscmod" title="craft2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_craft2macro" title="craft2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft2name}) check:}} {{checkroll=[[1d20 + [[@{craft2}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft2note" title="craft2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft2macro" title="craft2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft2name}) check:}} {{checkroll=[[1d20 + [[@{craft2}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft2note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft2check" title='craft2check' value="@{craft2macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1747,7 +1779,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3ranks" title="craft3ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3miscmod" title="craft3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_craft3macro" title="craft3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft3name}) check:}} {{checkroll=[[1d20 + [[@{craft3}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft3note" title="craft3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft3macro" title="craft3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft3name}) check:}} {{checkroll=[[1d20 + [[@{craft3}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft3note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft3check" title='craft3check' value="@{craft3macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1759,7 +1792,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_decipherscriptranks" title="decipherscriptranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_decipherscriptmiscmod" title="decipherscriptmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_decipherscriptmacro" title="decipherscriptmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Decipher Script](http://www.dandwiki.com/wiki/SRD:Decipher_Script_Skill ) check:}} {{checkroll=[[1d20 + [[@{decipherscript}]] ]] }} {{notes=If fail, [[(1d20 + [[@{wis-mod}]] )]] vs dc5 to avoid drawing a false conclusion. }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_decipherscriptnote" title="decipherscriptnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_decipherscriptmacro" title="decipherscriptmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Decipher Script](http://www.dandwiki.com/wiki/SRD:Decipher_Script_Skill ) check:}} {{checkroll=[[1d20 + [[@{decipherscript}]] ]] }} {{notes=If fail, [[(1d20 + [[@{wis-mod}]] )]] vs dc5 to avoid drawing a false conclusion. }} {{notes=@{decipherscriptnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_decipherscriptcheck" title='decipherscriptcheck' value="@{decipherscriptmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1771,7 +1805,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacyranks" title="diplomacyranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacymiscmod" title="diplomacymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_diplomacymacro" title="diplomacymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Diplomacy](http://www.dandwiki.com/wiki/SRD:Diplomacy_Skill ) check:}} {{checkroll=[[1d20 + [[@{diplomacy}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_diplomacynote" title="diplomacynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_diplomacymacro" title="diplomacymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Diplomacy](http://www.dandwiki.com/wiki/SRD:Diplomacy_Skill ) check:}} {{checkroll=[[1d20 + [[@{diplomacy}]] ]] }} {{notes=@{diplomacynote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_diplomacycheck" title='diplomacycheck' value="@{diplomacymacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1783,8 +1818,9 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_disabledeviceranks" title="disabledeviceranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disabledevicemiscmod" title="disabledevicemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_disabledevicemacro" title="disabledevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disable Device](http://www.dandwiki.com/wiki/SRD:Disable_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{disabledevice}]] ]] }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_disableDevicecheck" title='disableDevicecheck' value="@{disabledevicemacro}" ></button></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_disabledevicenote" title="disabledevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_disabledevicemacro" title="disabledevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disable Device](http://www.dandwiki.com/wiki/SRD:Disable_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{disabledevice}]] ]] }} {{notes=@{disabledevicenote} }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_disabledevicecheck" title='disabledevicecheck' value="@{disabledevicemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
 						<input type="checkbox" name="attr_disguiseclassskill" title="disguiseclassskill" value="1" style="width: 8px;">
@@ -1795,7 +1831,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguiseranks" title="disguiseranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguisemiscmod" title="disguisemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_disguisemacro" title="disguisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disguise](http://www.dandwiki.com/wiki/SRD:Disguise_Skill ) check:}} {{checkroll=[[1d20 + [[@{disguise}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_disguisenote" title="disguisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_disguisemacro" title="disguisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disguise](http://www.dandwiki.com/wiki/SRD:Disguise_Skill ) check:}} {{checkroll=[[1d20 + [[@{disguise}]] ]] }} {{notes=@{disguisenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_disguisecheck" title='disguisecheck' value="@{disguisemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1807,7 +1844,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistranks" title="escapeartistranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistarmorcheckpen" title="escapeartistarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistmiscmod" title="escapeartistmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_escapeartistmacro" title="escapeartistmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Escape Artist](http://www.dandwiki.com/wiki/SRD:Escape_Artist_Skill ) check:}} {{checkroll=[[1d20 + [[@{escapeartist}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_escapeartistnote" title="escapeartistnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_escapeartistmacro" title="escapeartistmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Escape Artist](http://www.dandwiki.com/wiki/SRD:Escape_Artist_Skill ) check:}} {{checkroll=[[1d20 + [[@{escapeartist}]] ]] }} {{notes=@{escapeartistnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_escapeartistcheck" title='escapeartistcheck' value="@{escapeartistmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1819,7 +1857,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgeryranks" title="forgeryranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgerymiscmod" title="forgerymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_forgerymacro" title="forgerymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Forgery](http://www.dandwiki.com/wiki/SRD:Forgery_Skill ) check:}} {{checkroll=[[1d20 + [[@{forgery}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_forgerynote" title="forgerynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_forgerymacro" title="forgerymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Forgery](http://www.dandwiki.com/wiki/SRD:Forgery_Skill ) check:}} {{checkroll=[[1d20 + [[@{forgery}]] ]] }} {{notes=@{forgerynote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_forgerycheck" title='forgerycheck' value="@{forgerymacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1831,7 +1870,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationranks" title="gatherinformationranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationmiscmod" title="gatherinformationmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_gatherinformationmacro" title="gatherinformationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Gather Information](http://www.dandwiki.com/wiki/SRD:Gather_Information_Skill ) check:}} {{checkroll=[[1d20 + [[@{gatherinformation}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_gatherinformationnote" title="gatherinformationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_gatherinformationmacro" title="gatherinformationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Gather Information](http://www.dandwiki.com/wiki/SRD:Gather_Information_Skill ) check:}} {{checkroll=[[1d20 + [[@{gatherinformation}]] ]] }} {{notes=@{gatherinformationnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_gatherinformationcheck" title='gatherinformationcheck' value="@{gatherinformationmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1843,7 +1883,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_handleanimalranks" title="handleanimalranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_handleanimalmiscmod" title="handleanimalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_handleanimalmacro" title="handleanimalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Handle Animal](http://www.dandwiki.com/wiki/SRD:Handle_Animal_Skill ) check:}} {{checkroll=[[1d20 + [[@{handleanimal}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_handleanimalnote" title="handleanimalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_handleanimalmacro" title="handleanimalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Handle Animal](http://www.dandwiki.com/wiki/SRD:Handle_Animal_Skill ) check:}} {{checkroll=[[1d20 + [[@{handleanimal}]] ]] }} {{notes=@{handleanimalnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_handleanimalcheck" title='handleanimalcheck' value="@{handleanimalmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1855,7 +1896,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healranks" title="healranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healmiscmod" title="healmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_healmacro" title="healmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Heal](http://www.dandwiki.com/wiki/SRD:Heal_Skill ) check:}} {{checkroll=[[1d20 + [[@{heal}]] +(?{Healer's Kit? (1 for yes)|0}*2)[Healer's Kit Circumstance Bonus] )]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_healnote" title="healnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_healmacro" title="healmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Heal](http://www.dandwiki.com/wiki/SRD:Heal_Skill ) check:}} {{checkroll=[[1d20 + [[@{heal}]] +(?{Healer's Kit? (1 for yes)|0}*2)[Healer's Kit Circumstance Bonus] )]] }} {{notes=@{healnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_healcheck" title='healcheck' value="@{healmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1867,7 +1909,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hideranks" title="hideranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidearmorcheckpen" title="hidearmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidemiscmod" title="hidemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_hidemacro" title="hidemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Hide](http://www.dandwiki.com/wiki/SRD:Hide_Skill ) check:}} {{checkroll=[[1d20 + [[@{hide}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_hidenote" title="hidenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_hidemacro" title="hidemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Hide](http://www.dandwiki.com/wiki/SRD:Hide_Skill ) check:}} {{checkroll=[[1d20 + [[@{hide}]] ]] }} {{notes=@{hidenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_hidecheck" title='hidecheck' value="@{hidemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1879,7 +1922,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidateranks" title="intimidateranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidatemiscmod" title="intimidatemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_intimidatemacro" title="intimidatemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Intimidate](http://www.dandwiki.com/wiki/SRD:Intimidate_Skill ) check:}} {{checkroll=[[1d20 + [[@{intimidate}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_intimidatenote" title="intimidatenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_intimidatemacro" title="intimidatemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Intimidate](http://www.dandwiki.com/wiki/SRD:Intimidate_Skill ) check:}} {{checkroll=[[1d20 + [[@{intimidate}]] ]] }} {{notes=@{intimidatenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_intimidatecheck" title='intimidatecheck' value="@{intimidatemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1895,7 +1939,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpranks" title="jumpranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumparmorcheckpen" title="jumparmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpmiscmod" title="jumpmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_jumpmacro" title="jumpmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Jump](http://www.dandwiki.com/wiki/SRD:Jump_Skill ) check:}} {{checkroll=[[1d20 + [[@{jump}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_jumpnote" title="jumpnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_jumpmacro" title="jumpmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Jump](http://www.dandwiki.com/wiki/SRD:Jump_Skill ) check:}} {{checkroll=[[1d20 + [[@{jump}]] ]] }} {{notes=@{jumpnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_jumpcheck" title='jumpcheck' value="@{jumpmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1907,7 +1952,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowarcanaranks" title="knowarcanaranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowarcanamiscmod" title="knowarcanamiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowarcanamacro" title="knowarcanamacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Arcana) check:}} {{checkroll=[[1d20 + [[@{knowarcana}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowarcananote" title="knowarcananote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowarcanamacro" title="knowarcanamacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Arcana) check:}} {{checkroll=[[1d20 + [[@{knowarcana}]] ]] }} {{notes=@{knowarcananote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowarcanacheck" title='knowarcanacheck' value="@{knowarcanamacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1919,7 +1965,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowengineerranks" title="knowengineerranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowengineermiscmod" title="knowengineermiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowengineermacro" title="knowengineermacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Engineering) check:}} {{checkroll=[[1d20 + [[@{knowengineer}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowengineernote" title="knowengineernote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowengineermacro" title="knowengineermacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Engineering) check:}} {{checkroll=[[1d20 + [[@{knowengineer}]] ]] }} {{notes=@{knowengineernote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowengineercheck" title='knowengineercheck' value="@{knowengineermacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1931,7 +1978,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowdungeonranks" title="knowdungeonranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeonmiscmod" title="knowdungeonmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowdungeonmacro" title="knowdungeonmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Dungeon) check:}} {{checkroll=[[1d20 + [[@{knowdungeon}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowdungeonnote" title="knowdungeonnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowdungeonmacro" title="knowdungeonmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Dungeoneering) check:}} {{checkroll=[[1d20 + [[@{knowdungeon}]] ]] }} {{notes=@{knowdungeonnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowdungeoncheck" title='knowdungeoncheck' value="@{knowdungeonmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1943,7 +1991,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowgeographyranks" title="knowgeographyranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowgeographymiscmod" title="knowgeographymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowgeographymacro" title="knowgeographymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Geography) check:}} {{checkroll=[[1d20 + [[@{knowgeography}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowgeographynote" title="knowgeographynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowgeographymacro" title="knowgeographymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Geography) check:}} {{checkroll=[[1d20 + [[@{knowgeography}]] ]] }} {{notes=@{knowgeographynote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowgeographycheck" title='knowgeographycheck' value="@{knowgeographymacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1955,7 +2004,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowhistoryranks" title="knowhistoryranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowhistorymiscmod" title="knowhistorymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowhistorymacro" title="knowhistorymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (History) check:}} {{checkroll=[[1d20 + [[@{knowhistory}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowhistorynote" title="knowhistorynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowhistorymacro" title="knowhistorymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (History) check:}} {{checkroll=[[1d20 + [[@{knowhistory}]] ]] }} {{notes=@{knowhistorynote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowhistorycheck" title='knowhistorycheck' value="@{knowhistorymacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1967,7 +2017,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowlocalranks" title="knowlocalranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowlocalmiscmod" title="knowlocalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowlocalmacro" title="knowlocalmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Local) check:}} {{checkroll=[[1d20 + [[@{knowlocal}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowlocalnote" title="knowlocalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowlocalmacro" title="knowlocalmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Local) check:}} {{checkroll=[[1d20 + [[@{knowlocal}]] ]] }} {{notes=@{knowlocalnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowlocalcheck" title='knowlocalcheck' value="@{knowlocalmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1979,7 +2030,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownatureranks" title="knownatureranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownaturemiscmod" title="knownaturemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knownaturemacro" title="knownaturemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nature) check:}} {{checkroll=[[1d20 + [[@{knownature}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knownaturenote" title="knownaturenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knownaturemacro" title="knownaturemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nature) check:}} {{checkroll=[[1d20 + [[@{knownature}]] ]] }} {{notes=@{knownaturenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knownaturecheck" title='knownaturecheck' value="@{knownaturemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -1991,7 +2043,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownobilityranks" title="knownobilityranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownobilitymiscmod" title="knownobilitymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knownobilitymacro" title="knownobilitymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nobility) check:}} {{checkroll=[[1d20 + [[@{knownobility}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knownobilitynote" title="knownobilitynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knownobilitymacro" title="knownobilitymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nobility) check:}} {{checkroll=[[1d20 + [[@{knownobility}]] ]] }} {{notes=@{knownobilitynote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knownobilitycheck" title='knownobilitycheck' value="@{knownobilitymacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2003,7 +2056,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowreligionranks" title="knowreligionranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowreligionmiscmod" title="knowreligionmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowreligionmacro" title="knowreligionmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Religion) check:}} {{checkroll=[[1d20 + [[@{knowreligion}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowreligionnote" title="knowreligionnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowreligionmacro" title="knowreligionmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Religion) check:}} {{checkroll=[[1d20 + [[@{knowreligion}]] ]] }} {{notes=@{knowreligionnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowreligioncheck" title='knowreligioncheck' value="@{knowreligionmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2015,7 +2069,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowplanesranks" title="knowplanesranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowplanesmiscmod" title="knowplanesmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_knowplanesmacro" title="knowplanesmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Planes) check:}} {{checkroll=[[1d20 + [[@{knowplanes}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowplanesnote" title="knowplanesnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowplanesmacro" title="knowplanesmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Planes) check:}} {{checkroll=[[1d20 + [[@{knowplanes}]] ]] }} {{notes=@{knowplanesnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowplanescheck" title='knowplanescheck' value="@{knowplanesmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2027,7 +2082,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenranks" title="listenranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenmiscmod" title="listenmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_listenmacro" title="listenmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Listen](http://www.dandwiki.com/wiki/SRD:Listen_Skill ) check:}} {{checkroll=[[1d20 + [[@{listen}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_listennote" title="listennote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_listenmacro" title="listenmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Listen](http://www.dandwiki.com/wiki/SRD:Listen_Skill ) check:}} {{checkroll=[[1d20 + [[@{listen}]] ]] }} {{notes=@{listennote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_listencheck" title='listencheck' value="@{listenmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2039,7 +2095,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentranks" title="movesilentranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentarmorcheckpen" title="movesilentarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentmiscmod" title="movesilentmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_movesilentmacro" title="movesilentmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Move Silently](http://www.dandwiki.com/wiki/SRD:Move_Silently_Skill ) check:}} {{checkroll=[[1d20 + [[@{movesilent}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_movesilentnote" title="movesilentnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_movesilentmacro" title="movesilentmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Move Silently](http://www.dandwiki.com/wiki/SRD:Move_Silently_Skill ) check:}} {{checkroll=[[1d20 + [[@{movesilent}]] ]] }} {{notes=@{movesilentnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_movesilentcheck" title='movesilentcheck' value="@{movesilentmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2051,7 +2108,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_openlockranks" title="openlockranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_openlockmiscmod" title="openlockmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_openlockmacro" title="openlockmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Open Lock](http://www.dandwiki.com/wiki/SRD:Open_Lock_Skill ) check:}} {{checkroll=[[1d20 + [[@{openlock}]] +(?{Thieves' Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2))[Tool Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_openlocknote" title="openlocknote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_openlockmacro" title="openlockmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Open Lock](http://www.dandwiki.com/wiki/SRD:Open_Lock_Skill ) check:}} {{checkroll=[[1d20 + [[@{openlock}]] +(?{Thieves' Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2))[Tool Circumstance Bonus] ]] }} {{notes=@{openlocknote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_openlockcheck" title='openlockcheck' value="@{openlockmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2063,7 +2121,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1ranks" title="perform1ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1miscmod" title="perform1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_perform1macro" title="perform1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform1name}) check:}} {{checkroll=[[1d20 + [[@{perform1}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform1note" title="perform1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform1macro" title="perform1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform1name}) check:}} {{checkroll=[[1d20 + [[@{perform1}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform1note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform1check" title='perform1check' value="@{perform1macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2075,7 +2134,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2ranks" title="perform2ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2miscmod" title="perform2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_perform2macro" title="perform2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform2}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform2note" title="perform2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform2macro" title="perform2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform2}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform2note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform2check" title='perform2check' value="@{perform2macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2087,7 +2147,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3ranks" title="perform3ranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3miscmod" title="perform3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_perform3macro" title="perform3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform3}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform3note" title="perform3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform3macro" title="perform3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform3}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform3note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform3check" title='perform3check' value="@{perform3macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2099,7 +2160,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession1ranks" title="profession1ranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession1miscmod" title="profession1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_profession1macro" title="profession1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession1name}) check:}} {{checkroll=[[1d20 + [[@{profession1}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession1note" title="profession1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession1macro" title="profession1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession1name}) check:}} {{checkroll=[[1d20 + [[@{profession1}]] ]] }} {{notes=@{profession1note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession1check" title='profession1check' value="@{profession1macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2111,7 +2173,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession2ranks" title="profession2ranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession2miscmod" title="profession2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_profession2macro" title="profession2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession2name}) check:}} {{checkroll=[[1d20 + [[@{profession2}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession2note" title="profession2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession2macro" title="profession2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession2name}) check:}} {{checkroll=[[1d20 + [[@{profession2}]] ]] }} {{notes=@{profession2note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession2check" title='profession2check' value="@{profession2macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2123,7 +2186,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession3ranks" title="profession3ranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession3miscmod" title="profession3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_profession3macro" title="profession3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession3name}) check:}} {{checkroll=[[1d20 + [[@{profession3}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession3note" title="profession3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession3macro" title="profession3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession3name}) check:}} {{checkroll=[[1d20 + [[@{profession3}]] ]] }} {{notes=@{profession3note} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession3check" title='profession3check' value="@{profession3macro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2135,7 +2199,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_rideranks" title="rideranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_ridemiscmod" title="ridemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_ridemacro" title="ridemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Ride](http://www.dandwiki.com/wiki/SRD:Ride_Skill ) check:}} {{checkroll=[[1d20 + [[@{ride}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_ridenote" title="ridenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_ridemacro" title="ridemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Ride](http://www.dandwiki.com/wiki/SRD:Ride_Skill ) check:}} {{checkroll=[[1d20 + [[@{ride}]] ]] }} {{notes=@{ridenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_ridecheck" title='ridecheck' value="@{ridemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2147,7 +2212,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchranks" title="searchranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchmiscmod" title="searchmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_searchmacro" title="searchmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Search](http://www.dandwiki.com/wiki/SRD:Search_Skill ) check:}} {{checkroll=[[1d20 + [[@{search}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_searchnote" title="searchnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_searchmacro" title="searchmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Search](http://www.dandwiki.com/wiki/SRD:Search_Skill ) check:}} {{checkroll=[[1d20 + [[@{search}]] ]] }} {{notes=@{searchnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_searchcheck" title='searchcheck' value="@{searchmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2159,7 +2225,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotiveranks" title="sensemotiveranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotivemiscmod" title="sensemotivemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_sensemotivemacro" title="sensemotivemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sense Motive](http://www.dandwiki.com/wiki/SRD:Sense_Motive_Skill ) check:}} {{checkroll=[[1d20 + [[@{sensemotive}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_sensemotivenote" title="sensemotivenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_sensemotivemacro" title="sensemotivemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sense Motive](http://www.dandwiki.com/wiki/SRD:Sense_Motive_Skill ) check:}} {{checkroll=[[1d20 + [[@{sensemotive}]] ]] }} {{notes=@{sensemotivenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_sensemotivecheck" title='sensemotivecheck' value="@{sensemotivemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2171,7 +2238,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_sleightofhandranks" title="sleightofhandranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightarmorcheckpen" title="sleightarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhandmiscmod" title="sleightofhandmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_sleightofhandmacro" title="sleightofhandmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sleight of Hand](http://www.dandwiki.com/wiki/SRD:Sleight_of_Hand_Skill ) check:}} {{checkroll=[[1d20 + [[@{sleightofhand}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_sleightofhandnote" title="sleightofhandnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_sleightofhandmacro" title="sleightofhandmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sleight of Hand](http://www.dandwiki.com/wiki/SRD:Sleight_of_Hand_Skill ) check:}} {{checkroll=[[1d20 + [[@{sleightofhand}]] ]] }} {{notes=@{sleightofhandnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_sleightofhandcheck" title='sleightofhandcheck' value="@{sleightofhandmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2183,7 +2251,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_spellcraftranks" title="spellcraftranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spellcraftmiscmod" title="spellcraftmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_spellcraftmacro" title="spellcraftmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spellcraft](http://www.dandwiki.com/wiki/SRD:Spellcraft_Skill ) check:}} {{checkroll=[[1d20 + [[@{spellcraft}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_spellcraftnote" title="spellcraftnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_spellcraftmacro" title="spellcraftmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spellcraft](http://www.dandwiki.com/wiki/SRD:Spellcraft_Skill ) check:}} {{checkroll=[[1d20 + [[@{spellcraft}]] ]] }} {{notes=@{spellcraftnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_spellcraftcheck" title='spellcraftcheck' value="@{spellcraftmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2195,7 +2264,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotranks" title="spotranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotmiscmod" title="spotmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_spotmacro" title="spotmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spot](http://www.dandwiki.com/wiki/SRD:Spot_Skill ) check:}} {{checkroll=[[1d20 + [[@{spot}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_spotnote" title="spotnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_spotmacro" title="spotmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spot](http://www.dandwiki.com/wiki/SRD:Spot_Skill ) check:}} {{checkroll=[[1d20 + [[@{spot}]] ]] }} {{notes=@{spotnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_spotcheck" title='spotcheck' value="@{spotmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2207,7 +2277,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalranks" title="survivalranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalmiscmod" title="survivalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_survivalmacro" title="survivalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Survival](http://www.dandwiki.com/wiki/SRD:Survival_Skill ) check:}} {{checkroll=[[1d20 + [[@{survival}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_survivalnote" title="survivalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_survivalmacro" title="survivalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Survival](http://www.dandwiki.com/wiki/SRD:Survival_Skill ) check:}} {{checkroll=[[1d20 + [[@{survival}]] ]] }} {{notes=@{survivalnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_survivalcheck" title='survivalcheck' value="@{survivalmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2219,7 +2290,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimranks" title="swimranks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimarmorcheckpen" title="swimarmorcheckpen" style="width: 40px;" value="2*(@{armorcheckpenalty} )" disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimmiscmod" title="swimmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_swimmacro" title="swimmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Swim](http://www.dandwiki.com/wiki/SRD:Swim_Skill ) check:}} {{checkroll=[[1d20 + [[@{swim}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_swimnote" title="swimnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_swimmacro" title="swimmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Swim](http://www.dandwiki.com/wiki/SRD:Swim_Skill ) check:}} {{checkroll=[[1d20 + [[@{swim}]] ]] }} {{notes=@{swimnote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_swimcheck" title='swimcheck' value="@{swimmacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2231,7 +2303,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_tumbleranks" title="tumbleranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblearmorcheckpen" title="tumblearmorcheckpen" style="width: 40px;" value="(@{armorcheckpenalty} )" disabled="true"></span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblemiscmod" title="tumblemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_tumblemacro" title="tumblemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Tumble](http://www.dandwiki.com/wiki/SRD:Tumble_Skill ) check:}} {{checkroll=[[1d20 + [[@{tumble}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_tumblenote" title="tumblenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_tumblemacro" title="tumblemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Tumble](http://www.dandwiki.com/wiki/SRD:Tumble_Skill ) check:}} {{checkroll=[[1d20 + [[@{tumble}]] ]] }} {{notes=@{tumblenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_tumblecheck" title='tumblecheck' value="@{tumblemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2243,7 +2316,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_usemagicdeviceranks" title="usemagicdeviceranks" min="1" max="1000" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevicemiscmod" title="usemagicdevicemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_usemagicdevicemacro" title="usemagicdevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Magic Device](http://www.dandwiki.com/wiki/SRD:Use_Magic_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{usemagicdevice}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_usemagicdevicenote" title="usemagicdevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_usemagicdevicemacro" title="usemagicdevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Magic Device](http://www.dandwiki.com/wiki/SRD:Use_Magic_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{usemagicdevice}]] ]] }} {{notes=@{usemagicdevicenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_usemagicdevicecheck" title='usemagicdevicecheck' value="@{usemagicdevicemacro}" ></button></span>
 					</div>
 					<div class="sheet-table-row">
@@ -2255,7 +2329,8 @@
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useroperanks" title="useroperanks" value="0"></span>
 						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
 						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useropemiscmod" title="useropemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 370px; height: 20px;" name="attr_useropemacro" title="useropemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Rope](http://www.dandwiki.com/wiki/SRD:Use_Rope_Skill ) check:}} {{checkroll=[[1d20 + [[@{userope}]] ]] }}</textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_useropenote" title="useropenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
+						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_useropemacro" title="useropemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Rope](http://www.dandwiki.com/wiki/SRD:Use_Rope_Skill ) check:}} {{checkroll=[[1d20 + [[@{userope}]] ]] }} {{notes=@{useropenote} }}</textarea></span>
 						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_useropecheck" title='useropecheck' value="@{useropemacro}" ></button></span>
 					</div>
 					</td>
@@ -2268,7 +2343,7 @@
 					<td></td>
 					<tr class="sheet-table-row">
 						<td class="sheet-table-header2" style="width: 8px;">&nbsp;</td>
-						<td class="sheet-table-header2-left" style="width: 125px;">Skill Names</td>
+						<td class="sheet-table-header2-left" style="width: 135px;">Skill Names</td>
 						<td class="sheet-table-header2" style="width: 34px;">Total<br>Bonus</td>
 						<td class="sheet-table-header2" style="width: 44px;">Ability<br>Stat</td>
 						<td class="sheet-table-header2" style="width: 34px;">Ability<br>Mod.</td>
@@ -2282,10 +2357,10 @@
 					<table cellpadding="0" cellspacing="0">
 						<tr>
 						<td class="sheet-table-header-left"><input type="checkbox" name="attr_otherskillskill" value="1" style="width: 8px;"></td>
-						<td class="sheet-table-header-left"><input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskillname" style="width:135px;" title="Skill name"></td>
+						<td class="sheet-table-header-left"><input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskillname" style="width:145px;" title="Skill name"></td>
 						<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskill" value="@{otherskillstat}+@{otherskillranks} +@{otherskillarmorcheckpen} +@{otherskillmiscmod} " disabled="true"></td>
 						<!--td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskillstat" value="Str" title="Enter the name for the ability stat used for this skill here."></td-->
-						<td><select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_otherskillstat" title="Ability used for skill">
+						<td>=<select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_otherskillstat" title="Ability used for skill">
 							<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 							<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
 							<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
@@ -2303,7 +2378,8 @@
 							<option type="text"value="2*(@{armorcheckpenalty} )">=2x(Armor check Penalty)</option>
 						</select></td-->
 						<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskillmiscmod" value="0"></td>
-						<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 375px; height: 20px;" name="attr_otherskillmacro" title="modify this macro to modify the skill check roll.">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=@{otherskillname} check:}} {{checkroll=[[1d20 + [[@{otherskill}]] ]] }}</textarea></td>
+						<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_otherskillnote" title="otherskillnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+						<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_otherskillmacro" title="modify this macro to modify the skill check roll.">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=@{otherskillname} check:}} {{checkroll=[[1d20 + [[@{otherskill}]] ]] }} {{notes=@{otherskillnote} }}</textarea></td>
 						<td class="sheet-table-data-center-sm"><button type="roll" name="attr_otherskillcheck" title='otherskillcheck' value="@{otherskillmacro}"></button></td>
 						</tr>
 					</table>
@@ -2420,7 +2496,7 @@
 											<td><input type="text" style="width: 120px;" name="attr_spellname01" value="Cure Minor Wounds"></td>
 											<td><input type="text" style="width: 20px;" name="attr_spelllevel01" value="0"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro01" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Minor Wounds](http://www.dandwiki.com/wiki/Cure_minor_wounds ).}} {{School:= Conj(Healing)}} {{Level:= Cleric 0}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{  Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes= ?{Recipient's name|@{character_name}} receives 1 heath (or 1 point of damage if an undead creature) }} </textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro01" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Minor Wounds](http://www.dandwiki.com/wiki/Cure_minor_wounds ).}} {{School:= Conj(Healing)}} {{Level:= Cleric 0}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{  Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes= ?{Recipient's name|@{character_name}} receives 1 heath (or 1 point of damage if an undead creature) }} </textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast01" text="Spell Cast01" title='repeating_spells01_x_spellcast01' value="@{spellmacro01}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2450,7 +2526,7 @@
 										<td><input type="text" style="width: 120px;" name="attr_spellname02" value="Mending"></td>
 										<td style="width: 20px;"><input type="text" name="attr_spelllevel02" value="0"></td>
 										<td>
-										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro02" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Mending](http://www.dandwiki.com/wiki/SRD:Mending ).}} {{check=One object within 10 feet of up to 1 lb. is repaired of small breaks or tears.}} {{checkroll=broken metallic objects such as a ring, a chain link, a medallion, or a slender dagger, are welded providing but one break exists. }} {{notes=Ceramic or wooden objects with multiple breaks can be invisibly rejoined to be as strong as new. A hole in a leather sack or a wineskin is completely healed over by mending. The spell can repair a magic item, but the item’s magical abilities are not restored. The spell cannot mend broken magic rods, staffs, or wands, nor does it affect creatures (including constructs). }}</textarea>
+										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro02" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Mending](http://www.dandwiki.com/wiki/SRD:Mending ).}} {{check=One object within 10 feet of up to 1 lb. is repaired of small breaks or tears.}} {{checkroll=broken metallic objects such as a ring, a chain link, a medallion, or a slender dagger, are welded providing but one break exists. }} {{notes=Ceramic or wooden objects with multiple breaks can be invisibly rejoined to be as strong as new. A hole in a leather sack or a wineskin is completely healed over by mending. The spell can repair a magic item, but the item’s magical abilities are not restored. The spell cannot mend broken magic rods, staffs, or wands, nor does it affect creatures (including constructs). }}</textarea>
 											</td>
 										<td><button type="roll" name="attr_spellcast02" text="Spell Cast02" title='repeating_spells02_x_spellcast02' value="@{spellmacro02}" style="height: 24px; width: 20px;" ></button>
 										</td>
@@ -2487,7 +2563,7 @@
 											<td><input type="text" style="width: 120px;" name="attr_spellname11" value="Doom"></td>
 											<td><input type="text" style="width: 20px;" name="attr_spelllevel11" value="1"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro11" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name= @{character_name} casts Doom on @{target|token_name} }} {{School:=Necromancy (Fear, Mind affecting)}} {{Level: =Cleric 1}} {{Cmpnts:=V, S, DF}} {{Casting Time:= 1 std action}} {{Range:= Medium ([[100+10*@{casterlevel}]]ft)}} {{Target:= 1 living creature}} {{Duration:= [[@{casterlevel}]] min.}} {{Saving Throw:= Will negates (DC=[[@{spelldc1}]]) }} {{Spell Resist.:= Yes }} {{Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes=Target is filled with a feeling of horrible dread that causes it to become shaken (-2 on attack rolls, saves, skill checks, ability checks).}} </textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro11" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name= @{character_name} casts Doom on @{target|token_name} }} {{School:=Necromancy (Fear, Mind affecting)}} {{Level: =Cleric 1}} {{Cmpnts:=V, S, DF}} {{Casting Time:= 1 std action}} {{Range:= Medium ([[100+10*@{casterlevel}]]ft)}} {{Target:= 1 living creature}} {{Duration:= [[@{casterlevel}]] min.}} {{Saving Throw:= Will negates (DC=[[@{spelldc1}]]) }} {{Spell Resist.:= Yes }} {{Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes=Target is filled with a feeling of horrible dread that causes it to become shaken (-2 on attack rolls, saves, skill checks, ability checks).}} </textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast11" text="Spell Cast11" title='repeating_spells11_x_spellcast11' value="@{spellmacro11}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2517,7 +2593,7 @@
 										<td><input type="text" style="width: 120px;" name="attr_spellname12" value="Magic Missile"></td>
 										<td style="width: 20px;"><input type="text" name="attr_spelllevel12" value="1"></td>
 										<td>
-										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro12" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Magic Missile!](http://www.dandwiki.com/wiki/SRD:Magic_Missile ).}} {{School:= Evo (Force)}} {{Level:= Sor/Wiz 1}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Medium ( [[100+10*@{casterlevel2}]] ft)}} {{Target:= Up to five creatures, no two of which can be more than 15 ft. apart }} {{Duration:= Instantaneous}} {{Saving Throw:= None}} {{Spell Resist.:= Yes}} {{Caster level check: = [[1d20+@{casterlevel2}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= [[{(d1*((@{casterlevel2}-1-((@{casterlevel2}-1)%2))/2)+1),d1*5}dh1}]] missiles fly from the caster’s fingers,}} {{checkroll=hitting for [[1d4+1]]|[[1d4+1]]|[[1d4+1]]|[[1d4+1]]|[[1d4+1]] force damage.}} {{notes= The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment. Specific parts of a creature can’t be singled out. Inanimate objects are not damaged by the spell. If you shoot multiple missiles, you can have them strike a single creature or several creatures. A single missile can strike only one creature. You must designate targets before you check for spell resistance or roll damage.  }}</textarea>
+										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro12" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Magic Missile!](http://www.dandwiki.com/wiki/SRD:Magic_Missile ).}} {{School:= Evo (Force)}} {{Level:= Sor/Wiz 1}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Medium ( [[100+10*@{casterlevel2}]] ft)}} {{Target:= Up to five creatures, no two of which can be more than 15 ft. apart }} {{Duration:= Instantaneous}} {{Saving Throw:= None}} {{Spell Resist.:= Yes}} {{Caster level check: = [[1d20+@{casterlevel2}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= [[{(d1*((@{casterlevel2}-1-((@{casterlevel2}-1)%2))/2)+1),d1*5}dh1}]] missiles fly from the caster’s fingers,}} {{checkroll=hitting for [[1d4+1]]|[[1d4+1]]|[[1d4+1]]|[[1d4+1]]|[[1d4+1]] force damage.}} {{notes= The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment. Specific parts of a creature can’t be singled out. Inanimate objects are not damaged by the spell. If you shoot multiple missiles, you can have them strike a single creature or several creatures. A single missile can strike only one creature. You must designate targets before you check for spell resistance or roll damage.  }}</textarea>
 											</td>
 										<td><button type="roll" name="attr_spellcast12" text="Spell Cast12" title='repeating_spells12_x_spellcast12' value="@{spellmacro12}" style="height: 24px; width: 20px;" ></button>
 										</td>
@@ -2554,7 +2630,7 @@
 											<td style="width: 120px;"><input type="text" name="attr_spellname21" value="Cure Moderate Wounds"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel21" value="2"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro21" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Moderate Wounds](http://www.dandwiki.com/wiki/SRD:Cure_Moderate_Wounds ).}} {{School:= Conj(Healing)}} {{Level:= Blg 2, Brd 2, Clr 2, Drd 3, Healing 2, Pal 3, Rgr 3 }} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|17}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check=@{target|token_name} receives }} {{checkroll= [[2d8+{@{casterlevel},10}dh1]] heath. }} {{notes=Undead creatures take damage instead of gaining healing. }}</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro21" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Moderate Wounds](http://www.dandwiki.com/wiki/SRD:Cure_Moderate_Wounds ).}} {{School:= Conj(Healing)}} {{Level:= Blg 2, Brd 2, Clr 2, Drd 3, Healing 2, Pal 3, Rgr 3 }} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{Caster level check: = [[1d20+@{casterlevel}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|17}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check=@{target|token_name} receives }} {{checkroll= [[2d8+{@{casterlevel},10}dh1]] heath. }} {{notes=Undead creatures take damage instead of gaining healing. }}</textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast21" text="Spell Cast21" title='repeating_spells21_x_spellcast21' value="@{spellmacro21}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2584,7 +2660,7 @@
 											<td style="width: 120px;"><input type="text" name="attr_spellname22" value="Bear's Endurance"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel22" value="2"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro22" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags= grants ?{target|@{character_name}} [Bear's Endurance](http://www.dandwiki.com/wiki/SRD:Bear%27s_Endurance )!}} {{School:= Transmutation}} {{Level:= Clr 2, Drd 2, Rgr 2, Sor/Wiz 2}} {{Cmpnts:=V, S, DF}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= 1 creature touched }} {{Duration:= @{casterlevel2} mins.}} {{Saving Throw:= Will negates(harmless)}} {{Spell Resist.:= Yes}} {{Caster level check: = [[1d20+@{casterlevel2}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= ?{target|@{character_name}} gains greater vitality and stamina, }} {{checkroll= receiving a +4 enh bonus to Constitution with the usual benefits to hit points(these temp hit points go away when spell ends), fortitude saves, constitution checks, etc. }}</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro22" title="Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags= grants ?{target|@{character_name}} [Bear's Endurance](http://www.dandwiki.com/wiki/SRD:Bear%27s_Endurance )!}} {{School:= Transmutation}} {{Level:= Clr 2, Drd 2, Rgr 2, Sor/Wiz 2}} {{Cmpnts:=V, S, DF}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= 1 creature touched }} {{Duration:= @{casterlevel2} mins.}} {{Saving Throw:= Will negates(harmless)}} {{Spell Resist.:= Yes}} {{Caster level check: = [[1d20+@{casterlevel2}+@{spellpen}]] vs spell resistance.}} {{compcheck= Conc:[[{1d20 +[[@{concentration}]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16}]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= ?{target|@{character_name}} gains greater vitality and stamina, }} {{checkroll= receiving a +4 enh bonus to Constitution with the usual benefits to hit points(these temp hit points go away when spell ends), fortitude saves, constitution checks, etc. }}</textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast22" text="Spell Cast22" title='repeating_spells22_x_spellcast22' value="@{spellmacro22}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2618,10 +2694,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused31">/<input type="text" style="width: 25px;" name="attr_spellprep31"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname31" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname31" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel31" value="3"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro31" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro31" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast31" text="Spell Cast31" title='repeating_spells31_x_spellcast31' value="@{spellmacro31}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2648,10 +2724,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused32">/<input type="text" style="width: 25px;" name="attr_spellprep32"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname32" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname32" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel32" value="3"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro32" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro32" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast32" text="Spell Cast32" title='repeating_spells32_x_spellcast32' value="@{spellmacro32}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2685,10 +2761,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused41">/<input type="text" style="width: 25px;" name="attr_spellprep41"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname41" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname41" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel41" value="4"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro41" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro41" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast41" text="Spell Cast41" title='repeating_spells41_x_spellcast41' value="@{spellmacro41}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2715,10 +2791,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused42">/<input type="text" style="width: 25px;" name="attr_spellprep42"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname42" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname42" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel42" value="4"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro42" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro42" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast42" text="Spell Cast42" title='repeating_spells42_x_spellcast42' value="@{spellmacro42}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2752,10 +2828,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused51">/<input type="text" style="width: 25px;" name="attr_spellprep51"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname51" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname51" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel51" value="5"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro51" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro51" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast51" text="Spell Cast51" title='repeating_spells51_x_spellcast51' value="@{spellmacro51}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2782,10 +2858,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused52">/<input type="text" style="width: 25px;" name="attr_spellprep52"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname52" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname52" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel52" value="5"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro52" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro52" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast52" text="Spell Cast52" title='repeating_spells52_x_spellcast52' value="@{spellmacro52}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2819,10 +2895,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused61">/<input type="text" style="width: 25px;" name="attr_spellprep61"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname61" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname61" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel61" value="6"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro61" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro61" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast61" text="Spell Cast61" title='repeating_spells61_x_spellcast61' value="@{spellmacro61}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2849,10 +2925,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused62">/<input type="text" style="width: 25px;" name="attr_spellprep62"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname62" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname62" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel62" value="6"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro62" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro62" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast62" text="Spell Cast62" title='repeating_spells62_x_spellcast62' value="@{spellmacro62}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2885,10 +2961,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused71">/<input type="text" style="width: 25px;" name="attr_spellprep71"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname71" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname71" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel71" value="7"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro71" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro71" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast71" text="Spell Cast71" title='repeating_spells71_x_spellcast71' value="@{spellmacro71}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2915,10 +2991,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused72">/<input type="text" style="width: 25px;" name="attr_spellprep72"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname72" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname72" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel72" value="7"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro72" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro72" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast72" text="Spell Cast72" title='repeating_spells72_x_spellcast72' value="@{spellmacro72}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2951,10 +3027,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused81">/<input type="text" style="width: 25px;" name="attr_spellprep81"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname81" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname81" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel81" value="8"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro81" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro81" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast81" text="Spell Cast81" title='repeating_spells81_x_spellcast81' value="@{spellmacro81}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -2981,10 +3057,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused82">/<input type="text" style="width: 25px;" name="attr_spellprep82"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname82" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname82" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel82" value="8"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro82" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro82" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast82" text="Spell Cast82" title='repeating_spells82_x_spellcast82' value="@{spellmacro82}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -3017,10 +3093,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused91">/<input type="text" style="width: 25px;" name="attr_spellprep91"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname91" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname91" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel91" value="9"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro91" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro91" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast91" text="Spell Cast91" title='repeating_spells91_x_spellcast91' value="@{spellmacro91}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -3047,10 +3123,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused92">/<input type="text" style="width: 25px;" name="attr_spellprep92"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname92" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname92" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel92" value="9"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro92" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro92" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast92" text="Spell Cast92" title='repeating_spells92_x_spellcast92' value="@{spellmacro92}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -3083,10 +3159,10 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused101">/<input type="text" style="width: 25px;" name="attr_spellprep101"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname101" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname101" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel101" value="6"></td>
 											<td>
-											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro101" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro101" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast101" text="Spell Cast101" title='repeating_spells101_x_spellcast101' value="@{spellmacro101}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -3113,9 +3189,9 @@
 									<table style="width: 350px;" class="sheet-table-row">
 										<tr>
 											<td><input type="text" style="width: 25px;" name="attr_spellused102">/<input type="text" style="width: 25px;" name="attr_spellprep102"></td>
-											<td style="width: 120px;"><input type="text" name="attr_spellname102" value="Spell Name"></td>
+											<td style="width: 120px;"><input type="text" name="attr_spellname102" placeholder="Spell Name"></td>
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel102" value="6"></td>
-											<td><textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 160px;" name="attr_spellmacro102" title="Edit this field to create the macro run by the roll button">spell macro goes here</textarea>
+											<td><textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro102" title="Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
 											<td><button type="roll" name="attr_spellcast102" text="Spell Cast102" title='repeating_spells102_x_spellcast102' value="@{spellmacro102}" style="height: 24px; width: 20px;" ></button>
 											</td>
@@ -3139,7 +3215,7 @@
 					<td colspan="2" class="sheet-statlabel-big-gray" style="width:800px; height: 35px; font-size: 1.5em;">Other</td>
 				</tr>
 			</table>
-			<input type="checkbox" class="sheet-pc-other1-show sheet-arrow" title="other1-show" name="attr_other1-show" value="1" checked /><span style="text-align: left;">Show? <input type="text" style="width: 25px;" name="attr_othergroup1used" title="othergroup1used">/<input type="text" style="width: 25px;" name="attr_othergroup1prep" title="othergroup1prep"> &nbsp; <input type="text" style="width: 395px;" name="attr_othergroup1name" title="othergroup1name" value="Wild Shapes or Summons"></span>
+			<input type="checkbox" class="sheet-pc-other1-show sheet-arrow" title="other1-show" name="attr_other1-show" value="1" checked /><span style="text-align: left;">Show? <input type="text" style="width: 25px;" name="attr_othergroup1used" title="othergroup1used">/<input type="text" style="width: 25px;" name="attr_othergroup1prep" title="othergroup1prep"> &nbsp; <input type="text" style="width: 395px;" name="attr_othergroup1name" title="othergroup1name" placeholder="Wild Shapes or Summons"></span>
 			<div class="sheet-pc-other1">
 				<table>
 					<tr>
@@ -3147,54 +3223,54 @@
 								<fieldset class="repeating_summons1">
 									<table style="width: 790px;" class="sheet-table-row">
 										<div class="sheet-table-row">
-											<span class="sheet-table-col"><input type="text" style="width: 360px;" name="attr_summonname" title="summonname" value="Name"> &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col"><input style="width: 140px;" type="text" name="attr_summonsize" title="summonsize" value="Size"> &nbsp; </span>
-											<span class="sheet-table-col"><input style="width: 160px;" type="text" name="attr_summontype" title="summontype" value="Type"></span>
+											<span class="sheet-table-col"><input type="text" style="width: 360px;" name="attr_summonname" title="summonname" placeholder="Name"> &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col"><input style="width: 140px;" type="text" name="attr_summonsize" title="summonsize" placeholder="Size"> &nbsp; </span>
+											<span class="sheet-table-col"><input style="width: 160px;" type="text" name="attr_summontype" title="summontype" placeholder="Type"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">HD:<input style="width: 50px;" type="text" name="attr_summonhitdie" title="summonhitdie" value="HD">(<input style="width: 30px;" type="text" name="attr_summonhitpoints" title="summonhitpoints" value="Hit Points">) &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Init:<input style="width: 40px;" type="text" name="attr_summoninitiative" title="summoninitiative" value="Initiative"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Spd:<input style="width: 70px;" type="text" name="attr_summonspeed" title="summonspeed" value="Speed"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">AC:<input style="width: 30px;" type="text" name="attr_summonarmorclass" title="summonarmorclass" value="AC">(<input style="width: 120px;" type="text" name="attr_summonarmorclassinfo" title="summonarmorclassinfo" value="Armor Class Mod Info">), Touch:<input style="width: 30px;" type="text" name="attr_summontoucharmorclass" title="summontoucharmorclass" value="T AC">, FF:<input style="width: 30px;" type="text" name="attr_summonflatfootarmorclass" title="summonflatfootarmorclass" value="FF AC"> &nbsp; &nbsp;</span>
-											<span class="sheet-table-col">BAB:<input style="width: 50px;" style="width: 30px;" type="text" name="attr_summonbaseatt" title="summonbaseatt" value="Base Attack">/Gr:<input style="width: 30px;" type="text" name="attr_summongrapple" title="summongrapple" value="Grapple"></span>
+											<span class="sheet-table-col">HD:<input style="width: 50px;" type="text" name="attr_summonhitdie" title="summonhitdie" placeholder="HD">(<input style="width: 30px;" type="text" name="attr_summonhitpoints" title="summonhitpoints" placeholder="Hit Points">) &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Init:<input style="width: 40px;" type="text" name="attr_summoninitiative" title="summoninitiative" placeholder="Initiative"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Spd:<input style="width: 70px;" type="text" name="attr_summonspeed" title="summonspeed" placeholder="Speed"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">AC:<input style="width: 30px;" type="text" name="attr_summonarmorclass" title="summonarmorclass" placeholder="AC">(<input style="width: 120px;" type="text" name="attr_summonarmorclassinfo" title="summonarmorclassinfo" placeholder="Armor Class Mod Info">), Touch:<input style="width: 30px;" type="text" name="attr_summontoucharmorclass" title="summontoucharmorclass" placeholder="T AC">, FF:<input style="width: 30px;" type="text" name="attr_summonflatfootarmorclass" title="summonflatfootarmorclass" placeholder="FF AC"> &nbsp; &nbsp;</span>
+											<span class="sheet-table-col">BAB:<input style="width: 50px;" style="width: 30px;" type="text" name="attr_summonbaseatt" title="summonbaseatt" placeholder="Base Attack">/Gr:<input style="width: 30px;" type="text" name="attr_summongrapple" title="summongrapple" placeholder="Grapple"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Att<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 750px;" name="attr_summonattack" title="summonattack">Attack</textarea>
-											<button type="roll" name="attr_summonattackbutton" title='summonattackbutton' value="@{summonattack}" style="height: 24px; width: 20px;" ></button></span>
+											<span class="sheet-table-col">Att<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 750px;" name="attr_summonattack" title="summonattack" placeholder="Attack"></textarea>
+											<button type="roll" name="attr_summonattackbutton" title='summonattackbutton' placeholder="@{summonattack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">FAtt<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 745px;" name="attr_summonfullattack" title="summonfullattack">Full Attack</textarea>
-											<button type="roll" name="attr_summonfullattackbutton" title='summonfullattackbutton' value="@{summonfullattack}" style="height: 24px; width: 20px;" ></button></span>
+											<span class="sheet-table-col">FAtt<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 745px;" name="attr_summonfullattack" title="summonfullattack" placeholder="Full Attack"></textarea>
+											<button type="roll" name="attr_summonfullattackbutton" title='summonfullattackbutton' placeholder="@{summonfullattack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Space/Reach:<input style="width: 40px;" type="text" name="attr_summonspace" title="summonspace" value="Space">/<input style="width: 40px;" type="text" name="attr_summonreach" title="summonreach" value="Reach"> &nbsp; &nbsp;</span>
-											<span class="sheet-table-col">Sp Att:<input style="width: 250px;" type="text" name="attr_summonspecialattacks" title="summonspecialattacks" value="Special Attacks"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Sp Qual:<input style="width: 250px;" type="text" name="attr_summonspecialqualities" title="summonspecialqualities" value="Special Qualities"></span>
+											<span class="sheet-table-col">Space/Reach:<input style="width: 40px;" type="text" name="attr_summonspace" title="summonspace" placeholder="Space">/<input style="width: 40px;" type="text" name="attr_summonreach" title="summonreach" placeholder="Reach"> &nbsp; &nbsp;</span>
+											<span class="sheet-table-col">Sp Att:<input style="width: 250px;" type="text" name="attr_summonspecialattacks" title="summonspecialattacks" placeholder="Special Attacks"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Sp Qual:<input style="width: 250px;" type="text" name="attr_summonspecialqualities" title="summonspecialqualities" placeholder="Special Qualities"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">F:<input style="width: 40px;" type="text" name="attr_summonfortsave" title="summonfortsave" value="Fort">, </span>
-											<span class="sheet-table-col">R:<input style="width: 40px;" type="text" name="attr_summonrefsave" title="summonrefsave" value="Ref">, </span>
-											<span class="sheet-table-col">W:<input style="width: 40px;" type="text" name="attr_summonwillsave" title="summonwillsave" value="Will"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Str:<input style="width: 40px;" type="text" name="attr_summonstr" title="summonstr" value="Str">, </span>
-											<span class="sheet-table-col">Dex:<input style="width: 40px;" type="text" name="attr_summondex" title="summondex" value="Dex">, </span>
-											<span class="sheet-table-col">Con:<input style="width: 40px;" type="text" name="attr_summoncon" title="summoncon" value="Con">, </span>
-											<span class="sheet-table-col">Int:<input style="width: 40px;" type="text" name="attr_summonint" title="summonint" value="Int">, </span>
-											<span class="sheet-table-col">Wis:<input style="width: 40px;" type="text" name="attr_summonwis" title="summonwis" value="Wis">, </span>
-											<span class="sheet-table-col">Cha:<input style="width: 40px;" type="text" name="attr_summoncha" title="summoncha" value="Cha"> </span>
+											<span class="sheet-table-col">F:<input style="width: 40px;" type="text" name="attr_summonfortsave" title="summonfortsave" placeholder="Fort">, </span>
+											<span class="sheet-table-col">R:<input style="width: 40px;" type="text" name="attr_summonrefsave" title="summonrefsave" placeholder="Ref">, </span>
+											<span class="sheet-table-col">W:<input style="width: 40px;" type="text" name="attr_summonwillsave" title="summonwillsave" placeholder="Will"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Str:<input style="width: 40px;" type="text" name="attr_summonstr" title="summonstr" placeholder="Str">, </span>
+											<span class="sheet-table-col">Dex:<input style="width: 40px;" type="text" name="attr_summondex" title="summondex" placeholder="Dex">, </span>
+											<span class="sheet-table-col">Con:<input style="width: 40px;" type="text" name="attr_summoncon" title="summoncon" placeholder="Con">, </span>
+											<span class="sheet-table-col">Int:<input style="width: 40px;" type="text" name="attr_summonint" title="summonint" placeholder="Int">, </span>
+											<span class="sheet-table-col">Wis:<input style="width: 40px;" type="text" name="attr_summonwis" title="summonwis" placeholder="Wis">, </span>
+											<span class="sheet-table-col">Cha:<input style="width: 40px;" type="text" name="attr_summoncha" title="summoncha" placeholder="Cha"> </span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Skills:<input style="width: 350px;" type="text" name="attr_summonskills" title="summonskills" value="Skills"> &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Feats:<input style="width: 350px;" type="text" name="attr_summonfeats" title="summonfeats" value="Feats"></span>
+											<span class="sheet-table-col">Skills:<input style="width: 350px;" type="text" name="attr_summonskills" title="summonskills" placeholder="Skills"> &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Feats:<input style="width: 350px;" type="text" name="attr_summonfeats" title="summonfeats" placeholder="Feats"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Env:<input style="width: 250px;" type="text" name="attr_summonenv" title="summonenv" value="Environment"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Org:<input style="width: 250px;" type="text" name="attr_summonorg" title="summonorg" value="Organization"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">CR:<input style="width: 50px;" type="text" name="attr_summoncr" title="summoncr" value="CR"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Adv:<input style="width: 90px;" type="text" name="attr_summonadv" title="summonadv" value="Advancement"></span>
+											<span class="sheet-table-col">Env:<input style="width: 250px;" type="text" name="attr_summonenv" title="summonenv" placeholder="Environment"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Org:<input style="width: 250px;" type="text" name="attr_summonorg" title="summonorg" placeholder="Organization"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">CR:<input style="width: 50px;" type="text" name="attr_summoncr" title="summoncr" placeholder="CR"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Adv:<input style="width: 90px;" type="text" name="attr_summonadv" title="summonadv" placeholder="Advancement"></span>
 										</div>
 										<div class="sheet-table-row">
 											<span class="sheet-table-col">								
-											<textarea input class="sheet-inputbox" rows="3" cols="55" style="height: 60px; width: 790px;" name="attr_summondescr" title="summondescr">Description etc</textarea>
+											<textarea input class="sheet-inputbox" rows="3" cols="55" style="height: 60px; width: 790px;" name="attr_summondescr" title="summondescr" placeholder="Description etc"></textarea>
 												</span>
 										</div>
 									</table>
@@ -3205,7 +3281,7 @@
 				</table>
 			</div>
 			<hr/>
-			<input type="checkbox" class="sheet-pc-other2-show sheet-arrow" title="other2-show" name="attr_other2-show" value="1" checked /><span style="text-align: left;">Show? <input type="text" style="width: 25px;" name="attr_othergroup2used" title="othergroup2used">/<input type="text" style="width: 25px;" name="attr_othergroup2prep" title="othergroup2prep"> &nbsp; <input type="text" style="width: 395px;" name="attr_othergroup2name" title="othergroup2name" value="Wild Shapes or Summons"></span>
+			<input type="checkbox" class="sheet-pc-other2-show sheet-arrow" title="other2-show" name="attr_other2-show" value="1" checked /><span style="text-align: left;">Show? <input type="text" style="width: 25px;" name="attr_othergroup2used" title="othergroup2used">/<input type="text" style="width: 25px;" name="attr_othergroup2prep" title="othergroup2prep"> &nbsp; <input type="text" style="width: 395px;" name="attr_othergroup2name" title="othergroup2name" placeholder="Wild Shapes or Summons"></span>
 			<div class="sheet-pc-other2">
 				<table>
 					<tr>
@@ -3213,54 +3289,54 @@
 								<fieldset class="repeating_summons2">
 									<table style="width: 790px;" class="sheet-table-row">
 										<div class="sheet-table-row">
-											<span class="sheet-table-col"><input type="text" style="width: 360px;" name="attr_summon2name" title="summon2name" value="Name"> &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col"><input style="width: 140px;" type="text" name="attr_summon2size" title="summon2size" value="Size"> &nbsp; </span>
-											<span class="sheet-table-col"><input style="width: 160px;" type="text" name="attr_summon2type" title="summon2type" value="Type"></span>
+											<span class="sheet-table-col"><input type="text" style="width: 360px;" name="attr_summon2name" title="summon2name" placeholder="Name"> &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col"><input style="width: 140px;" type="text" name="attr_summon2size" title="summon2size" placeholder="Size"> &nbsp; </span>
+											<span class="sheet-table-col"><input style="width: 160px;" type="text" name="attr_summon2type" title="summon2type" placeholder="Type"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">HD:<input style="width: 50px;" type="text" name="attr_summon2hitdie" title="summon2hitdie" value="HD">(<input style="width: 30px;" type="text" name="attr_summon2hitpoints" title="summon2hitpoints" value="Hit Points">) &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Init:<input style="width: 40px;" type="text" name="attr_summon2initiative" title="summon2initiative" value="Initiative"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Spd:<input style="width: 70px;" type="text" name="attr_summon2speed" title="summon2speed" value="Speed"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">AC:<input style="width: 30px;" type="text" name="attr_summon2armorclass" title="summon2armorclass" value="AC">(<input style="width: 120px;" type="text" name="attr_summon2armorclassinfo" title="summon2armorclassinfo" value="Armor Class Mod Info">), Touch:<input style="width: 30px;" type="text" name="attr_summon2toucharmorclass" title="summon2toucharmorclass" value="T AC">, FF:<input style="width: 30px;" type="text" name="attr_summon2flatfootarmorclass" title="summon2flatfootarmorclass" value="FF AC"> &nbsp; &nbsp;</span>
-											<span class="sheet-table-col">BAB:<input style="width: 50px;" style="width: 30px;" type="text" name="attr_summon2baseatt" title="summon2baseatt" value="Base Attack">/Gr:<input style="width: 30px;" type="text" name="attr_summon2grapple" title="summon2grapple" value="Grapple"></span>
+											<span class="sheet-table-col">HD:<input style="width: 50px;" type="text" name="attr_summon2hitdie" title="summon2hitdie" placeholder="HD">(<input style="width: 30px;" type="text" name="attr_summon2hitpoints" title="summon2hitpoints" placeholder="Hit Points">) &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Init:<input style="width: 40px;" type="text" name="attr_summon2initiative" title="summon2initiative" placeholder="Initiative"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Spd:<input style="width: 70px;" type="text" name="attr_summon2speed" title="summon2speed" placeholder="Speed"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">AC:<input style="width: 30px;" type="text" name="attr_summon2armorclass" title="summon2armorclass" placeholder="AC">(<input style="width: 120px;" type="text" name="attr_summon2armorclassinfo" title="summon2armorclassinfo" placeholder="Armor Class Mod Info">), Touch:<input style="width: 30px;" type="text" name="attr_summon2toucharmorclass" title="summon2toucharmorclass" placeholder="T AC">, FF:<input style="width: 30px;" type="text" name="attr_summon2flatfootarmorclass" title="summon2flatfootarmorclass" placeholder="FF AC"> &nbsp; &nbsp;</span>
+											<span class="sheet-table-col">BAB:<input style="width: 50px;" style="width: 30px;" type="text" name="attr_summon2baseatt" title="summon2baseatt" placeholder="Base Attack">/Gr:<input style="width: 30px;" type="text" name="attr_summon2grapple" title="summon2grapple" placeholder="Grapple"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Att<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 750px;" name="attr_summon2attack" title="summon2attack">Attack</textarea>
-											<button type="roll" name="attr_summon2attackbutton" title='summon2attackbutton' value="@{summon2attack}" style="height: 24px; width: 20px;" ></button></span>
+											<span class="sheet-table-col">Att<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 750px;" name="attr_summon2attack" title="summon2attack" placeholder="Attack"></textarea>
+											<button type="roll" name="attr_summon2attackbutton" title='summon2attackbutton' placeholder="@{summon2attack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">FAtt<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 745px;" name="attr_summon2fullattack" title="summon2fullattack">Full Attack</textarea>
-											<button type="roll" name="attr_summon2fullattackbutton" title='summon2fullattackbutton' value="@{summon2fullattack}" style="height: 24px; width: 20px;" ></button></span>
+											<span class="sheet-table-col">FAtt<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 745px;" name="attr_summon2fullattack" title="summon2fullattack" placeholder="Full Attack"></textarea>
+											<button type="roll" name="attr_summon2fullattackbutton" title='summon2fullattackbutton' placeholder="@{summon2fullattack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Space/Reach:<input style="width: 40px;" type="text" name="attr_summon2space" title="summon2space" value="Space">/<input style="width: 40px;" type="text" name="attr_summon2reach" title="summon2reach" value="Reach"> &nbsp; &nbsp;</span>
-											<span class="sheet-table-col">Sp Att:<input style="width: 250px;" type="text" name="attr_summon2specialattacks" title="summon2specialattacks" value="Special Attacks"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Sp Qual:<input style="width: 250px;" type="text" name="attr_summon2specialqualities" title="summon2specialqualities" value="Special Qualities"></span>
+											<span class="sheet-table-col">Space/Reach:<input style="width: 40px;" type="text" name="attr_summon2space" title="summon2space" placeholder="Space">/<input style="width: 40px;" type="text" name="attr_summon2reach" title="summon2reach" placeholder="Reach"> &nbsp; &nbsp;</span>
+											<span class="sheet-table-col">Sp Att:<input style="width: 250px;" type="text" name="attr_summon2specialattacks" title="summon2specialattacks" placeholder="Special Attacks"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Sp Qual:<input style="width: 250px;" type="text" name="attr_summon2specialqualities" title="summon2specialqualities" placeholder="Special Qualities"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">F:<input style="width: 40px;" type="text" name="attr_summon2fortsave" title="summon2fortsave" value="Fort">, </span>
-											<span class="sheet-table-col">R:<input style="width: 40px;" type="text" name="attr_summon2refsave" title="summon2refsave" value="Ref">, </span>
-											<span class="sheet-table-col">W:<input style="width: 40px;" type="text" name="attr_summon2willsave" title="summon2willsave" value="Will"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Str:<input style="width: 40px;" type="text" name="attr_summon2str" title="summon2str" value="Str">, </span>
-											<span class="sheet-table-col">Dex:<input style="width: 40px;" type="text" name="attr_summon2dex" title="summon2dex" value="Dex">, </span>
-											<span class="sheet-table-col">Con:<input style="width: 40px;" type="text" name="attr_summon2con" title="summon2con" value="Con">, </span>
-											<span class="sheet-table-col">Int:<input style="width: 40px;" type="text" name="attr_summon2int" title="summon2int" value="Int">, </span>
-											<span class="sheet-table-col">Wis:<input style="width: 40px;" type="text" name="attr_summon2wis" title="summon2wis" value="Wis">, </span>
-											<span class="sheet-table-col">Cha:<input style="width: 40px;" type="text" name="attr_summon2cha" title="summon2cha" value="Cha"> </span>
+											<span class="sheet-table-col">F:<input style="width: 40px;" type="text" name="attr_summon2fortsave" title="summon2fortsave" placeholder="Fort">, </span>
+											<span class="sheet-table-col">R:<input style="width: 40px;" type="text" name="attr_summon2refsave" title="summon2refsave" placeholder="Ref">, </span>
+											<span class="sheet-table-col">W:<input style="width: 40px;" type="text" name="attr_summon2willsave" title="summon2willsave" placeholder="Will"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Str:<input style="width: 40px;" type="text" name="attr_summon2str" title="summon2str" placeholder="Str">, </span>
+											<span class="sheet-table-col">Dex:<input style="width: 40px;" type="text" name="attr_summon2dex" title="summon2dex" placeholder="Dex">, </span>
+											<span class="sheet-table-col">Con:<input style="width: 40px;" type="text" name="attr_summon2con" title="summon2con" placeholder="Con">, </span>
+											<span class="sheet-table-col">Int:<input style="width: 40px;" type="text" name="attr_summon2int" title="summon2int" placeholder="Int">, </span>
+											<span class="sheet-table-col">Wis:<input style="width: 40px;" type="text" name="attr_summon2wis" title="summon2wis" placeholder="Wis">, </span>
+											<span class="sheet-table-col">Cha:<input style="width: 40px;" type="text" name="attr_summon2cha" title="summon2cha" placeholder="Cha"> </span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Skills:<input style="width: 350px;" type="text" name="attr_summon2skills" title="summon2skills" value="Skills"> &nbsp; &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Feats:<input style="width: 350px;" type="text" name="attr_summon2feats" title="summon2feats" value="Feats"></span>
+											<span class="sheet-table-col">Skills:<input style="width: 350px;" type="text" name="attr_summon2skills" title="summon2skills" placeholder="Skills"> &nbsp; &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Feats:<input style="width: 350px;" type="text" name="attr_summon2feats" title="summon2feats" placeholder="Feats"></span>
 										</div>
 										<div class="sheet-table-row">
-											<span class="sheet-table-col">Env:<input style="width: 250px;" type="text" name="attr_summon2env" title="summon2env" value="Environment"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Org:<input style="width: 250px;" type="text" name="attr_summon2org" title="summon2org" value="Organization"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">CR:<input style="width: 50px;" type="text" name="attr_summon2cr" title="summon2cr" value="CR"> &nbsp; &nbsp; </span>
-											<span class="sheet-table-col">Adv:<input style="width: 90px;" type="text" name="attr_summon2adv" title="summon2adv" value="Advancement"></span>
+											<span class="sheet-table-col">Env:<input style="width: 250px;" type="text" name="attr_summon2env" title="summon2env" placeholder="Environment"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Org:<input style="width: 250px;" type="text" name="attr_summon2org" title="summon2org" placeholder="Organization"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">CR:<input style="width: 50px;" type="text" name="attr_summon2cr" title="summon2cr" placeholder="CR"> &nbsp; &nbsp; </span>
+											<span class="sheet-table-col">Adv:<input style="width: 90px;" type="text" name="attr_summon2adv" title="summon2adv" placeholder="Advancement"></span>
 										</div>
 										<div class="sheet-table-row">
 											<span class="sheet-table-col">								
-											<textarea input class="sheet-inputbox" rows="3" cols="55" style="height: 60px; width: 790px;" name="attr_summon2descr" title="summon2descr">Description etc</textarea>
+											<textarea input class="sheet-inputbox" rows="3" cols="55" style="height: 60px; width: 790px;" name="attr_summon2descr" title="summon2descr" placeholder="Description etc"></textarea>
 												</span>
 										</div>
 									</table>
@@ -3291,9 +3367,9 @@
 							<fieldset class="repeating_notes1">
 								<table style="width: 790px;" class="sheet-table-row">
 									<div class="sheet-table-row">
-										<span class="sheet-table-col"><input style="width: 80px;" type="text" name="attr_note1date" title="repeating_notes1_x_note1date" value="Date"> &nbsp; </span>
+										<span class="sheet-table-col"><input style="width: 80px;" type="text" name="attr_note1date" title="repeating_notes1_x_note1date" placeholder="Date"> &nbsp; </span>
 										<span class="sheet-table-col">
-										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 710px;" name="attr_note1body" title="repeating_notes1_x_note1body">Note etc</textarea>
+										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 690px;" name="attr_note1body" title="repeating_notes1_x_note1body" placeholder="Note etc"></textarea>
 											</span>
 									</div>
 								</table>
@@ -3311,9 +3387,9 @@
 							<fieldset class="repeating_notes2">
 								<table style="width: 790px;" class="sheet-table-row">
 									<div class="sheet-table-row">
-										<span class="sheet-table-col"><input style="width: 80px;" type="text" name="attr_note2date" title="repeating_notes2_x_note2date" value="Date"> &nbsp; </span>
+										<span class="sheet-table-col"><input style="width: 80px;" type="text" name="attr_note2date" title="repeating_notes2_x_note2date" placeholder="Date"> &nbsp; </span>
 										<span class="sheet-table-col">
-										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 710px;" name="attr_note2body" title="repeating_notes2_x_note2body">Note etc</textarea>
+										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 690px;" name="attr_note2body" title="repeating_notes2_x_note2body" placeholder="Note etc"></textarea>
 											</span>
 									</div>
 								</table>
@@ -3384,7 +3460,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"> &nbsp; </td>
-			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcattackmacro" title="npcattackmacro">Attack Macro</textarea><button type="roll" name="attr_npcattackbutton" title='npcattackbutton' value="@{npcattackmacro}" style="height: 24px; width: 20px;" ></button></td>
+			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcattackmacro" title="npcattackmacro" placeholder="Attack Macro"></textarea><button type="roll" name="attr_npcattackbutton" title='npcattackbutton' value="@{npcattackmacro}" style="height: 24px; width: 20px;" ></button></td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right">Full Attack:</td>
@@ -3392,7 +3468,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"> &nbsp; </td>
-			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcfullattackmacro" title="npcfullattackmacro">Full Attack Macro</textarea><button type="roll" name="attr_npcfullattackbutton" title='npcfullattackbutton' value="@{npcfullattackmacro}" style="height: 24px; width: 20px;" ></button></td>
+			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcfullattackmacro" title="npcfullattackmacro" placeholder="Full Attack Macro"></textarea><button type="roll" name="attr_npcfullattackbutton" title='npcfullattackbutton' value="@{npcfullattackmacro}" style="height: 24px; width: 20px;" ></button></td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right">Space/Reach:</td>
@@ -3459,7 +3535,7 @@
 			<td> </td>
 		</tr>
 		<tr>
-			<td class="sheet-table-left" colspan="2"><textarea input class="sheet-inputbox" rows="4" cols="55" style="height: 60px; width: 790px;" name="attr_npcdescr" title="npcdescr">Description etc</textarea></td>
+			<td class="sheet-table-left" colspan="2"><textarea input class="sheet-inputbox" rows="4" cols="55" style="height: 60px; width: 790px;" name="attr_npcdescr" title="npcdescr" placeholder="Description etc"></textarea></td>
 		</tr>
 		<tr>
 			<td> </td>
@@ -3468,7 +3544,7 @@
 			<td class="sheet-table-header-left" colspan="2">COMBAT</td>
 		</tr>
 		<tr>
-			<td class="sheet-table-left" colspan="2"><textarea input class="sheet-inputbox" rows="8" cols="55" style="height: 60px; width: 790px;" name="attr_npccombatdescr" title="npccombatdescr">Combat information</textarea></td>
+			<td class="sheet-table-left" colspan="2"><textarea input class="sheet-inputbox" rows="8" cols="55" style="height: 60px; width: 790px;" name="attr_npccombatdescr" title="npccombatdescr" placeholder="Combat information"></textarea></td>
 		</tr>
 	</table>
 
@@ -3906,4 +3982,4 @@
 
 </div>
 <br>
-<p style="font-size: 0.6em;">D&D3.5e Character Sheet v2.6.19 7/28/15 by Diana P.</p>
+<p style="font-size: 0.6em;">D&D3.5e Character Sheet v2.6.20 8/10/15 by Diana P.</p>


### PR DESCRIPTION
Added notes areas for saves and skills to use in the roll template notes
property.  Added support for epic levels by adding Epic Save Bonus and
Epic Attack Bonus.  Switched some value= to placeholder= to make text
fields a bit more friendly to edit.  Adjusted the size of several fields
and removed some redundant styles.

Also added additional checkbox to CSS to support the save notes.