### PR TITLE
 fix for unicode symbol ± not being display correctly

### DIFF
--- a/fate_core_with_rolls/fate_core_with_rolls.html
+++ b/fate_core_with_rolls/fate_core_with_rolls.html
@@ -42,7 +42,7 @@
 <div class="sheet-section-skills sheet-section">
 	<div class="sheet-header">Skills</div>
   <button type='roll' class="sheet-roll_4df" name='roll_4dF' value='/roll 4dF' title="Roll 4dF+Skill only"></button> 4dF &nbsp;&nbsp;&nbsp;
-  <button type='roll' class="sheet-roll_4dfm" name='roll_4dFModifiers' value='/roll 4dF + ?{Modifier?|0} ± Modifier' title="Roll 4dF+Modifiers"></button> 4dF± &nbsp;&nbsp;&nbsp;
+  <button type='roll' class="sheet-roll_4dfm" name='roll_4dFModifiers' value='/roll 4dF + ?{Modifier?|0} ± Modifier' title="Roll 4dF+Modifiers"></button> 4dF&plusmn; &nbsp;&nbsp;&nbsp;
 <input type="radio" class="sheet-roll_method_1" name="attr_roll_method" value="1" title="Roll 4dF+Skill only" checked="checked" /><span>&nbsp;Roll 4dF+Skill only</span>
   &nbsp;&nbsp;&nbsp;
   <input type="radio" class="sheet-roll_method_2" name="attr_roll_method" value="2" title="Roll 4dF+Skill+Modifiers" /><span>&nbsp;Roll 4dF+Skill+Modifiers</span>

--- a/fate_core_with_rolls_VF/fate_core_vf.html
+++ b/fate_core_with_rolls_VF/fate_core_vf.html
@@ -42,7 +42,7 @@
 <div class="sheet-section-skills sheet-section">
 	<div class="sheet-header">Comp&eacute;tences</div>
   <button type='roll' class="sheet-roll_4df" name='roll_4dF' value='/roll 4dF' title="Roll 4dF+Skill only"></button> 4dF &nbsp;&nbsp;&nbsp;
-  <button type='roll' class="sheet-roll_4dfm" name='roll_4dFModifiers' value='/roll 4dF + ?{Modifier?|0} ± Modifier' title="Roll 4dF+Modifiers"></button> 4dF± &nbsp;&nbsp;&nbsp;
+  <button type='roll' class="sheet-roll_4dfm" name='roll_4dFModifiers' value='/roll 4dF + ?{Modifier?|0} ± Modifier' title="Roll 4dF+Modifiers"></button> 4dF&plusmn; &nbsp;&nbsp;&nbsp;
 <input type="radio" class="sheet-roll_method_1" name="attr_roll_method" value="1" title="Roll 4dF+Skill only" checked="checked" /><span>&nbsp;Roll 4dF+Comp&eacute;tences</span>
   &nbsp;&nbsp;&nbsp;
   <input type="radio" class="sheet-roll_method_2" name="attr_roll_method" value="2" title="Roll 4dF+Skill+Modifiers" /><span>&nbsp;Roll 4dF+Comp&eacute;tences+Modificateurs</span>


### PR DESCRIPTION
fix for unicode symbol ± not being display correctly on Fate Core Character sheet with roll in english and in French