### PR TITLE
Pathfinder - Neceros v19

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.css
+++ b/Pathfinder-Neceros/pathfinder-neceros.css
@@ -1,4 +1,5 @@
 .sheet-desc-show:not(:checked)~.sheet-desc,
+.sheet-repeating_ids-show:not(:checked)~.sheet-repeating_ids,
 .sheet-macro-text-show:not(:checked)~.sheet-macro-text,
 .sheet-sect-show:not(:checked)~.sheet-sect,
 .sheet-options-show:not(:checked)~.sheet-options,
@@ -182,17 +183,10 @@ input[type="text"], input[type="number"] {
 	border-bottom-width: 1px;
 }
 
-
-
-
 span.sheet-table-data.sheet-center, span.sheet-table-data {
 	padding-left:1px;
 	padding-right:1px;
 }
-
-
-
-
 
 span.sheet-table-data.sheet-center input.sheet-calc,
 span.sheet-table-data input.sheet-calc ,
@@ -202,12 +196,8 @@ span.sheet-table-data  input[readonly],
 	margin-top:1px;
 	margin-bottom:1px;
 }
-			
 
-	
 /* color for disabled/sheet-calc */
-
-
 
 .sheet-calc, input[readonly] ,
 input[type="text"].sheet-calc, input[type="number"].sheet-calc,
@@ -222,25 +212,10 @@ input.sheet-calc, textarea.sheet-calc {
 	min-width:2.5em;
 }
 
-
-
-
-
-
-
-
-
-
-
-/* hide spinner in FF except on hover (emulate chrome)*/
- /*
-.charsheet input[type="number"]:hover,
-.charsheet input[type="number"]:focus {
-   -moz-appearance: number-input;
-}*/
 .charsheet input[type="number"]{
 	-moz-appearance: textfield;
 }
+
 /* hide spinner for all disabled/sheet-calc */
 .charsheet input.sheet-calc[type="number"]:hover,
 .charsheet input.sheet-calc[type="number"]:focus,
@@ -488,6 +463,7 @@ hr {
 textarea {
 	box-sizing: border-box;
 	height:100px;
+	resize:vertical;
 }
 .sheet-spellrange-header {
 	width: 15%;
@@ -524,13 +500,13 @@ textarea {
 	height: 25px;
 	overflow: hidden;
 	margin: 0;
+	resize:vertical;
 }
 .charsheet .sheet-weapon-notes {
-    max-height: 2.15em;
+    height: 2.15em;
     overflow: hidden;
-    white-space: nowrap;
-    resize: none;
     margin: 0;
+	resize:vertical;
 }
 .charsheet .repcontainer .repitem {
 	padding: 5px !important;

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -2191,8 +2191,7 @@
 		<div class="sheet-sect">
 			<div class="sheet-repeating-fields">
 				<fieldset class="repeating_weapon">
-
-						<input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_attack-show" title="@{repeating_weapon_$X_attack-show}" value="1" style="opacity:0 ; height:1.5em ; position: absolute ; top:20px; width:3% ; cursor:pointer ; z-index:1" checked="checked" />
+					<input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_attack-show" title="@{repeating_weapon_$X_attack-show}" value="1" style="opacity:0 ; height:1.5em ; position: absolute ; top:20px; width:2% ; cursor:pointer ; z-index:1" checked="checked" />
 					<span class="sheet-table-data sheet-divider"></span>
 						<span class="sheet-table-data sheet-center"><button type="roll" name="attr_attack-roll" title="%{selected|repeating_weapon_$X_attack-roll}" value="@{macro-text}"></button></span>
 						<span class="sheet-table-data sheet-center sheet-small-label"><input type="number"  name="attr_enhance" title="@{repeating_weapon_$X_enhance}" value="0" style="width:40px;"  /><br>Enh</span>
@@ -2221,8 +2220,8 @@
 						<span class="sheet-table-data sheet-center sheet-small-label"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_$X_crit-multiplier}" style="width:40px;" value="2" min="0" /><br>Mult</span>
 						<span class="sheet-table-data sheet-center sheet-small-label">
 							<select title="@{repeating_weapon_$X_proficiency}" name="attr_proficiency">
-								<option value="0"  >Yes</option>
-								<option value="-4" selected>&#8226;No</option>
+							<option value="0" selected>&#8226;Yes</option>
+							<option value="-4">No</option>
 							</select>
 							<br>Proficiency
 						</span>
@@ -2282,7 +2281,8 @@
 						</div>
 						<div class="sheet-table">
 							<div class="sheet-table-row">
-								<span class="sheet-table-data sheet-center sheet-small-label" style="width:50%;" ><textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea><br>Notes</span>
+								<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes" style="margin-top: 0px; margin-bottom: 0px; height: 28px;"></textarea>
+								<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
 							</div>
 						</div>
 							<b title="Add additional attacks for this weapon.">Iterative Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
@@ -2487,7 +2487,7 @@
 							<span class="sheet-table-name">Adventure Skills</span>
 							<div class="sheet-table-row">
 								<span class="sheet-table-header"></span>
-								<span class="sheet-table-header">CS</span>
+								<span class="sheet-table-header" title="Class Skill" >CS</span>
 								<span class="sheet-table-header" style="width: 180px;">Skill</span>
 								<span class="sheet-table-header">Total</span>
 								<span class="sheet-table-header"></span>
@@ -3389,7 +3389,7 @@
 							
 							
 						</div>
-						<div class="sheet-table sheet-center sheet-sect">CS = Class Skill | RT = Requires Training | Cl/Ac/Sz/Co = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
+						<div class="sheet-table sheet-center sheet-sect"><b>CS</b> = Class Skill | <b>RT</b> = Requires Training | <b>Cl/Ac/Sz/Co</b> = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
 						<br>
 					</div>
 					
@@ -3398,7 +3398,7 @@
 							<span class="sheet-table-name">Background Skills</span>
 							<div class="sheet-table-row">
 								<span class="sheet-table-header"></span>
-								<span class="sheet-table-header">CS</span>
+								<span class="sheet-table-header" title="Class Skill" >CS</span>
 								<span class="sheet-table-header" style="width: 180px;">Skill</span>
 								<span class="sheet-table-header">Total</span>
 								<span class="sheet-table-header"></span>
@@ -4130,7 +4130,7 @@
 
 
 						</div>
-						<div class="sheet-table sheet-center sheet-sect">CS = Class Skill | RT = Requires Training | Cl/Ac/Sz/Co = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
+						<div class="sheet-table sheet-center sheet-sect"><b>CS</b> = Class Skill | <b>RT</b> = Requires Training | <b>Cl/Ac/Sz/Co</b> = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
 						<br>
 					</div>
 					
@@ -4140,7 +4140,7 @@
 							<span class="sheet-table-name">Consolidated Skills</span>
 							<div class="sheet-table-row">
 								<span class="sheet-table-header"></span>
-								<span class="sheet-table-header">CS</span>
+								<span class="sheet-table-header" title="Class Skill" >CS</span>
 								<span class="sheet-table-header" style="width: 180px;">Skill</span>
 								<span class="sheet-table-header">Total</span>
 								<span class="sheet-table-header"></span>
@@ -4555,7 +4555,7 @@
 								<span class="sheet-table-data sheet-center"><textarea class="sheet-skill-macro-text" title="@{CS-Survival-macro}" name="attr_CS-Survival-macro">@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}}  {{subtitle}} {{name=Survival}} {{Check=[[ 1d20 + [[ @{CS-Survival} ]] ]]}}</textarea></span>
 							</div>
 						</div>
-						<div class="sheet-table sheet-center sheet-sect">CS = Class Skill | RT = Requires Training | Cl/Ac/Sz/Co = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
+						<div class="sheet-table sheet-center sheet-sect"><b>CS</b> = Class Skill | <b>RT</b> = Requires Training | <b>Cl/Ac/Sz/Co</b> = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
 						<br>
 					</div>
 				
@@ -4570,7 +4570,7 @@
                     <span class="sheet-table-name">Skills</span>
                     <div class="sheet-table-row">
                         <span class="sheet-table-header"></span>
-                        <span class="sheet-table-header">CS</span>
+                        <span class="sheet-table-header" title="Class Skill" >CS</span>
                         <span class="sheet-table-header" style="width: 180px;">Skill</span>
                         <span class="sheet-table-header">Total</span>
                         <span class="sheet-table-header"></span>
@@ -6169,7 +6169,7 @@
                     </div>
 
                 </div>
-		<div class="sheet-table sheet-center sheet-sect">CS = Class Skill | RT = Requires Training | Cl/Ac/Sz/Co = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
+		<div class="sheet-table sheet-center sheet-sect"><b>CS</b> = Class Skill | <b>RT</b> = Requires Training | <b>Cl/Ac/Sz/Co</b> = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
 		<br>		
 	</div>
     <div><b>Skill Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
@@ -8571,7 +8571,7 @@
                 <div class="sheet-sect">
                     <div class="sheet-repeating-fields">
                         <fieldset class="repeating_weapon">
-                            <input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_attack-show" title="@{repeating_weapon_$X_attack-show}" value="1" style="opacity:0 ; height:1.5em ; position: absolute ; top:20px; width:3% ; cursor:pointer ; z-index:1" checked="checked" />
+                            <input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_attack-show" title="@{repeating_weapon_$X_attack-show}" value="1" style="opacity:0 ; height:1.5em ; position: absolute ; top:20px; width:2% ; cursor:pointer ; z-index:1" checked="checked" />
                             <span class="sheet-table-data sheet-divider"></span>
                             <span class="sheet-table-data sheet-center"><button type="roll" name="attr_attack-npc-roll" title="@{repeating_weapon_$X_attack-npc-roll" value="@{macro-text}"></button></span>
 							<span class="sheet-table-data sheet-center sheet-small-label"><input type="number"  name="attr_enhance" title="@{repeating_weapon_$X_enhance}" value="0" style="width:40px;"  /><br>Enh</span>
@@ -8599,17 +8599,17 @@
 							<span class="sheet-table-data sheet-center sheet-small-label"><input type="number" name="attr_crit-multiplier" title="@{repeating_weapon_$X_crit-multiplier}" style="width:40px;" value="2" min="0" /><br>Mult</span>
 							<span class="sheet-table-data sheet-center sheet-small-label">
 								<select title="@{repeating_weapon_$X_proficiency}" name="attr_proficiency">
-									<option value="0" >Yes</option>
-									<option value="-4" selected>&#8226;No</option>
+									<option value="0" selected>&#8226;Yes</option>
+									<option value="-4" >No</option>
 								</select>
 								<br>Proficiency
 							</span>
                             <div class="sheet-sect">
                                 <div class="sheet-table">
                                     <div class="sheet-table-row">
-								<span class="sheet-table-data sheet-center sheet-small-label"><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_$X_damage-dice-num}" style="width:40px;" value="0" min="0" /><br>Dice</span>
-                                        <span class="sheet-table-data sheet-divider-lg" style="padding-bottom:10px;">d</span>
-								<span class="sheet-table-data sheet-center sheet-small-label"><input type="number" name="attr_damage-die" title="@{repeating_weapon_$X_damage-die}" style="width:40px;" value="0" min="0" /><br>Die</span>
+										<span class="sheet-table-data sheet-center sheet-small-label" ><input type="number" name="attr_damage-dice-num" title="@{repeating_weapon_$X_damage-dice-num}"  style="width:2.8em;" value="0" min="0" /><br>Dice</span>
+										<span class="sheet-table-data sheet-divider" style="padding-bottom: 10px;">d</span>
+										<span class="sheet-table-data sheet-center sheet-small-label" style="width:3em;" ><input type="number" name="attr_damage-die" title="@{repeating_weapon_$X_damage-die}" style="width:2.8em;" value="0" min="0" /><br>Die</span>
 										<span class="sheet-table-data sheet-divider">+</span>
 										<span class="sheet-table-data sheet-center sheet-small-label sheet-entry_med" ><input type="text" name="attr_damage" title="@{repeating_weapon_$X_damage}" placeholder="Damage Modifiers" /><br>DMG Mods</span>
 										<span class="sheet-table-data sheet-center sheet-small-label"  ><input type="number" name="attr_damage-mod" title="@{repeating_weapon_$X_damage-mod}" value="0" style="width:2.4em;" class="sheet-calc" readonly="readonly" /><br>val</span>
@@ -8660,7 +8660,8 @@
 								</div>
 								<div class="sheet-table">
 									<div class="sheet-table-row">
-										<span class="sheet-table-data sheet-center sheet-small-label" style="width:50%;" ><textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea><br>Notes</span>
+										<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes" style="margin-top: 0px; margin-bottom: 0px; height: 28px;"></textarea>
+										<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
 									</div>
 								</div>
 							</div>
@@ -9654,7 +9655,7 @@
 					<span class="sheet-table-data" style="vertical-align:top;"><button type="roll" value="@{pf_spell_example}" name="roll_pf_spell_example" title="Display pf_spell example"></button>
 					<b>Spell Roll Template </b>(pf_spell)<br>Used for all spell-based sheet rolls. Primarily formatted to emulate a typical spell stat-block. (<b>note:</b> @{spell_options} is used by the sheet to enable the toggling of spell attributes and contains ALL pf_spell specific properties.)
 					</span><br>
-					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_spell_example" title="pf_spell macro">@{PC-whisper} &{templatepf_spell} {{header_image=@{header_image-pf_spell}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{school=school}} {{level=level}} {{casting_time=casting time}} {{components=components}} {{range=range}} {{targets=targets}} {{duration=duration}} {{saving_throw=saving throw}} {{dc= 10}} {{dc1}} {{dc2}} {{sr=sr}} {{attack=[[1d20cs>10]]}} {{crit_confirm=[[1d20]]}} {{damage=[[1d6]]}} {{crit_damage=[[1d6]]}} {{attack2=[[1d20cs>10]]}} {{crit_confirm2=[[1d20]]}} {{damage2=[[1d6]]}} {{crit_damage2=[[1d6]]}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
+					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_spell_example" title="pf_spell macro">@{PC-whisper} &{template:pf_spell} {{header_image=@{header_image-pf_spell}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{school=school}} {{level=level}} {{casting_time=casting time}} {{components=components}} {{range=range}} {{targets=targets}} {{duration=duration}} {{saving_throw=saving throw}} {{dc= 10}} {{dc1}} {{dc2}} {{sr=sr}} {{attack=[[1d20cs>10]]}} {{crit_confirm=[[1d20]]}} {{damage=[[1d6]]}} {{crit_damage=[[1d6]]}} {{attack2=[[1d20cs>10]]}} {{crit_confirm2=[[1d20]]}} {{damage2=[[1d6]]}} {{crit_damage2=[[1d6]]}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
 					</span>
 
 				</span>
@@ -9665,7 +9666,7 @@
 					<span class="sheet-table-data" style="vertical-align:top;"><button type="roll" value="@{pf_attack_example}" name="roll_pf_attack_example" title="Display pf_attack example"></button>
 					<b>Attack Roll Template </b>(pf_attack)<br>Used for attacks. 2 column format except for the "description" property. (<b>note:</b> @{macro_options} is used by the sheet to enable the toggling of notes related to attacks and contains the properties for @{melee_notes}, @{ranged_notes}, @{cmb_notes}, and @{attack_notes}.)
 					</span><br>
-					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_attack_example" title="pf_attack macro">@{PC-whisper} &{templatepf_attack} {{header_image=@{header_image-pf_attack-melee} @{header_image-pf_attack-ranged} @{header_image-pf_attack-cmb}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{attack=[[1d20cs>10]]}} {{crit_confirm=[[1d20]]}} {{damage=[[1d6]]}} {{crit_damage=[[1d6]]}} {{attack(2-8)}} {{crit_confirm(2-8)}} {{damage(2-8)}} {{crit_damage(2-8)}} {{melee_notes=melee notes}} {{ranged_notes=ranged notes}} {{CMB_notes=cmb notes}} {{attack_notes=attack notes}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
+					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_attack_example" title="pf_attack macro">@{PC-whisper} &{template:pf_attack} {{header_image=@{header_image-pf_attack-melee} @{header_image-pf_attack-ranged} @{header_image-pf_attack-cmb}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{attack=[[1d20cs>10]]}} {{crit_confirm=[[1d20]]}} {{damage=[[1d6]]}} {{crit_damage=[[1d6]]}} {{attack(2-8)}} {{crit_confirm(2-8)}} {{damage(2-8)}} {{crit_damage(2-8)}} {{melee_notes=melee notes}} {{ranged_notes=ranged notes}} {{CMB_notes=cmb notes}} {{attack_notes=attack notes}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
 					</span>
 
 				</span>
@@ -9676,7 +9677,7 @@
 					<span class="sheet-table-data" style="vertical-align:top;"><button type="roll" value="@{pf_defense_example}" name="roll_pf_defense_example" title="Display pf_defense example"></button>
 					<b>Defense Roll Template </b>(pf_defense)<br>Used for Saving Throws. (<b>note:</b> @{macro_options} is used by the sheet to enable the toggling of notes related to defense and contains the properties for @{dr_notes}, @{resistances_notes}, @{immunities_notes}, @{weaknesses_notes}, @{sr_notes}, @{armor_notes}, @{save_notes}, @{cmd_notes}, and @{defense-notes}.)
 					</span><br>					
-					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_defense_example" title="pf_defense macro">@{PC-whisper} &{templatepf_defense} {{header_image=@{header_image-pf_defense}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{dr_notes}} {{resistances_notes}} {{immunities_notes}} {{weaknesses_notes}} {{sr_notes}} {{armor_notes}} {{save_notes}} {{cmd_notes}} {{defense_notes}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
+					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_defense_example" title="pf_defense macro">@{PC-whisper} &{template:pf_defense} {{header_image=@{header_image-pf_defense}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{dr_notes}} {{resistances_notes}} {{immunities_notes}} {{weaknesses_notes}} {{sr_notes}} {{armor_notes}} {{save_notes}} {{cmd_notes}} {{defense_notes}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
 					</span>
 				</span>
 			</div>
@@ -9686,7 +9687,7 @@
 					<span class="sheet-table-data" style="vertical-align:top;"><button type="roll" value="@{pf_generic_example}" name="roll_pf_generic_example" title="Display pf_generic example"></button>
 					<b>Generic Roll Template </b>(pf_generic)<br>Used for Ability checks, Initiative, Spell Failure Check, Skill Checks, Concentration Check, Caster Level Check. 2 column format, except for righttext_X(1-10), lefttext_X(1-10), and the description keys.
 					</span><br>					
-					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_generic_example" title="pf_generic macro">@{PC-whisper} &{templatepf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{check=[[1d20]]}} {{righttext_1=right aligned text}} {{lefttext_1=left aligned text}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
+					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_generic_example" title="pf_generic macro">@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{check=[[1d20]]}} {{righttext_1=right aligned text}} {{lefttext_1=left aligned text}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}} {{foo=foo}}</textarea><br>
 					</span>
 				</span>
 			</div>
@@ -9696,7 +9697,7 @@
 					<span class="sheet-table-data" style="vertical-align:top;"><button type="roll" value="@{pf_block_example}" name="roll_pf_block_example" title="Display pf_block example"></button>
 					<b>Block Text Roll Template </b>(pf_block)<br>Used for Class Abilities, Feats, Inventory, Racial Traits, Traits. Key/Property names are not shown in this template. Best for long blocks of text.
 					</span><br>					
-					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_block_example" title="pf_block macro">@{PC-whisper} &{templatepf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}}</textarea><br>
+					<span class="sheet-table-data" style="width:50%;"><textarea name="attr_pf_block_example" title="pf_block macro">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=name of roll}} {{name_link=www.url.com}} {{subtitle=subtitle}} {{=just some text}} {{description=descriptive text will span both columns and wrap as needed.}}</textarea><br>
 					</span>
 				</span>
 			</div>
@@ -9729,7 +9730,7 @@
 <div class="sheet-footer">
 	<div class="sheet-table">
 		<div class="sheet-table-row">
-			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.12.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
+			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.13.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
 		</div>
 		<div class="sheet-table-row">
 			<span class="sheet-table-data sheet-center">Have questions or feedback?  This thread can help:<input type="text" style="width:50%; border:none;" value="https://app.roll20.net/forum/post/2788628/pf-pathfinder-sheet-thread-5" /></span>


### PR DESCRIPTION
- weapon proficiency set to "yes" by default
- weapon notes set to a resizable field to accommodate longer text
entries
- set large macro-text fields to resize:vertical to help keep sheet
alignment
- added title text for CS (class skills) and bolded keys at the bottom
of skills
- roll template examples in Config tab were missing " : "