### PR TITLE
Update Palladium-Rifts.html

### DIFF
--- a/Palladium-Rifts/Palladium-Rifts.html
+++ b/Palladium-Rifts/Palladium-Rifts.html
@@ -84,11 +84,11 @@
     <h6 class="sheet-SectionHeader">Skills</h6>
     <h5 class="sheet-CharacterOverview">
         IQ Bonus to Skill:
-        <input type="number" style="width:40px;" name="attr_IQ_max" value=0/>
+        <input type="number" style="width:40px;" name="attr_IQmax" value=0/>
         Trust/Intimidate:
-        <input type="number" style="width:40px;" name="attr_MA_max" value=0/>
+        <input type="number" style="width:40px;" name="attr_MAmax" value=0/>
         Charm/Impress:
-        <input type="number" style="width:40px;" name="attr_PB_max" value=0>
+        <input type="number" style="width:40px;" name="attr_PBmax" value=0>
     </h5>
     <table frame="box">
         <tr>
@@ -105,7 +105,7 @@
                 <table style="border: 1px solid grey;">
                     <tr>
                         <fieldset class="repeating_OCCSK">
-                            <input float="left" type="text" style="width:60%;" name="attr_OCCSK"><input float="left" type="number" style="width:13%;" name="attr_OCCSKP" value=0><input float="left" type="number" style="width:13%;" name="attr_OCCSKPL" value = 0><input float="left" type="text" style="width:14%;" name="attr_OCCT" value="@{OCCSKP}+(@{OCCSKPL}*(@{Level}-1))+@{IQ_max}" disabled="true">
+                            <input float="left" type="text" style="width:60%;" name="attr_OCCSK"><input float="left" type="number" style="width:13%;" name="attr_OCCSKP" value=0><input float="left" type="number" style="width:13%;" name="attr_OCCSKPL" value = 0><input float="left" type="text" style="width:14%;" name="attr_OCCT" value="@{OCCSKP}+(@{OCCSKPL}*(@{Level}-1))+@{IQmax}" disabled="true">
                         </fieldset>
                     </tr>
                 </table>
@@ -123,7 +123,7 @@
                 <table style="border: 1px solid grey;">
                     <tr>
                         <fieldset class="repeating_OCRCSK">
-                            <input float="left" type="text" style="width:60%;" name="attr_OCRCSK"><input float="left" type="number" style="width:13%;" name="attr_OCRCSKP" value=0><input float="left" type="number" style="width:13%;" name="attr_OCRCSKPL" value = 0><input float="left" type="text" style="width:14%;" name="attr_OCRCT" value="@{OCRCSKP}+(@{OCRCSKPL}*(@{Level}-1))+@{IQ_max}" disabled="true">
+                            <input float="left" type="text" style="width:60%;" name="attr_OCRCSK"><input float="left" type="number" style="width:13%;" name="attr_OCRCSKP" value=0><input float="left" type="number" style="width:13%;" name="attr_OCRCSKPL" value = 0><input float="left" type="text" style="width:14%;" name="attr_OCRCT" value="@{OCRCSKP}+(@{OCRCSKPL}*(@{Level}-1))+@{IQmax}" disabled="true">
                         </fieldset>
                     </tr>
                 </table>
@@ -141,7 +141,7 @@
                 <table style="border: 1px solid grey;">
                     <tr>
                         <fieldset class="repeating_SECSK">
-                            <input float="left" type="text" style="width:60%;" name="attr_SECSK"><input float="left" type="number" style="width:13%;" name="attr_SECSKp" value=0><input float="left" type="number" style="width:13%;" name="attr_SECSKpl" value = 0><input float="left" type="text" style="width:14%;" name="attr_SECT" value="@{SECSKp}+(@{SECSKpl}*(@{Level}-1))+@{IQ_max}" disabled="true">
+                            <input float="left" type="text" style="width:60%;" name="attr_SECSK"><input float="left" type="number" style="width:13%;" name="attr_SECSKp" value=0><input float="left" type="number" style="width:13%;" name="attr_SECSKpl" value = 0><input float="left" type="text" style="width:14%;" name="attr_SECT" value="@{SECSKp}+(@{SECSKpl}*(@{Level}-1))+@{IQmax}" disabled="true">
                         </fieldset>
                     </tr>
                 </table>


### PR DESCRIPTION
Changed name of "attr_IQ_max" to  "attr_IQmax". Applied similar changes for MA, and PB

Justification for changing the attribute name:
Some bug in the formula replacement component of Roll20 doesn't evaluate the version with an underscore. These values are trivial to lookup in Palladium (a standard, long standing, table is used); and getting it working saves a lot of effort maintaining a character as it levels up.