### PR TITLE
#1032 Patch

### DIFF
--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -218,7 +218,7 @@
         <div class="sheet-col sheet-ship-defense"><label>Special Effects</label></div>
         <div class="sheet-col sheet-ship-defense"><label class="sheet-ship-item-halfsize">Broken?</label></div>
       </div>
-      <fieldset class="repeating_weapons repeating repeating-ship-defenses">
+      <fieldset class="repeating_defenses repeating repeating-ship-defenses">
         <div class="sheet-ship-weapons sheet-3colrow">
           <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_name"></div>
           <div class="sheet-col sheet-ship-defense"><input type="text" name="attr_ship_defense_special_effects"></div>
@@ -233,7 +233,7 @@
         <div class="sheet-col sheet-ship-fitting"><label>Special Effects</label></div>
         <div class="sheet-col sheet-ship-fitting"><label class="sheet-ship-item-halfsize">Broken?</label></div>
       </div>
-      <fieldset class="repeating_weapons repeating repeating-ship-fittings">
+      <fieldset class="repeating_fittings repeating repeating-ship-fittings">
         <div class="sheet-ship-weapons sheet-3colrow">
           <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_name"></div>
           <div class="sheet-col sheet-ship-fitting"><input type="text" name="attr_ship_fitting_special_effects"></div>


### PR DESCRIPTION
In response to #1032. 

Quick patch to stop a few repeating fields from having the same name.

Weapons, Defenses, and Fittings were all labeled as "repeating_weapons". Defenses and Fittings were given their own repeating values. After some testing in roll20, the issue seems to be fixed.

