### PR TITLE
Fix for Disabled Fields in Mozilla

### DIFF
--- a/DungeonWorld/DungeonWorld.css
+++ b/DungeonWorld/DungeonWorld.css
@@ -37,6 +37,8 @@ input[type=number]:disabled::-webkit-outer-spin-button {
   margin: 0; 
 }
 
+input[disabled] {-moz-appearance: textfield}
+
 .repcontainer .btn,
 .repcontrol .btn {
     border-radius: 0;


### PR DESCRIPTION
Added a single line to force disabled input fields to use textbox appearance to avoid input spinners in those fields when using Firefox