### PR TITLE
Numenera tabbed v4.8: unified basic roll template

### DIFF
--- a/Numenera_NathasNumenera_English/NathasNumenera_tabs.css
+++ b/Numenera_NathasNumenera_English/NathasNumenera_tabs.css
@@ -434,6 +434,26 @@
     font-family: "Verdana";
     color: #000066;
 }
+button[type=roll].sheet-apibt{
+    padding: 2px 0px 0px 0px;
+    margin: 0px 0px 0px 0px;
+    text-shadow: none;
+    box-shadow: none;
+    text-align:center;
+    vertical-align: middle;
+    line-height: 0px;
+    font-size: 1em;
+    font-weight: normal;
+    width:15px;
+    height: 15px;
+    color: #6D0100;
+    border: 1px solid #CC9F9F;
+    border-radius: 0px 3px 0px 3px;
+}
+button[type=roll].sheet-apibt:hover{
+    border-color: #6D0100;
+    font-weight: bold;
+}
 .charsheet hr {
     margin: 4px 0 4px 0;
     border: 0;

--- a/Numenera_NathasNumenera_English/NathasNumenera_tabs.htm
+++ b/Numenera_NathasNumenera_English/NathasNumenera_tabs.htm
@@ -4,7 +4,7 @@
         <span class="sheet-heavy">NAME</span>
         <input type="text" name="attr_character_name" style="width: 200px;" />
     </div>
-    <div class="sheet-col" align="center"><span style="font-size:0.8em;color:lightgrey;text-align:center;">Version 4.7 (2015-09-19)</span></div>
+    <div class="sheet-col" align="center"><span style="font-size:0.8em;color:lightgrey;text-align:center;">Version 4.8 (2015-10-10)</span></div>
     <div class="sheet-col" align="right">
         <img src="http://upload.wikimedia.org/wikipedia/en/8/8e/Numenera_Logo.png" width="250px"/>
     </div>
@@ -105,7 +105,7 @@
                         <td><input type="number" name="attr_mightedge" value="1" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Might Roll (API)" value="!nathanum-numeneroll @{character_id}|might" name="roll_MightCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Might Roll"
-                        value="&{template:nathaNumBasicRoll} {{stat=might}}  {{attribute=Might}} {{attrEdge=@{mightedge}}}  {{totalCost=[[@{MightCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=might}}  {{attribute=Might}} {{attrEdge=@{mightedge}}}  {{totalCost=[[@{MightCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                          name="roll_basicMightCheck"></button></td>
                     </tr>
                     <tr>
@@ -118,7 +118,7 @@
                         <td><input type="number" name="attr_speededge" value="1" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Speed Roll (API)" value="!nathanum-numeneroll @{character_id}|speed" name="roll_SpeedCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Speed Roll"
-                        value="&{template:nathaNumBasicRoll} {{stat=speed}}  {{attribute=Speed}} {{attrEdge=@{speededge}}}  {{totalCost=[[@{SpeedCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=speed}}  {{attribute=Speed}} {{attrEdge=@{speededge}}}  {{totalCost=[[@{SpeedCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                         name="roll_basicSpeedCheck"></button></td>
                     </tr>
                     <tr>
@@ -131,7 +131,7 @@
                         <td><input type="number" name="attr_intellectedge" value="0" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Intellect Roll (API)" value="!nathanum-numeneroll @{character_id}|intellect" name="roll_IntellectCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Intellect Roll"
-                        value="&{template:nathaNumBasicRoll} {{stat=intellect}}  {{attribute=Intellect}} {{attrEdge=@{intellectedge}}}  {{totalCost=[[@{IntelCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=intellect}}  {{attribute=Intellect}} {{attrEdge=@{intellectedge}}}  {{totalCost=[[@{IntelCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}}  {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                         name="roll_basicIntellectCheck"></button></td>
                     </tr>
                 </table>
@@ -144,7 +144,6 @@
                 <input type="hidden" name="attr_SpeedCost" value="@{totalCost}-@{speededge}" />
                 <input type="hidden" name="attr_IntelCost" value="@{totalCost}-@{intellectedge}" />
                 <input type="hidden" name="attr_diceRoll" value="1d20cs>17cf1" />
-                <input type="hidden" name="attr_diceRollNoDiff" value="1d20cs>17cf1+(@{rollVarAsset}+@{rollVarRollEff}+[[@{rollVarSkill}]])*3+@{rollVarBonus}" />
                 <input type="hidden" name="attr_finalDiff" value="@{rollVarDiff}-(@{rollVarAsset}+@{rollVarRollEff}+@{rollVarSkill})">
                 <input type="hidden" name="attr_targetRoll" value="3*@{rollVarDiff}-3*(@{rollVarAsset}+@{rollVarRollEff}+@{rollVarSkill})-@{rollVarBonus}">
                 <input type="hidden" name="attr_bonusDmg" value="@{rollVarRollDmg}*3">
@@ -199,7 +198,12 @@
                             <input style="width:40px;height:18px;padding:0px;" type="number" min="0" max="2" name="attr_rollVarAsset" title="Asset(s) : position, equipment etc. (0, 1 or 2 maximum)" value="0" />
                         </td>
                         <td class="sheet-tdsmall-right">
-                            &nbsp;
+                            <button type="roll"
+                                    class="sheet-apibt"
+                                    title="Reset Action Parameters (API)"
+                                    value="!nathanum-resetaction @{character_id}"
+                                    name="roll_resetaction">
+                            </button>
                         </td>
                     </tr>
                     <tr><td COLSPAN="7"><hr/></td></tr>
@@ -804,132 +808,102 @@
     </table>
 </rolltemplate> <!-- End template nathaNumRecovery !-->
 <rolltemplate class="sheet-rolltemplate-nathaNumBasicRoll">
-    <table>
+   <table>
         <tr><th COLSPAN="2">{{attribute}} Roll</th></tr>
+        <tr>
+            <td>1d20</td>
+            <td>
+                {{diceRoll}} (Diff.
+                {{#rollLess() diceRoll 3}}0{{/rollLess() diceRoll 3}}
+                {{#rollBetween() diceRoll 3 5}}1{{/rollBetween() diceRoll 3 5}}
+                {{#rollBetween() diceRoll 6 8}}2{{/rollBetween() diceRoll 6 8}}
+                {{#rollBetween() diceRoll 9 11}}3{{/rollBetween() diceRoll 9 11}}
+                {{#rollBetween() diceRoll 12 14}}4{{/rollBetween() diceRoll 12 14}}
+                {{#rollBetween() diceRoll 15 17}}5{{/rollBetween() diceRoll 15 17}}
+                {{#rollBetween() diceRoll 18 20}}6{{/rollBetween() diceRoll 18 20}}
+                )
+            </td>
+        </tr>
+        {{#rollGreater() bonusToRoll 0}}
+            <tr><td></td>
+                <td>
+                        <i>+{{bonusToRoll}} (bonus)</i>
+                </td>
+            </tr>
+        {{/rollGreater() bonusToRoll 0}}
+        {{#rollWasCrit() diceRoll}}
+            <tr>
+                <td style="color:green;text-align:center;font-weight:bold;">Special:</td>
+                <td style="vertical-align: top;font-size: 95%;">
+                    {{#rollTotal() diceRoll 17}}+1 damage{{/rollTotal() diceRoll 17}}
+                    {{#rollTotal() diceRoll 18}}+2 damage{{/rollTotal() diceRoll 18}}
+                    {{#rollTotal() diceRoll 19}}Minor effect<br/>or +3 damage{{/rollTotal() diceRoll 19}}
+                    {{#rollTotal() diceRoll 20}}Major effect<br/>or +4 damage{{/rollTotal() diceRoll 20}}
+                </td>
+            </tr>
+        {{/rollWasCrit() diceRoll}}
+        {{#rollWasFumble() diceRoll}}
+            <tr><td COLSPAN="2" style="color:red;text-align:center;font-weight:bold;">GM Intrusion</td></tr>
+        {{/rollWasFumble() diceRoll}}
         {{#rollGreater() difficulty 0}}
             {{#rollGreater() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Success: {{diceRoll}}</td></tr>
-                {{#rollWasCrit() diceRoll}}
-                    <tr>
-                        <td style="color:green;text-align:center;font-weight:bold;">Special:</td>
-                        <td style="vertical-align: top;font-size: 95%;">
-                            {{#rollTotal() diceRoll 17}}+1 damage{{/rollTotal() diceRoll 17}}
-                            {{#rollTotal() diceRoll 18}}+2 damage{{/rollTotal() diceRoll 18}}
-                            {{#rollTotal() diceRoll 19}}Minor effect<br/>or +3 damage{{/rollTotal() diceRoll 19}}
-                            {{#rollTotal() diceRoll 20}}Major effect<br/>or +4 damage{{/rollTotal() diceRoll 20}}
-                        </td>
-                    </tr>
-                {{/rollWasCrit() diceRoll}}
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Success!</td></tr>
             {{/rollGreater() diceRoll targetRoll}}
             {{#rollTotal() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Success: {{diceRoll}}</td></tr>
-                {{#rollWasCrit() diceRoll}}
-                    <tr>
-                        <td style="color:green;text-align:center;font-weight:bold;">Special:</td>
-                        <td style="vertical-align: top;font-size: 95%;">
-                            {{#rollTotal() diceRoll 17}}+1 damage{{/rollTotal() diceRoll 17}}
-                            {{#rollTotal() diceRoll 18}}+2 damage{{/rollTotal() diceRoll 18}}
-                            {{#rollTotal() diceRoll 19}}Minor effect<br/>or +3 damage{{/rollTotal() diceRoll 19}}
-                            {{#rollTotal() diceRoll 20}}Major effect<br/>or +4 damage{{/rollTotal() diceRoll 20}}
-                        </td>
-                    </tr>
-                {{/rollWasCrit() diceRoll}}
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Success!</td></tr>
             {{/rollTotal() diceRoll targetRoll}}
             {{#rollLess() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:red;text-align:center;">Failure: {{diceRoll}}</td></tr>
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:red;text-align:center;">Failure</td></tr>
             {{/rollLess() diceRoll targetRoll}}
-            {{#rollWasFumble() diceRoll}}
-                <tr><td COLSPAN="2" style="font-size:105%;color:red;text-align:center;font-weight:bold;">GM Intrusion</td></tr>
-            {{/rollWasFumble() diceRoll}}
-            <tr><td><span>Difficulty</span></td><td>{{difficulty}} ({{target}})</td></tr>
-            {{#skilled}}
-                <tr>
-                    {{#rollTotal() skilled -1}}
-                        <td>Inability</td><td><i>+1</i></td>
-                    {{/rollTotal() skilled -1}}
-                    {{#rollTotal() skilled 0}}
-                        <td>Untrained</td><td><i>+0</i></td>
-                    {{/rollTotal() skilled 0}}
-                    {{#rollTotal() skilled 1}}
-                        <td>Trained</td><td><i>-1</i></td>
-                    {{/rollTotal() skilled 1}}
-                    {{#rollTotal() skilled 2}}
-                        <td>Specialized</td><td><i>-2</i></td>
-                    {{/rollTotal() skilled 2}}
-                </tr>
-            {{/skilled}}
-            {{#rollGreater() assets 0}}
-                <tr><td>Asset(s)</td><td><i>- {{assets}}</i></td></tr>
-            {{/rollGreater() assets 0}}
-            {{#rollGreater() effortRoll 0}}
-                <tr><td>Effort</td><td><i>- {{effortRoll}}</i></td></tr>
-            {{/rollGreater() effortRoll 0}}
+            {{#rollLess() finalDiff difficulty}}
+                <tr><td COLSPAN="2"><hr/></td></tr>
+            {{/rollLess() finalDiff difficulty}}
+            <tr>
+                <td><span>Difficulty</span></td>
+                <td>{{difficulty}} (TN {{target}})</td>
+            </tr>
+        {{/rollGreater() difficulty 0}}
+        {{#rollTotal() difficulty 0}}
+            <tr><td COLSPAN="2"><hr/></td></tr>
+        {{/rollTotal() difficulty 0}}
+        {{#skilled}}
+            {{#rollTotal() skilled -1}}
+                <tr><td>Inability</td><td><i>+1</i></td></tr>
+            {{/rollTotal() skilled -1}}
+            {{#rollTotal() skilled 1}}
+                <tr><td>Trained</td><td><i>-1</i></td></tr>
+            {{/rollTotal() skilled 1}}
+            {{#rollTotal() skilled 2}}
+                <tr><td>Specialized</td><td><i>-2</i></td></tr>
+            {{/rollTotal() skilled 2}}
+        {{/skilled}}
+        {{#rollGreater() assets 0}}
+            <tr><td>Asset(s)</td><td><i>- {{assets}}</i></td></tr>
+        {{/rollGreater() assets 0}}
+        {{#rollGreater() effortRoll 0}}
+            <tr><td>Effort</td><td><i>- {{effortRoll}}</i></td></tr>
+        {{/rollGreater() effortRoll 0}}
+        {{#rollGreater() difficulty 0}}
             {{#rollLess() targetRoll target}}
                 <tr>
-                    <td style="font-weight:bold;">Target</td>
-                    <td style="font-weight:bold;">{{finalDiff}} (
-                        {{#rollGreater() bonusToRoll 0}}
-                        -{{bonusToRoll}}=
-                        {{/rollGreater() bonusToRoll 0}}
-                        {{targetRoll}})
-                    </td>
+                    <td style="text-align: right;">=</td>
+                    <td style="text-align: left;">{{finalDiff}} (TN {{targetRoll}})</td>
                 </tr>
             {{/rollLess() targetRoll target}}
         {{/rollGreater() difficulty 0}}
         {{#rollTotal() difficulty 0}}
+            {{#rollLess() finalDiff 0}}
                 <tr>
-                    <td>1d20</td>
-                    <td>
-                        {{#rollGreater() bonusToRoll 0}}
-                            <i>+{{bonusToRoll}} (bonus)</i>
-                        {{/rollGreater() bonusToRoll 0}}
-                    </td>
+                    <td style="text-align: right;">= Difficulty </td>
+                    <td style="text-align: left;" >{{finalDiff}} steps</td>
                 </tr>
-            {{#skilled}}
+            {{/rollLess() finalDiff 0}}
+            {{#rollGreater() finalDiff 0}}
                 <tr>
-                    {{#rollTotal() skilled -1}}
-                        <td>Inability</td><td><i>-1 (x3)</i></td>
-                    {{/rollTotal() skilled -1}}
-                    {{#rollTotal() skilled 0}}
-                        <td>Untrained</td><td><i>+0</i></td>
-                    {{/rollTotal() skilled 0}}
-                    {{#rollTotal() skilled 1}}
-                        <td>Trained</td><td><i>+1 (x3)</i></td>
-                    {{/rollTotal() skilled 1}}
-                    {{#rollTotal() skilled 2}}
-                        <td>Specialized</td><td><i>+2 (x3)</i></td>
-                    {{/rollTotal() skilled 2}}
+                    <td style="text-align: right;">= Difficulty </td>
+                    <td style="text-align: left;" >+ {{finalDiff}} steps</td>
                 </tr>
-            {{/skilled}}
-            {{#rollGreater() assets 0}}
-                <tr><td>Asset(s)</td><td><i>+ {{assets}} (x3)</i></td>
-            {{/rollGreater() assets 0}}
-            {{#rollGreater() effortRoll 0}}
-                <tr><td>Effort</td><td><i>+ {{effortRoll}} (x3)</i></td></tr>
-            {{/rollGreater() effortRoll 0}}
-            <tr>
-                <td style="font-weight:bold;white-space: nowrap;" title="Difficulty beaten by the roll">Beaten diff.</td>
-                <td style="text-align:center;font-weight:bold;">=
-                    {{#rollLess() diceRollNoDiff 3}}0{{/rollLess() diceRollNoDiff 3}}
-                    {{#rollBetween() diceRollNoDiff 3 5}}1{{/rollBetween() diceRollNoDiff 3 5}}
-                    {{#rollBetween() diceRollNoDiff 6 8}}2{{/rollBetween() diceRollNoDiff 6 8}}
-                    {{#rollBetween() diceRollNoDiff 9 11}}3{{/rollBetween() diceRollNoDiff 9 11}}
-                    {{#rollBetween() diceRollNoDiff 12 14}}4{{/rollBetween() diceRollNoDiff 12 14}}
-                    {{#rollBetween() diceRollNoDiff 15 17}}5{{/rollBetween() diceRollNoDiff 15 17}}
-                    {{#rollBetween() diceRollNoDiff 18 20}}6{{/rollBetween() diceRollNoDiff 18 20}}
-                    {{#rollBetween() diceRollNoDiff 21 23}}7{{/rollBetween() diceRollNoDiff 21 23}}
-                    {{#rollBetween() diceRollNoDiff 24 26}}8{{/rollBetween() diceRollNoDiff 24 26}}
-                    {{#rollBetween() diceRollNoDiff 27 29}}9{{/rollBetween() diceRollNoDiff 27 29}}
-                    {{#rollGreater() diceRollNoDiff 29}}10+{{/rollGreater() diceRollNoDiff 29}}
-                     ({{diceRollNoDiff}})
-                </td>
-            </tr>
-            {{#rollWasFumble() diceRollNoDiff}}
-                <tr><td COLSPAN="2" style="font-size:105%;color:red;text-align:center;font-weight:bold;">GM Intrusion</td></tr>
-            {{/rollWasFumble() diceRollNoDiff}}
-            {{#rollWasCrit() diceRollNoDiff}}
-                <tr><td COLSPAN="2" style="color:green;text-align:center;font-weight:bold;">Special Roll! (17+)</td></tr>
-            {{/rollWasCrit() diceRollNoDiff}}
+            {{/rollGreater() finalDiff 0}}
         {{/rollTotal() difficulty 0}}
         {{#rollGreater() effortDmg 0}}
             <tr><td COLSPAN="2"><hr/></td></tr>

--- a/Numenera_NathasNumenera_English/ReadMe.md
+++ b/Numenera_NathasNumenera_English/ReadMe.md
@@ -5,7 +5,7 @@ Note: there's a french version of the very same sheet/macros/scripts, for those 
 Follow [this link](https://github.com/Roll20/roll20-character-sheets/tree/master/Numenera_NathasNumenera_French).
 
 # Current version:
-Version 4.7 (September 2015) : [Screenshot](NathasNumenera_tabs_v4-5.jpg).
+Version 4.8 (October 10th, 2015) : [Screenshot](NathasNumenera_tabs_v4-5.jpg).
 
 # Basic use:
 
@@ -39,6 +39,12 @@ Version 4.7 (September 2015) : [Screenshot](NathasNumenera_tabs_v4-5.jpg).
 3. If needed, to create you own macros or buttons, read the [Wiki page](https://wiki.roll20.net/Script:Numenera_Natha).
 
 # Release Notes
+
+##Release 4.8 (October 10th, 2015)
+The API script must be updated in version 4.8.
+
+* By popular demand, the basic (non API) stat/skill roll template has been unified and only rolls one d20 dice (for the 3D dice users out there), whatever is the "Difficulty" roll parameter from the "Action" section. If the difficulty parameter has been set to 0, the beaten difficulty is no longer calculated (due to Roll20 limitations), but the raw d20 dice is shown, as the special natural rolls (1 or 17+), and the steps modifiying the difficulty are displayed (and summed).
+* New (small) API button to reset Action parameters
 
 ##Release 4.7 (September 2015)
 Note that the [API script](https://github.com/Roll20/roll20-api-scripts/blob/master/Numenera_Natha/Numenera_Natha.js) needs to be updated to use the red buttons!

--- a/Numenera_NathasNumenera_English/sheet.json
+++ b/Numenera_NathasNumenera_English/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Nathanael TERRIEN",
 	"roll20userid": "75857",
 	"preview": "NathasNumenera_tabs_v4-5.jpg",
-	"instructions": "v4.7 (2015-09-19) To set up a token that's linked to the character sheet, and optionally for API scripts to enhance rolls, check the README.md file at https://github.com/Roll20/roll20-character-sheets/blob/master/Numenera_NathasNumenera_English/ReadMe.md."
+	"instructions": "v4.8 (2015-10-10) To set up a token that's linked to the character sheet, and optionally for API scripts to enhance rolls, check the README.md file at https://github.com/Roll20/roll20-character-sheets/blob/master/Numenera_NathasNumenera_English/ReadMe.md."
 }

--- a/Numenera_NathasNumenera_French/NathasNumenera_tabs.css
+++ b/Numenera_NathasNumenera_French/NathasNumenera_tabs.css
@@ -434,6 +434,26 @@
     font-family: "Verdana";
     color: #000066;
 }
+button[type=roll].sheet-apibt{
+    padding: 2px 0px 0px 0px;
+    margin: 0px 0px 0px 0px;
+    text-shadow: none;
+    box-shadow: none;
+    text-align:center;
+    vertical-align: middle;
+    line-height: 0px;
+    font-size: 1em;
+    font-weight: normal;
+    width:15px;
+    height: 15px;
+    color: #6D0100;
+    border: 1px solid #CC9F9F;
+    border-radius: 0px 3px 0px 3px;
+}
+button[type=roll].sheet-apibt:hover{
+    border-color: #6D0100;
+    font-weight: bold;
+}
 .charsheet hr {
     margin: 4px 0 4px 0;
     border: 0;

--- a/Numenera_NathasNumenera_French/NathasNumenera_tabs.htm
+++ b/Numenera_NathasNumenera_French/NathasNumenera_tabs.htm
@@ -4,7 +4,7 @@
         <span class="sheet-heavy">NOM</span>
         <input type="text" name="attr_character_name" style="width: 200px;" />
     </div>
-    <div class="sheet-col" align="center"><span style="font-size:0.8em;color:lightgrey;text-align:center;">Version 4.7 (2015-09-19)</span></div>
+    <div class="sheet-col" align="center"><span style="font-size:0.8em;color:lightgrey;text-align:center;">Version 4.8 (2015-10-10)</span></div>
     <div class="sheet-col" align="right">
         <img src="http://upload.wikimedia.org/wikipedia/en/8/8e/Numenera_Logo.png" width="250px"/>
     </div>
@@ -105,7 +105,7 @@
                         <td><input type="number" name="attr_mightedge" value="1"  min="0" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Jet de Puissance (API)" value="!nathanum-numeneroll @{character_id}|might" name="roll_MightCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Jet de Puissance"
-                        value="&{template:nathaNumBasicRoll} {{stat=might}}  {{attribute=Puissance}} {{attrEdge=@{mightedge}}}  {{totalCost=[[@{MightCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=might}}  {{attribute=Puissance}} {{attrEdge=@{mightedge}}}  {{totalCost=[[@{MightCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                         name="roll_basicMightCheck"></button></td>
                     </tr>
                     <tr>
@@ -118,7 +118,7 @@
                         <td><input type="number" name="attr_speededge" value="1" min="0" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Jet de Célérité (API)" value="!nathanum-numeneroll @{character_id}|speed" name="roll_SpeedCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Jet de Célérité"
-                        value="&{template:nathaNumBasicRoll} {{stat=speed}}  {{attribute=Célérité}} {{attrEdge=@{speededge}}}  {{totalCost=[[@{SpeedCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=speed}}  {{attribute=Célérité}} {{attrEdge=@{speededge}}}  {{totalCost=[[@{SpeedCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                         name="roll_basicSpeedCheck"></button></td>
                     </tr>
                     <tr>
@@ -131,7 +131,7 @@
                         <td><input type="number" name="attr_intellectedge" value="0"  min="0" /></td>
                         <td class="sheet-td-right"><button style="background-color:red;color:red" type="roll" title="Jet d'Intellect (API)" value="!nathanum-numeneroll @{character_id}|intellect" name="roll_IntellectCheck"></button></td>
                         <td class="sheet-td-right"><button style="background-color:green;color:green" type="roll" title="Jet d'Intellect"
-                        value="&{template:nathaNumBasicRoll} {{stat=intellect}}  {{attribute=Intellect}} {{attrEdge=@{intellectedge}}}  {{totalCost=[[@{IntelCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{diceRollNoDiff=[[@{diceRollNoDiff}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
+                        value="&{template:nathaNumBasicRoll} {{stat=intellect}}  {{attribute=Intellect}} {{attrEdge=@{intellectedge}}}  {{totalCost=[[@{IntelCost}]]}} {{charid=@{character_id}}} {{diceRoll=[[@{diceRoll}]]}} {{bonusToRoll=[[@{rollVarBonus}]]}} {{difficulty=[[@{rollVarDiff}]]}} {{target=[[@{target}]]}} {{finalDiff=[[@{finalDiff}]]}} {{targetRoll=[[@{targetRoll}]]}} {{effortCost=[[@{effortCost}]]}} {{effortRoll=[[@{rollVarRollEff}]]}} {{effortDmg=[[@{rollVarRollDmg}]]}} {{statExpense=[[@{rollVarCost}]]}} {{assets=[[@{rollVarAsset}]]}} {{bonusDmg=[[@{bonusDmg}]]}} {{skilled=[[@{rollVarSkill}]]}}"
                         name="roll_basicIntellectCheck"></button></td>
                     </tr>
                 </table>
@@ -144,7 +144,6 @@
                 <input type="hidden" name="attr_SpeedCost" value="@{totalCost}-@{speededge}" />
                 <input type="hidden" name="attr_IntelCost" value="@{totalCost}-@{intellectedge}" />
                 <input type="hidden" name="attr_diceRoll" value="1d20cs>17cf1" />
-                <input type="hidden" name="attr_diceRollNoDiff" value="1d20cs>17cf1+(@{rollVarAsset}+@{rollVarRollEff}+[[@{rollVarSkill}]])*3+@{rollVarBonus}" />
                 <input type="hidden" name="attr_finalDiff" value="@{rollVarDiff}-(@{rollVarAsset}+@{rollVarRollEff}+@{rollVarSkill})">
                 <input type="hidden" name="attr_targetRoll" value="3*@{rollVarDiff}-3*(@{rollVarAsset}+@{rollVarRollEff}+@{rollVarSkill})-@{rollVarBonus}">
                 <input type="hidden" name="attr_bonusDmg" value="@{rollVarRollDmg}*3">
@@ -198,7 +197,12 @@
                             <input style="width:40px;height:18px;padding:0px;" type="number" min="0" max="2" name="attr_rollVarAsset" title="Atout(s) : position, &eacute;quipement etc. (0, 1 ou 2 maximum)" value="0" />
                         </td>
                         <td class="sheet-tdsmall-right">
-                            &nbsp;
+                            <button type="roll"
+                                class="sheet-apibt"
+                                title="Remise à zéro des paramètres de jet (API)"
+                                value="!nathanum-resetaction @{character_id}"
+                                name="roll_resetaction">
+                            </button>
                         </td>
                     </tr>
                     <tr><td COLSPAN="7"><hr/></td></tr>
@@ -805,130 +809,97 @@
 <rolltemplate class="sheet-rolltemplate-nathaNumBasicRoll">
    <table>
         <tr><th COLSPAN="2">Jet de {{attribute}}</th></tr>
+        <tr>
+            <td>1d20</td>
+            <td>
+                {{diceRoll}} (Diff.
+                {{#rollLess() diceRoll 3}}0{{/rollLess() diceRoll 3}}
+                {{#rollBetween() diceRoll 3 5}}1{{/rollBetween() diceRoll 3 5}}
+                {{#rollBetween() diceRoll 6 8}}2{{/rollBetween() diceRoll 6 8}}
+                {{#rollBetween() diceRoll 9 11}}3{{/rollBetween() diceRoll 9 11}}
+                {{#rollBetween() diceRoll 12 14}}4{{/rollBetween() diceRoll 12 14}}
+                {{#rollBetween() diceRoll 15 17}}5{{/rollBetween() diceRoll 15 17}}
+                {{#rollBetween() diceRoll 18 20}}6{{/rollBetween() diceRoll 18 20}}
+                )
+            </td>
+        </tr>
+        {{#rollGreater() bonusToRoll 0}}
+            <tr><td></td>
+                <td>
+                        <i>+{{bonusToRoll}} (bonus)</i>
+                </td>
+            </tr>
+        {{/rollGreater() bonusToRoll 0}}
+        {{#rollWasCrit() diceRoll}}
+            <tr>
+                <td style="color:green;text-align:center;font-weight:bold;">Spécial :</td>
+                <td style="vertical-align: top;font-size: 95%;">
+                    {{#rollTotal() diceRoll 17}}+1 dégâts{{/rollTotal() diceRoll 17}}
+                    {{#rollTotal() diceRoll 18}}+2 dégâts{{/rollTotal() diceRoll 18}}
+                    {{#rollTotal() diceRoll 19}}Effet Mineur<br/>ou +3 dégâts{{/rollTotal() diceRoll 19}}
+                    {{#rollTotal() diceRoll 20}}Effet Majeur<br/>ou +4 dégâts{{/rollTotal() diceRoll 20}}
+                </td>
+            </tr>
+        {{/rollWasCrit() diceRoll}}
+        {{#rollWasFumble() diceRoll}}
+            <tr><td COLSPAN="2" style="color:red;text-align:center;font-weight:bold;">Intrusion du MJ</td></tr>
+        {{/rollWasFumble() diceRoll}}
         {{#rollGreater() difficulty 0}}
             {{#rollGreater() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Réussite : {{diceRoll}}</td></tr>
-                {{#rollWasCrit() diceRoll}}
-                    <tr>
-                        <td style="color:green;text-align:center;font-weight:bold;">Spécial :</td>
-                        <td style="vertical-align: top;font-size: 95%;">
-                            {{#rollTotal() diceRoll 17}}+1 dégâts{{/rollTotal() diceRoll 17}}
-                            {{#rollTotal() diceRoll 18}}+2 dégâts{{/rollTotal() diceRoll 18}}
-                            {{#rollTotal() diceRoll 19}}Effet Mineur<br/>ou +3 dégâts{{/rollTotal() diceRoll 19}}
-                            {{#rollTotal() diceRoll 20}}Effet Majeur<br/>ou +4 dégâts{{/rollTotal() diceRoll 20}}
-                        </td>
-                    </tr>
-                {{/rollWasCrit() diceRoll}}
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Réussite !</td></tr>
             {{/rollGreater() diceRoll targetRoll}}
             {{#rollTotal() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Réussite: {{diceRoll}}</td></tr>
-                {{#rollWasCrit() diceRoll}}
-                    <tr>
-                        <td style="color:green;text-align:center;font-weight:bold;">Special:</td>
-                        <td style="vertical-align: top;font-size: 95%;">
-                            {{#rollTotal() diceRoll 17}}+1 dégâts{{/rollTotal() diceRoll 17}}
-                            {{#rollTotal() diceRoll 18}}+2 dégâts{{/rollTotal() diceRoll 18}}
-                            {{#rollTotal() diceRoll 19}}Effet Mineur<br/>or +3 dégâts{{/rollTotal() diceRoll 19}}
-                            {{#rollTotal() diceRoll 20}}Effet Majeur<br/>or +4 dégâts{{/rollTotal() diceRoll 20}}
-                        </td>
-                    </tr>
-                {{/rollWasCrit() diceRoll}}
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:green;text-align:center;">Réussite !</td></tr>
             {{/rollTotal() diceRoll targetRoll}}
             {{#rollLess() diceRoll targetRoll}}
-                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:red;text-align:center;">&Eacute;chec : {{diceRoll}}</td></tr>
+                <tr><td  COLSPAN="2" style="font-size:105%;font-weight:bold;color:red;text-align:center;">&Eacute;chec !</td></tr>
             {{/rollLess() diceRoll targetRoll}}
-            {{#rollWasFumble() diceRoll}}
-                <tr><td COLSPAN="2" style="font-size:105%;color:red;text-align:center;font-weight:bold;">Intrusion du MJ</td></tr>
-            {{/rollWasFumble() diceRoll}}
-            <tr><td><span>Difficulté</span></td><td>{{difficulty}} ({{target}})</td></tr>
-            {{#skilled}}
-                <tr>
-                    {{#rollTotal() skilled -1}}
-                        <td>Incapacité</td><td><i>+1</i></td>
-                    {{/rollTotal() skilled -1}}
-                    {{#rollTotal() skilled 0}}
-                        <td>Non entraîné</td><td><i>+0</i></td>
-                    {{/rollTotal() skilled 0}}
-                    {{#rollTotal() skilled 1}}
-                        <td>Entraîné</td><td><i>-1</i></td>
-                    {{/rollTotal() skilled 1}}
-                    {{#rollTotal() skilled 2}}
-                        <td>Spécialisé</td><td><i>-2</i></td>
-                    {{/rollTotal() skilled 2}}
-                </tr>
-            {{/skilled}}
-            {{#rollGreater() assets 0}}
-                <tr><td>Atout(s)</td><td><i>- {{assets}}</i></td></tr>
-            {{/rollGreater() assets 0}}
-            {{#rollGreater() effortRoll 0}}
-                <tr><td>Effort(s)</td><td><i>- {{effortRoll}}</i></td></tr>
-            {{/rollGreater() effortRoll 0}}
+            {{#rollLess() finalDiff difficulty}}
+                <tr><td COLSPAN="2"><hr/></td></tr>
+            {{/rollLess() finalDiff difficulty}}
+            <tr><td><span>Difficulté</span></td><td>{{difficulty}} (SR {{target}})</td></tr>
+        {{/rollGreater() difficulty 0}}
+        {{#rollTotal() difficulty 0}}
+            <tr><td COLSPAN="2"><hr/></td></tr>
+        {{/rollTotal() difficulty 0}}
+        {{#skilled}}
+            {{#rollTotal() skilled -1}}
+                <tr><td>Incapacité</td><td><i>+1</i></td></tr>
+            {{/rollTotal() skilled -1}}
+            {{#rollTotal() skilled 1}}
+                <tr><td>Entraîné</td><td><i>-1</i></td></tr>
+            {{/rollTotal() skilled 1}}
+            {{#rollTotal() skilled 2}}
+                <tr><td>Spécialisé</td><td><i>-2</i></td></tr>
+            {{/rollTotal() skilled 2}}
+        {{/skilled}}
+        {{#rollGreater() assets 0}}
+            <tr><td>Atout(s)</td><td><i>- {{assets}}</i></td></tr>
+        {{/rollGreater() assets 0}}
+        {{#rollGreater() effortRoll 0}}
+            <tr><td>Effort(s)</td><td><i>- {{effortRoll}}</i></td></tr>
+        {{/rollGreater() effortRoll 0}}
+        {{#rollGreater() difficulty 0}}
             {{#rollLess() targetRoll target}}
                 <tr>
-                    <td style="font-weight:bold;" title="Seuil de Réussite">SR</td>
-                    <td style="font-weight:bold;" title="Seuil de Réussite">{{finalDiff}} (
-                        {{#rollGreater() bonusToRoll 0}}
-                        -{{bonusToRoll}}=
-                        {{/rollGreater() bonusToRoll 0}}
-                        {{targetRoll}})
-                    </td>
+                    <td style="text-align: right;" title="Seuil de Réussite">=</td>
+                    <td style="text-align: left;" title="Seuil de Réussite">{{finalDiff}} (SR {{targetRoll}})</td>
                 </tr>
             {{/rollLess() targetRoll target}}
         {{/rollGreater() difficulty 0}}
         {{#rollTotal() difficulty 0}}
+            {{#rollLess() finalDiff 0}}
                 <tr>
-                    <td>1d20</td>
-                    <td>
-                        {{#rollGreater() bonusToRoll 0}}
-                            <i>+{{bonusToRoll}} (bonus)</i>
-                        {{/rollGreater() bonusToRoll 0}}
-                    </td>
+                    <td style="text-align: right;">= Difficulté </td>
+                    <td style="text-align: left;" >{{finalDiff}} niveaux</td>
                 </tr>
-            {{#skilled}}
+            {{/rollLess() finalDiff 0}}
+            {{#rollGreater() finalDiff 0}}
                 <tr>
-                    {{#rollTotal() skilled -1}}
-                        <td>Incapacité</td><td><i>-1 (x3)</i></td>
-                    {{/rollTotal() skilled -1}}
-                    {{#rollTotal() skilled 0}}
-                        <td>Non entraîné</td><td><i>+0</i></td>
-                    {{/rollTotal() skilled 0}}
-                    {{#rollTotal() skilled 1}}
-                        <td>Entraîné</td><td><i>+1 (x3)</i></td>
-                    {{/rollTotal() skilled 1}}
-                    {{#rollTotal() skilled 2}}
-                        <td>Spécialisé</td><td><i>+2 (x3)</i></td>
-                    {{/rollTotal() skilled 2}}
+                    <td style="text-align: right;">= Difficulté </td>
+                    <td style="text-align: left;" >+ {{finalDiff}} niveaux</td>
                 </tr>
-            {{/skilled}}
-            {{#rollGreater() assets 0}}
-                <tr><td>Atout(s)</td><td><i>+ {{assets}} (x3)</i></td>
-            {{/rollGreater() assets 0}}
-            {{#rollGreater() effortRoll 0}}
-                <tr><td>Effort(s)</td><td><i>+ {{effortRoll}} (x3)</i></td></tr>
-            {{/rollGreater() effortRoll 0}}
-            <tr>
-                <td style="font-weight:bold;white-space: nowrap;" title="Difficulté dépassée par le jet">Diff. battue</td>
-                <td style="text-align:center;font-weight:bold;">=
-                    {{#rollLess() diceRollNoDiff 3}}0{{/rollLess() diceRollNoDiff 3}}
-                    {{#rollBetween() diceRollNoDiff 3 5}}1{{/rollBetween() diceRollNoDiff 3 5}}
-                    {{#rollBetween() diceRollNoDiff 6 8}}2{{/rollBetween() diceRollNoDiff 6 8}}
-                    {{#rollBetween() diceRollNoDiff 9 11}}3{{/rollBetween() diceRollNoDiff 9 11}}
-                    {{#rollBetween() diceRollNoDiff 12 14}}4{{/rollBetween() diceRollNoDiff 12 14}}
-                    {{#rollBetween() diceRollNoDiff 15 17}}5{{/rollBetween() diceRollNoDiff 15 17}}
-                    {{#rollBetween() diceRollNoDiff 18 20}}6{{/rollBetween() diceRollNoDiff 18 20}}
-                    {{#rollBetween() diceRollNoDiff 21 23}}7{{/rollBetween() diceRollNoDiff 21 23}}
-                    {{#rollBetween() diceRollNoDiff 24 26}}8{{/rollBetween() diceRollNoDiff 24 26}}
-                    {{#rollBetween() diceRollNoDiff 27 29}}9{{/rollBetween() diceRollNoDiff 27 29}}
-                    {{#rollGreater() diceRollNoDiff 29}}10+{{/rollGreater() diceRollNoDiff 29}}
-                     ({{diceRollNoDiff}})
-                </td>
-            </tr>
-            {{#rollWasFumble() diceRollNoDiff}}
-                <tr><td COLSPAN="2" style="font-size:105%;color:red;text-align:center;font-weight:bold;"> Intrusion du MJ</td></tr>
-            {{/rollWasFumble() diceRollNoDiff}}
-            {{#rollWasCrit() diceRollNoDiff}}
-                <tr><td COLSPAN="2" style="color:green;text-align:center;font-weight:bold;">Jet Spécial (17+)</td></tr>
-            {{/rollWasCrit() diceRollNoDiff}}
+            {{/rollGreater() finalDiff 0}}
         {{/rollTotal() difficulty 0}}
         {{#rollGreater() effortDmg 0}}
             <tr><td COLSPAN="2"><hr/></td></tr>

--- a/Numenera_NathasNumenera_French/ReadMe.md
+++ b/Numenera_NathasNumenera_French/ReadMe.md
@@ -5,7 +5,7 @@ Bas&eacute;e sur la feuille de personnage "Numenera" d&eacute;j&agrave; pr&eacut
 Voir en fin de fichier pour les notes de versions.
 
 # Version courante :
-Version 4.7 (19 Septembre 2015) : [Capture d'&eacute;cran](NathasNumenera_tabs_v4-5.jpg).
+Version 4.8 (10 Octobre 2015) : [Capture d'&eacute;cran](NathasNumenera_tabs_v4-5.jpg).
 
 # Utilisation basique :
 
@@ -50,7 +50,13 @@ Alternative (permettant de modifier les sources &agrave; votre convenance si vou
 
 # Notes de version
 
-##Release 4.7 (19 Septembre 2015)
+##Version 4.8 (10 Octobre 2015)
+Le script API doit &ecirc;tre mis &agrave; jour en version 4.8.
+
+* &Agrave; la demande d'utilisateurs de la FdP, le template de jet basique (non API) a &eacute;t&eacute; unifi&eacute;, en ne lan&ccedil;ant qu'un seul d20 dont le r&eacute;sultat brut est affich&eacute;. Si le param&egrave;tre de difficult&eacute; n'est pas pas renseign&eacute; dans le groupe "Action" (=0), la difficult&eacute; battue n'est plus calcul&eacute;e (du fait de limitations technique de Roll20), mais seulement les niveaux la diminuant ou l'augmentant.
+* Ajout d'un bouton de remise &agrave; z&eacute;ro des param&egrave;tres de jet dans la section "Action"
+
+##Version 4.7 (19 Septembre 2015)
 Notez que le [script API](https://github.com/Roll20/roll20-api-scripts/blob/master/Numenera_Natha/Numenera_Natha.js) doit &ecirc;tre mis &agrave; jour pour utiliser les boutons "rouges" !
 
 Les valeurs par d&eacute;faut sont d&eacute;sormais valu&eacute;es automatiquement par la fiche ou l'API, au besoin, et donc les boutons de jets sont imm&eacute;diatement utilisables apr&egrave;s la cr&eacute;tion du personnage.

--- a/Numenera_NathasNumenera_French/sheet.json
+++ b/Numenera_NathasNumenera_French/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Nathanael TERRIEN",
 	"roll20userid": "75857",
 	"preview": "NathasNumenera_tabs_v4-5.jpg",
-	"instructions": "v4.7 (2015-09-19). Lisez le ficher README.md (https://github.com/Roll20/roll20-character-sheets/blob/master/Numenera_NathasNumenera_French/ReadMe.md) pour mettre en place un pion avec la feuille de personnage, et &eacute;ventuellement ajouter les scripts API accompagnant la fiche de personnage."
+	"instructions": "v4.8 (2015-10-10). Lisez le ficher README.md (https://github.com/Roll20/roll20-character-sheets/blob/master/Numenera_NathasNumenera_French/ReadMe.md) pour mettre en place un pion avec la feuille de personnage, et &eacute;ventuellement ajouter les scripts API accompagnant la fiche de personnage."
 }


### PR DESCRIPTION
By popular demand, the basic (non API) stat/skill roll template has been
unified and only rolls one d20 dice (for the 3D dice users out there),
whatever is the "Difficulty" roll parameter from the "Action" section.
If the difficulty parameter has been set to 0, the beaten difficulty is
no longer calculated (due to Roll20 limitations), but the raw d20 dice
is shown, as the special natural rolls (1 or 17+), and the steps
modifiying the difficulty are displayed (and summed).
New (small) API button to reset Action parameters.