### PR TITLE
Pathfinder v19

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -703,61 +703,61 @@
 						<span class="sheet-table-data sheet-buff-toggle" ><input  title="@{buff8_Toggle}" type="checkbox" name="attr_buff8_Toggle" value="1"> <b>8.</b></span>
 						<span class="sheet-table-data sheet-entry_med"><input class="sheet-entry_med" title="@{buff8_Name}" name="attr_buff8_Name" type="text" value="" placeholder="Buff 1" ></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_Melee}" name="attr_buff8_Melee" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Melee}" name="attr_buff8_Melee"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>				
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_Ranged}" name="attr_buff8_Ranged" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Ranged}" name="attr_buff8_Ranged"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_DMG}" name="attr_buff8_DMG" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_DMG}" name="attr_buff8_DMG"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>	
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_AC}" name="attr_buff8_AC" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Touch}" name="attr_buff8_Touch" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_CMD}" name="attr_buff8_CMD" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_AC}" name="attr_buff8_AC"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Touch}" name="attr_buff8_Touch"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_CMD}" name="attr_buff8_CMD"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_HP-temp}" name="attr_buff8_HP-temp" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_HP-temp}" name="attr_buff8_HP-temp"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_Fort}" name="attr_buff8_Fort" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_Ref}" name="attr_buff8_Ref" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_Will}" name="attr_buff8_Will" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Fort}" name="attr_buff8_Fort"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Ref}" name="attr_buff8_Ref"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Will}" name="attr_buff8_Will"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
 						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_Check}" name="attr_buff8_Check"  value="" /></span>
 						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_CasterLevel}" name="attr_buff8_CasterLevel"  value="" /></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_STR}" name="attr_buff8_STR" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_DEX}" name="attr_buff8_DEX" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_CON}" name="attr_buff8_CON" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_INT}" name="attr_buff8_INT" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_WIS}" name="attr_buff8_WIS" min="0"  value="0" /></span>
-						<span class="sheet-table-data sheet-buff-cell"><input type="number" class="sheet-calc" readonly="readonly" title="@{buff8_CHA}" name="attr_buff8_CHA" min="0"  value="0" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_STR}" name="attr_buff8_STR" min="0"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_DEX}" name="attr_buff8_DEX" min="0"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_CON}" name="attr_buff8_CON" min="0"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_INT}" name="attr_buff8_INT" min="0"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_WIS}" name="attr_buff8_WIS" min="0"  value="" /></span>
+						<span class="sheet-table-data sheet-buff-cell"><input class="sheet-calc" readonly="readonly" type="number" title="@{buff8_CHA}" name="attr_buff8_CHA" min="0"  value="" /></span>
 					</div>				
 					<div class="sheet-buff-row">
 						<span class="sheet-table-data sheet-buff-toggle"></span>
 						<span class="sheet-table-data sheet-entry_med"><textarea class="sheet-entry_med sheet-skill-macro-text" title="@{buff8-notes}" name="attr_buff8-notes" placeholder="Notes" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Melee_macro-text}" name="attr_buff8_Melee_macro-text"  >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Melee_macro-text}" name="attr_buff8_Melee_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>				
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Ranged_macro-text}" name="attr_buff8_Ranged_macro-text"  >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Ranged_macro-text}" name="attr_buff8_Ranged_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_DMG_macro-text}" name="attr_buff8_DMG_macro-text" >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_DMG_macro-text}" name="attr_buff8_DMG_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>	
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_AC_macro-text}" name="attr_buff8_AC_macro-text" >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_AC_macro-text}" name="attr_buff8_AC_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Touch_macro-text}" name="attr_buff8_Touch_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CMD_macro-text}" name="attr_buff8_CMD_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_HP-temp_macro-text}" name="attr_buff8_HP-temp_macro-text" >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_HP-temp_macro-text}" name="attr_buff8_HP-temp_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Fort_macro-text}" name="attr_buff8_Fort_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Ref_macro-text}" name="attr_buff8_Ref_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Will_macro-text}" name="attr_buff8_Will_macro-text" >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Fort_macro-text}" name="attr_buff8_Fort_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Ref_macro-text}" name="attr_buff8_Ref_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Will_macro-text}" name="attr_buff8_Will_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
 						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_Check_macro-text}" name="attr_buff8_Check_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CasterLevel_macro-text}" name="attr_buff8_CasterLevel_macro-text"  Placeholder="0" ></textarea></span>
 						<span class="sheet-table-data sheet-center sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_STR_macro-text}" name="attr_buff8_STR_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_DEX_macro-text}" name="attr_buff8_DEX_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CON_macro-text}" name="attr_buff8_CON_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_INT_macro-text}" name="attr_buff8_INT_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_WIS_macro-text}" name="attr_buff8_WIS_macro-text" >0</textarea></span>
-						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CHA_macro-text}" name="attr_buff8_CHA_macro-text" >0</textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_STR_macro-text}" name="attr_buff8_STR_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_DEX_macro-text}" name="attr_buff8_DEX_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CON_macro-text}" name="attr_buff8_CON_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_INT_macro-text}" name="attr_buff8_INT_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_WIS_macro-text}" name="attr_buff8_WIS_macro-text"  Placeholder="0" ></textarea></span>
+						<span class="sheet-table-data sheet-buff-cell"><textarea class="sheet-skill-macro-text" title="@{buff8_CHA_macro-text}" name="attr_buff8_CHA_macro-text"  Placeholder="0" ></textarea></span>
 					</div>								
 					<div class="sheet-buff-row">
 						<span class="sheet-table-data sheet-buff-toggle" ><input  title="@{buff9_Toggle}" type="checkbox" name="attr_buff9_Toggle" value="1"> <b>9.</b></span>
@@ -977,7 +977,7 @@
 				<span class="sheet-table-header"></span>
 				<span class="sheet-table-header">Buffs</span>
 				<span class="sheet-table-header">&nbsp;</span>
-                <span class="sheet-table-header">Non-lethal Dmg</span>
+                <span class="sheet-table-header">Nonlethal Dmg</span>
             </div>
             <div class="sheet-table-row" style="line-height:.1em;">
                 <span class="sheet-table-data sheet-center"><input type="number" style="width:100%;" style="width:100%;" title="@{HP}" name="attr_HP" value="0" /></span>
@@ -989,7 +989,7 @@
 						<option value="0" >None</option>
 						<option value="@{STR-mod}">STR</option>
 						<option value="@{DEX-mod}">DEX</option>
-						<option value="@{CON-mod}" selected>CON</option>
+						<option value="@{CON-mod}" selected>&#8226;CON</option>
 						<option value="@{INT-mod}">INT</option>
 						<option value="@{WIS-mod}">WIS</option>
 						<option value="@{CHA-mod}">CHA</option>
@@ -1048,6 +1048,7 @@
 							<span class="sheet-table-data sheet-divider">=</span>
 							<span class="sheet-table-data sheet-center">
 							<select title="@{init-ability}" name="attr_init-ability" class="sheet-select-small">
+								<option value="0" >None</option>
                                 <option value="@{STR-mod}">STR</option>
                                 <option value="@{DEX-mod}" selected>&#8226;DEX</option>
                                 <option value="@{CON-mod}">CON</option>
@@ -1253,8 +1254,8 @@
 				<span class="sheet-table-header" style="width:3%;"></span>
                 <span class="sheet-table-header" style="width:8%;">Class #</span>
                 <span class="sheet-table-header" style="width:8%;">Class</span>
-                <span class="sheet-table-header" style="width:15%;">Name</span>
-                <span class="sheet-table-header" style="width:32%;">Short Description</span>
+                <span class="sheet-table-header" style="width:14%;">Name</span>
+                <span class="sheet-table-header" style="width:30%;">Short Description</span>
                 <span class="sheet-table-header" style="width:5%; text-align:right;">Uses</span>
                 <span class="sheet-table-header sheet-divider-lg" style="width:2%;">/</span>
                 <span class="sheet-table-header" style="width:5%; text-align:left;">Max</span>
@@ -1267,10 +1268,9 @@
 					<input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_class-show" title="@{repeating_class-ability_$X_class-show}" value="1" style="opacity: 0 ; height: 1.5em ; position: absolute; top: 10px; width: 2% ; cursor: pointer ; z-index: 1" checked="checked" />
 					<span class="sheet-table-data sheet-divider"></span>				
 					<span class="sheet-table-data sheet-center" style="width:4%;"><button type="roll" name="attr_roll" title="%{selected|repeating_class-ability_$X_roll}" value="@{macro-text}"></button></span>
-					<span class="sheet-table-data sheet-center" style="width:3em;">
-						<select title="@{repeating_class-ability_$X_class-number}" name="attr_class-number">
-							<option value="" selected>&#8226;Select Class</option>
-							<option value="@{class-0-name}">0</option>
+					<span class="sheet-table-data sheet-center" style="8%">
+						<select title="@{repeating_class-ability_$X_class-number}" name="attr_class-number" style="min-width:3.5em;">
+							<option value="@{class-0-name}" selected>0</option>
 							<option value="@{class-1-name}">1</option>
 							<option value="@{class-2-name}">2</option>
 							<option value="@{class-3-name}">3</option>
@@ -2202,8 +2202,8 @@
 						<span class="sheet-table-data sheet-divider">+</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
 							<select title="@{repeating_weapon_$X_attack-type}" name="attr_attack-type">
-								<option value="0" selected>&#8226;None</option>
-								<option value="@{attk-melee}">Melee</option>
+							<option value="0">None</option>
+							<option value="@{attk-melee}" selected>&#8226;Melee</option>
 								<option value="@{attk-ranged}">Ranged</option>
 								<option value="@{CMB}">CMB</option>
 							</select>
@@ -2237,14 +2237,14 @@
 								<span class="sheet-table-data sheet-divider">+</span>
 								<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
 									<select title="@{repeating_weapon_$X_damage-ability}" name="attr_damage-ability" style="font-size:1em;">
-										<option value="0 - [[ @{condition-sickened} ]]" selected>&#8226;None</option>
+										<option value="0 - [[ @{condition-sickened} ]]">None</option>
 										<option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
 										<option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
 										<option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
 										<option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
 										<option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
 										<option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
-										<option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
+										<option value="@{STR-mod} - [[ @{condition-sickened} ]]" selected>&#8226;STR</option>
 										<option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
 										<option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
 										<option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
@@ -2265,7 +2265,7 @@
 									</select>
 									<br>DMG Ability
 								</span>
-    							<span class="sheet-table-data sheet-center sheet-small-label" style="width:2em;" ><input style="width:2em;" type="text" name="attr_damage-ability-max" title="@{repeating_weapon_$X_attr_damage-ability-max} for strength bows, etc." value="" Placeholder="NA" /><br/>Max</span>
+    							<span class="sheet-table-data sheet-center sheet-small-label" style="width:2em;" ><input style="width:2em;" type="text" name="attr_damage-ability-max" title="@{repeating_weapon_$X_damage-ability-max} for strength bows, etc." value="" Placeholder="NA" /><br/>Max</span>
     							<span class="sheet-table-data sheet-center sheet-small-label" ><input type="number" name="attr_damage-ability-mod" title="@{repeating_weapon_$X_attr_damage-ability-mod}" value="0" style="width:2.4em;" class="sheet-calc" readonly="readonly" /><br/>Mod</span>
 								<span class="sheet-table-data sheet-divider">+</span>
 								<span class="sheet-table-data sheet-center"><span class="sheet-table-data sheet-center sheet-small-label" ><input type="number" name="attr_dmg-effect-total-copy" title="@{repeating_weapon_$X_dmg-effect-total-copy}" value="0" style="width:2.8em;" class="sheet-calc" readonly="readonly"  /><br><b title="Additional modifier from Attack and Damage Effects.">Other</b></span></span>
@@ -2281,7 +2281,7 @@
 						</div>
 						<div class="sheet-table">
 							<div class="sheet-table-row">
-								<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes" style="margin-top: 0px; margin-bottom: 0px; height: 28px;"></textarea>
+								<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea>
 								<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
 							</div>
 						</div>
@@ -3486,7 +3486,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft-Check}" type="roll" value="@{Craft-macro}" name="roll_Craft-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft-cs}" type="checkbox" name="attr_Craft-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:57%;" type="text" name="attr_Craft-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Craft-name}" style="width:96%;" type="text" name="attr_Craft-name"  Placeholder="Craft" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft}" type="text" name="attr_Craft" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft-ranks}" type="number" name="attr_Craft-ranks" value="0"  /></span>
@@ -3518,7 +3518,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft2-Check}" type="roll" value="@{Craft2-macro}" name="roll_Craft2-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft2-cs}" type="checkbox" name="attr_Craft2-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:57%;" type="text" name="attr_Craft2-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Craft2-name}" style="width:96%;" type="text" name="attr_Craft2-name"  Placeholder="Craft" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="text" name="attr_Craft2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft2-ranks}" type="number" name="attr_Craft2-ranks" value="0"  /></span>
@@ -3550,7 +3550,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft3-Check}" type="roll" value="@{Craft3-macro}" name="roll_Craft3-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft3-cs}" type="checkbox" name="attr_Craft3-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:57%;" type="text" name="attr_Craft3-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Craft3-name}" style="width:96%;" type="text" name="attr_Craft3-name" Placeholder="Craft" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="text" name="attr_Craft3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Craft3-ranks}" type="number" name="attr_Craft3-ranks" value="0"  /></span>
@@ -3806,7 +3806,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform-Check}" type="roll" value="@{Perform-macro}" name="roll_Perform-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform-cs}" type="checkbox" name="attr_Perform-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:66%;" type="text" name="attr_Perform-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Perform-name}" style="width:96%;" type="text" name="attr_Perform-name" Placeholder="Perform" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform}" type="text" name="attr_Perform" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform-ranks}" type="number" name="attr_Perform-ranks" value="0"  /></span>
@@ -3838,7 +3838,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform2-Check}" type="roll" value="@{Perform2-macro}" name="roll_Perform2-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform2-cs}" type="checkbox" name="attr_Perform2-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:66%;" type="text" name="attr_Perform2-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Perform2-name}" style="width:96%;" type="text" name="attr_Perform2-name" Placeholder="Perform" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="text" name="attr_Perform2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform2-ranks}" type="number" name="attr_Perform2-ranks" value="0"  /></span>
@@ -3870,7 +3870,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform3-Check}" type="roll" value="@{Perform3-macro}" name="roll_Perform3-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform3-cs}" type="checkbox" name="attr_Perform3-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:66%;" type="text" name="attr_Perform3-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Perform3-name}" style="width:96%;" type="text" name="attr_Perform3-name" Placeholder="Perform" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="text" name="attr_Perform3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Perform3-ranks}" type="number" name="attr_Perform3-ranks" value="0"  /></span>
@@ -3902,7 +3902,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession-Check}" type="roll" value="@{Profession-macro}" name="roll_Profession-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession-cs}" type="checkbox" name="attr_Profession-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:57%;" type="text" name="attr_Profession-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Profession-name}" style="width:96%;" type="text" name="attr_Profession-name" Placeholder="Profession" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession}" type="text" name="attr_Profession" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession-ranks}" type="number" name="attr_Profession-ranks" value="0"  /></span>
@@ -3934,7 +3934,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession2-Check}" type="roll" value="@{Profession2-macro}" name="roll_Profession2-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession2-cs}" type="checkbox" name="attr_Profession2-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:57%;" type="text" name="attr_Profession2-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Profession2-name}" style="width:96%;" type="text" name="attr_Profession2-name" Placeholder="Profession" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="text" name="attr_Profession2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession2-ranks}" type="number" name="attr_Profession2-ranks" value="0"  /></span>
@@ -3966,7 +3966,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession3-Check}" type="roll" value="@{Profession3-macro}" name="roll_Profession3-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession3-cs}" type="checkbox" name="attr_Profession3-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:57%;" type="text" name="attr_Profession3-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Profession3-name}" style="width:96%;" type="text" name="attr_Profession3-name" Placeholder="Profession" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="text" name="attr_Profession3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Profession3-ranks}" type="number" name="attr_Profession3-ranks" value="0"  /></span>
@@ -4030,7 +4030,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-3-Check}" type="roll" value="@{Misc-Skill-3-macro}" name="roll_Misc-Skill-3-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-cs}" type="checkbox" name="attr_Misc-Skill-3-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-3-name}" style="width:57%;" type="text" name="attr_Misc-Skill-3-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-3-name}" type="text" name="attr_Misc-Skill-3-name" placeholder="Misc. Skill" style="width:96%;" /></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="text" name="attr_Misc-Skill-3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-ranks}" type="number" name="attr_Misc-Skill-3-ranks" value="0"  /></span>
@@ -4063,7 +4063,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-4-Check}" type="roll" value="@{Misc-Skill-4-macro}" name="roll_Misc-Skill-4-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-cs}" type="checkbox" name="attr_Misc-Skill-4-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-4-name}" style="width:57%;" type="text" name="attr_Misc-Skill-4-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-4-name}" type="text" name="attr_Misc-Skill-4-name" placeholder="Misc. Skill" style="width:96%;"/></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="text" name="attr_Misc-Skill-4" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-ranks}" type="number" name="attr_Misc-Skill-4-ranks" value="0"  /></span>
@@ -4096,7 +4096,7 @@
 							<div class="sheet-table-row">
 								<span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-5-Check}" type="roll" value="@{Misc-Skill-5-macro}" name="roll_Misc-Skill-5-Check"></button></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-cs}" type="checkbox" name="attr_Misc-Skill-5-cs" value="3" /></span>
-								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-5-name}" style="width:57%;" type="text" name="attr_Misc-Skill-5-name" /></span>
+								<span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-5-name}" type="text" name="attr_Misc-Skill-5-name"  placeholder="Misc. Skill" style="width:96%;"/></span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="text" name="attr_Misc-Skill-5" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
 								<span class="sheet-table-data sheet-divider">=</span>
 								<span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-ranks}" type="number" name="attr_Misc-Skill-5-ranks" value="0"  /></span>
@@ -4754,7 +4754,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft-Check}" type="roll" value="@{Craft-macro}" name="roll_Craft-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft-cs}" type="checkbox" name="attr_Craft-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:57%;" type="text" name="attr_Craft-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft-name}" style="width:96%;" type="text" name="attr_Craft-name" Placeholder="Craft" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft}" type="text" name="attr_Craft" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft-ranks}" type="number" name="attr_Craft-ranks" value="0"  /></span>
@@ -4786,7 +4786,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft2-Check}" type="roll" value="@{Craft2-macro}" name="roll_Craft2-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2-cs}" type="checkbox" name="attr_Craft2-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:57%;" type="text" name="attr_Craft2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft2-name}" style="width:96%;" type="text" name="attr_Craft2-name" Placeholder="Craft" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="text" name="attr_Craft2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2-ranks}" type="number" name="attr_Craft2-ranks" value="0"  /></span>
@@ -4818,7 +4818,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Craft3-Check}" type="roll" value="@{Craft3-macro}" name="roll_Craft3-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3-cs}" type="checkbox" name="attr_Craft3-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:57%;" type="text" name="attr_Craft3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft3-name}" style="width:96%;" type="text" name="attr_Craft3-name" Placeholder="Craft" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="text" name="attr_Craft3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3-ranks}" type="number" name="attr_Craft3-ranks" value="0"  /></span>
@@ -5522,7 +5522,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform-Check}" type="roll" value="@{Perform-macro}" name="roll_Perform-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform-cs}" type="checkbox" name="attr_Perform-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:66%;" type="text" name="attr_Perform-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform-name}" style="width:96%;" type="text" name="attr_Perform-name" Placeholder="Perform" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform}" type="text" name="attr_Perform" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform-ranks}" type="number" name="attr_Perform-ranks" value="0"  /></span>
@@ -5554,7 +5554,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform2-Check}" type="roll" value="@{Perform2-macro}" name="roll_Perform2-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2-cs}" type="checkbox" name="attr_Perform2-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:66%;" type="text" name="attr_Perform2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform2-name}" style="width:96%;" type="text" name="attr_Perform2-name" Placeholder="Perform"  /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="text" name="attr_Perform2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2-ranks}" type="number" name="attr_Perform2-ranks" value="0"  /></span>
@@ -5586,7 +5586,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Perform3-Check}" type="roll" value="@{Perform3-macro}" name="roll_Perform3-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3-cs}" type="checkbox" name="attr_Perform3-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:66%;" type="text" name="attr_Perform3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform3-name}" style="width:96%;" type="text" name="attr_Perform3-name" Placeholder="Perform" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="text" name="attr_Perform3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3-ranks}" type="number" name="attr_Perform3-ranks" value="0"  /></span>
@@ -5618,7 +5618,7 @@
 					<div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession-Check}" type="roll" value="@{Profession-macro}" name="roll_Profession-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession-cs}" type="checkbox" name="attr_Profession-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:57%;" type="text" name="attr_Profession-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession-name}" style="width:96%;" type="text" name="attr_Profession-name" Placeholder="Profession" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession}" type="text" name="attr_Profession" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession-ranks}" type="number" name="attr_Profession-ranks" value="0"  /></span>
@@ -5650,7 +5650,7 @@
 					<div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession2-Check}" type="roll" value="@{Profession2-macro}" name="roll_Profession2-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2-cs}" type="checkbox" name="attr_Profession2-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:57%;" type="text" name="attr_Profession2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession2-name}" style="width:96%;" type="text" name="attr_Profession2-name" Placeholder="Profession" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="text" name="attr_Profession2" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2-ranks}" type="number" name="attr_Profession2-ranks" value="0"  /></span>
@@ -5682,7 +5682,7 @@
 					<div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Profession3-Check}" type="roll" value="@{Profession3-macro}" name="roll_Profession3-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3-cs}" type="checkbox" name="attr_Profession3-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:57%;" type="text" name="attr_Profession3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession3-name}" style="width:96%;" type="text" name="attr_Profession3-name" Placeholder="Profession" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="text" name="attr_Profession3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3-ranks}" type="number" name="attr_Profession3-ranks" value="0"  /></span>
@@ -6071,7 +6071,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-3-Check}" type="roll" value="@{Misc-Skill-3-macro}" name="roll_Misc-Skill-3-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-cs}" type="checkbox" name="attr_Misc-Skill-3-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-3-name}" style="width:57%;" type="text" name="attr_Misc-Skill-3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-3-name}" type="text" name="attr_Misc-Skill-3-name"  placeholder="Misc. Skill" style="width:96%;"/></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="text" name="attr_Misc-Skill-3" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-ranks}" type="number" name="attr_Misc-Skill-3-ranks" value="0"  /></span>
@@ -6104,7 +6104,7 @@
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-4-Check}" type="roll" value="@{Misc-Skill-4-macro}" name="roll_Misc-Skill-4-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-cs}" type="checkbox" name="attr_Misc-Skill-4-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-4-name}" style="width:57%;" type="text" name="attr_Misc-Skill-4-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-4-name}" type="text" name="attr_Misc-Skill-4-name"  placeholder="Misc. Skill" style="width:96%;"/></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="text" name="attr_Misc-Skill-4" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-ranks}" type="number" name="attr_Misc-Skill-4-ranks" value="0"  /></span>
@@ -6137,7 +6137,7 @@
 					<div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|Misc-Skill-5-Check}" type="roll" value="@{Misc-Skill-5-macro}" name="roll_Misc-Skill-5-Check"></button></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-cs}" type="checkbox" name="attr_Misc-Skill-5-cs" value="3" /></span>
-                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-5-name}" style="width:57%;" type="text" name="attr_Misc-Skill-5-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Misc-Skill-5-name}" type="text" name="attr_Misc-Skill-5-name"  placeholder="Misc. Skill" style="width:96%;"/></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="text" name="attr_Misc-Skill-5" value="0" style="width:3.5em;" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-ranks}" type="number" name="attr_Misc-Skill-5-ranks" value="0"  /></span>
@@ -6363,10 +6363,10 @@
             <div class="sheet-table-row">
 				<span class="sheet-table-header" style="width:5%;"></span>
                 <span class="sheet-table-header" style="width:5%;"></span>
-                <span class="sheet-table-header" style="width:23%;">Name</span>
+                <span class="sheet-table-header" style="width:18%;">Name</span>
                 <span class="sheet-table-header" style="width:40%;">Short Description</span>
                 <span class="sheet-table-header" style="width:5%; text-align:right;">Charges/Qty</span>
-                <span class="sheet-table-header sheet-divider-lg" >/</span>
+                <span class="sheet-table-header sheet-divider-lg" style="width:1%;">/</span>
                 <span class="sheet-table-header" style="width:5%;text-align:left;">Max</span>
                 <span class="sheet-table-header" style="width:5%;">Weight</span>
             </div>
@@ -8582,8 +8582,8 @@
                             <span class="sheet-table-data sheet-divider">+</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
 								<select title="@{repeating_weapon_$X_attack-type}" name="attr_attack-type">
-									<option value="0"  selected>&#8226;None</option>
-									<option value="@{attk-melee}">Melee</option>
+									<option value="0">None</option>
+									<option value="@{attk-melee}" selected>&#8226;Melee</option>
 									<option value="@{attk-ranged}">Ranged</option>
 									<option value="@{CMB}">CMB</option>
 								</select>
@@ -8616,14 +8616,14 @@
 										<span class="sheet-table-data sheet-divider">+</span>
 										<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
 											<select title="@{repeating_weapon_$X_damage-ability}" name="attr_damage-ability" style="font-size:1em;">
-												<option value="0 - [[ @{condition-sickened} ]]" selected>&#8226;None</option>
+										<option value="0 - [[ @{condition-sickened} ]]">None</option>
 												<option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
 												<option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
 												<option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
 												<option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
 												<option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
 												<option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
-												<option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
+										<option value="@{STR-mod} - [[ @{condition-sickened} ]]" selected>&#8226;STR</option>
 												<option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
 												<option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
 												<option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
@@ -8644,7 +8644,7 @@
 											</select>
 											<br>DMG Ability
 										</span>
-										<span class="sheet-table-data sheet-center sheet-small-label" style="width:2em;" ><input style="width:2em;" type="text" name="attr_damage-ability-max" title="@{repeating_weapon_$X_attr_damage-ability-max} for strength bows, etc." value="" Placeholder="NA" /><br/>Max</span>
+										<span class="sheet-table-data sheet-center sheet-small-label" style="width:2em;" ><input style="width:2em;" type="text" name="attr_damage-ability-max" title="@{repeating_weapon_$X_damage-ability-max} for strength bows, etc." value="" Placeholder="NA" /><br/>Max</span>
 										<span class="sheet-table-data sheet-center sheet-small-label" ><input type="number" name="attr_damage-ability-mod" title="@{repeating_weapon_$X_attr_damage-ability-mod}" value="0" style="width:2.4em;" class="sheet-calc" readonly="readonly" /><br/>Mod</span>
 										<span class="sheet-table-data sheet-divider">+</span>
 										<span class="sheet-table-data sheet-center"><span class="sheet-table-data sheet-center sheet-small-label" ><input type="number" name="attr_dmg-effect-total-copy" title="@{repeating_weapon_$X_dmg-effect-total-copy}" value="0" style="width:2.8em;" class="sheet-calc" readonly="readonly"  /><br><b title="Additional modifier from Attack and Damage Effects.">Other</b></span></span>
@@ -8660,7 +8660,7 @@
 								</div>
 								<div class="sheet-table">
 									<div class="sheet-table-row">
-										<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes" style="margin-top: 0px; margin-bottom: 0px; height: 28px;"></textarea>
+										<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea>
 										<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
 									</div>
 								</div>
@@ -9212,18 +9212,18 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Climb-misc}" type="number" name="attr_Climb-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft-Check}" type="roll" value="@{NPC-whisper} @{Craft-macro}" name="roll_NPC-Craft-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft-name}" style="width:50%;" type="text" name="attr_Craft-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft-name}" type="text" name="attr_Craft-name" Placeholder="Craft" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft}" type="number" name="attr_Craft" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft-misc}" type="number" name="attr_Craft-misc" value="0" /></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft2-Check}" type="roll" value="@{NPC-whisper} @{Craft2-macro}" name="roll_NPC-Craft2-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft2-name}" style="width:50%;" type="text" name="attr_Craft2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft2-name}" type="text" name="attr_Craft2-name" Placeholder="Craft 2" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2}" type="number" name="attr_Craft2" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft2-misc}" type="number" name="attr_Craft2-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Craft3-Check}" type="roll" value="@{NPC-whisper} @{Craft3-macro}" name="roll_NPC-Craft3-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Craft: <input title="@{Craft3-name}" style="width:50%;" type="text" name="attr_Craft3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Craft3-name}" type="text" name="attr_Craft3-name" Placeholder="Craft 3" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3}" type="number" name="attr_Craft3" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Craft3-misc}" type="number" name="attr_Craft3-misc" value="0" /></span>
 
@@ -9330,7 +9330,7 @@
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Lore-Check}" type="roll" value="@{NPC-whisper} @{Lore-macro}" name="roll_NPC-Lore-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><span title="Optional Ruleset">Lore: <input title="@{Lore-name}" style="width: 50%" type="text" name="attr_Lore-name" /></span></span>
+                        <span class="sheet-table-data sheet-left"><span title="Optional Ruleset"><input title="@{Lore-name}" type="text" name="attr_Lore-name" Placeholder="Lore" /></span></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Lore}" type="number" name="attr_Lore" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Lore-misc}" type="number" name="attr_Lore-misc" value="0" /></span>
 
@@ -9340,34 +9340,34 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Perception-misc}" type="number" name="attr_Perception-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform-Check}" type="roll" value="@{NPC-whisper} @{Perform-macro}" name="roll_NPC-Perform-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform-name}" style="width:50%;" type="text" name="attr_Perform-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform-name}" type="text" name="attr_Perform-name" Placeholder="Perform" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform}" type="number" name="attr_Perform" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform-misc}" type="number" name="attr_Perform-misc" value="0" /></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform2-Check}" type="roll" value="@{NPC-whisper} @{Perform2-macro}" name="roll_NPC-Perform2-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform2-name}" style="width:50%;" type="text" name="attr_Perform2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform2-name}" type="text" name="attr_Perform2-name" Placeholder="Perform 2" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2}" type="number" name="attr_Perform2" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform2-misc}" type="number" name="attr_Perform2-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Perform3-Check}" type="roll" value="@{NPC-whisper} @{Perform3-macro}" name="roll_NPC-Perform3-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Perform: <input title="@{Perform3-name}" style="width:50%;" type="text" name="attr_Perform3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Perform3-name}" type="text" name="attr_Perform3-name" Placeholder="Perform 3" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3}" type="number" name="attr_Perform3" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Perform3-misc}" type="number" name="attr_Perform3-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession-Check}" type="roll" value="@{NPC-whisper} @{Profession-macro}" name="roll_NPC-Profession-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession-name}" style="width:50%;" type="text" name="attr_Profession-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession-name}" type="text" name="attr_Profession-name" Placeholder="Profession" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession}" type="number" name="attr_Profession" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession-misc}" type="number" name="attr_Profession-misc" value="0" /></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession2-Check}" type="roll" value="@{NPC-whisper} @{Profession2-macro}" name="roll_NPC-Profession2-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession2-name}" style="width:50%;" type="text" name="attr_Profession2-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession2-name}" type="text" name="attr_Profession2-name" Placeholder="Profession 2" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2}" type="number" name="attr_Profession2" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession2-misc}" type="number" name="attr_Profession2-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Profession3-Check}" type="roll" value="@{NPC-whisper} @{Profession3-macro}" name="roll_NPC-Profession3-Check"></button></span>
-                        <span class="sheet-table-data sheet-left">Profession: <input title="@{Profession3-name}" style="width:50%;" type="text" name="attr_Profession3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input title="@{Profession3-name}" type="text" name="attr_Profession3-name" Placeholder="Profession 3" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3}" type="number" name="attr_Profession3" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Profession3-misc}" type="number" name="attr_Profession3-misc" value="0" /></span>
 
@@ -9415,34 +9415,34 @@
                         <span class="sheet-table-data sheet-center"><input title="@{Use-Magic-Device-misc}" type="number" name="attr_Use-Magic-Device-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-0-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-0-macro}" name="roll_NPC-Misc-Skill-0-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-0-name}" name="attr_Misc-Skill-0-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-0-name}" name="attr_Misc-Skill-0-name" placeholder="Misc Skill 0" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0}" type="number" name="attr_Misc-Skill-0" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-0-misc}" type="number" name="attr_Misc-Skill-0-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-1-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-1-macro}" name="roll_NPC-Misc-Skill-1-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-1-name}" name="attr_Misc-Skill-1-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-1-name}" name="attr_Misc-Skill-1-name" placeholder="Misc Skill 1" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1}" type="number" name="attr_Misc-Skill-1" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-1-misc}" type="number" name="attr_Misc-Skill-1-misc" value="0" /></span>
                     </div>
                     <div class="sheet-table-row">
-                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-2-Check}" type="roll" value="@{NPC-whisper}@{Misc-Skill-2-macro}" name="roll_NPC-Misc-Skill-2-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-2-name}" name="attr_Misc-Skill-2-name" /></span>
+                        <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-2-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-2-macro}" name="roll_NPC-Misc-Skill-2-Check"></button></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-2-name}" name="attr_Misc-Skill-2-name" placeholder="Misc Skill 2" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2}" type="number" name="attr_Misc-Skill-2" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-2-misc}" type="number" name="attr_Misc-Skill-2-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-3-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-3-macro}" name="roll_NPC-Misc-Skill-3-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-3-name}" name="attr_Misc-Skill-3-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-3-name}" name="attr_Misc-Skill-3-name" placeholder="Misc Skill 3" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3}" type="number" name="attr_Misc-Skill-3" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-3-misc}" type="number" name="attr_Misc-Skill-3-misc" value="0" /></span>
 
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-4-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-4-macro}" name="roll_NPC-Misc-Skill-4-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-4-name}" name="attr_Misc-Skill-4-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-4-name}" name="attr_Misc-Skill-4-name" placeholder="Misc Skill 4" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4}" type="number" name="attr_Misc-Skill-4" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-4-misc}" type="number" name="attr_Misc-Skill-4-misc" value="0" /></span>
                     </div>
                     <div class="sheet-table-row">
                         <span class="sheet-table-data sheet-center"><button style="font-size:100%;" title="%{selected|NPC-Misc-Skill-5-Check}" type="roll" value="@{NPC-whisper} @{Misc-Skill-5-macro}" name="roll_NPC-Misc-Skill-5-Check"></button></span>
-                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-5-name}" name="attr_Misc-Skill-5-name" /></span>
+                        <span class="sheet-table-data sheet-left"><input type="text" title="@{Misc-Skill-5-name}" name="attr_Misc-Skill-5-name" placeholder="Misc Skill 5" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5}" type="number" name="attr_Misc-Skill-5" value="0" class="sheet-calc" readonly="readonly" /></span>
                         <span class="sheet-table-data sheet-center"><input title="@{Misc-Skill-5-misc}" type="number" name="attr_Misc-Skill-5-misc" value="0" /></span>
                     </div>
@@ -9730,7 +9730,7 @@
 <div class="sheet-footer">
 	<div class="sheet-table">
 		<div class="sheet-table-row">
-			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.13.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
+			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.15.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
 		</div>
 		<div class="sheet-table-row">
 			<span class="sheet-table-data sheet-center">Have questions or feedback?  This thread can help:<input type="text" style="width:50%; border:none;" value="https://app.roll20.net/forum/post/2788628/pf-pathfinder-sheet-thread-5" /></span>


### PR DESCRIPTION
- minor formatting updates
- added "none" option to Init ability selector
- changed "Non-lethal DMG" to "Nonlethal DMG" to help a little with the
forced line break
- changed the size and default value of the class selector for repeating
class abilities and adjusted some column sizes to compensate
- changed default of Attack type to melee and Damage ability to STR
(these were set to none previously to force users to change them due to
repeating section limitations) None is still an option.
- added additional labels to NPC skills and enlarged some of the
"field-only" skills like craft, perform, profession, misc...