### PR TITLE
Correct repeating item flexboxes & widths for FFX

### DIFF
--- a/Exalted2e/exalted2e.css
+++ b/Exalted2e/exalted2e.css
@@ -204,6 +204,16 @@ ul.sheet-craft-types li { clear: right; }
 
 .repcontainer[data-groupname=repeating_attacks] .repitem:last-child .sheet-rolls { border-bottom: 3px solid #000; }
 
+.repcontainer[data-groupname=repeating_merits],
+.repcontainer[data-groupname=repeating_flaws],
+.repcontainer[data-groupname=repeating_charms],
+.repcontainer[data-groupname=repeating_combos],
+.repcontainer[data-groupname=repeating_sorcery],
+.repcontainer[data-groupname=repeating_artifacts],
+.repcontainer[data-groupname=repeating_hearthstones] { clear: left; }
+
+.repcontainer[data-groupname=repeating_intimacies] .repitem { width: calc(50% - 20px); }
+
 .sheet-weapons .repcontrol { width: 400px; }
 
 .sheet-anima:first-of-type > tbody > tr > td:last-child,

--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -597,10 +597,10 @@
 
 <div class="tab-content magic-tab">
     <h1 class="separator"><span>Sorcery</span></h1>
-    <span class="span-header" style="width: 178px">Name</span>
-    <span class="span-header" style="width: 94px">Duration</span>
-    <span class="span-header" style="width: 60px">Cost</span>
-    <span class="span-header" style="width: 475px">Effect</span>
+    <span class="span-header" style="width: 310px">Name</span>
+    <span class="span-header" style="width: 120px">Duration</span>
+    <span class="span-header" style="width: 80px">Cost</span>
+    <span class="span-header">Effect</span>
     <fieldset class="repeating_sorcery">
         <div class="sorcery">
             <input type="text" name="attr_SorceryName" />
@@ -613,7 +613,7 @@
     <h1 class="separator"><span>Artifacts</span></h1>
     <span class="span-header" style="width: 193px">Name</span>
     <span class="span-header" style="width: 77px">Rating</span>
-    <span class="span-header" style="width: 545px">Effect</span>
+    <span class="span-header">Effect</span>
     <fieldset class="repeating_artifacts">
         <div class="artifacts">
             <input type="text" name="attr_ArtifactName" />
@@ -630,11 +630,11 @@
     </fieldset>
     
     <h1 class="separator"><span>Hearthstones</span></h1>
-    <span class="span-header" style="width: 153px">Name</span>
-    <span class="span-header" style="width: 93px">Aspect</span>
-    <span class="span-header" style="width: 63px">Rating</span>
-    <span class="span-header" style="width: 420px">Effect</span>
-    <span class="span-header" style="width: 70px">Socketed</span>
+    <span class="span-header" style="width: 265px">Name</span>
+    <span class="span-header" style="width: 120px">Aspect</span>
+    <span class="span-header" style="width: 80px">Rating</span>
+    <span class="span-header" style="width: 250px">Effect</span>
+    <span class="span-header">Socketed</span>
     <fieldset class="repeating_hearthstones">
         <div class="hearthstones">
             <input type="text" name="attr_HearthstoneName" />
@@ -729,7 +729,7 @@
     <span class="span-header center" style="width: 112px">Type</span>
     <span class="span-header center" style="width: 105px">Duration</span>
     <span class="span-header center" style="width: 105px">Cost</span>
-    <span class="span-header" style="width: 235px">Effect</span>
+    <span class="span-header">Effect</span>
     <fieldset class="repeating_charms">
         <div class="charm">
             <input type="text" name="attr_CharmName" />
@@ -749,7 +749,7 @@
     <h1 class="separator vspace"><span>Combos</span></h1>
     <span class="span-header" style="width: 368px">Name</span>
     <span class="span-header" style="width: 368px">Charms</span>
-    <span class="span-header center" style="width: 72px">Cost</span>
+    <span class="span-header center">Cost</span>
     <fieldset class="repeating_combos">
         <div class="combo">
             <input type="text" name="attr_ComboName" />


### PR DESCRIPTION
In FFX, repeating items with flexboxes below floating content weren't
beginning below the floated content. Additionally, "header" widths for
several repeating sections had incorrect widths, and intimacy repitems
weren't flowing correctly..