### PR TITLE
Dice Rule Fix + Extra Bruised Health Level

### DIFF
--- a/CWOD-W20/W20.html
+++ b/CWOD-W20/W20.html
@@ -1547,7 +1547,7 @@
     <input type="checkbox" class="sheet-hidden sheet-block_switch" name="attr_switch" value="1"/>
     <div class="sheet-block_a">
         <div class="sheet-formsbanner">
-    		<!-- Stuff in the visible area -->
+            <!-- Stuff in the visible area -->
             <table class="sheet-center sheet-shifter" style="width:800px">
                 <tr>
                     <td><br><br><br></td>
@@ -1914,7 +1914,7 @@
             <th>Clip</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-1}! [[{(@{weapon_attribute-1} + @{weapon_skill-1} + @{weapon_Modifier-1})d10!}>@{weapon_Difficulty-1}]] successes to attack and deals [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1})d10!}>6}]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-1}! [[{(@{weapon_attribute-1} + @{weapon_skill-1} + @{weapon_Modifier-1})d10}>@{weapon_Difficulty-1}f1]] successes to attack and deals [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1})d10}>6}]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-1" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-1" value="0" >
                     <option value="0" selected></option> 
@@ -1952,7 +1952,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-1" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-2}! [[{(@{weapon_attribute-2} + @{weapon_skill-2} + @{weapon_Modifier-2})d10!}>@{weapon_Difficulty-2}]] successes to attack and deals [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-2}! [[{(@{weapon_attribute-2} + @{weapon_skill-2} + @{weapon_Modifier-2})d10}>@{weapon_Difficulty-2}f1]] successes to attack and deals [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-2" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-2" value="0" >
                     <option value="0" selected></option> 
@@ -1990,7 +1990,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-2" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-3}! [[{(@{weapon_attribute-3} + @{weapon_skill-3} + @{weapon_Modifier-3})d10!}>@{weapon_Difficulty-3}]] successes to attack and deals [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-3}! [[{(@{weapon_attribute-3} + @{weapon_skill-3} + @{weapon_Modifier-3})d10}>@{weapon_Difficulty-3}f1]] successes to attack and deals [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-3" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-3" value="0" >
                     <option value="0" selected></option> 
@@ -2028,7 +2028,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-3" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-4}! [[{(@{weapon_attribute-4} + @{weapon_skill-4} + @{weapon_Modifier-4})d10!}>@{weapon_Difficulty-4}]] successes to attack and deals [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-4}! [[{(@{weapon_attribute-4} + @{weapon_skill-4} + @{weapon_Modifier-4})d10}>@{weapon_Difficulty-4}f1]] successes to attack and deals [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-4" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-4" value="0" >
                     <option value="0" selected></option> 
@@ -2066,7 +2066,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-4" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-5}! [[{(@{weapon_attribute-5} + @{weapon_skill-5} + @{weapon_Modifier-5})d10!}>@{weapon_Difficulty-5}]] successes to attack and deals [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-5}! [[{(@{weapon_attribute-5} + @{weapon_skill-5} + @{weapon_Modifier-5})d10}>@{weapon_Difficulty-5}f1]] successes to attack and deals [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-5" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-5" value="0" >
                     <option value="0" selected></option> 
@@ -2104,7 +2104,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-5" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-6}! [[{(@{weapon_attribute-6} + @{weapon_skill-6} + @{weapon_Modifier-6})d10!}>@{weapon_Difficulty-6}]] successes to attack and deals [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-6}! [[{(@{weapon_attribute-6} + @{weapon_skill-6} + @{weapon_Modifier-6})d10}>@{weapon_Difficulty-6}f1]] successes to attack and deals [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-6" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-6" value="0" >
                     <option value="0" selected></option> 
@@ -2142,7 +2142,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-6" value="0"/></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-7}! [[{(@{weapon_attribute-7} + @{weapon_skill-7} + @{weapon_Modifier-7})d10!}>@{weapon_Difficulty-7}]] successes to attack and deals [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7})d10!}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-7}! [[{(@{weapon_attribute-7} + @{weapon_skill-7} + @{weapon_Modifier-7})d10}>@{weapon_Difficulty-7f1}]] successes to attack and deals [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7})d10}>6}]]] damage"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-7" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-7" value="0" >
                     <option value="0" selected></option> 
@@ -2194,7 +2194,7 @@
             <th>Damage<br>Type</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Bite! [[{(@{Dexterity} + @{Brawl} + @{Bite_Mod-Attack})d10!}>5]] successes to attack and deals [[{(@{Strength} + 1 + @{Bite_Mod-Damage})d10!}>@{Bite_Difficulty}]] damage">Bite</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Bite! [[{(@{Dexterity} + @{Brawl} + @{Bite_Mod-Attack})d10}>5f1]] successes to attack and deals [[{(@{Strength} + 1 + @{Bite_Mod-Damage})d10}>@{Bite_Difficulty}]] damage">Bite</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Attack" value="0"/></th>
             <th>5</th>
@@ -2204,7 +2204,7 @@
             <th>Aggravated</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Hispo Bite! [[ { (@{Dexterity} + @{Brawl} + @{HispoBite_Mod-Attack} )d10! }>5]] successes to attack and deals [[ { ( @{Strength} + 2 + @{HispoBite_Mod-Damage} )d10! }>@{HispoBite_Difficulty} ]] damage">Hispo Bite</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Hispo Bite! [[ { (@{Dexterity} + @{Brawl} + @{HispoBite_Mod-Attack} )d10}>5f1]] successes to attack and deals [[ { ( @{Strength} + 2 + @{HispoBite_Mod-Damage} )d10 }>@{HispoBite_Difficulty} ]] damage">Hispo Bite</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Attack" value="0"/></th>
             <th>5</th>
@@ -2214,7 +2214,7 @@
             <th>Aggravated</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Body Tackle! [[{(@{Dexterity} + @{Brawl} + @{BodyTackle_Mod-Attack})d10!}>7]] successes to attack">Body Tackle</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Body Tackle! [[{(@{Dexterity} + @{Brawl} + @{BodyTackle_Mod-Attack})d10}>7f1]] successes to attack">Body Tackle</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Attack" value="0"/></th>
             <th>7</th>
@@ -2224,7 +2224,7 @@
             <th>Bashing</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with Claws! [[{(@{Dexterity} + @{Brawl} + @{Claw_Mod-Attack})d10!}>6]] successes to attack and deals [[{(@{Strength} + 1 + @{Claw_Mod-Damage})d10!}>@{Claw_Difficulty}]] damage">Claw</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with Claws! [[{(@{Dexterity} + @{Brawl} + @{Claw_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + 1 + @{Claw_Mod-Damage})d10}>@{Claw_Difficulty}]] damage">Claw</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Attack" value="0"/></th>
             <th>6</th>
@@ -2234,7 +2234,7 @@
             <th>Aggravated</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Grapple! [[{(@{Dexterity} + @{Brawl} + @{Grapple_Mod-Attack})d10!}>6]] successes to attack and deals [[{(@{Strength} + @{Grapple_Mod-Damage})d10!}>@{Grapple_Difficulty}]] damage">Grapple</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Grapple! [[{(@{Dexterity} + @{Brawl} + @{Grapple_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + @{Grapple_Mod-Damage})d10}>@{Grapple_Difficulty}]] damage">Grapple</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Attack" value="0"/></th>
             <th>6</th>
@@ -2244,7 +2244,7 @@
             <th>Bashing</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Kick! [[{(@{Dexterity} + @{Brawl} + @{Kick_Mod-Attack})d10!}>7]] successes to attack and deals [[{(@{Strength} + 1 + @{Kick_Mod-Damage})d10!}>@{Kick_Difficulty}]] damage">Kick</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Kick! [[{(@{Dexterity} + @{Brawl} + @{Kick_Mod-Attack})d10}>7f1]] successes to attack and deals [[{(@{Strength} + 1 + @{Kick_Mod-Damage})d10}>@{Kick_Difficulty}]] damage">Kick</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Attack" value="0"/></th>
             <th>7</th>
@@ -2254,7 +2254,7 @@
             <th>Bashing</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Punch! [[{(@{Dexterity} + @{Brawl} + @{Punch_Mod-Attack})d10!}>6]] successes to attack and deals [[{(@{Strength} + @{Punch_Mod-Damage})d10!}>@{Punch_Difficulty}]] damage">Punch</button></th>
+            <th><button type="roll" class="sheet-adv" value="/e attacks with a Punch! [[{(@{Dexterity} + @{Brawl} + @{Punch_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + @{Punch_Mod-Damage})d10}>@{Punch_Difficulty}]] damage">Punch</button></th>
             <th>Dex + Brawl</th>
             <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Attack" value="0"/></th>
             <th>6</th>
@@ -2269,6 +2269,17 @@
         <div class="sheet-col">
         <h3 style="text-align: center">Health</h3>
             <table class="sheet-center" style="width:50%">
+                <tr>
+                    <th>Extra Bruised</th>
+                    <td></td>
+                    <td><select name="attr_Bruised_extra">
+                        <option></option>
+                        <option value="Bashing">-</option>
+                        <option value="Leathal">/</option> 
+                        <option value="Aggravated">X</option>
+                        </select>
+                    </td>
+                </tr>
                 <tr>
                     <th>Bruised</th>
                     <td></td>
@@ -2372,28 +2383,28 @@
                     <th>Apply Armor?</th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak bashing damage! [[ {(@{Stamina} + @{Soak_mod-Bashing} + @{Armor_toggle-Bashing})d10!}>@{Soak_diff-Bashing} ]]">Bashing</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak bashing damage! [[ {(@{Stamina} + @{Soak_mod-Bashing} + @{Armor_toggle-Bashing})d10}>@{Soak_diff-Bashing}f1 ]]">Bashing</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Bashing" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Bashing" value="6" /></th>
                     <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Bashing" value="@{armor-Rating}"/><span></span></th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_Lethal" value="/e tries to soak Lethal damage! [[ {(@{Stamina} + @{Soak_mod-Lethal} + @{Armor_toggle-Lethal})d10!}>@{Soak_diff-Lethal} ]]">Lethal</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_Lethal" value="/e tries to soak Lethal damage! [[ {(@{Stamina} + @{Soak_mod-Lethal} + @{Armor_toggle-Lethal})d10}>@{Soak_diff-Lethal}f1 ]]">Lethal</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Lethal" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Lethal" value="6" /></th>
                     <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Lethal" value="@{armor-Rating}"/><span></span></th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_Aggravated" value="/e tries to soak Aggravated damage! [[ {(@{Stamina} + @{Soak_mod-Aggravated} + @{Armor_toggle-Aggravated})d10!}>@{Soak_diff-Aggravated} ]]">Aggravated</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_Aggravated" value="/e tries to soak Aggravated damage! [[ {(@{Stamina} + @{Soak_mod-Aggravated} + @{Armor_toggle-Aggravated})d10}>@{Soak_diff-Aggravated}f1 ]]">Aggravated</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Aggravated" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Aggravated" value="6" /></th>
                      <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Aggravated" value="@{armor-Rating}"/><span></span></th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak with armor only! [[ {(@{armor-Rating})d10!}>@{Soak_diff-armor} ]]">Armor Only</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak with armor only! [[ {(@{armor-Rating})d10}>@{Soak_diff-armor}f1 ]]">Armor Only</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{armor-Rating}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-armor" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-armor" value="6" /></th>


### PR DESCRIPTION
This fixes the dice rules used in the buttons on the Character sheet.
Werewolf 20 does not use exploding dice (either for normal rolls or
specialties)

The buttons also neglected to use the 1s subtract from successes rule
standard to classic world of darkness (with the exception of damage
rolls). Buttons have been modified to correct this.

An extra Bruised health box has been added to accommodate users with the
Huge Size merit.