### PR TITLE
PF v19

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.css
+++ b/Pathfinder-Neceros/pathfinder-neceros.css
@@ -3,6 +3,9 @@
 .sheet-macro-text-show:not(:checked)~.sheet-macro-text,
 .sheet-sect-show:not(:checked)~.sheet-sect,
 .sheet-options-show:not(:checked)~.sheet-options,
+.sheet-spell_ranges0-show:not(:checked)~.sheet-spell_ranges0,
+.sheet-spell_ranges1-show:not(:checked)~.sheet-spell_ranges1,
+.sheet-spell_ranges2-show:not(:checked)~.sheet-spell_ranges2,
 .sheet-buffs-show:not(:checked)~.sheet-buffs,
 .sheet-buffs2-show:not(:checked)~.sheet-buffs2 {
 	display: none;
@@ -233,6 +236,9 @@ input[type="text"], select {
 }
 select {
 	min-width:6em;
+}
+select.sheet-medium {
+	width:4em;
 }
 input[type="number"] {
 	min-width:3em;
@@ -517,6 +523,37 @@ textarea {
 .charsheet button[type=roll] {
     margin: 2px 2px 0 2px !important;
 }
+
+[data-groupname=repeating_class-ability] > button.btn.repcontrol_add::after {
+	content: " New Class Ability";
+}
+[data-groupname=repeating_weapon] > button.btn.repcontrol_add::after {
+	content: " New Weapon";
+}
+[data-groupname=repeating_feat] > button.btn.repcontrol_add::after {
+	content: " New Feat";
+}
+[data-groupname=repeating_item] > button.btn.repcontrol_add::after {
+	content: " New Item";
+}
+[data-groupname=repeating_racial-trait] > button.btn.repcontrol_add::after {
+	content: " New Racial Trait";
+}
+[data-groupname=repeating_trait] > button.btn.repcontrol_add::after {
+	content: " New Trait";
+}
+
+.charsheet .repcontrol_add,
+.charsheet .repcontrol_edit,
+.charsheet .repcontrol_del {
+    display: block;
+    background: #000;
+    color: white;
+    box-shadow:none;
+    font-size:0.9em;
+    height:2.2em;
+}
+
 /*Roll Templates*/
 /*Spells*/
 .sheet-rolltemplate-pf_spell table {

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -1,6 +1,6 @@
 <div>
     <b style="color:red;font-size:150%;">Attention: </b>
-    <input type="checkbox" class="sheet-sect-show" title="@{attention-show}" name="attr_attention-show" value="1" style="opacity:0; width:64px; height:16px;position:relative; top:0; left:0; margin:-32px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+    <input type="checkbox" class="sheet-sect-show" title="@{attention-show}" name="attr_attention-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 	<div class="sheet-footer sheet-sect" ​style="text-align:left; padding:5px; margin:5px;">
 		<ol>
 			<li>Button bars are no longer necessary and have been removed. Buttons within repeating sections now work directly and can be dragged to the macro quick bar. To learn the id/name of the button, drag/drop the button to the macro quick bar.</li>
@@ -57,8 +57,8 @@
 <div class="sheet-section sheet-section-core">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Ability Scores&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{ability-scores-show}" name="attr_ability-scores-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Ability Scores</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{ability-scores-show}" name="attr_ability-scores-show" value="1" style="opacity:0;width: 105px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -90px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Ability Scores</span>
             <div class="sheet-table-row">
@@ -177,12 +177,12 @@
         <br>
     </div>
 	<div class="sheet-buff-flow" style="overflow-x:auto;">
-		<b>Buffs&nbsp; &nbsp; &nbsp; &nbsp; </b>
-		<input type="checkbox" class="sheet-sect-show" title="@{buffs-show}" name="attr_buffs-show" value="1" style="opacity:0; width:35px; height:16px; position:relative; top:0; left:0; margin:-32px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+		<b>Buffs</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{buffs-show}" name="attr_buffs-show" value="1" style="opacity:0;width: 50px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -35px; cursor:pointer; z-index:1;" /><span></span>
 		<div class="sheet-table sheet-sect sheet-buff-grid">
 				<span class="sheet-table-name">Buffs</span>
-				<b>Buffs 1-5&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</b>
-				<input type="checkbox" class="sheet-buffs-show" title="@{buffs_1-5-show}" name="attr_buffs_1-5-show" value="1" style="opacity:0; width:35px; height:16px; position:relative; top:0; left:0; margin:-32px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+				<b>Buffs 1-5</b>
+				<input type="checkbox" class="sheet-buffs-show" title="@{buffs_1-5-show}" name="attr_buffs_1-5-show" value="1" style="opacity:0; width:75px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 				<div class="sheet-table-buff sheet-buffs">			
 					<div class="sheet-buff-row">
 						<span class="sheet-table-header sheet-buff-toggle" style="text-align:right;  padding-right:10px;">#</span>
@@ -546,8 +546,8 @@
 					</div>			
 				</div>
 				<br>
-				<b>Buffs 6-10&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</b>
-				<input type="checkbox" class="sheet-buffs2-show" title="@{buffs_6-10-show}" name="attr_buffs_6-10-show" value="1" style="opacity:0; width:35px; height:16px; position:relative; top:0; left:0; margin:-32px; cursor:pointer; z-index:1;" /><span></span>
+				<b>Buffs 6-10</b>
+				<input type="checkbox" class="sheet-buffs2-show" title="@{buffs_6-10-show}" name="attr_buffs_6-10-show" value="1" style="opacity:0; width:75px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>
 				<div class="sheet-table-buff sheet-buffs2">
 					<div class="sheet-buff-row">
 						<span class="sheet-table-header sheet-buff-toggle" style="text-align:right;  padding-right:10px;">#</span>
@@ -915,8 +915,8 @@
 	</div>
 
     <div>
-        <b title="Toggle common conditions.">Conditions&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{conditions-show}" name="attr_conditions-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b title="Toggle common conditions.">Conditions</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{conditions-show}" name="attr_conditions-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Conditions</span>
             <div class="sheet-table-row" style="line-height:1.85em;">
@@ -955,8 +955,8 @@
         <br>
     </div>
     <div>
-        <b>Health and Wounds&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{health-and-wounds-show}" name="attr_health-and-wounds-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Health and Wounds</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{health-and-wounds-show}" name="attr_health-and-wounds-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Health and Wounds</span>
             <div class="sheet-table-row">
@@ -1024,8 +1024,8 @@
         <br>
     </div>
     <div>
-        <b>Initiative and Speeds&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{initiative-and-speeds-show}" name="attr_initiative-and-speeds-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Initiative and Speeds</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{initiative-and-speeds-show}" name="attr_initiative-and-speeds-show" value="1" style="opacity:0;width: 150px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -133px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <div class="sheet-table-row" style="vertical-align:top;">
                 <div class="sheet-table-data sheet-center">
@@ -1048,7 +1048,6 @@
 							<span class="sheet-table-data sheet-divider">=</span>
 							<span class="sheet-table-data sheet-center">
 							<select title="@{init-ability}" name="attr_init-ability" class="sheet-select-small">
-								<option value="0" >None</option>
                                 <option value="@{STR-mod}">STR</option>
                                 <option value="@{DEX-mod}" selected>&#8226;DEX</option>
                                 <option value="@{CON-mod}">CON</option>
@@ -1092,8 +1091,8 @@
         <br>
     </div>
     <div>
-        <b>Experience and Hero Points&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{experience-and-hero-points-show}" name="attr_experience-and-hero-points-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Experience and Hero Points</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{experience-and-hero-points-show}" name="attr_experience-and-hero-points-show" value="1" style="opacity: 0;width: 195px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -176px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Experience and Hero Points</span>
             <div class="sheet-table-row">
@@ -1125,8 +1124,8 @@
 <div class="sheet-section sheet-section-class">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Class Information&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{class-info-show}" name="attr_class-info-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Class Information</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{class-info-show}" name="attr_class-info-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Class Information</span>
             <div class="sheet-table-row">
@@ -1245,8 +1244,8 @@
         <br>
     </div>
     <div>
-        <b>Class Features and Abilities&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{class-features-show}" name="attr_class-features-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Class Features and Abilities</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{class-features-show}" name="attr_class-features-show" value="1" style="opacity: 0;width: 195px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -176px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Class Features and Abilities</span>
             <div class="sheet-table-row">
@@ -1286,13 +1285,23 @@
 					<span class="sheet-table-data sheet-center"><input title="@{repeating_class-ability_$X_used|max}" type="number" name="attr_used_max" value="0" class="sheet-calc" readonly="readonly" /></span>
 					<span class="sheet-table-data sheet-center" style="width:20%;"><input title="@{repeating_class-ability_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /></span>
 					<div class="sheet-sect">									
-						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-desc-show" title="@{repeating_class-ability_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+						<b>Description</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_class-ability_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_class-ability_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_class-ability_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
 						<textarea class="sheet-desc" title="@{repeating_class-ability_$X_description}" name="attr_description"></textarea>
-						<br>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_class-ability_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+						
 						<textarea class="sheet-macro-text" title="@{repeating_class-ability_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{Class=**Class**: @{class-number}}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_class-ability_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_class-ability_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_class-ability_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
@@ -1303,8 +1312,8 @@
 <div class="sheet-section sheet-section-defenses">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Defense Values&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{defense-values-show}" name="attr_defense-values-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Defense Values</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{defense-values-show}" name="attr_defense-values-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Defense Values</span>
             <div class="sheet-table-row">
@@ -1552,8 +1561,8 @@
         <br>
     </div>
     <div>
-        <b>Special Defenses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{special-defenses-show}" name="attr_special-defenses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Special Defenses</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{special-defenses-show}" name="attr_special-defenses-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Special Defenses</span>
             <div class="sheet-table-row">
@@ -1576,8 +1585,8 @@
 	  <br>	   	  
     </div>
     <div>
-        <b>Armor Penalties&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{armor-penalties-show}" name="attr_armor-penalties-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Armor Penalties</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{armor-penalties-show}" name="attr_armor-penalties-show" value="1" style="opacity: 0;width: 120px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -105px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Armor Penalties</span>
             <div class="sheet-table-row">
@@ -1612,8 +1621,8 @@
         <br>
     </div>
     <div>
-        <b>Saving Throws&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{saves-show}" name="attr_saves-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Saving Throws</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{saves-show}" name="attr_saves-show" value="1" style="opacity:0;width: 105px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -90px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-sect">
             <span class="sheet-table-name">Saving Throws</span>
             <div class="sheet-table-row">
@@ -1728,8 +1737,8 @@
 				<span class="sheet-table-data sheet-center" style="width:9%;" ><input style="width:100%;" title="@{buff_Will-total}" type="number" name="attr_buff_Will-total" value="@{buff_Will-total}" class="sheet-calc" readonly="readonly"  /></span>
             </div>
 			<div>
-				<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-				<input type="checkbox" class="sheet-options-show" title="@{options_defense_notes-show}" name="attr_options_defense_notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>    
+				<b>Options</b>
+				<input type="checkbox" class="sheet-options-show" title="@{options_defense_notes-show}" name="attr_options_defense_notes-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>    
 					<input type="hidden" name="attr_var_dr_notes" value="{{dr_notes=@{DR}}}" disabled />
 					<input type="hidden" name="attr_var_resistances_notes" value="{{resistances_notes=@{resistances}}}" disabled />
 					<input type="hidden" name="attr_var_immunities_notes" value="{{immunities_notes=@{immunities}}}" disabled />
@@ -1762,8 +1771,8 @@
 		</div>		
     </div>
     <div>
-        <b>Armor and Shield&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{armor-shield-show}" name="attr_armor-shield-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Armor and Shield</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{armor-shield-show}" name="attr_armor-shield-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Armor and Shield</span>
             <div class="sheet-table-row">
@@ -1865,8 +1874,8 @@
         <br>
     </div>
     <div>
-        <b>Defense Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{defense-notes-show}" name="attr_defense-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Defense Notes</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{defense-notes-show}" name="attr_defense-notes-show" value="1" style="opacity:0;width: 105px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -90px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <div class="sheet-table-row">
                 <div class="sheet-table-data sheet-center">
@@ -1909,8 +1918,8 @@
 <div class="sheet-section sheet-section-attacks">
 	<div class="sheet-table sheet-header-row">&nbsp;</div>
 	<div>
-		<b>Attack and Combat Maneuver Bonuses&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{attack-bonuses-show}" name="attr_attack-bonuses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+		<b>Attack and Combat Maneuver Bonuses</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-bonuses-show}" name="attr_attack-bonuses-show" value="1" style="opacity: 0;width: 260px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0px -15px 0 -245px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<span class="sheet-table-name">Attack and Combat Maneuver Bonuses</span>
 			<div class="sheet-table-row">
@@ -2045,8 +2054,8 @@
 		<br>
 	</div>
 	<div>
-		<b title="Apply attack and damage modifiers to all attacks.">Attack and Damage Effects&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{attack_damage_status_effects-show}" name="attr_attack_damage_status_effects-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+		<b title="Apply attack and damage modifiers to all attacks.">Attack and Damage Effects</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack_damage_status_effects-show}" name="attr_attack_damage_status_effects-show" value="1" style="opacity: 0;width: 195px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -176px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<span class="sheet-table-name">Attack and Damage Effects</span>
 			<div class="sheet-table-row">
@@ -2140,8 +2149,8 @@
 		<br>
 	</div>
 	<div>
-		<b>Attack Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{attack-notes-show}" name="attr_attack-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+		<b>Attack Notes</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack-notes-show}" name="attr_attack-notes-show" value="1" style="opacity:0;width: 100px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -83px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<div class="sheet-table">
 				<div class="sheet-table-row">
@@ -2183,8 +2192,8 @@
 		<br/>
 	</div>
 	<div>
-		<b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+		<b>Attacks</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<span class="sheet-table-name">Attacks</span>
 		</div>		
@@ -2202,8 +2211,8 @@
 						<span class="sheet-table-data sheet-divider">+</span>
 						<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
 							<select title="@{repeating_weapon_$X_attack-type}" name="attr_attack-type">
-							<option value="0">None</option>
-							<option value="@{attk-melee}" selected>&#8226;Melee</option>
+								<option value="0" selected>&#8226;None</option>
+								<option value="@{attk-melee}">Melee</option>
 								<option value="@{attk-ranged}">Ranged</option>
 								<option value="@{CMB}">CMB</option>
 							</select>
@@ -2237,14 +2246,14 @@
 								<span class="sheet-table-data sheet-divider">+</span>
 								<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
 									<select title="@{repeating_weapon_$X_damage-ability}" name="attr_damage-ability" style="font-size:1em;">
-										<option value="0 - [[ @{condition-sickened} ]]">None</option>
+										<option value="0 - [[ @{condition-sickened} ]]" selected>&#8226;None</option>
 										<option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
 										<option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
 										<option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
 										<option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
 										<option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
 										<option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
-										<option value="@{STR-mod} - [[ @{condition-sickened} ]]" selected>&#8226;STR</option>
+										<option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
 										<option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
 										<option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
 										<option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
@@ -2282,11 +2291,19 @@
 						<div class="sheet-table">
 							<div class="sheet-table-row">
 								<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea>
-								<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
+								<span class="sheet-center sheet-small-label" style="display: block;">Notes</span>
 							</div>
 						</div>
-							<b title="Add additional attacks for this weapon.">Iterative Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-							<input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_$X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+						<b title="Add additional attacks for this weapon.">
+						Iterative Attacks</b>
+						<input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_$X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0; width:120px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -105px; cursor:pointer; z-index:1;" /><span></span>
+						<b>Options</b>
+						<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_weapon_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+
 							<div class="sheet-table sheet-sect sheet-iterative_attack_section">
 								<span class="sheet-table-name">Iterative Attacks</span>
 								<div class="sheet-table-row">
@@ -2399,17 +2416,15 @@
 									</span>
 									<input type="hidden" name="attr_var_iterative_attack8" value="{{attack8=@{iterative_attack8_macro}}}" />
 								</div>
-							</div>
 							<input type="hidden" name="attr_iterative_attacks" value="@{toggle_iterative_attack2} @{toggle_iterative_attack3} @{toggle_iterative_attack4} @{toggle_iterative_attack5} @{toggle_iterative_attack6} @{toggle_iterative_attack7} @{toggle_iterative_attack8}" />
-							<div>
-								<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-								<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>    
+							</div>
+						
+						<div class="sheet-table sheet-options">
 										<textarea style="display:none;" name="attr_var_melee_notes">{{melee_notes=@{melee-attack-notes}}} {{header_image=@{header_image-pf_attack-melee}}}</textarea>
 										<textarea style="display:none;" name="attr_var_ranged_notes">{{ranged_notes=@{ranged-attack-notes}}} {{header_image=@{header_image-pf_attack-ranged}}}</textarea>
 										<textarea style="display:none;" name="attr_var_CMB_notes">{{CMB_notes=@{CMB-notes}}} {{header_image=@{header_image-pf_attack-cmb}}}</textarea>
 										<textarea style="display:none;" name="attr_var_none_notes">{{header_image=@{header_image-pf_attack-melee}}}</textarea>
 										<textarea style="display:none;" name="attr_var_attack_notes">{{attack_notes=@{attack-notes}}}</textarea>
-								<div class="sheet-table sheet-options">
 									<div class="sheet-table-row sheet-table-header">
 										<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these additional notes with this attack roll.">Include notes?</b></span>
 										<span class="sheet-table-data sheet-center sheet-small-label" style="width:13%;"><label>( <input type="checkbox" name="attr_toggle_notes" value="@{var_melee_notes}" title="@{repeating_weapon_$X_toggle_notes}" /><b title="Include Melee attack notes."> Melee Notes</b></label></span>
@@ -2418,12 +2433,17 @@
 											<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><label><input type="checkbox" name="attr_toggle_notes" value="@{var_none_notes}" title="@{repeating_weapon_$X_toggle_notes}" checked /><b title="Do not include Melee, Ranged, or CMB notes."> None</b> )</label></span>					
 										<span class="sheet-table-data sheet-center sheet-small-label"><label style="text-align:right;"><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{repeating_weapon_$X_toggle_attack_notes}" /><b title="Include Attack notes."> Attack Notes</b></label></span>
 									</div>
-								</div>
 									<textarea style="display:none;" name="attr_macro_options">@{toggle_notes} @{toggle_attack_notes}</textarea>
 							</div>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+						
 						<textarea class="sheet-macro-text" title="@{repeating_weapon_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{attack=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} ]] ]]}} {{damage=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm=[[ 1d20 + [[ @{total-attack} ]] ]]}} {{crit_damage=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}} {{type=@{type}}} {{description=@{notes}}} @{iterative_attacks} @{macro_options}</textarea>
+						
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_weapon_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_weapon_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_weapon_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
@@ -2433,8 +2453,8 @@
 </div>
 <div class="sheet-section sheet-section-skills">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
-    <div><b>Skill Ranks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{skill-ranks-show}" name="attr_skill-ranks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+    <div><b>Skill Ranks</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{skill-ranks-show}" name="attr_skill-ranks-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Skill Ranks</span>
             <div class="sheet-table-row">
@@ -2471,8 +2491,8 @@
 
         <input type="checkbox" class="sheet-sect-show" title="@{unchained_skills-show}" name="attr_unchained_skills-show" value="1" style="margin:-9999px;" /><span></span>
 		<div class="sheet-sect">
-			<div><b>Unchained Skills&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-				<input type="checkbox" class="sheet-sect-show" title="@{unchained_skill_sub-show}" name="attr_unchained_skill_sub-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+			<div><b>Unchained Skills</b>
+				<input type="checkbox" class="sheet-sect-show" title="@{unchained_skill_sub-show}" name="attr_unchained_skill_sub-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
 				
 				<div class="sheet-sect">		
 					<input type="radio" name="attr_skills_tab" class="sheet-tab sheet-skill-tab sheet-skills-tab1" value="1" title="Adventure Skills" checked="checked" />
@@ -4564,8 +4584,8 @@
 		</div>
 
 	</div>
-	<div style="margin-top:-15px;"><b>Skills&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{skills-show}" name="attr_skills-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+	<div style="margin-top:-15px;"><b>Skills</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{skills-show}" name="attr_skills-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
                     <span class="sheet-table-name">Skills</span>
                     <div class="sheet-table-row">
@@ -6172,8 +6192,8 @@
 		<div class="sheet-table sheet-center sheet-sect"><b>CS</b> = Class Skill | <b>RT</b> = Requires Training | <b>Cl/Ac/Sz/Co</b> = Class Skill Bonus / Armor check penalty / Size mod / Condition penalty</div>
 		<br>		
 	</div>
-    <div><b>Skill Notes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{skill-notes-show}" name="attr_skill-notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+    <div><b>Skill Notes</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{skill-notes-show}" name="attr_skill-notes-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-center sheet-sect">
             <span class="sheet-table-name">Skill Notes</span>
             <div class="sheet-table-row">
@@ -6186,8 +6206,8 @@
 <div class="sheet-section sheet-section-feats">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Feats Available&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{feats-available-show}" name="attr_feats-available-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Feats Available</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{feats-available-show}" name="attr_feats-available-show" value="1" style="opacity: 0;width: 130px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -115px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Feats Available</span>
             <div class="sheet-table-row">
@@ -6216,8 +6236,8 @@
         <br>
     </div>
     <div>
-        <b>Feats&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{feats-show}" name="attr_feats-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Feats</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{feats-show}" name="attr_feats-show" value="1" style="opacity:0;width: 50px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -35px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Feats</span>
             <div class="sheet-table-row">
@@ -6243,13 +6263,21 @@
 					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_feat_$X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" class="sheet-calc" readonly="readonly" /></span>
 					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_feat_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /></span>
 					<div class="sheet-sect">				
-						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+						<b>Description</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_feat_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
 						<textarea class="sheet-desc" title="@{repeating_feat_$X_description}" name="attr_description"></textarea>
-						<br>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
 						<textarea class="sheet-macro-text" title="@{repeating_feat_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}}  {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_feat_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_feat_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_feat_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
@@ -6260,8 +6288,8 @@
 <div class="sheet-section sheet-section-inventory">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Currency&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{currency-show}" name="attr_currency-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Currency</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{currency-show}" name="attr_currency-show" value="1" style="opacity:0; width:80px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -65px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Currency</span>
             <div class="sheet-table-row">
@@ -6278,8 +6306,8 @@
         <br>
     </div>
     <div>
-        <b>Worn Magic Equipment&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{worn-equipment-show}" name="attr_worn-equipment-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+        <b>Worn Magic Equipment</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{worn-equipment-show}" name="attr_worn-equipment-show" value="1" style="opacity:0;width: 150px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -133px; cursor:pointer; z-index:1;" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Worn Magic Equipment</span>
             <div class="sheet-table-row">
@@ -6356,8 +6384,8 @@
         <br>
     </div>
     <div>
-        <b>Inventory&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{inventory-show}" name="attr_inventory-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Inventory</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{inventory-show}" name="attr_inventory-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Inventory</span>
             <div class="sheet-table-row">
@@ -6383,21 +6411,29 @@
 					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_item_$X_qty|max" type="number" name="attr_qty_max" value="0" /></span>
 					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_item_$X_weight}" type="number" name="attr_weight" value="0"  step="any" min="0" /></span>
 					<div class="sheet-sect">				
-						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-desc-show" title="@{repeating_item_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+						<b>Description</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_item_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_item_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_item_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
 						<textarea class="sheet-desc" title="@{repeating_item_$X_description}" name="attr_description"></textarea>
-						<br>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_item_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
 						<textarea class="sheet-macro-text" title="@{repeating_item_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_item_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_item_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_item_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
         </div>
     </div>
     <div>
-        <b>Carried Weight&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{carried-weight-show}" name="attr_carried-weight-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Carried Weight</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{carried-weight-show}" name="attr_carried-weight-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Carried Weight</span>
             <div class="sheet-table-row">
@@ -6426,8 +6462,8 @@
         <br>
     </div>
     <div>
-        <b>Loads and Lift&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{loads-show}" name="attr_loads-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Loads and Lift</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{loads-show}" name="attr_loads-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Loads and Lift</span>
             <div class="sheet-table-row">
@@ -6465,8 +6501,8 @@
 <div class="sheet-section sheet-section-spells">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Spells Classes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{spellclasses-show}" name="attr_spellclasses-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Spells Classes</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{spellclasses-show}" name="attr_spellclasses-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-sect">
             <input type="radio" name="attr_spellclass_tab" value="0"  title="Spell Class 0" class="sheet-tab sheet-spellclass sheet-spellclass-tab0" checked="checked" />
             <span class="sheet-tab sheet-spellclass sheet-spellclass-tab0">Spell Class 0</span>
@@ -6532,8 +6568,8 @@
                 </div>
                 <br>
                 <div>
-                    <b>Spells Per Day&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-0-show}" name="attr_spellsPerDay-0-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                    <b>Spells Per Day</b>
+                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-0-show}" name="attr_spellsPerDay-0-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                     <div class="sheet-table sheet-sect">
                         <span class="sheet-table-name">Spells Per Day</span>
                         <div class="sheet-table-row">
@@ -6667,9 +6703,11 @@
                             <span class="sheet-table-data sheet-center"></span>
                         </div>
                     </div>
-                    <br>
                 </div>
-                <div class="sheet-table">
+				<div>
+					<b>Spell Ranges</b>
+					<input type="checkbox" class="sheet-spell_ranges0-show" title="@{spell_ranges0-show}" name="attr_spell_ranges0-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+					<div class="sheet-table sheet-spell_ranges0">
                     <span class="sheet-table-name">Spell Ranges</span>
                     <div class="sheet-table-row">
                         <span class="sheet-table-row-name sheet-spellrange-header">Close</span>
@@ -6680,6 +6718,7 @@
                         <span class="sheet-table-data sheet-center"><input class="sheet-spellrange-data" title="@{spellclass-0-long}" type="number" name="attr_spellclass-0-long" value="(400 + (40 * @{spellclass-0-level}))" disabled /></span>
                     </div>
                 </div>
+            </div>
             </div>
             <div class="sheet-section sheet-section-spellclass-1">
                 <div class="sheet-table">
@@ -6716,7 +6755,7 @@
 						<span class="sheet-table-data sheet-divider">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{buff_CasterLevel-total}" name="attr_buff_CasterLevel-total" type="number" value="0" class="sheet-calc" readonly="readonly"/></span>						
 						<span class="sheet-table-data sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-center"><button style="font-size:1em; white-space:nowrap;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=Concentration Check}} {{Class=@{spellclass-1-name} [[ @{spellclass-1-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]] ]]}}">&nbsp;Concentration&nbsp;</button></span>
+						<span class="sheet-table-data sheet-center"><button style="font-size:1em; white-space:nowrap;" title="%{selected|Concentration-Check-1}" type="roll" name="roll_Concentration-Check-1" value="@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=Concentration Check}} {{Class=@{spellclass-1-name} [[ @{spellclass-1-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]] ]]}}">&nbsp;Concentration&nbsp;</button></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-1-level} + [[ @{Concentration-1-ability} ]] + [[ @{buff_Check-total} ]] + [[ @{Concentration-1-misc} ]])" disabled /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center">
@@ -6739,8 +6778,8 @@
                 </div>
                 <br>
                 <div>
-                    <b>Spells Per Day&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-1-show}" name="attr_spellsPerDay-1-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                    <b>Spells Per Day</b>
+                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-1-show}" name="attr_spellsPerDay-1-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                     <div class="sheet-table sheet-sect">
                         <span class="sheet-table-name">Spells Per Day</span>
                         <div class="sheet-table-row">
@@ -6874,9 +6913,11 @@
                             <span class="sheet-table-data sheet-center"></span>
                         </div>
                     </div>
-                    <br>
                 </div>
-                <div class="sheet-table">
+				<div>
+					<b>Spell Ranges</b>
+					<input type="checkbox" class="sheet-spell_ranges1-show" title="@{spell_ranges1-show}" name="attr_spell_ranges1-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+					<div class="sheet-table sheet-spell_ranges1">
                     <span class="sheet-table-name">Spell Ranges</span>
                     <div class="sheet-table-row">
                         <span class="sheet-table-row-name sheet-spellrange-header">Close</span>
@@ -6887,6 +6928,7 @@
                         <span class="sheet-table-data sheet-center"><input class="sheet-spellrange-data" title="@{spellclass-1-long}" type="number" name="attr_spellclass-1-long" value="(400 + (40 * @{spellclass-1-level}))" disabled /></span>
                     </div>
                 </div>
+            </div>
             </div>
             <div class="sheet-section sheet-section-spellclass-2">
                 <div class="sheet-table">
@@ -6923,7 +6965,7 @@
 						<span class="sheet-table-data sheet-divider">+</span>
                         <span class="sheet-table-data sheet-center"><input title="@{buff_CasterLevel-total}" name="attr_buff_CasterLevel-total" type="number" value="0" class="sheet-calc" readonly="readonly"/></span>						
 						<span class="sheet-table-data sheet-divider-lg" >|</span>
-						<span class="sheet-table-data sheet-center"><button style="font-size:1em; white-space:nowrap;" title="%{selected|Concentration-Check-0}" type="roll" name="roll_Concentration-Check-0" value="@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=Concentration Check}} {{Class=@{spellclass-2-name} [[ @{spellclass-2-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]] ]]}}">&nbsp;Concentration&nbsp;</button></span>
+						<span class="sheet-table-data sheet-center"><button style="font-size:1em; white-space:nowrap;" title="%{selected|Concentration-Check-2}" type="roll" name="roll_Concentration-Check-2" value="@{PC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=Concentration Check}} {{Class=@{spellclass-2-name} [[ @{spellclass-2-level} ]]}} {{Check=[[ 1d20 + [[ @{Concentration-0} ]] ]]}}">&nbsp;Concentration&nbsp;</button></span>
 						<span class="sheet-table-data sheet-center"><input title="@{Concentration-0}" type="number" name="attr_Concentration-0" value="(@{spellclass-2-level} + [[ @{Concentration-2-ability} ]] + [[ @{buff_Check-total} ]] + [[ @{Concentration-2-misc} ]])" disabled /></span>
                         <span class="sheet-table-data sheet-divider">=</span>
                         <span class="sheet-table-data sheet-center">
@@ -6946,8 +6988,8 @@
                 </div>
                 <br>
                 <div>
-                    <b>Spells Per Day&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-2-show}" name="attr_spellsPerDay-2-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                    <b>Spells Per Day</b>
+                    <input type="checkbox" class="sheet-sect-show" title="@{spellsPerDay-2-show}" name="attr_spellsPerDay-2-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                     <div class="sheet-table sheet-sect">
                         <span class="sheet-table-name">Spells Per Day</span>
                         <div class="sheet-table-row">
@@ -7081,9 +7123,11 @@
                             <span class="sheet-table-data sheet-center"></span>
                         </div>
                     </div>
-                    <br>
                 </div>
-                <div class="sheet-table">
+				<div>
+					<b>Spell Ranges</b>
+					<input type="checkbox" class="sheet-spell_ranges2-show" title="@{spell_ranges2-show}" name="attr_spell_ranges2-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+					<div class="sheet-table sheet-spell_ranges2">
                     <span class="sheet-table-name">Spell Ranges</span>
                     <div class="sheet-table-row">
                         <span class="sheet-table-row-name sheet-spellrange-header">Close</span>
@@ -7096,11 +7140,11 @@
                 </div>
             </div>
         </div>
-        <br>
+        </div>
     </div>
     <div>
-        <b>Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{spells-show}" name="attr_spells-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Spells</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{spells-show}" name="attr_spells-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-sect">
             <input type="radio" name="attr_spells_tab" value="0"  title="Level 0 Spells" class="sheet-tab sheet-spell_level sheet-spells_level-tab0" checked="checked" />
             <span class="sheet-tab sheet-spell_level sheet-spells_level-tab0">Level 0</span>
@@ -8121,8 +8165,8 @@
 <div class="sheet-section sheet-section-details">
     <div class="sheet-table sheet-header-row">&nbsp;</div>
     <div>
-        <b>Character Details&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{character-details-show}" name="attr_character-details-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Character Details</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{character-details-show}" name="attr_character-details-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Character Details</span>
         </div>
@@ -8173,8 +8217,8 @@
         <br>
     </div>
     <div>
-        <b>Racial Traits&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{racial-traits-show}" name="attr_racial-traits-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Racial Traits</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{racial-traits-show}" name="attr_racial-traits-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Racial Traits</span>
             <div class="sheet-table-row">
@@ -8200,21 +8244,29 @@
 					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_racial-trait_$X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" class="sheet-calc" readonly="readonly" /></span>
 					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_racial-trait_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /></span>
 					<div class="sheet-sect">
-						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+						<b>Description</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_racial-trait_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
 						<textarea class="sheet-desc" title="@{repeating_racial-trait_$X_description}" name="attr_description"></textarea>
-						<br>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
 						<textarea class="sheet-macro-text" title="@{repeating_racial-trait_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_racial-trait_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_racial-trait_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_racial-trait_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
         </div>
     </div>
     <div>
-        <b>Traits&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{traits-show}" name="attr_traits-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Traits</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{traits-show}" name="attr_traits-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Traits</span>
             <div class="sheet-table-row">
@@ -8240,13 +8292,21 @@
 					<span class="sheet-table-data sheet-center" style="width:5%;"><input title="@{repeating_trait_$X_used|max" type="number" name="attr_used_max" value="@{max-calculation}" class="sheet-calc" readonly="readonly" /></span>
 					<span class="sheet-table-data sheet-center" style="width:15%;"><input title="@{repeating_trait_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /></span>
 					<div class="sheet-sect">					
-						<b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-desc-show" title="@{repeating_trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+						<b>Description</b>
+						<input type="checkbox" class="sheet-desc-show" title="@{repeating_trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+						<b>Macro Text</b>
+						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_trait_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
 						<textarea class="sheet-desc" title="@{repeating_trait_$X_description}" name="attr_description"></textarea>
-						<br>
-						<b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-						<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
 						<textarea class="sheet-macro-text" title="@{repeating_trait_$X_macro-text}" name="attr_macro-text">@{PC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_trait_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_trait_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_trait_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
 					</div>
 				</fieldset>
 			</div>
@@ -8308,8 +8368,8 @@
     </div>
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>QUICK STATS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-quick_stats-show}" name="attr_npc-quick_stats-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>QUICK STATS</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-quick_stats-show}" name="attr_npc-quick_stats-show" value="1" style="opacity: 0;width: 110px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -95px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
 		<div class="sheet-table sheet-sect">
 			<div class="sheet-table-row">
@@ -8330,8 +8390,8 @@
 	</div>	
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>DEFENSE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-defense-show}" name="attr_npc-defense-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>DEFENSE</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-defense-show}" name="attr_npc-defense-show" value="1" style="opacity: 0;width: 85px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -65px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
         <div style="text-align:left;" class="sheet-sect">
 				<div class="sheet-table">
@@ -8408,17 +8468,17 @@
             </div>
             <div class="sheet-table">
                 <div class="sheet-table-row">
-                    <span class="sheet-table-data sheet-center sheet-small-label"  ><input type="text" title="@{npc-defensive-abilities}" name="attr_npc-defensive-abilities" placeholder="Defensive abilities" /><br>Defensive Abilities</span>
-                    <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%" ><input title="@{DR}" type="text" name="attr_DR"  /><br>DR</span>
-                    <span class="sheet-table-data sheet-center sheet-small-label"  ><input title="@{immunities}" type="text" name="attr_immunities" placeholder="Immune" /><br>Immunities</span>
-                    <span class="sheet-table-data sheet-center sheet-small-label"  ><input title="@{resistances}" type="text" name="attr_resistances" placeholder="Resist" /><br>Resistances</span>
+                    <span class="sheet-table-data sheet-center sheet-small-label"><input type="text" title="@{npc-defensive-abilities}" name="attr_npc-defensive-abilities" placeholder="Defensive abilities" /><br>Defensive Abilities</span>
+                    <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{DR}" type="text" name="attr_DR"  /><br>DR</span>
+                    <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{immunities}" type="text" name="attr_immunities" placeholder="Immune" /><br>Immunities</span>
+                    <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{resistances}" type="text" name="attr_resistances" placeholder="Resist" /><br>Resistances</span>
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%"  ><input title="@{SR}" type="number" name="attr_SR" value="0" /><br>SR</span>
-                    <span class="sheet-table-data sheet-center sheet-small-label"  ><input title="@{weaknesses}" type="text" name="attr_weaknesses" placeholder="Weaknesses" /><br>Weaknesses</span>
+                    <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{weaknesses}" type="text" name="attr_weaknesses" placeholder="Weaknesses" /><br>Weaknesses</span>
                 </div>
             </div>
 			<div>
-				<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-				<input type="checkbox" class="sheet-options-show" title="@{options_defense_notes-show}" name="attr_options_defense_notes-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>    
+				<b>Options</b>
+				<input type="checkbox" class="sheet-options-show" title="@{options_defense_notes-show}" name="attr_options_defense_notes-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>    
 					<input type="hidden" name="attr_var_dr_notes" value="{{dr_notes=@{DR}}}" disabled />
 					<input type="hidden" name="attr_var_resistances_notes" value="{{resistances_notes=@{resistances}}}" disabled />
 					<input type="hidden" name="attr_var_immunities_notes" value="{{immunities_notes=@{immunities}}}" disabled />
@@ -8452,8 +8512,8 @@
     </div>
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>OFFENSE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-offense-show}" name="attr_npc-offense-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>OFFENSE</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-offense-show}" name="attr_npc-offense-show" value="1" style="opacity: 0;width: 85px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -65px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
         <div style="text-align:left;" class="sheet-sect">
             <div class="sheet-table">
@@ -8471,8 +8531,8 @@
             </div>
             <br>
 	<div>
-		<b title="Apply attack and damage modifiers to all attacks.">Attack and Damage Effects&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{attack_damage_status_effects-show}" name="attr_attack_damage_status_effects-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+		<b title="Apply attack and damage modifiers to all attacks.">Attack and Damage Effects</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{attack_damage_status_effects-show}" name="attr_attack_damage_status_effects-show" value="1" style="opacity: 0 ; width: 195px ; height: 1.5em ; position: relative ; top: 0 ; left: 0 ; margin: 0 -15px 0 -176px ; cursor: pointer ; z-index: 1" checked="checked" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<span class="sheet-table-name">Attack and Damage Effects</span>
 			<div class="sheet-table-row">
@@ -8566,14 +8626,14 @@
 		<br>
 	</div>
             <div>
-                <b>Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Attacks</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{attacks-show}" name="attr_attacks-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <div class="sheet-sect">
                     <div class="sheet-repeating-fields">
                         <fieldset class="repeating_weapon">
                             <input type="checkbox" class="sheet-counted sheet-sect-show" name="attr_attack-show" title="@{repeating_weapon_$X_attack-show}" value="1" style="opacity:0 ; height:1.5em ; position: absolute ; top:20px; width:2% ; cursor:pointer ; z-index:1" checked="checked" />
                             <span class="sheet-table-data sheet-divider"></span>
-                            <span class="sheet-table-data sheet-center"><button type="roll" name="attr_attack-npc-roll" title="@{repeating_weapon_$X_attack-npc-roll" value="@{macro-text}"></button></span>
+                            <span class="sheet-table-data sheet-center"><button type="roll" name="attr_attack-npc-roll" title="%{selected|repeating_weapon_$X_attack-npc-roll}" value="@{macro-text}"></button></span>
 							<span class="sheet-table-data sheet-center sheet-small-label"><input type="number"  name="attr_enhance" title="@{repeating_weapon_$X_enhance}" value="0" style="width:40px;"  /><br>Enh</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="padding-top: 8px;"><input type="checkbox" name="attr_masterwork" title="@{repeating_weapon_$X_masterwork}" value="1" style="width:15px;height:15px;" /><br>Mwk</span>
                             <span class="sheet-table-data sheet-center sheet-small-label"><input type="text" name="attr_name" title="@{repeating_weapon_$X_name}" placeholder="Name" /><br>Name</span>
@@ -8582,8 +8642,8 @@
                             <span class="sheet-table-data sheet-divider">+</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;">
 								<select title="@{repeating_weapon_$X_attack-type}" name="attr_attack-type">
-									<option value="0">None</option>
-									<option value="@{attk-melee}" selected>&#8226;Melee</option>
+									<option value="0"  selected>&#8226;None</option>
+									<option value="@{attk-melee}">Melee</option>
 									<option value="@{attk-ranged}">Ranged</option>
 									<option value="@{CMB}">CMB</option>
 								</select>
@@ -8616,14 +8676,14 @@
 										<span class="sheet-table-data sheet-divider">+</span>
 										<span class="sheet-table-data sheet-center sheet-small-label" style="width:8%;">
 											<select title="@{repeating_weapon_$X_damage-ability}" name="attr_damage-ability" style="font-size:1em;">
-										<option value="0 - [[ @{condition-sickened} ]]">None</option>
+												<option value="0 - [[ @{condition-sickened} ]]" selected>&#8226;None</option>
 												<option value="floor(0.5 * @{STR-mod}) - [[ @{condition-sickened} ]]">1/2 STR</option>
 												<option value="floor(0.5 * @{DEX-mod}) - [[ @{condition-sickened} ]]">1/2 DEX</option>
 												<option value="floor(0.5 * @{CON-mod}) - [[ @{condition-sickened} ]]">1/2 CON</option>
 												<option value="floor(0.5 * @{INT-mod}) - [[ @{condition-sickened} ]]">1/2 INT</option>
 												<option value="floor(0.5 * @{WIS-mod}) - [[ @{condition-sickened} ]]">1/2 WIS</option>
 												<option value="floor(0.5 * @{CHA-mod}) - [[ @{condition-sickened} ]]">1/2 CHA</option>
-										<option value="@{STR-mod} - [[ @{condition-sickened} ]]" selected>&#8226;STR</option>
+												<option value="@{STR-mod} - [[ @{condition-sickened} ]]">STR</option>
 												<option value="@{DEX-mod} - [[ @{condition-sickened} ]]">DEX</option>
 												<option value="@{CON-mod} - [[ @{condition-sickened} ]]">CON</option>
 												<option value="@{INT-mod} - [[ @{condition-sickened} ]]">INT</option>
@@ -8661,12 +8721,19 @@
 								<div class="sheet-table">
 									<div class="sheet-table-row">
 										<textarea class="sheet-weapon-notes" name="attr_notes" title="@{repeating_weapon_$X_notes}" placeholder="Weapon Notes"></textarea>
-										<div class="sheet-center sheet-small-label" style="display: block;">Notes</div>
+										<span class="sheet-center sheet-small-label" style="display: block;">Notes</span>
 									</div>
 								</div>
-							</div>
-                                <b title="Add additional attacks for this weapon.">Iterative Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                <input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_$X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                                <b title="Add additional attacks for this weapon.">
+								Iterative Attacks</b>
+								<input type="checkbox" class="sheet-sect-show" title="@{repeating_weapon_$X_iterative-attacks-show}" name="attr_iterative-attacks-show" value="1" style="opacity:0; width:120px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -105px; cursor:pointer; z-index:1;" /><span></span>
+								<b>Options</b>
+								<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>
+								<b>Macro Text</b>
+								<input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+								<!-- <b>IDs</b>
+								<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_weapon_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+							
                                 <div class="sheet-table sheet-sect sheet-iterative_attack_section">
                                     <span class="sheet-table-name">Iterative Attacks</span>
                                     <div class="sheet-table-row">
@@ -8779,17 +8846,15 @@
 									</span>
                                         <input type="hidden" name="attr_var_iterative_attack8" value="{{attack8=@{iterative_attack8_macro}}}" />
                                     </div>
+									<input type="hidden" name="attr_iterative_attacks" value="@{toggle_iterative_attack2} @{toggle_iterative_attack3} @{toggle_iterative_attack4} @{toggle_iterative_attack5} @{toggle_iterative_attack6} @{toggle_iterative_attack7} @{toggle_iterative_attack8}" />
                                 </div>
-                                <input type="hidden" name="attr_iterative_attacks" value="@{toggle_iterative_attack2} @{toggle_iterative_attack3} @{toggle_iterative_attack4} @{toggle_iterative_attack5} @{toggle_iterative_attack6} @{toggle_iterative_attack7} @{toggle_iterative_attack8}" />
-								<div>
-									<b>Options&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-									<input type="checkbox" class="sheet-options-show" title="@{options-show}" name="attr_options-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>    
+																	
+								<div class="sheet-table sheet-options">    
 										<textarea style="display:none;" name="attr_var_melee_notes">{{melee_notes=@{melee-attack-notes}}} {{header_image=@{header_image-pf_attack-melee}}}</textarea>
 										<textarea style="display:none;" name="attr_var_ranged_notes">{{ranged_notes=@{ranged-attack-notes}}} {{header_image=@{header_image-pf_attack-ranged}}}</textarea>
 										<textarea style="display:none;" name="attr_var_CMB_notes">{{CMB_notes=@{CMB-notes}}} {{header_image=@{header_image-pf_attack-cmb}}}</textarea>
 										<textarea style="display:none;" name="attr_var_none_notes">{{header_image=@{header_image-pf_attack-melee}}}</textarea>
 										<textarea style="display:none;" name="attr_var_attack_notes">{{attack_notes=@{attack-notes}}}</textarea>
-									<div class="sheet-table sheet-options">
 										<div class="sheet-table-row sheet-table-header">
 											<span class="sheet-table-data sheet-center sheet-small-label"><b title="Include these additional notes with this attack roll.">Include notes?</b></span>
 											<span class="sheet-table-data sheet-center sheet-small-label" style="width:13%;"><label>( <input type="checkbox" name="attr_toggle_notes" value="@{var_melee_notes}" title="@{repeating_weapon_$X_toggle_notes}" /><b title="Include Melee attack notes."> Melee Notes</b></label></span>
@@ -8798,12 +8863,17 @@
 											<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;"><label><input type="checkbox" name="attr_toggle_notes" value="@{var_none_notes}" title="@{repeating_weapon_$X_toggle_notes}" checked /><b title="Do not include Melee, Ranged, or CMB notes."> None</b> )</label></span>					
 											<span class="sheet-table-data sheet-center sheet-small-label"><label style="text-align:right;"><input type="checkbox" name="attr_toggle_attack_notes" value="@{var_attack_notes}" title="@{repeating_weapon_$X_toggle_attack_notes}" /><b title="Include Attack notes."> Attack Notes</b></label></span>
 										</div>
-									</div>
 									<textarea style="display:none;" name="attr_macro_options">@{toggle_notes} @{toggle_attack_notes}</textarea>
 								</div>
-                                <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_weapon_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                                
                                 <textarea class="sheet-macro-text" title="@{repeating_weapon_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_attack} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{attack=[[ 1d20cs>[[ @{crit-target} ]] + [[ @{total-attack} ]] ]]}} {{damage=[[ @{damage-dice-num}d@{damage-die} + [[ @{total-damage} ]] ]]}} {{crit_confirm=[[ 1d20 + [[ @{total-attack} ]] ]]}} {{crit_damage=[[ [[ (@{damage-dice-num} * (@{crit-multiplier} - 1)) ]]d@{damage-die} + [[ (@{total-damage} * (@{crit-multiplier} - 1)) ]] ]]}} {{type=@{type}}} {{description=@{notes}}} @{iterative_attacks} @{macro_options}</textarea>
+								<!-- <div class="sheet-repeating_ids sheet-table-row">
+									<input type="hidden" title="@{repeating_weapon_$X_new_flag}" name="attr_new_flag" value="0"  />
+									<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_weapon_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+									<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_weapon_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+									<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+								</div> -->
+							</div>
                         </fieldset>
                     </div>
                 </div>
@@ -8814,14 +8884,14 @@
             <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{reach-notes}" type="text" name="attr_reach-notes" placeholder="Reach notes" /><br>Reach Notes</span>
             <br>
             <div>
-                <b>Special Attacks&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-special-attacks-show}" name="attr_npc-special-attacks-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Special Attacks</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-special-attacks-show}" name="attr_npc-special-attacks-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                 <textarea style="height:50px;" class="sheet-sect" title="@{npc-special-attacks}" name="attr_npc-special-attacks" placeholder="List all special combat actions here, in alphabetical order. Do not list feats."></textarea>
             </div>
             <br/>
             <div>
-                <b>Spell-Like Abilities (class-0)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-show}" name="attr_npc-spell-like-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Spell-Like Abilities (class-0)</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-show}" name="attr_npc-spell-like-abilities-show" value="1" style="opacity: 0;width: 195px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -176px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                 <div class="sheet-sect">
                     <div class="sheet-table">
                         <span class="sheet-table-name sheet-secondary-table-name">Spell Like Abilities Class 0</span>
@@ -8868,8 +8938,8 @@
                     </div>
                     <br/>
                     <div>
-                        <b>Spell-Like Abilities&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-sect-show}" name="attr_npc-spell-like-abilities-sect-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                        <b>Spell-Like Abilities</b>
+                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell-like-abilities-sect-show}" name="attr_npc-spell-like-abilities-sect-show" value="1" style="opacity:0;width: 150px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -133px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                         <div class="sheet-sect">
                             <div class="sheet-repeating-fields">
                                 <fieldset class="repeating_npc-spell-like-abilities">
@@ -8893,9 +8963,17 @@
 										<br>SR
 									</span>
                                     <div class="sheet-sect">
-                                        <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                                        <b>Macro Text</b>
+                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
                                         <textarea class="sheet-macro-text" title="@{repeating_npc-spell-like-abilities_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{Level=@{level}}} {{Range=@{range}}} {{Duration=@{duration}}} {{Save=@{save}}} {{SR=@{sr}}} {{description=@{short-description}}}</textarea>
+										<br><!-- <b>IDs</b>
+										<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_npc-spell-like-abilities_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+										<!-- <div class="sheet-repeating_ids sheet-table-row">
+											<input type="hidden" title="@{repeating_npc-spell-like-abilities_$X_new_flag}" name="attr_new_flag" value="0"  />
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_npc-spell-like-abilities_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_npc-spell-like-abilities_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+											<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+										</div> -->
                                         <hr/>
                                     </div>
                                 </fieldset>
@@ -8906,8 +8984,8 @@
                 <br/>
             </div>
             <div>
-                <b>Spells (class-1)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell1-show}" name="attr_npc-spell1-show" value="0"  style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                <b>Spells (class-1)</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell1-show}" name="attr_npc-spell1-show" value="0"  style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" /><span></span>
                 <div class="sheet-sect">
                     <div class="sheet-table">
                         <span class="sheet-table-name sheet-secondary-table-name">Spell Class 1</span>
@@ -8954,8 +9032,8 @@
                     </div>
                     <br/>
                     <div>
-                        <b>Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell1-sect-show}" name="attr_npc-spell1-sect-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                        <b>Spells</b>
+                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell1-sect-show}" name="attr_npc-spell1-sect-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                         <div class="sheet-sect">
                             <div class="sheet-repeating-fields">
                                 <fieldset class="repeating_npc-spells1">
@@ -8979,9 +9057,17 @@
 										<br>SR
 									</span>
                                     <div class="sheet-sect">
-                                        <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells1_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                                        <b>Macro Text</b>
+                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells1_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
                                         <textarea class="sheet-macro-text" title="@{repeating_npc-spells1_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{Level=@{level}}} {{Range=@{range}}} {{Duration=@{duration}}} {{Save=@{save}}} {{SR=@{sr}}} {{description=@{short-description}}}</textarea>
+										<br><!-- <b>IDs</b>
+										<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_npc-spells1_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+										<!-- <div class="sheet-repeating_ids sheet-table-row">
+											<input type="hidden" title="@{repeating_npc-spells1_$X_new_flag}" name="attr_new_flag" value="0"  />
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_npc-spells1_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_npc-spells1_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+											<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+										</div> -->
                                         <hr/>
                                     </div>
                                 </fieldset>
@@ -8992,8 +9078,8 @@
                 <br/>
             </div>
             <div>
-                <b>Spells (class-2)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell2-show}" name="attr_npc-spell2-show" value="0"  style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                <b>Spells (class-2)</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-spell2-show}" name="attr_npc-spell2-show" value="0"  style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" /><span></span>
                 <div class="sheet-sect">
                     <div class="sheet-table">
                         <span class="sheet-table-name sheet-secondary-table-name">Spell Class 2</span>
@@ -9040,8 +9126,8 @@
                     </div>
                     <br/>
                     <div>
-                        <b>Spells&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell2-sect-show}" name="attr_npc-spell2-sect-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                        <b>Spells</b>
+                        <input type="checkbox" class="sheet-sect-show" title="@{npc-spell2-sect-show}" name="attr_npc-spell2-sect-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                         <div class="sheet-sect">
                             <div class="sheet-repeating-fields">
                                 <fieldset class="repeating_npc-spells2">
@@ -9065,9 +9151,17 @@
 										<br>SR
 									</span>
                                     <div class="sheet-sect">
-                                        <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells2_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                                        <b>Macro Text</b>
+                                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_npc-spells2_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
                                         <textarea class="sheet-macro-text" title="@{repeating_npc-spells2_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{Level=@{level}}} {{Range=@{range}}} {{Duration=@{duration}}} {{Save=@{save}}} {{SR=@{sr}}} {{description=@{short-description}}}</textarea>
+										<br><!-- <b>IDs</b>
+										<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_npc-spells2_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+										<!-- <div class="sheet-repeating_ids sheet-table-row">
+											<input type="hidden" title="@{repeating_npc-spells2_$X_new_flag}" name="attr_new_flag" value="0"  />
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_npc-spells2_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+											<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_npc-spells2_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+											<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+										</div> -->
                                         <hr/>
                                     </div>
                                 </fieldset>
@@ -9081,36 +9175,36 @@
     </div>
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>TACTICS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-tactics-show}" name="attr_npc-tactics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+        <b>TACTICS</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-tactics-show}" name="attr_npc-tactics-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
         <div style="text-align:left;" class="sheet-sect">
             <div>
-                <b>Before Combat&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-before-combat-show}" name="attr_npc-before-combat-show" value="0"  style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                <b>Before Combat</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-before-combat-show}" name="attr_npc-before-combat-show" value="0"  style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" /><span></span>
                 <textarea class="sheet-sect" title="@{npc-before-combat}" name="attr_npc-before-combat" placeholder="List any spells and/or abilities used before combat. His stats should reflect these spells."></textarea>
             </div>
             <div>
-                <b>During Combat&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-during-combat-show}" name="attr_npc-during-combat-show" value="0"  style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+                <b>During Combat</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-during-combat-show}" name="attr_npc-during-combat-show" value="0"  style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" /><span></span>
                 <textarea class="sheet-sect" title="@{npc-during-combat}" name="attr_npc-during-combat" placeholder="List all combat tactics here, including spell, feat, and magic item use."></textarea>
             </div>
             <div>
-                <b>Morale&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-morale-show}" name="attr_npc-morale-show" value="0"  style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Morale</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-morale-show}" name="attr_npc-morale-show" value="0"  style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <textarea class="sheet-sect" title="@{npc-morale}" name="attr_npc-morale" placeholder="List here under what condition the creature flees combat, if any."></textarea>
             </div>
             <div>
-                <b>Base Statistics&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-base-statistics-show}" name="attr_npc-base-statistics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Base Statistics</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-base-statistics-show}" name="attr_npc-base-statistics-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
                 <input class="sheet-sect" type="text" title="@{npc-base-statistics}" name="attr_npc-base-statistics" placeholder="If the creature has buffs and other effects active that modify his stats, the base stats should be quickly summarized here." />
             </div>
         </div>
     </div>
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>STATISTICS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-statistics-show}" name="attr_npc-statistics-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>STATISTICS</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-statistics-show}" name="attr_npc-statistics-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
         <div style="text-align:left;" class="sheet-sect">
 			<div class="sheet-table">
@@ -9129,7 +9223,7 @@
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{class-0-bab}" type="number" name="attr_class-0-bab" value="0" /><br>BAB</span>
                     <span class="sheet-table-data sheet-center"><b>&nbsp;</b></span>
                     <span class="sheet-table-data sheet-center"><input title="@{CMB}" type="number" name="attr_CMB" value="0"  class="sheet-calc" readonly="readonly" />
-						<br><button style="font-size:100%;" type="roll" title="NPC-CMB-Check" name="roll_NPC-CMB-Check" value="@{NPC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]] ]]}}">CMB</button></span>
+						<br><button style="font-size:100%;" type="roll" title="%{selected|NPC-CMB-Check}" name="roll_NPC-CMB-Check" value="@{NPC-whisper} &{template:pf_generic} {{header_image=@{header_image-pf_generic}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=CMB}} {{Check=[[ 1d20 + [[ @{CMB} ]] ]]}}">CMB</button></span>
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{attk-CMB-misc}" type="number" name="attr_attk-CMB-misc" value="0" /><br>Misc</span>
                     <span class="sheet-table-data sheet-center"><b>&nbsp;</b></span>
                     <span class="sheet-table-data sheet-center sheet-small-label"><input title="@{CMD}" type="number" name="attr_CMD" value="0"  class="sheet-calc" readonly="readonly" /><br>CMD</span>
@@ -9139,13 +9233,13 @@
             </div>
             <br>
             <div>
-                <b>Feats&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-feats-show}" name="attr_npc-feats-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Feats</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-feats-show}" name="attr_npc-feats-show" value="1" style="opacity:0;width: 50px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -35px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <div class="sheet-table sheet-sect">
                     <div class="sheet-repeating-fields">
                         <fieldset class="repeating_feat">
                             <input type="checkbox" class="sheet-counted sheet-sect-show" title="@{repeating_feat_$X_feat-show}" name="attr_feat-show" value="1" style="opacity: 0 ; height: 1.5em ; position: absolute; top: 15px; width: 5% ; cursor: pointer ; z-index: 1" checked="checked" /><span class="sheet-table-data sheet-center" style="width:5%;"></span>
-                            <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" name="attr_npc-roll" title="@{repeating_feat_$X_npc-roll" value="@{macro-text}"></button><br>&nbsp;</span>
+                            <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><button type="roll" name="attr_npc-roll" title="%{selected|repeating_feat_$X_npc-roll" value="@{macro-text}"></button><br>&nbsp;</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:23%;"><input title="@{repeating_feat_$X_name}" type="text" name="attr_name" placeholder="Feat Name"><br>Name</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:45%;"><input title="@{repeating_feat_$X_short-description}" type="text" name="attr_short-description" placeholder="Short Description" /><br>Short Description</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_feat_$X_used}" type="number" name="attr_used" value="0" /><br>Used</span>
@@ -9153,13 +9247,21 @@
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_feat_$X_used|max" type="number" name="attr_used_max" value="@{max-calculation}"  class="sheet-calc" readonly="readonly" /><br>Max</span>
                             <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{repeating_feat_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /><br>Max Calc</span>
                             <div class="sheet-sect">
-                                <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                <input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                                <b>Description</b>
+                                <input type="checkbox" class="sheet-desc-show" title="@{repeating_feat_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+                                <b>Macro Text</b>
+                                <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+								<!-- <b>IDs</b>
+								<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_feat_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+								
                                 <textarea class="sheet-desc" title="@{repeating_feat_$X_description}" name="attr_description"></textarea>
-                                <br>
-                                <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                                <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_feat_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
                                 <textarea class="sheet-macro-text" title="@{repeating_feat_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+								<!-- <div class="sheet-repeating_ids sheet-table-row">
+									<input type="hidden" title="@{repeating_feat_$X_new_flag}" name="attr_new_flag" value="0"  />
+									<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_feat_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+									<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_feat_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+									<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+								</div> -->
                             </div>
                         </fieldset>
                     </div>
@@ -9167,8 +9269,8 @@
             </div>
             <br>
             <div>
-                <b>Skills&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-skills-show}" name="attr_npc-skills-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Skills</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-skills-show}" name="attr_npc-skills-show" value="1" style="opacity:0; width:70px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -55px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <div class="sheet-table sheet-sect">
                     <div class="sheet-table-row">
                         <span class="sheet-table-header"></span>
@@ -9464,16 +9566,16 @@
             </div>
             <br>
             <div class="sheet-table">
-                <b>Combat Gear&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-cgear-show}" name="attr_npc-cgear-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Combat Gear</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-cgear-show}" name="attr_npc-cgear-show" value="1" style="opacity:0; width:100px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -80px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <div class="sheet-table-row sheet-sect">
                     <span class="sheet-table-data sheet-center"><textarea title="@{npc-combat-gear}" name="attr_npc-combat-gear" style="height:50px;width:97%;" placeholder="Gear used in combat"></textarea></span>
                 </div>
             </div>
             <br>
             <div class="sheet-table">
-                <b>Other Gear&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                <input type="checkbox" class="sheet-sect-show" title="@{npc-ogear-show}" name="attr_npc-ogear-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                <b>Other Gear</b>
+                <input type="checkbox" class="sheet-sect-show" title="@{npc-ogear-show}" name="attr_npc-ogear-show" value="1" style="opacity:0; width:100px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 --80px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
                 <div class="sheet-table-row sheet-sect">
                     <span class="sheet-table-data sheet-center"><textarea title="@{npc-other-gear}" name="attr_npc-other-gear" style="height:50px;width:97%;" placeholder="Gear not used in combat"></textarea></span>
                 </div>
@@ -9482,14 +9584,14 @@
     </div>
     <div>
         <hr class="sheet-npc-hr sheet-margin-top" />
-        <b>SPECIAL ABILITIES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{npc-special-abilities-show}" name="attr_npc-special-abilities-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>SPECIAL ABILITIES</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{npc-special-abilities-show}" name="attr_npc-special-abilities-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
         <hr class="sheet-npc-hr sheet-margin-bottom" />
         <div class="sheet-table sheet-sect">
             <div class="sheet-repeating-fields">
                 <fieldset class="repeating_racial-trait">
                     <input type="checkbox" class="sheet-counted sheet-sect-show" title="@{repeating_racial-trait_$X_racial-trait-show}" name="attr_racial-trait-show" value="1" style="opacity: 0 ; height: 1.5em ; position: absolute; top: 15px; width: 5% ; cursor: pointer ; z-index: 1" checked="checked" /><span class="sheet-table-data sheet-center" style="width:5%;"></span>
-                    <span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" name"attr_npc-roll" title="@{repeating_racial-trait_$X_npc-roll}" value="@{macro-text}"></button><br>&nbsp;</span>
+                    <span class="sheet-table-data sheet-center" style="width:5%;"><button type="roll" name"attr_npc-roll" title="%{selected|repeating_racial-trait_$X_npc-roll}" value="@{macro-text}"></button><br>&nbsp;</span>
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:23%;"><input title="@{repeating_racial-trait_$X_name}" type="text" name="attr_name" placeholder="Special Ability Name" /><br>Name</span>
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:45%;"><input title="@{repeating_racial-trait_$X_short-description}" type="text" name="attr_short-description" placeholder="Short Description" /><br>Short Description</span>
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_racial-trait_$X_used}" type="number" name="attr_used" value="0" /><br>Uses</span>
@@ -9497,13 +9599,21 @@
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:5%;"><input title="@{repeating_racial-trait_$X_used|max" type="number" name="attr_used_max" value="@{max-calculation}"  class="sheet-calc" readonly="readonly" /><br>Max</span>
                     <span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;"><input title="@{repeating_racial-trait_$X_max-calculation}" type="text" name="attr_max-calculation" value="" Placeholder="macro" /><br>Max Calc</span>
                     <div class="sheet-sect">
-                        <b>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                        <input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+                        <b>Description</b>
+                        <input type="checkbox" class="sheet-desc-show" title="@{repeating_racial-trait_$X_description-show}" name="attr_description-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
+                        <b>Macro Text</b>
+                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0; width:90px; height:1.5em; position:relative; top:0; left:0; margin:0 -15px 0 -75px; cursor:pointer; z-index:1;" /><span></span>
+						<!-- <b>IDs</b>
+						<input type="checkbox" class="sheet-repeating_ids-show" title="@{repeating_racial-trait_$X_ids-show}" name="attr_ids-show" value="1" style="opacity:0;width: 40px; height:1.5em; position:relative; top:0; left:0;margin: 0px -15px 0 -25px; cursor:pointer; z-index:1;" /><span></span> -->
+						
                         <textarea class="sheet-desc" title="@{repeating_racial-trait_$X_description}" name="attr_description"></textarea>
-                        <br>
-                        <b>Macro Text&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-                        <input type="checkbox" class="sheet-macro-text-show" title="@{repeating_racial-trait_$X_macro-text-show}" name="attr_macro-text-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
                         <textarea class="sheet-macro-text" title="@{repeating_racial-trait_$X_macro-text}" name="attr_macro-text">@{NPC-whisper} &{template:pf_block} {{header_image=@{header_image-pf_block}}} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle}} {{name=@{name}}} {{description=@{short-description}}}</textarea>
+						<!-- <div class="sheet-repeating_ids sheet-table-row">
+							<input type="hidden" title="@{repeating_racial-trait_$X_new_flag}" name="attr_new_flag" value="0"  />
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:10%;" ><input title="@{repeating_racial-trait_$X_row_index}" type="number" name="attr_row_index" value="0" class="sheet-calc" readonly="readonly" /><br>Index</span>
+							<span class="sheet-table-data sheet-center sheet-small-label" style="width:15%;" ><input title="@{repeating_racial-trait_$X_row_id}" type="text" name="attr_row_id" value="" class="sheet-calc" readonly="readonly" /><br>ID</span>
+							<span class="sheet-table-data sheet-center sheet-small-label">&nbsp;</span>
+						</div> -->
                     </div>
                 </fieldset>
             </div>
@@ -9514,8 +9624,8 @@
 <div class="sheet-section sheet-section-config">
 	<div class="sheet-table sheet-header-row">&nbsp;</div>
     <div class="sheet-header_images">
-		<b>Header Images&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-		<input type="checkbox" class="sheet-sect-show" title="@{header_images-show}" name="attr_header_images-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>
+		<b>Header Images</b>
+		<input type="checkbox" class="sheet-sect-show" title="@{header_images-show}" name="attr_header_images-show" value="1" style="opacity: 0;width: 125px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -110px; cursor: pointer; z-index: 1" /><span></span>
 		<div class="sheet-table sheet-sect">
 			<span class="sheet-table-name">Header Images</span>
 			<span style="display:table-caption;"><p>Header images are iconic images that appear in the header of roll templates. All macros on the sheet include <b>{{header_image=<i>image attriubute</i>}}</b>. Each roll template has a specific image attribute that works with the options below. ie The Spells roll template would use <b>{{header_image=@{header_image-pf_spell}}}</b> Hover over the template names below to learn the specific image attributes. You can substitute images for any roll template by using the URL column below or using the syntax <b>{{header_image=<i>[name](url)}}</i></b></p></span>
@@ -9611,8 +9721,8 @@
 	<br>
     </div>  
     <div class="sheet-unchained">
-        <b>Pathfinder Unchained&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{pathfinder-unchained-show}" name="attr_pathfinder-unchained-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Pathfinder Unchained</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{pathfinder-unchained-show}" name="attr_pathfinder-unchained-show" value="1" style="opacity:0;width: 150px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -133px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
 		<span class="sheet-table-name">Pathfinder Unchained</span>
             <div class="sheet-table-row">
@@ -9636,8 +9746,8 @@
 	<br>	
     </div>
     <div class="sheet-roll_template_info">
-        <b>Roll Template Info&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{roll-template-info-show}" name="attr_roll-template-info-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;"/><span></span>
+        <b>Roll Template Info</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{roll-template-info-show}" name="attr_roll-template-info-show" value="1" style="opacity: 0;width: 140px; height: 1.5em; position: relative; top: 0; left: 0;margin: 0 -15px 0 -125px; cursor: pointer; z-index: 1" /><span></span>
         <div class="sheet-table sheet-sect">
             <span class="sheet-table-name">Roll Template Info</span>    
 			<div class="sheet-table sheet-options">
@@ -9705,8 +9815,8 @@
         </div>
     </div>
     <div class="sheet-sheetconfig">
-        <b>Sheet configuration&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b>
-        <input type="checkbox" class="sheet-sect-show" title="@{pathfinder-sheetconfig-show}" name="attr_pathfinder-sheetconfig-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 0;left: 0;margin: -32px;cursor: pointer;z-index: 1;" checked="checked" /><span></span>
+        <b>Sheet configuration</b>
+        <input type="checkbox" class="sheet-sect-show" title="@{pathfinder-sheetconfig-show}" name="attr_pathfinder-sheetconfig-show" value="1" style="opacity:0;width: 150px; height:1.5em; position:relative; top:0; left:0;margin: 0 -15px 0 -133px; cursor:pointer; z-index:1;" checked="checked" /><span></span>
         <div class="sheet-table sheet-sect">
 		<span class="sheet-table-name">Sheet configuration</span>
             <div class="sheet-table-row">
@@ -9730,7 +9840,7 @@
 <div class="sheet-footer">
 	<div class="sheet-table">
 		<div class="sheet-table-row">
-			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.15.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
+			<span class="sheet-table-data sheet-center">Created by Samuel Marino w/contributions by Vince, Samuel Terrazas, Nibrodooh, Chris Buchholz | Last updated: <i>1.26.16'&nbsp;&nbsp;</i>v.<input type="text" style="width: 2.5em;height:1.4em; vertical-align:top;padding:0px 2px 0px 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="Version non blank indicates attributes have been successfully recalculated."></span>
 		</div>
 		<div class="sheet-table-row">
 			<span class="sheet-table-data sheet-center">Have questions or feedback?  This thread can help:<input type="text" style="width:50%; border:none;" value="https://app.roll20.net/forum/post/2788628/pf-pathfinder-sheet-thread-5" /></span>


### PR DESCRIPTION
- rollback defaults for attack mod and damage type to value="0" and
"none"
- fixed concentration button roll names so drag/drop works
- made section/sub-section text clickable for hide/show
- small adjustments to title text on some button rolls
- made spell ranges collapsible
- misc format/text adjustments