### PR TITLE
D&D3.5 Spacing fixes, color/error fixes etc

### DIFF
--- a/D&D_3-5/charsheet_3-5.css
+++ b/D&D_3-5/charsheet_3-5.css
@@ -148,149 +148,149 @@ select.sheet-dtype {
 }
 
 .sheet-statlabel-weapons {
-    display:table-cell;
+    display: table-cell;
     border: 1px solid white;
     background-color: black;
     color: white;
     font-size: 0.7em;
-    vertical-align:bottom;
+    vertical-align: bottom;
 }
 
 .sheet-table-name {
-    display:table-caption;
-    text-align:center;
-    font-weight:bold;
-    color:white;
-    background-color:black;
-    width:100%;
+    display: table-caption;
+    text-align: center;
+    font-weight: bold;
+    color: white;
+    background-color: black;
+    width: 100%;
 }
 
 .sheet-table-header {
-    display:table-cell;
-    text-align:center;
-    font-weight:bold;
-    vertical-align:bottom;
+    display: table-cell;
+    text-align: center;
+    font-weight: bold;
+    vertical-align: bottom;
 }
 
 .sheet-table-header-left {
-    display:table-cell;
-    text-align:left;
-    font-weight:bold;
+    display: table-cell;
+    text-align: left;
+    font-weight: bold;
 }
 
 .sheet-table-header2-left {
-    display:table-cell;
-    text-align:left;
-    font-weight:bold;
+    display: table-cell;
+    text-align: left;
+    font-weight: bold;
     font-size: 0.7em;
 }
 
 .sheet-table-header-right {
-    display:table-cell;
-    text-align:right;
-    font-weight:bold;
+    display: table-cell;
+    text-align: right;
+    font-weight: bold;
 }
 
 .sheet-table-header2 {
-    display:table-cell;
-    text-align:center;
-    font-weight:bold;
+    display: table-cell;
+    text-align: center;
+    font-weight: bold;
     font-size: 0.7em;
-    vertical-align:bottom;
+    vertical-align: bottom;
 }
 
 .sheet-table-header3 {
-    display:table-cell;
-    text-align:center;
-    font-weight:bold;
+    display: table-cell;
+    text-align: center;
+    font-weight: bold;
     font-size: 0.7em;
-    vertical-align:top;
+    vertical-align: top;
 }
 
 .sheet-table-encumbrance {
-    display:table-cell;
+    display: table-cell;
 	font-size: 0.65em; 
 	width: 126px;
 }
 
 .sheet-table-load {
-    display:table-cell;
+    display: table-cell;
 	font-size: 0.65em; 
 	width: 95px;
 }
 
 .sheet-table-left {
-    display:table-cell;
-    text-align:left;
+    display: table-cell;
+    text-align: left;
 }
 
 .sheet-table-right {
-    display:table-cell;
-    text-align:right;
+    display: table-cell;
+    text-align: right;
 }
 
 .sheet-table-center {
-    margin-left:auto; 
-    margin-right:auto;
+    margin-left: auto; 
+    margin-right: auto;
 }
 
 .sheet-table-data-left {
-    display:table-cell;
-    text-align:left;
-    vertical-align:top;
+    display: table-cell;
+    text-align: left;
+    vertical-align: top;
 }
 
 .sheet-table-data-right {
-    display:table-cell;
-    text-align:right;
-    vertical-align:top;
+    display: table-cell;
+    text-align: right;
+    vertical-align: top;
 }
 
 .sheet-table-data-center {
-    display:table-cell;
-    text-align:center;
-    vertical-align:top;
+    display: table-cell;
+    text-align: center;
+    vertical-align: top;
 }
 
 .sheet-table-data-center-sm {
-    display:table-cell;
-    text-align:center;
+    display: table-cell;
+    text-align: center;
     font-size: 0.7em;
-    vertical-align:top;
+    vertical-align: top;
 }
 
 .sheet-table-data-center-skills {
-    display:table-cell;
+    display: table-cell;
     width: 28px;
 }
 
 .sheet-table-data-center-skills-rep {
-    display:table-cell;
+    display: table-cell;
     width: 31px;
 }
 
 .sheet-table-col {
-    display:table-col;
-    vertical-align:center;
-    width:100%;
+    display: table-col;
+    vertical-align: center;
+    width: 100%;
 }
 
 .sheet-table-row {
-    display:table-row;
-    vertical-align:top;
-    width:100%;
+    display: table-row;
+    vertical-align: top;
+    width: 100%;
 }
 
 .sheet-table-row-name {
-    display:table-cell;
-    text-align:center;
-    color:white;
-    background-color:black;
-    font-weight:bold;
+    display: table-cell;
+    text-align: center;
+    color: white;
+    background-color: black;
+    font-weight: bold;
 }
 
 .sheet-table-row-small {
-    display:table-cell;
+    display: table-cell;
     width: 40px; 
 }
 
@@ -298,16 +298,6 @@ textarea { height: auto; }
 
 input, select {
     width:100%;
-}
-
-/*Adding styling to number fields with range. For untrained skills.*/
-input:in-range {
-    background-color: transparent;
-}
-input:out-of-range {
-    background-color: rgba(255, 0, 0, 0.05);
-    color: red;
-	/* text-decoration: line-through; */
 }
 
 /* Take out the spinner arrows on number inputs. */

--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -2,7 +2,7 @@
 <!-- by Diana P. -->
 <!-- based on Pathfinder sheets from Barry R., Sam, Brian, and Justin N. -->
 <!-- with lots of help from Toby-->
-<!-- Version 2.6.20 8/10/15 (Tabs, Roll Templates, Inline Rolls, NPC toggle, encumbrance w/ ACP & MaxDex, Trained-Only)-->
+<!-- Version 2.6.22 9/20/15 (Tabs, Roll Templates, Inline Rolls, NPC toggle, encumbrance w/ ACP & MaxDex, Trained-Only)-->
 <input type="radio" class="sheet-switch-pc-show sheet-switch" title="npc-show" name="attr_npc-show" value="1" checked /><span style="text-align: left;">PC &nbsp; &nbsp; &nbsp; &nbsp;</span>
 <input type="radio" class="sheet-switch-npc-show sheet-switch" title="npc-show" name="attr_npc-show" value="2" /><span style="text-align: left;">NPC</span>
 
@@ -1663,676 +1663,679 @@
 						<td colspan="9" class="sheet-statlabel-big" style="width: 790px;">skill points/lvl=<input type="text" name="attr_skillpoints" title="skillpoints" value="@{skillpointsint}+@{skillpointsclass}" style="width: 40px; color: white;" disabled="true">=(<input type="text" name="attr_skillpointsint" value="(floor((@{int-base}) / 2) - 5)[base int bonus]" title="skillpointsint (Skill points/lvl from base int.)" style="width: 35px; color: white;" disabled="true">+<input type="text" name="attr_skillpointsclass" value="2" title="skillpointsclass (Skill points/lvl from class; humans add+1.)" style="width: 35px; color: white;">)</td>
 					</tr>
 					<td>
-					<div class="sheet-table-row">
-						<span class="sheet-table-header2">&nbsp;</span>
-						<span class="sheet-table-header2-left">Skill Names</span>
-						<span class="sheet-table-header2">Total<br>Bonus</span>
-						<span class="sheet-table-header2">Stat</span>
-						<span class="sheet-table-header2">Ability<br>Mod.</span>
-						<span class="sheet-table-header2">Ranks</span>
-						<span class="sheet-table-header2">Armor<br>Penalty</span>
-						<span class="sheet-table-header2">Misc<br>Mod.</span>
-						<span class="sheet-table-header2">Notes</span>
-						<span class="sheet-table-header2">Macro</span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_appraiseclassskill" title="appraiseclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Appraise</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_appraise" title="appraise" value="(@{int-mod} +@{appraiseranks} +@{appraisemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraiseranks" title="appraiseranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraisemiscmod" title="appraisemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_appraisenote" title="appraisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_appraisemacro" title="appraisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Appraise](http://www.dandwiki.com/wiki/SRD:Appraise_Skill ) check:}} {{checkroll=[[1d20 + [[@{appraise}]] ]] {{notes=@{appraisenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_appraisecheck" title='appraisecheck' value="@{appraisemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_balanceclassskill" title="balanceclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Balance</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_balance" title="balance" value="(@{dex-mod} +@{balanceranks} +@{balancemiscmod} +@{balancearmorcheckpen} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balanceranks" title="balanceranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancearmorcheckpen" title="balancearmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancemiscmod" title="balancemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_balancenote" title="balancenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_balancemacro" title="balancemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Balance](http://www.dandwiki.com/wiki/SRD:Balance_Skill ) check:}} {{checkroll=[[1d20 + [[@{balance}]] ]] }} {{notes=@{balancenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_balancecheck" title='balancecheck' value="@{balancemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_bluffclassskill" title="bluffclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Bluff</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_bluff" title="bluff" value="(@{cha-mod} +@{bluffranks} +@{bluffmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffranks" title="bluffranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffmiscmod" title="bluffmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_bluffnote" title="bluffnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_bluffmacro" title="bluffmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Bluff](http://www.dandwiki.com/wiki/SRD:Bluff_Skill ) check:}} {{checkroll=[[1d20 + [[@{bluff}]] ]] }} {{notes=@{bluffnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_bluffcheck" title='bluffcheck' value="@{bluffmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_climbclassskill" title="climbclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Climb</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_climb" title="climb" value="(@{climbstat} +@{climbranks} +@{climbmiscmod} +@{climbarmorcheckpen} )" disabled="true"></span>
-						<span><select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_climbstat" title="climbstat">
-							<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
-							<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
-						</select></span>
-						<!--span class="sheet-table-data-center-sm">= Str</span-->
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_climbstatmod" title="climbstatmod" value="@{climbstat}" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbranks" title="climbranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbarmorcheckpen" title="climbarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbmiscmod" title="climbmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_climbnote" title="climbnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_climbmacro" title="climbmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Climb](http://www.dandwiki.com/wiki/SRD:Climb_Skill ) check:}} {{checkroll=[[1d20 + [[@{climb}]] ]] }} {{notes=@{climbnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_climbcheck" title='climbcheck' value="@{climbmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_concentrationclassskill" title="concentrationclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Concentration</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_concentration" title="concentration" value="(@{con-mod} +@{concentrationranks} +@{concentrationmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Con</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_conmod" title="conmod" value="@{con-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationranks" title="concentrationranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationmiscmod" title="concentrationmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_concentrationnote" title="concentrationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_concentrationmacro" title="concentrationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Concentration](http://www.dandwiki.com/wiki/SRD:Concentration_Skill ) check:}} {{checkroll=[[1d20 + [[@{concentration}]] ]] }} {{notes=@{concentrationnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_concentrationcheck" title='concentrationcheck' value="@{concentrationmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_craft1classskill" title="craft1classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Craft <input type="text" name="attr_craft1name" title="craft1name" style="font-size: 0.95em; width: 100px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft1" title="craft1" value="(@{int-mod} +@{craft1ranks} +@{craft1miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1ranks" title="craft1ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1miscmod" title="craft1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft1note" title="craft1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft1macro" title="craft1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft1name}) check:}} {{checkroll=[[1d20 + [[@{craft1}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft1note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft1check" title='craft1check' value="@{craft1macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_craft2classskill" title="craft2classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Craft <input type="text" name="attr_craft2name" title="craft2name" style="font-size: 0.95em; width: 100px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft2" title="craft2" value="(@{int-mod} +@{craft2ranks} +@{craft2miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2ranks" title="craft2ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2miscmod" title="craft2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft2note" title="craft2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft2macro" title="craft2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft2name}) check:}} {{checkroll=[[1d20 + [[@{craft2}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft2note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft2check" title='craft2check' value="@{craft2macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_craft3classskill" title="craft3classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Craft <input type="text" name="attr_craft3name" title="craft3name" style="font-size: 0.95em; width: 100px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft3" title="craft3" value="(@{int-mod} +@{craft3ranks} +@{craft3miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3ranks" title="craft3ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3miscmod" title="craft3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_craft3note" title="craft3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_craft3macro" title="craft3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft3name}) check:}} {{checkroll=[[1d20 + [[@{craft3}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft3note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_craft3check" title='craft3check' value="@{craft3macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_decipherscriptclassskill" title="decipherscriptclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Decipher Script <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_decipherscript" title="decipherscript" value="(@{int-mod} +@{decipherscriptranks} +@{decipherscriptmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_decipherscriptranks" title="decipherscriptranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_decipherscriptmiscmod" title="decipherscriptmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_decipherscriptnote" title="decipherscriptnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_decipherscriptmacro" title="decipherscriptmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Decipher Script](http://www.dandwiki.com/wiki/SRD:Decipher_Script_Skill ) check:}} {{checkroll=[[1d20 + [[@{decipherscript}]] ]] }} {{notes=If fail, [[(1d20 + [[@{wis-mod}]] )]] vs dc5 to avoid drawing a false conclusion. }} {{notes=@{decipherscriptnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_decipherscriptcheck" title='decipherscriptcheck' value="@{decipherscriptmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_diplomacyclassskill" title="diplomacyclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Diplomacy</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_diplomacy" title="diplomacy" value="(@{cha-mod} +@{diplomacyranks} +@{diplomacymiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacyranks" title="diplomacyranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacymiscmod" title="diplomacymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_diplomacynote" title="diplomacynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_diplomacymacro" title="diplomacymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Diplomacy](http://www.dandwiki.com/wiki/SRD:Diplomacy_Skill ) check:}} {{checkroll=[[1d20 + [[@{diplomacy}]] ]] }} {{notes=@{diplomacynote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_diplomacycheck" title='diplomacycheck' value="@{diplomacymacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_disabledeviceclassskill" title="disabledeviceclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Disable Device <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_disabledevice" title="disabledevice" value="(@{int-mod} +@{disabledeviceranks} +@{disabledevicemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_disabledeviceranks" title="disabledeviceranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disabledevicemiscmod" title="disabledevicemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_disabledevicenote" title="disabledevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_disabledevicemacro" title="disabledevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disable Device](http://www.dandwiki.com/wiki/SRD:Disable_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{disabledevice}]] ]] }} {{notes=@{disabledevicenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_disabledevicecheck" title='disabledevicecheck' value="@{disabledevicemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_disguiseclassskill" title="disguiseclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Disguise</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" title="disguise" name="attr_disguise" value="(@{cha-mod} +@{disguiseranks} +@{disguisemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguiseranks" title="disguiseranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguisemiscmod" title="disguisemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_disguisenote" title="disguisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_disguisemacro" title="disguisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disguise](http://www.dandwiki.com/wiki/SRD:Disguise_Skill ) check:}} {{checkroll=[[1d20 + [[@{disguise}]] ]] }} {{notes=@{disguisenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_disguisecheck" title='disguisecheck' value="@{disguisemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_escapeartistclassskill" title="escapeartistclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Escape Artist</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_escapeartist" title="escapeartist" title="age" value="(@{dex-mod} +@{escapeartistranks} +@{escapeartistmiscmod} +@{escapeartistarmorcheckpen} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistranks" title="escapeartistranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistarmorcheckpen" title="escapeartistarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistmiscmod" title="escapeartistmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_escapeartistnote" title="escapeartistnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_escapeartistmacro" title="escapeartistmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Escape Artist](http://www.dandwiki.com/wiki/SRD:Escape_Artist_Skill ) check:}} {{checkroll=[[1d20 + [[@{escapeartist}]] ]] }} {{notes=@{escapeartistnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_escapeartistcheck" title='escapeartistcheck' value="@{escapeartistmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_forgeryclassskill" title="forgeryclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Forgery</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_forgery" title="forgery" value="(@{int-mod} +@{forgeryranks} +@{forgerymiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgeryranks" title="forgeryranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgerymiscmod" title="forgerymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_forgerynote" title="forgerynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_forgerymacro" title="forgerymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Forgery](http://www.dandwiki.com/wiki/SRD:Forgery_Skill ) check:}} {{checkroll=[[1d20 + [[@{forgery}]] ]] }} {{notes=@{forgerynote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_forgerycheck" title='forgerycheck' value="@{forgerymacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_gatherinformationclassskill" title="gatherinformationclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Gather Information</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformation" title="gatherinformation" value="(@{cha-mod} +@{gatherinformationranks} +@{gatherinformationmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationranks" title="gatherinformationranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationmiscmod" title="gatherinformationmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_gatherinformationnote" title="gatherinformationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_gatherinformationmacro" title="gatherinformationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Gather Information](http://www.dandwiki.com/wiki/SRD:Gather_Information_Skill ) check:}} {{checkroll=[[1d20 + [[@{gatherinformation}]] ]] }} {{notes=@{gatherinformationnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_gatherinformationcheck" title='gatherinformationcheck' value="@{gatherinformationmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_handleanimalclassskill" title="handleanimalclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Handle Animal <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_handleanimal" title="handleanimal" value="(@{cha-mod} +@{handleanimalranks} +@{handleanimalmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_handleanimalranks" title="handleanimalranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_handleanimalmiscmod" title="handleanimalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_handleanimalnote" title="handleanimalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_handleanimalmacro" title="handleanimalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Handle Animal](http://www.dandwiki.com/wiki/SRD:Handle_Animal_Skill ) check:}} {{checkroll=[[1d20 + [[@{handleanimal}]] ]] }} {{notes=@{handleanimalnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_handleanimalcheck" title='handleanimalcheck' value="@{handleanimalmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_healclassskill" title="healclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Heal</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_heal" title="heal" value="(@{wis-mod} +@{healranks} +@{healmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healranks" title="healranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healmiscmod" title="healmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_healnote" title="healnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_healmacro" title="healmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Heal](http://www.dandwiki.com/wiki/SRD:Heal_Skill ) check:}} {{checkroll=[[1d20 + [[@{heal}]] +(?{Healer's Kit? (1 for yes)|0}*2)[Healer's Kit Circumstance Bonus] )]] }} {{notes=@{healnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_healcheck" title='healcheck' value="@{healmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_hideclassskill" title="hideclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Hide</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_hide" title="hide" value="(@{dex-mod} +@{hideranks} +@{hidemiscmod} +@{hidearmorcheckpen} -@{specialattacksizemod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hideranks" title="hideranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidearmorcheckpen" title="hidearmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidemiscmod" title="hidemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_hidenote" title="hidenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_hidemacro" title="hidemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Hide](http://www.dandwiki.com/wiki/SRD:Hide_Skill ) check:}} {{checkroll=[[1d20 + [[@{hide}]] ]] }} {{notes=@{hidenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_hidecheck" title='hidecheck' value="@{hidemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_intimidateclassskill" title="intimidateclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Intimidate</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intimidate" title="intimidate" value="(@{cha-mod} +@{intimidateranks} +@{intimidatemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidateranks" title="intimidateranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidatemiscmod" title="intimidatemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_intimidatenote" title="intimidatenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_intimidatemacro" title="intimidatemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Intimidate](http://www.dandwiki.com/wiki/SRD:Intimidate_Skill ) check:}} {{checkroll=[[1d20 + [[@{intimidate}]] ]] }} {{notes=@{intimidatenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_intimidatecheck" title='intimidatecheck' value="@{intimidatemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_jumpclassskill" title="jumpclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Jump</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_jump" title="jump" value="(@{jumpstat}+@{jumpranks} +@{jumpmiscmod} +@{jumparmorcheckpen} )" disabled="true"></span>
-						<span><select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_jumpstat" title="jumpstat">
-							<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
-							<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
-						</select></span>
-						<!--span class="sheet-table-data-center-sm">= Str</span-->
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_jumpstatmod" title="jumpstatmod" value="@{jumpstat}" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpranks" title="jumpranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumparmorcheckpen" title="jumparmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpmiscmod" title="jumpmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_jumpnote" title="jumpnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_jumpmacro" title="jumpmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Jump](http://www.dandwiki.com/wiki/SRD:Jump_Skill ) check:}} {{checkroll=[[1d20 + [[@{jump}]] ]] }} {{notes=@{jumpnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_jumpcheck" title='jumpcheck' value="@{jumpmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowarcanaclassskill" title="knowarcanaclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Arcana) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowarcana" title="knowarcana" value="(@{int-mod} +@{knowarcanaranks} +@{knowarcanamiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowarcanaranks" title="knowarcanaranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowarcanamiscmod" title="knowarcanamiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowarcananote" title="knowarcananote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowarcanamacro" title="knowarcanamacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Arcana) check:}} {{checkroll=[[1d20 + [[@{knowarcana}]] ]] }} {{notes=@{knowarcananote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowarcanacheck" title='knowarcanacheck' value="@{knowarcanamacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowengineerclassskill" title="knowengineerclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Engineer) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowengineer" title="knowengineer" value="(@{int-mod} +@{knowengineerranks} +@{knowengineermiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowengineerranks" title="knowengineerranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowengineermiscmod" title="knowengineermiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowengineernote" title="knowengineernote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowengineermacro" title="knowengineermacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Engineering) check:}} {{checkroll=[[1d20 + [[@{knowengineer}]] ]] }} {{notes=@{knowengineernote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowengineercheck" title='knowengineercheck' value="@{knowengineermacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowdungeonclassskill" title="knowdungeonclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Dungeon) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeon" title="knowdungeon" value="(@{int-mod} +@{knowdungeonranks} +@{knowdungeonmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowdungeonranks" title="knowdungeonranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeonmiscmod" title="knowdungeonmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowdungeonnote" title="knowdungeonnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowdungeonmacro" title="knowdungeonmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Dungeoneering) check:}} {{checkroll=[[1d20 + [[@{knowdungeon}]] ]] }} {{notes=@{knowdungeonnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowdungeoncheck" title='knowdungeoncheck' value="@{knowdungeonmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowgeographyclassskill" title="knowgeographyclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Geography) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowgeography" title="knowgeography" value="(@{int-mod} +@{knowgeographyranks} +@{knowgeographymiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowgeographyranks" title="knowgeographyranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowgeographymiscmod" title="knowgeographymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowgeographynote" title="knowgeographynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowgeographymacro" title="knowgeographymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Geography) check:}} {{checkroll=[[1d20 + [[@{knowgeography}]] ]] }} {{notes=@{knowgeographynote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowgeographycheck" title='knowgeographycheck' value="@{knowgeographymacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowhistoryclassskill" title="knowhistoryclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (History) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowhistory" title="knowhistory" value="(@{int-mod} +@{knowhistoryranks} +@{knowhistorymiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" value="@{int-mod} " title="intmod" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowhistoryranks" title="knowhistoryranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowhistorymiscmod" title="knowhistorymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowhistorynote" title="knowhistorynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowhistorymacro" title="knowhistorymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (History) check:}} {{checkroll=[[1d20 + [[@{knowhistory}]] ]] }} {{notes=@{knowhistorynote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowhistorycheck" title='knowhistorycheck' value="@{knowhistorymacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowlocalclassskill" title="knowlocalclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Local) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowlocal" title="knowlocal" value="(@{int-mod} +@{knowlocalranks} +@{knowlocalmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowlocalranks" title="knowlocalranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowlocalmiscmod" title="knowlocalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowlocalnote" title="knowlocalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowlocalmacro" title="knowlocalmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Local) check:}} {{checkroll=[[1d20 + [[@{knowlocal}]] ]] }} {{notes=@{knowlocalnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowlocalcheck" title='knowlocalcheck' value="@{knowlocalmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knownatureclassskill" title="knownatureclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Nature) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knownature" title="knownature" value="(@{int-mod} +@{knownatureranks} +@{knownaturemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownatureranks" title="knownatureranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownaturemiscmod" title="knownaturemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knownaturenote" title="knownaturenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knownaturemacro" title="knownaturemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nature) check:}} {{checkroll=[[1d20 + [[@{knownature}]] ]] }} {{notes=@{knownaturenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knownaturecheck" title='knownaturecheck' value="@{knownaturemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knownobilityclassskill" title="knownobilityclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Nobility) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knownobility" title="knownobility" value="(@{int-mod} +@{knownobilityranks} +@{knownobilitymiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownobilityranks" title="knownobilityranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownobilitymiscmod" title="knownobilitymiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knownobilitynote" title="knownobilitynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knownobilitymacro" title="knownobilitymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nobility) check:}} {{checkroll=[[1d20 + [[@{knownobility}]] ]] }} {{notes=@{knownobilitynote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knownobilitycheck" title='knownobilitycheck' value="@{knownobilitymacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowreligionclassskill" title="knowreligionclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (Religion) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowreligion" title="knowreligion" value="(@{int-mod} +@{knowreligionranks} +@{knowreligionmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowreligionranks" title="knowreligionranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowreligionmiscmod" title="knowreligionmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowreligionnote" title="knowreligionnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowreligionmacro" title="knowreligionmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Religion) check:}} {{checkroll=[[1d20 + [[@{knowreligion}]] ]] }} {{notes=@{knowreligionnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowreligioncheck" title='knowreligioncheck' value="@{knowreligionmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_knowplanesclassskill" title="knowplanesclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left"> Knowledge (The Planes) <b>*</b> &nbsp; </span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowplanes" title="knowplanes" value="(@{int-mod} +@{knowplanesranks} +@{knowplanesmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowplanesranks" title="knowplanesranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowplanesmiscmod" title="knowplanesmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_knowplanesnote" title="knowplanesnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_knowplanesmacro" title="knowplanesmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Planes) check:}} {{checkroll=[[1d20 + [[@{knowplanes}]] ]] }} {{notes=@{knowplanesnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_knowplanescheck" title='knowplanescheck' value="@{knowplanesmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_listenclassskill" title="listenclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Listen</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_listen" title="listen" value="(@{wis-mod} +@{listenranks} +@{listenmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenranks" title="listenranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenmiscmod" title="listenmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_listennote" title="listennote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_listenmacro" title="listenmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Listen](http://www.dandwiki.com/wiki/SRD:Listen_Skill ) check:}} {{checkroll=[[1d20 + [[@{listen}]] ]] }} {{notes=@{listennote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_listencheck" title='listencheck' value="@{listenmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_movesilentclassskill" title="movesilentclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Move Silently</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_movesilent" title="movesilent" value="(@{dex-mod} +@{movesilentranks} +@{movesilentarmorcheckpen} +@{movesilentmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentranks" title="movesilentranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentarmorcheckpen" title="movesilentarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentmiscmod" title="movesilentmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_movesilentnote" title="movesilentnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_movesilentmacro" title="movesilentmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Move Silently](http://www.dandwiki.com/wiki/SRD:Move_Silently_Skill ) check:}} {{checkroll=[[1d20 + [[@{movesilent}]] ]] }} {{notes=@{movesilentnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_movesilentcheck" title='movesilentcheck' value="@{movesilentmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_openlockclassskill" title="openlockclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Open Lock <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_openlock" title="openlock" value="(@{dex-mod} +@{openlockranks} +@{openlockmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_openlockranks" title="openlockranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_openlockmiscmod" title="openlockmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_openlocknote" title="openlocknote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_openlockmacro" title="openlockmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Open Lock](http://www.dandwiki.com/wiki/SRD:Open_Lock_Skill ) check:}} {{checkroll=[[1d20 + [[@{openlock}]] +(?{Thieves' Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2))[Tool Circumstance Bonus] ]] }} {{notes=@{openlocknote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_openlockcheck" title='openlockcheck' value="@{openlockmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_perform1classskill" title="perform1classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Perform <input type="text" name="attr_perform1name" title="perform1name" style="font-size: 0.95em; width: 90px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform1" title="perform1" value="(@{cha-mod} +@{perform1ranks} +@{perform1miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1ranks" title="perform1ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1miscmod" title="perform1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform1note" title="perform1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform1macro" title="perform1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform1name}) check:}} {{checkroll=[[1d20 + [[@{perform1}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform1note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform1check" title='perform1check' value="@{perform1macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_perform2classskill" title="perform2classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Perform <input type="text" name="attr_perform2name" title="perform2name" style="font-size: 0.95em; width: 90px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform2" title="perform2" value="(@{cha-mod} +@{perform2ranks} +@{perform2miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2ranks" title="perform2ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2miscmod" title="perform2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform2note" title="perform2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform2macro" title="perform2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform2}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform2note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform2check" title='perform2check' value="@{perform2macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_perform3classskill" title="perform3classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Perform <input type="text" name="attr_perform3name" title="perform3name" style="font-size: 0.95em; width: 90px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform3" title="perform3" value="(@{cha-mod} +@{perform3ranks} +@{perform3miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3ranks" title="perform3ranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3miscmod" title="perform3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_perform3note" title="perform3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_perform3macro" title="perform3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform3}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform3note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_perform3check" title='perform3check' value="@{perform3macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_profession1classskill" title="profession1classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession1name" title="profession1name" style="font-size: 0.95em; width: 75px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession1" title="profession1" value="(@{wis-mod} +@{profession1ranks} +@{profession1miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession1ranks" title="profession1ranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession1miscmod" title="profession1miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession1note" title="profession1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession1macro" title="profession1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession1name}) check:}} {{checkroll=[[1d20 + [[@{profession1}]] ]] }} {{notes=@{profession1note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession1check" title='profession1check' value="@{profession1macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_profession2classskill" title="profession2classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession2name" title="profession2name" style="font-size: 0.95em; width: 75px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession2" title="profession2" value="(@{wis-mod} +@{profession2ranks} +@{profession2miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession2ranks" title="profession2ranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession2miscmod" title="profession2miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession2note" title="profession2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession2macro" title="profession2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession2name}) check:}} {{checkroll=[[1d20 + [[@{profession2}]] ]] }} {{notes=@{profession2note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession2check" title='profession2check' value="@{profession2macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_profession3classskill" title="profession3classskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession3name" title="profession3name" style="font-size: 0.95em; width: 75px;"></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession3" title="profession3" value="(@{wis-mod} +@{profession3ranks} +@{profession3miscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession3ranks" title="profession3ranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession3miscmod" title="profession3miscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_profession3note" title="profession3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_profession3macro" title="profession3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession3name}) check:}} {{checkroll=[[1d20 + [[@{profession3}]] ]] }} {{notes=@{profession3note} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_profession3check" title='profession3check' value="@{profession3macro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_rideclassskill" title="rideclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Ride</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_ride" title="ride" value="(@{dex-mod} +@{rideranks} +@{ridemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_rideranks" title="rideranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_ridemiscmod" title="ridemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_ridenote" title="ridenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_ridemacro" title="ridemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Ride](http://www.dandwiki.com/wiki/SRD:Ride_Skill ) check:}} {{checkroll=[[1d20 + [[@{ride}]] ]] }} {{notes=@{ridenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_ridecheck" title='ridecheck' value="@{ridemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_searchclassskill" title="searchclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Search</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_search" title="search" value="(@{int-mod} +@{searchranks} +@{searchmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchranks" title="searchranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchmiscmod" title="searchmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_searchnote" title="searchnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_searchmacro" title="searchmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Search](http://www.dandwiki.com/wiki/SRD:Search_Skill ) check:}} {{checkroll=[[1d20 + [[@{search}]] ]] }} {{notes=@{searchnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_searchcheck" title='searchcheck' value="@{searchmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_sensemotiveclassskill" title="sensemotiveclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Sense Motive</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_sensemotive" title="sensemotive" value="(@{wis-mod} +@{sensemotiveranks} +@{sensemotivemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotiveranks" title="sensemotiveranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotivemiscmod" title="sensemotivemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_sensemotivenote" title="sensemotivenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_sensemotivemacro" title="sensemotivemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sense Motive](http://www.dandwiki.com/wiki/SRD:Sense_Motive_Skill ) check:}} {{checkroll=[[1d20 + [[@{sensemotive}]] ]] }} {{notes=@{sensemotivenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_sensemotivecheck" title='sensemotivecheck' value="@{sensemotivemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_sleightofhandclassskill" title="sleightofhandclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Sleight of Hand <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhand" title="sleightofhand" value="(@{dex-mod} +@{sleightofhandranks} +@{sleightarmorcheckpen} +@{sleightofhandmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_sleightofhandranks" title="sleightofhandranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightarmorcheckpen" title="sleightarmorcheckpen" style="width: 40px;" value="@{armorcheckpenalty} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhandmiscmod" title="sleightofhandmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_sleightofhandnote" title="sleightofhandnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_sleightofhandmacro" title="sleightofhandmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sleight of Hand](http://www.dandwiki.com/wiki/SRD:Sleight_of_Hand_Skill ) check:}} {{checkroll=[[1d20 + [[@{sleightofhand}]] ]] }} {{notes=@{sleightofhandnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_sleightofhandcheck" title='sleightofhandcheck' value="@{sleightofhandmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_spellcraftclassskill" title="spellcraftclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Spellcraft <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_spellcraft" title="spellcraft" value="(@{int-mod} +@{spellcraftranks} +@{spellcraftmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Int</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_spellcraftranks" title="spellcraftranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spellcraftmiscmod" title="spellcraftmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_spellcraftnote" title="spellcraftnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_spellcraftmacro" title="spellcraftmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spellcraft](http://www.dandwiki.com/wiki/SRD:Spellcraft_Skill ) check:}} {{checkroll=[[1d20 + [[@{spellcraft}]] ]] }} {{notes=@{spellcraftnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_spellcraftcheck" title='spellcraftcheck' value="@{spellcraftmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_spotclassskill" title="spotclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Spot</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_spot" title="spot" value="(@{wis-mod} +@{spotranks} +@{spotmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotranks" title="spotranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotmiscmod" title="spotmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_spotnote" title="spotnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_spotmacro" title="spotmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spot](http://www.dandwiki.com/wiki/SRD:Spot_Skill ) check:}} {{checkroll=[[1d20 + [[@{spot}]] ]] }} {{notes=@{spotnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_spotcheck" title='spotcheck' value="@{spotmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_survivalclassskill" title="survivalclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Survival</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_survival" title="survival" value="(@{wis-mod} +@{survivalranks} +@{survivalmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Wis</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalranks" title="survivalranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalmiscmod" title="survivalmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_survivalnote" title="survivalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_survivalmacro" title="survivalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Survival](http://www.dandwiki.com/wiki/SRD:Survival_Skill ) check:}} {{checkroll=[[1d20 + [[@{survival}]] ]] }} {{notes=@{survivalnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_survivalcheck" title='survivalcheck' value="@{survivalmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_swimclassskill" title="swimclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Swim</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_swim" title="swim" value="(@{str-mod} +@{swimranks} +@{swimarmorcheckpen} +@{swimmiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Str</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_strmod" title="strmod" value="@{str-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimranks" title="swimranks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimarmorcheckpen" title="swimarmorcheckpen" style="width: 40px;" value="2*(@{armorcheckpenalty} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimmiscmod" title="swimmiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_swimnote" title="swimnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_swimmacro" title="swimmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Swim](http://www.dandwiki.com/wiki/SRD:Swim_Skill ) check:}} {{checkroll=[[1d20 + [[@{swim}]] ]] }} {{notes=@{swimnote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_swimcheck" title='swimcheck' value="@{swimmacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_tumbleclassskill" title="tumbleclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Tumble <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_tumble" title="tumble" value="(@{dex-mod} +@{tumbleranks} +@{tumblearmorcheckpen} +@{tumblemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_tumbleranks" title="tumbleranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblearmorcheckpen" title="tumblearmorcheckpen" style="width: 40px;" value="(@{armorcheckpenalty} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblemiscmod" title="tumblemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_tumblenote" title="tumblenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_tumblemacro" title="tumblemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Tumble](http://www.dandwiki.com/wiki/SRD:Tumble_Skill ) check:}} {{checkroll=[[1d20 + [[@{tumble}]] ]] }} {{notes=@{tumblenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_tumblecheck" title='tumblecheck' value="@{tumblemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_usemagicdeviceclassskill" title="usemagicdeviceclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Use Magic Device <b>*</b></span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevice" title="usemagicdevice" value="(@{cha-mod} +@{usemagicdeviceranks} +@{usemagicdevicemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Cha</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="number" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_usemagicdeviceranks" title="usemagicdeviceranks" min="1" max="1000" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevicemiscmod" title="usemagicdevicemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_usemagicdevicenote" title="usemagicdevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_usemagicdevicemacro" title="usemagicdevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Magic Device](http://www.dandwiki.com/wiki/SRD:Use_Magic_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{usemagicdevice}]] ]] }} {{notes=@{usemagicdevicenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_usemagicdevicecheck" title='usemagicdevicecheck' value="@{usemagicdevicemacro}" ></button></span>
-					</div>
-					<div class="sheet-table-row">
-						<input type="checkbox" name="attr_useropeclassskill" title="useropeclassskill" value="1" style="width: 8px;">
-						<span class="sheet-table-header-left">Use Rope</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_userope" title="userope" value="(@{dex-mod} +@{useroperanks} +@{useropemiscmod} )" disabled="true"></span>
-						<span class="sheet-table-data-center-sm">= Dex</span>
-						<span class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useroperanks" title="useroperanks" value="0"></span>
-						<span class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </span>
-						<span class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useropemiscmod" title="useropemiscmod" value="0"></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_useropenote" title="useropenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></span>
-						<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_useropemacro" title="useropemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Rope](http://www.dandwiki.com/wiki/SRD:Use_Rope_Skill ) check:}} {{checkroll=[[1d20 + [[@{userope}]] ]] }} {{notes=@{useropenote} }}</textarea></span>
-						<span class="sheet-table-data-center-sm"><button type="roll" name="attr_useropecheck" title='useropecheck' value="@{useropemacro}" ></button></span>
-					</div>
+						<table>
+							<tr>
+								<td class="sheet-table-header2" style="width: 8px;">&nbsp;</td>
+								<td class="sheet-table-header2-left">Skill Names</td>
+								<td class="sheet-table-header2">Total<br>Bonus</td>
+								<td class="sheet-table-header2">Stat</td>
+								<td class="sheet-table-header2">Ability<br>Mod.</td>
+								<td class="sheet-table-header2">Ranks</td>
+								<td class="sheet-table-header2">Armor<br>Penalty</td>
+								<td class="sheet-table-header2">Misc<br>Mod.</td>
+								<td class="sheet-table-header2">Notes</td>
+								<td class="sheet-table-header2">Macro</td>
+								<td class="sheet-table-header2">&nbsp;</td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_appraiseclassskill" title="appraiseclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Appraise</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_appraise" title="appraise" value="(@{int-mod} +@{appraiseranks} +@{appraisemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraiseranks" title="appraiseranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraisemiscmod" title="appraisemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_appraisenote" title="appraisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_appraisemacro" title="appraisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Appraise](http://www.dandwiki.com/wiki/SRD:Appraise_Skill ) check:}} {{checkroll=[[1d20 + [[@{appraise}]] ]] }} {{notes=@{appraisenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_appraisecheck" title='appraisecheck' value="@{appraisemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_balanceclassskill" title="balanceclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Balance</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_balance" title="balance" value="(@{dex-mod} +@{balanceranks} +@{balancemiscmod} +@{balancearmorcheckpen} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balanceranks" title="balanceranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancearmorcheckpen" title="balancearmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancemiscmod" title="balancemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_balancenote" title="balancenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_balancemacro" title="balancemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Balance](http://www.dandwiki.com/wiki/SRD:Balance_Skill ) check:}} {{checkroll=[[1d20 + [[@{balance}]] ]] }} {{notes=@{balancenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_balancecheck" title='balancecheck' value="@{balancemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_bluffclassskill" title="bluffclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Bluff</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_bluff" title="bluff" value="(@{cha-mod} +@{bluffranks} +@{bluffmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffranks" title="bluffranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffmiscmod" title="bluffmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_bluffnote" title="bluffnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_bluffmacro" title="bluffmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Bluff](http://www.dandwiki.com/wiki/SRD:Bluff_Skill ) check:}} {{checkroll=[[1d20 + [[@{bluff}]] ]] }} {{notes=@{bluffnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_bluffcheck" title='bluffcheck' value="@{bluffmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_climbclassskill" title="climbclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Climb</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_climb" title="climb" value="(@{climbstat} +@{climbranks} +@{climbmiscmod} +@{climbarmorcheckpen} )" disabled="true"></td>
+								<td class="sheet-table-data-center"><select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_climbstat" title="climbstat">
+									<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
+									<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+								</select></td>
+								<!--td class="sheet-table-data-center-sm">= Str</td-->
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_climbstatmod" title="climbstatmod" value="@{climbstat}" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbranks" title="climbranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbarmorcheckpen" title="climbarmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbmiscmod" title="climbmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_climbnote" title="climbnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_climbmacro" title="climbmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Climb](http://www.dandwiki.com/wiki/SRD:Climb_Skill ) check:}} {{checkroll=[[1d20 + [[@{climb}]] ]] }} {{notes=@{climbnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_climbcheck" title='climbcheck' value="@{climbmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_concentrationclassskill" title="concentrationclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Concentration</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_concentration" title="concentration" value="(@{con-mod} +@{concentrationranks} +@{concentrationmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Con</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_conmod" title="conmod" value="@{con-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationranks" title="concentrationranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationmiscmod" title="concentrationmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_concentrationnote" title="concentrationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_concentrationmacro" title="concentrationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Concentration](http://www.dandwiki.com/wiki/SRD:Concentration_Skill ) check:}} {{checkroll=[[1d20 + [[@{concentration}]] ]] }} {{notes=@{concentrationnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_concentrationcheck" title='concentrationcheck' value="@{concentrationmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_craft1classskill" title="craft1classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Craft <input type="text" name="attr_craft1name" title="craft1name" style="font-size: 0.95em; width: 100px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft1" title="craft1" value="(@{int-mod} +@{craft1ranks} +@{craft1miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1ranks" title="craft1ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1miscmod" title="craft1miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft1note" title="craft1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft1macro" title="craft1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft1name}) check:}} {{checkroll=[[1d20 + [[@{craft1}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft1note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft1check" title='craft1check' value="@{craft1macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_craft2classskill" title="craft2classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Craft <input type="text" name="attr_craft2name" title="craft2name" style="font-size: 0.95em; width: 100px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft2" title="craft2" value="(@{int-mod} +@{craft2ranks} +@{craft2miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2ranks" title="craft2ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2miscmod" title="craft2miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft2note" title="craft2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft2macro" title="craft2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft2name}) check:}} {{checkroll=[[1d20 + [[@{craft2}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft2note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft2check" title='craft2check' value="@{craft2macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_craft3classskill" title="craft3classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Craft <input type="text" name="attr_craft3name" title="craft3name" style="font-size: 0.95em; width: 100px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_craft3" title="craft3" value="(@{int-mod} +@{craft3ranks} +@{craft3miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3ranks" title="craft3ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3miscmod" title="craft3miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft3note" title="craft3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft3macro" title="craft3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft3name}) check:}} {{checkroll=[[1d20 + [[@{craft3}]] +(?{Artisan's Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2)[Tool Circumstance Bonus] ]] }} {{notes=@{craft3note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft3check" title='craft3check' value="@{craft3macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_decipherscriptclassskill" title="decipherscriptclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Decipher Script <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_decipherscript" title="decipherscript" value="(@{int-mod} +@{decipherscriptranks} +@{decipherscriptmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_decipherscriptranks" title="decipherscriptranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_decipherscriptmiscmod" title="decipherscriptmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_decipherscriptnote" title="decipherscriptnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_decipherscriptmacro" title="decipherscriptmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Decipher Script](http://www.dandwiki.com/wiki/SRD:Decipher_Script_Skill ) check:}} {{checkroll=[[1d20 + [[@{decipherscript}]] ]] }} {{notes=If fail, [[(1d20 + [[@{wis-mod}]] )]] vs dc5 to avoid drawing a false conclusion. }} {{notes=@{decipherscriptnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_decipherscriptcheck" title='decipherscriptcheck' value="@{decipherscriptmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_diplomacyclassskill" title="diplomacyclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Diplomacy</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_diplomacy" title="diplomacy" value="(@{cha-mod} +@{diplomacyranks} +@{diplomacymiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacyranks" title="diplomacyranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacymiscmod" title="diplomacymiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_diplomacynote" title="diplomacynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_diplomacymacro" title="diplomacymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Diplomacy](http://www.dandwiki.com/wiki/SRD:Diplomacy_Skill ) check:}} {{checkroll=[[1d20 + [[@{diplomacy}]] ]] }} {{notes=@{diplomacynote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_diplomacycheck" title='diplomacycheck' value="@{diplomacymacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_disabledeviceclassskill" title="disabledeviceclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Disable Device <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_disabledevice" title="disabledevice" value="(@{int-mod} +@{disabledeviceranks} +@{disabledevicemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_disabledeviceranks" title="disabledeviceranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disabledevicemiscmod" title="disabledevicemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disabledevicenote" title="disabledevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disabledevicemacro" title="disabledevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disable Device](http://www.dandwiki.com/wiki/SRD:Disable_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{disabledevice}]] ]] }} {{notes=@{disabledevicenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_disabledevicecheck" title='disabledevicecheck' value="@{disabledevicemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_disguiseclassskill" title="disguiseclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Disguise</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" title="disguise" name="attr_disguise" value="(@{cha-mod} +@{disguiseranks} +@{disguisemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguiseranks" title="disguiseranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguisemiscmod" title="disguisemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disguisenote" title="disguisenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disguisemacro" title="disguisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disguise](http://www.dandwiki.com/wiki/SRD:Disguise_Skill ) check:}} {{checkroll=[[1d20 + [[@{disguise}]] ]] }} {{notes=@{disguisenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_disguisecheck" title='disguisecheck' value="@{disguisemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_escapeartistclassskill" title="escapeartistclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Escape Artist</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_escapeartist" title="escapeartist" title="age" value="(@{dex-mod} +@{escapeartistranks} +@{escapeartistmiscmod} +@{escapeartistarmorcheckpen} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistranks" title="escapeartistranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistarmorcheckpen" title="escapeartistarmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistmiscmod" title="escapeartistmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_escapeartistnote" title="escapeartistnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_escapeartistmacro" title="escapeartistmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Escape Artist](http://www.dandwiki.com/wiki/SRD:Escape_Artist_Skill ) check:}} {{checkroll=[[1d20 + [[@{escapeartist}]] ]] }} {{notes=@{escapeartistnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_escapeartistcheck" title='escapeartistcheck' value="@{escapeartistmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_forgeryclassskill" title="forgeryclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Forgery</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_forgery" title="forgery" value="(@{int-mod} +@{forgeryranks} +@{forgerymiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgeryranks" title="forgeryranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgerymiscmod" title="forgerymiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_forgerynote" title="forgerynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_forgerymacro" title="forgerymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Forgery](http://www.dandwiki.com/wiki/SRD:Forgery_Skill ) check:}} {{checkroll=[[1d20 + [[@{forgery}]] ]] }} {{notes=@{forgerynote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_forgerycheck" title='forgerycheck' value="@{forgerymacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_gatherinformationclassskill" title="gatherinformationclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Gather Information</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformation" title="gatherinformation" value="(@{cha-mod} +@{gatherinformationranks} +@{gatherinformationmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationranks" title="gatherinformationranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationmiscmod" title="gatherinformationmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_gatherinformationnote" title="gatherinformationnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_gatherinformationmacro" title="gatherinformationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Gather Information](http://www.dandwiki.com/wiki/SRD:Gather_Information_Skill ) check:}} {{checkroll=[[1d20 + [[@{gatherinformation}]] ]] }} {{notes=@{gatherinformationnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_gatherinformationcheck" title='gatherinformationcheck' value="@{gatherinformationmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_handleanimalclassskill" title="handleanimalclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Handle Animal <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_handleanimal" title="handleanimal" value="(@{cha-mod} +@{handleanimalranks} +@{handleanimalmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_handleanimalranks" title="handleanimalranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_handleanimalmiscmod" title="handleanimalmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_handleanimalnote" title="handleanimalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_handleanimalmacro" title="handleanimalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Handle Animal](http://www.dandwiki.com/wiki/SRD:Handle_Animal_Skill ) check:}} {{checkroll=[[1d20 + [[@{handleanimal}]] ]] }} {{notes=@{handleanimalnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_handleanimalcheck" title='handleanimalcheck' value="@{handleanimalmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_healclassskill" title="healclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Heal</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_heal" title="heal" value="(@{wis-mod} +@{healranks} +@{healmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healranks" title="healranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healmiscmod" title="healmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_healnote" title="healnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_healmacro" title="healmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Heal](http://www.dandwiki.com/wiki/SRD:Heal_Skill ) check:}} {{checkroll=[[1d20 + [[@{heal}]] +(?{Healer's Kit? (1 for yes)|0}*2)[Healer's Kit Circumstance Bonus] )]] }} {{notes=@{healnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_healcheck" title='healcheck' value="@{healmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_hideclassskill" title="hideclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Hide</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_hide" title="hide" value="(@{dex-mod} +@{hideranks} +@{hidemiscmod} +@{hidearmorcheckpen} -@{specialattacksizemod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hideranks" title="hideranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidearmorcheckpen" title="hidearmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidemiscmod" title="hidemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_hidenote" title="hidenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_hidemacro" title="hidemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Hide](http://www.dandwiki.com/wiki/SRD:Hide_Skill ) check:}} {{checkroll=[[1d20 + [[@{hide}]] ]] }} {{notes=@{hidenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_hidecheck" title='hidecheck' value="@{hidemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_intimidateclassskill" title="intimidateclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Intimidate</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intimidate" title="intimidate" value="(@{cha-mod} +@{intimidateranks} +@{intimidatemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidateranks" title="intimidateranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidatemiscmod" title="intimidatemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_intimidatenote" title="intimidatenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_intimidatemacro" title="intimidatemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Intimidate](http://www.dandwiki.com/wiki/SRD:Intimidate_Skill ) check:}} {{checkroll=[[1d20 + [[@{intimidate}]] ]] }} {{notes=@{intimidatenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_intimidatecheck" title='intimidatecheck' value="@{intimidatemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_jumpclassskill" title="jumpclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Jump</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_jump" title="jump" value="(@{jumpstat}+@{jumpranks} +@{jumpmiscmod} +@{jumparmorcheckpen} )" disabled="true"></td>
+								<td class="sheet-table-data-center"><select class="sheet-table-data-center-sm" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_jumpstat" title="jumpstat">
+									<option type="text" style="width: 44px;" value="@{str-mod} " selected>Str</option>
+									<option type="text" style="width: 44px;" value="@{dex-mod} ">Dex</option>
+								</select></td>
+								<!--td class="sheet-table-data-center-sm">= Str</td-->
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_jumpstatmod" title="jumpstatmod" value="@{jumpstat}" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpranks" title="jumpranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumparmorcheckpen" title="jumparmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpmiscmod" title="jumpmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_jumpnote" title="jumpnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_jumpmacro" title="jumpmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Jump](http://www.dandwiki.com/wiki/SRD:Jump_Skill ) check:}} {{checkroll=[[1d20 + [[@{jump}]] ]] }} {{notes=@{jumpnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_jumpcheck" title='jumpcheck' value="@{jumpmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowarcanaclassskill" title="knowarcanaclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Arcana) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowarcana" title="knowarcana" value="(@{int-mod} +@{knowarcanaranks} +@{knowarcanamiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowarcanaranks" title="knowarcanaranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowarcanamiscmod" title="knowarcanamiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowarcananote" title="knowarcananote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowarcanamacro" title="knowarcanamacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Arcana) check:}} {{checkroll=[[1d20 + [[@{knowarcana}]] ]] }} {{notes=@{knowarcananote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowarcanacheck" title='knowarcanacheck' value="@{knowarcanamacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowengineerclassskill" title="knowengineerclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Engineer) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowengineer" title="knowengineer" value="(@{int-mod} +@{knowengineerranks} +@{knowengineermiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowengineerranks" title="knowengineerranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowengineermiscmod" title="knowengineermiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowengineernote" title="knowengineernote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowengineermacro" title="knowengineermacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Engineering) check:}} {{checkroll=[[1d20 + [[@{knowengineer}]] ]] }} {{notes=@{knowengineernote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowengineercheck" title='knowengineercheck' value="@{knowengineermacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowdungeonclassskill" title="knowdungeonclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Dungeon) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeon" title="knowdungeon" value="(@{int-mod} +@{knowdungeonranks} +@{knowdungeonmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowdungeonranks" title="knowdungeonranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeonmiscmod" title="knowdungeonmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowdungeonnote" title="knowdungeonnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowdungeonmacro" title="knowdungeonmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Dungeoneering) check:}} {{checkroll=[[1d20 + [[@{knowdungeon}]] ]] }} {{notes=@{knowdungeonnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowdungeoncheck" title='knowdungeoncheck' value="@{knowdungeonmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowgeographyclassskill" title="knowgeographyclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Geography) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowgeography" title="knowgeography" value="(@{int-mod} +@{knowgeographyranks} +@{knowgeographymiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowgeographyranks" title="knowgeographyranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowgeographymiscmod" title="knowgeographymiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowgeographynote" title="knowgeographynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowgeographymacro" title="knowgeographymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Geography) check:}} {{checkroll=[[1d20 + [[@{knowgeography}]] ]] }} {{notes=@{knowgeographynote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowgeographycheck" title='knowgeographycheck' value="@{knowgeographymacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowhistoryclassskill" title="knowhistoryclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (History) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowhistory" title="knowhistory" value="(@{int-mod} +@{knowhistoryranks} +@{knowhistorymiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" value="@{int-mod} " title="intmod" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowhistoryranks" title="knowhistoryranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowhistorymiscmod" title="knowhistorymiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowhistorynote" title="knowhistorynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowhistorymacro" title="knowhistorymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (History) check:}} {{checkroll=[[1d20 + [[@{knowhistory}]] ]] }} {{notes=@{knowhistorynote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowhistorycheck" title='knowhistorycheck' value="@{knowhistorymacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowlocalclassskill" title="knowlocalclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Local) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowlocal" title="knowlocal" value="(@{int-mod} +@{knowlocalranks} +@{knowlocalmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowlocalranks" title="knowlocalranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowlocalmiscmod" title="knowlocalmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowlocalnote" title="knowlocalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowlocalmacro" title="knowlocalmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Local) check:}} {{checkroll=[[1d20 + [[@{knowlocal}]] ]] }} {{notes=@{knowlocalnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowlocalcheck" title='knowlocalcheck' value="@{knowlocalmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knownatureclassskill" title="knownatureclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Nature) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knownature" title="knownature" value="(@{int-mod} +@{knownatureranks} +@{knownaturemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownatureranks" title="knownatureranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownaturemiscmod" title="knownaturemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownaturenote" title="knownaturenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownaturemacro" title="knownaturemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nature) check:}} {{checkroll=[[1d20 + [[@{knownature}]] ]] }} {{notes=@{knownaturenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knownaturecheck" title='knownaturecheck' value="@{knownaturemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knownobilityclassskill" title="knownobilityclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Nobility) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knownobility" title="knownobility" value="(@{int-mod} +@{knownobilityranks} +@{knownobilitymiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knownobilityranks" title="knownobilityranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownobilitymiscmod" title="knownobilitymiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownobilitynote" title="knownobilitynote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownobilitymacro" title="knownobilitymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nobility) check:}} {{checkroll=[[1d20 + [[@{knownobility}]] ]] }} {{notes=@{knownobilitynote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knownobilitycheck" title='knownobilitycheck' value="@{knownobilitymacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowreligionclassskill" title="knowreligionclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (Religion) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowreligion" title="knowreligion" value="(@{int-mod} +@{knowreligionranks} +@{knowreligionmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowreligionranks" title="knowreligionranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowreligionmiscmod" title="knowreligionmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowreligionnote" title="knowreligionnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowreligionmacro" title="knowreligionmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Religion) check:}} {{checkroll=[[1d20 + [[@{knowreligion}]] ]] }} {{notes=@{knowreligionnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowreligioncheck" title='knowreligioncheck' value="@{knowreligionmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_knowplanesclassskill" title="knowplanesclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left"> Knowledge (The Planes) <b>*</b> &nbsp; </td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_knowplanes" title="knowplanes" value="(@{int-mod} +@{knowplanesranks} +@{knowplanesmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_knowplanesranks" title="knowplanesranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowplanesmiscmod" title="knowplanesmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowplanesnote" title="knowplanesnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowplanesmacro" title="knowplanesmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Planes) check:}} {{checkroll=[[1d20 + [[@{knowplanes}]] ]] }} {{notes=@{knowplanesnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowplanescheck" title='knowplanescheck' value="@{knowplanesmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_listenclassskill" title="listenclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Listen</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_listen" title="listen" value="(@{wis-mod} +@{listenranks} +@{listenmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenranks" title="listenranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenmiscmod" title="listenmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_listennote" title="listennote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_listenmacro" title="listenmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Listen](http://www.dandwiki.com/wiki/SRD:Listen_Skill ) check:}} {{checkroll=[[1d20 + [[@{listen}]] ]] }} {{notes=@{listennote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_listencheck" title='listencheck' value="@{listenmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_movesilentclassskill" title="movesilentclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Move Silently</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_movesilent" title="movesilent" value="(@{dex-mod} +@{movesilentranks} +@{movesilentarmorcheckpen} +@{movesilentmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentranks" title="movesilentranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentarmorcheckpen" title="movesilentarmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentmiscmod" title="movesilentmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_movesilentnote" title="movesilentnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_movesilentmacro" title="movesilentmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Move Silently](http://www.dandwiki.com/wiki/SRD:Move_Silently_Skill ) check:}} {{checkroll=[[1d20 + [[@{movesilent}]] ]] }} {{notes=@{movesilentnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_movesilentcheck" title='movesilentcheck' value="@{movesilentmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_openlockclassskill" title="openlockclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Open Lock <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_openlock" title="openlock" value="(@{dex-mod} +@{openlockranks} +@{openlockmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_openlockranks" title="openlockranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_openlockmiscmod" title="openlockmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_openlocknote" title="openlocknote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_openlockmacro" title="openlockmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Open Lock](http://www.dandwiki.com/wiki/SRD:Open_Lock_Skill ) check:}} {{checkroll=[[1d20 + [[@{openlock}]] +(?{Thieves' Tools? (-1 for no, 0 for Normal, 1 for Masterwork)|0}*2))[Tool Circumstance Bonus] ]] }} {{notes=@{openlocknote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_openlockcheck" title='openlockcheck' value="@{openlockmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_perform1classskill" title="perform1classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Perform <input type="text" name="attr_perform1name" title="perform1name" style="font-size: 0.95em; width: 90px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform1" title="perform1" value="(@{cha-mod} +@{perform1ranks} +@{perform1miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1ranks" title="perform1ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1miscmod" title="perform1miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform1note" title="perform1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform1macro" title="perform1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform1name}) check:}} {{checkroll=[[1d20 + [[@{perform1}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform1note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform1check" title='perform1check' value="@{perform1macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_perform2classskill" title="perform2classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Perform <input type="text" name="attr_perform2name" title="perform2name" style="font-size: 0.95em; width: 90px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform2" title="perform2" value="(@{cha-mod} +@{perform2ranks} +@{perform2miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2ranks" title="perform2ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2miscmod" title="perform2miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform2note" title="perform2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform2macro" title="perform2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform2}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform2note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform2check" title='perform2check' value="@{perform2macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_perform3classskill" title="perform3classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Perform <input type="text" name="attr_perform3name" title="perform3name" style="font-size: 0.95em; width: 90px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_perform3" title="perform3" value="(@{cha-mod} +@{perform3ranks} +@{perform3miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3ranks" title="perform3ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3miscmod" title="perform3miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform3note" title="perform3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform3macro" title="perform3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll=[[1d20 + [[@{perform3}]] +(?{Masterwork Instrument? (1 for Yes)|0}*2)[Instrument Circumstance Bonus] ]] }} {{notes=@{perform3note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform3check" title='perform3check' value="@{perform3macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_profession1classskill" title="profession1classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession1name" title="profession1name" style="font-size: 0.95em; width: 75px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession1" title="profession1" value="(@{wis-mod} +@{profession1ranks} +@{profession1miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession1ranks" title="profession1ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession1miscmod" title="profession1miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession1note" title="profession1note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession1macro" title="profession1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession1name}) check:}} {{checkroll=[[1d20 + [[@{profession1}]] ]] }} {{notes=@{profession1note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession1check" title='profession1check' value="@{profession1macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_profession2classskill" title="profession2classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession2name" title="profession2name" style="font-size: 0.95em; width: 75px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession2" title="profession2" value="(@{wis-mod} +@{profession2ranks} +@{profession2miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession2ranks" title="profession2ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession2miscmod" title="profession2miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession2note" title="profession2note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession2macro" title="profession2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession2name}) check:}} {{checkroll=[[1d20 + [[@{profession2}]] ]] }} {{notes=@{profession2note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession2check" title='profession2check' value="@{profession2macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_profession3classskill" title="profession3classskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Profession <b>*</b> <input type="text" name="attr_profession3name" title="profession3name" style="font-size: 0.95em; width: 75px;"></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_profession3" title="profession3" value="(@{wis-mod} +@{profession3ranks} +@{profession3miscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_profession3ranks" title="profession3ranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession3miscmod" title="profession3miscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession3note" title="profession3note (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession3macro" title="profession3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession3name}) check:}} {{checkroll=[[1d20 + [[@{profession3}]] ]] }} {{notes=@{profession3note} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession3check" title='profession3check' value="@{profession3macro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_rideclassskill" title="rideclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Ride</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_ride" title="ride" value="(@{dex-mod} +@{rideranks} +@{ridemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_rideranks" title="rideranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_ridemiscmod" title="ridemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_ridenote" title="ridenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_ridemacro" title="ridemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Ride](http://www.dandwiki.com/wiki/SRD:Ride_Skill ) check:}} {{checkroll=[[1d20 + [[@{ride}]] ]] }} {{notes=@{ridenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_ridecheck" title='ridecheck' value="@{ridemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_searchclassskill" title="searchclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Search</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_search" title="search" value="(@{int-mod} +@{searchranks} +@{searchmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchranks" title="searchranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchmiscmod" title="searchmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_searchnote" title="searchnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_searchmacro" title="searchmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Search](http://www.dandwiki.com/wiki/SRD:Search_Skill ) check:}} {{checkroll=[[1d20 + [[@{search}]] ]] }} {{notes=@{searchnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_searchcheck" title='searchcheck' value="@{searchmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_sensemotiveclassskill" title="sensemotiveclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Sense Motive</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_sensemotive" title="sensemotive" value="(@{wis-mod} +@{sensemotiveranks} +@{sensemotivemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotiveranks" title="sensemotiveranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotivemiscmod" title="sensemotivemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sensemotivenote" title="sensemotivenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sensemotivemacro" title="sensemotivemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sense Motive](http://www.dandwiki.com/wiki/SRD:Sense_Motive_Skill ) check:}} {{checkroll=[[1d20 + [[@{sensemotive}]] ]] }} {{notes=@{sensemotivenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_sensemotivecheck" title='sensemotivecheck' value="@{sensemotivemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_sleightofhandclassskill" title="sleightofhandclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Sleight of Hand <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhand" title="sleightofhand" value="(@{dex-mod} +@{sleightofhandranks} +@{sleightarmorcheckpen} +@{sleightofhandmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_sleightofhandranks" title="sleightofhandranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightarmorcheckpen" title="sleightarmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhandmiscmod" title="sleightofhandmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sleightofhandnote" title="sleightofhandnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sleightofhandmacro" title="sleightofhandmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sleight of Hand](http://www.dandwiki.com/wiki/SRD:Sleight_of_Hand_Skill ) check:}} {{checkroll=[[1d20 + [[@{sleightofhand}]] ]] }} {{notes=@{sleightofhandnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_sleightofhandcheck" title='sleightofhandcheck' value="@{sleightofhandmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_spellcraftclassskill" title="spellcraftclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Spellcraft <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_spellcraft" title="spellcraft" value="(@{int-mod} +@{spellcraftranks} +@{spellcraftmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Int</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_intmod" title="intmod" value="@{int-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_spellcraftranks" title="spellcraftranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spellcraftmiscmod" title="spellcraftmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spellcraftnote" title="spellcraftnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spellcraftmacro" title="spellcraftmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spellcraft](http://www.dandwiki.com/wiki/SRD:Spellcraft_Skill ) check:}} {{checkroll=[[1d20 + [[@{spellcraft}]] ]] }} {{notes=@{spellcraftnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_spellcraftcheck" title='spellcraftcheck' value="@{spellcraftmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_spotclassskill" title="spotclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Spot</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_spot" title="spot" value="(@{wis-mod} +@{spotranks} +@{spotmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotranks" title="spotranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotmiscmod" title="spotmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spotnote" title="spotnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spotmacro" title="spotmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spot](http://www.dandwiki.com/wiki/SRD:Spot_Skill ) check:}} {{checkroll=[[1d20 + [[@{spot}]] ]] }} {{notes=@{spotnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_spotcheck" title='spotcheck' value="@{spotmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_survivalclassskill" title="survivalclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Survival</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_survival" title="survival" value="(@{wis-mod} +@{survivalranks} +@{survivalmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Wis</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_wismod" title="wismod" value="@{wis-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalranks" title="survivalranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalmiscmod" title="survivalmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_survivalnote" title="survivalnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_survivalmacro" title="survivalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Survival](http://www.dandwiki.com/wiki/SRD:Survival_Skill ) check:}} {{checkroll=[[1d20 + [[@{survival}]] ]] }} {{notes=@{survivalnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_survivalcheck" title='survivalcheck' value="@{survivalmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_swimclassskill" title="swimclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Swim</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_swim" title="swim" value="(@{str-mod} +@{swimranks} +@{swimarmorcheckpen} +@{swimmiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Str</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_strmod" title="strmod" value="@{str-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimranks" title="swimranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimarmorcheckpen" title="swimarmorcheckpen" style="width: 28px;" value="2*(@{armorcheckpenalty} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimmiscmod" title="swimmiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_swimnote" title="swimnote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_swimmacro" title="swimmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Swim](http://www.dandwiki.com/wiki/SRD:Swim_Skill ) check:}} {{checkroll=[[1d20 + [[@{swim}]] ]] }} {{notes=@{swimnote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_swimcheck" title='swimcheck' value="@{swimmacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_tumbleclassskill" title="tumbleclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Tumble <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_tumble" title="tumble" value="(@{dex-mod} +@{tumbleranks} +@{tumblearmorcheckpen} +@{tumblemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_tumbleranks" title="tumbleranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblearmorcheckpen" title="tumblearmorcheckpen" style="width: 28px;" value="@{armorcheckpenalty}  " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblemiscmod" title="tumblemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_tumblenote" title="tumblenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_tumblemacro" title="tumblemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Tumble](http://www.dandwiki.com/wiki/SRD:Tumble_Skill ) check:}} {{checkroll=[[1d20 + [[@{tumble}]] ]] }} {{notes=@{tumblenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_tumblecheck" title='tumblecheck' value="@{tumblemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_usemagicdeviceclassskill" title="usemagicdeviceclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Use Magic Device <b>*</b></td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevice" title="usemagicdevice" value="(@{cha-mod} +@{usemagicdeviceranks} +@{usemagicdevicemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Cha</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_chamod" title="chamod" value="@{cha-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" style="width: 28px;" name="attr_usemagicdeviceranks" title="usemagicdeviceranks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevicemiscmod" title="usemagicdevicemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_usemagicdevicenote" title="usemagicdevicenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_usemagicdevicemacro" title="usemagicdevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Magic Device](http://www.dandwiki.com/wiki/SRD:Use_Magic_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{usemagicdevice}]] ]] }} {{notes=@{usemagicdevicenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_usemagicdevicecheck" title='usemagicdevicecheck' value="@{usemagicdevicemacro}" ></button></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="attr_useropeclassskill" title="useropeclassskill" value="1" style="width: 8px;"></td>
+								<td class="sheet-table-header-left">Use Rope</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_userope" title="userope" value="(@{dex-mod} +@{useroperanks} +@{useropemiscmod} )" disabled="true"></td>
+								<td class="sheet-table-data-center-sm">= Dex</td>
+								<td class="sheet-table-data-center-sm"><input type="text" class="sheet-table-data-center-skills" name="attr_dexmod" title="dexmod" value="@{dex-mod} " disabled="true"></td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useroperanks" title="useroperanks" value="0"></td>
+								<td class="sheet-table-data-center-sm">+ &nbsp; -N/A- &nbsp; </td>
+								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useropemiscmod" title="useropemiscmod" value="0"></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_useropenote" title="useropenote (Notes for the note field on the default macro)" placeholder="Notes"></textarea></td>
+								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_useropemacro" title="useropemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Rope](http://www.dandwiki.com/wiki/SRD:Use_Rope_Skill ) check:}} {{checkroll=[[1d20 + [[@{userope}]] ]] }} {{notes=@{useropenote} }}</textarea></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_useropecheck" title='useropecheck' value="@{useropemacro}" ></button></td>
+							</tr>
+						</table>
 					</td>
 				</table>
 					<br>
@@ -2340,7 +2343,6 @@
 				<tr>
 					<td colspan="9" class="sheet-statlabel-big" style="width: 790px;"><b>Other Skills</b></td>
 					</tr>
-					<td></td>
 					<tr class="sheet-table-row">
 						<td class="sheet-table-header2" style="width: 8px;">&nbsp;</td>
 						<td class="sheet-table-header2-left" style="width: 135px;">Skill Names</td>
@@ -3982,4 +3984,4 @@
 
 </div>
 <br>
-<p style="font-size: 0.6em;">D&D3.5e Character Sheet v2.6.20 8/10/15 by Diana P.</p>
+<p style="font-size: 0.6em;">D&D3.5e Character Sheet v2.6.22 9/20/15 by Diana P.</p>


### PR DESCRIPTION
Reverted old pull due to an issue/mistake I made with the repository. 
This commit has fixes to solve the spacing/alignment issue previously 
seen in Chrome, reverts the colorizing of the skill rank box at zero 
ranks for trained only skills (and thus solves the error it produced), 
fixes the appraise macro issue, etc.  Also standardizes spacing in 
CSS file.