### PR TITLE
Fix spelling of Deity (label only)

### DIFF
--- a/Swords_&_Wizardry/SWSheet.html
+++ b/Swords_&_Wizardry/SWSheet.html
@@ -35,11 +35,11 @@
                     <td><input type=text width=10 name="attr_langs" class="medinput"/></td>
                 </tr>
                 <tr>
-                    <td class="tdlabel">Diety</td>
+                    <td class="tdlabel">Deity</td>
                     <td><input type=text width=10 name="attr_diety" class="medinput"/></td>
                 </tr>
             </table>
-    
+
         <!-- char physical info-->
         <H2>Physical</H2>
         <table>
@@ -56,7 +56,7 @@
                 <td><input type=text width=10 name="attr_weight" class="shortinput"></td>
             </tr>
         </table>
-        
+
         <!-- movement -->
         <H2>Movement</H2>
         <table>
@@ -80,12 +80,12 @@
                 <td class="tdnote"><b>151-300 lbs:</b></td><td class="tdnote">1 sqr</td>
             </tr>
         </table>
-        
+
         </td>
         <!-- column 2 -->
         <td width = 33% valign=top bgcolor="#e9e9e9">
-       
-        
+
+
         <!-- character attributes-->
         <h2>Attributes</h2>
             <tabLe>
@@ -138,9 +138,9 @@
                     <td>&nbsp;</td>
                 </tr>
             </tabLe>
-        
-        
-        
+
+
+
         <!-- defense -->
             <H2>Defense</H2>
             <table>
@@ -170,7 +170,7 @@
                     <td><input type=number name="attr_AC" value=10></td>
                 </tr>
             </table>
-        
+
 
         </td>
         <!-- column 3 -->
@@ -226,10 +226,10 @@
                         <br><b>Hit Roll&nbsp;&nbsp;</b><input type=text width=10 name="attr_wpnhit" class="shortinput" value="1d20">
                         <b>Dmg Roll&nbsp;&nbsp;</b><input type=text width=10 name="attr_wpndmg" class="shortinput" value="1d6">
                     </tr>
-                </fieldset>               
+                </fieldset>
         </td>
     </tr>
-    
+
     <!-- bottom row -->
     <tr>
         <td valign=top>
@@ -283,14 +283,11 @@
                     <td><input type=number class="tinyinput" name="attr_lvl10spells"></td>
                 </tr>
             </table>
-            <b>Spell/Ability Names</b>    
+            <b>Spell/Ability Names</b>
                     <fieldset class="repeating_magic">
                             <input type=checkbox name="attr_magicused">&nbsp;&nbsp;<input type=text name="attr_magicname"></td>
-                    </fieldset>            
+                    </fieldset>
             </table>
         </td>
     </tr>
 </table>
-
-
-


### PR DESCRIPTION
I fixed the spelling of "Deity" but only in the label (did not change the form field's attribute, in other words).  Apparently there was some spurious whitespace in there, too.