### PR TITLE
SWN: Fixed "Always readied" gear

### DIFF
--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -1031,7 +1031,7 @@
         <fieldset class="repeating_gear">
           <div class="sheet-3colrow">
             <div class="sheet-col sheet-gear-name"><input type="text" name="attr_gear_name"></div>
-            <div class="sheet-col sheet-gear-readied"><input type="checkbox" name="attr_gear_readied" value="0"></div>
+            <div class="sheet-col sheet-gear-readied"><input type="checkbox" name="attr_gear_readied" value="1"></div>
             <div class="sheet-col sheet-gear-encumbrance"><input type="number" min="0" name="attr_gear_encumbrance"></div>
           </div>
         </fieldset>


### PR DESCRIPTION
Fixed checkboxes in the gear section with value set to 0 causing roll20 to always set them as checked after they were checked once.