### PR TITLE
DungeonWorld character sheet modifier calculation tweak

### DIFF
--- a/DungeonWorld/DungeonWorld.html
+++ b/DungeonWorld/DungeonWorld.html
@@ -53,7 +53,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_strmod" value="round(0.018*(@{strength}*@{strength}) - 0.127 * @{strength} - 0.76) - @{weak}" disabled="true">
+			<input type="number" name="attr_strmod" value="round(0.00072*(@{strength}*@{strength}*@{strength}) - 0.025*(@{strength}*@{strength}) + 0.6 * @{strength} - 4.35) - @{weak}" disabled="true">
 			<button type="roll" name="roll_TestStrength" value="/me rolls [[2d6 + @{strmod}]] on STR."></button>
 		</div>
 
@@ -74,7 +74,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_dexmod" value="round(0.018*(@{dexterity}*@{dexterity}) - 0.127 * @{dexterity} - 0.76) - @{shaky}" disabled="true">
+			<input type="number" name="attr_dexmod" value="round(0.00072*(@{dexterity}*@{dexterity}*@{dexterity}) - 0.025*(@{dexterity}*@{dexterity}) + 0.6 * @{dexterity} - 4.35) - @{shaky}" disabled="true">
 			<button type="roll" name="roll_TestDexterity" value="/me rolls [[2d6 + @{dexmod}]] on DEX."></button>
 		</div>
 
@@ -95,7 +95,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_conmod" value="round(0.018*(@{constitution}*@{constitution}) - 0.127 * @{constitution} - 0.76) - @{sick}" disabled="true">
+			<input type="number" name="attr_conmod" value="round(0.00072*(@{constitution}*@{constitution}*@{constitution}) - 0.025*(@{constitution}*@{constitution}) + 0.6 * @{constitution} - 4.35) - @{sick}" disabled="true">
 			<button type="roll" name="roll_TestConstitution" value="/me rolls [[2d6 + @{conmod}]] on CON."></button>
 		</div>
 
@@ -116,7 +116,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_intmod" value="round(0.018*(@{intelligence}*@{intelligence}) - 0.127 * @{intelligence} - 0.76) - @{stunned}" disabled="true">
+			<input type="number" name="attr_intmod" value="round(0.00072*(@{intelligence}*@{intelligence}*@{intelligence}) - 0.025*(@{intelligence}*@{intelligence}) + 0.6 * @{intelligence} - 4.35) - @{stunned}" disabled="true">
 			<button type="roll" name="roll_TestIntelligence" value="/me rolls [[2d6 + @{intmod}]] on INT."></button>
 		</div>
 
@@ -137,7 +137,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_wismod" value="round(0.018*(@{wisdom}*@{wisdom}) - 0.127 * @{wisdom} - 0.76) - @{confused}" disabled="true">
+			<input type="number" name="attr_wismod" value="round(0.00072*(@{wisdom}*@{wisdom}*@{wisdom}) - 0.025*(@{wisdom}*@{wisdom}) + 0.6 * @{wisdom} - 4.35) - @{confused}" disabled="true">
 			<button type="roll" name="roll_TestWisdom" value="/me rolls [[2d6 + @{wismod}]] on WIS."></button>
 		</div>
 
@@ -158,7 +158,7 @@
 		</div>
 
 		<div class="sheet-row-3">
-			<input type="number" name="attr_chamod" value="round(0.018*(@{charisma}*@{charisma}) - 0.127 * @{charisma} - 0.76) - @{scarred}" disabled="true">
+			<input type="number" name="attr_chamod" value="round(0.00072*(@{charisma}*@{charisma}*@{charisma}) - 0.025*(@{charisma}*@{charisma}) + 0.6 * @{charisma} - 4.35) - @{scarred}" disabled="true">
 			<button type="roll" name="roll_TestCharisma" value="/me rolls [[2d6 + @{chamod}]] on CHA."></button>
 		</div>
 


### PR DESCRIPTION
Modified the Dungeon World sheet automatic modifiers to better match the table in the book. This fixes discrepancies for stats lower than 5, correctly setting the modifier to -2/-3.

For full calculations/demonstrations, see this gdoc:
https://docs.google.com/spreadsheets/d/1EnI0PmM7sgqAPYxGdS94O2jvUQhYQrTruRB1iXh0Cxo/edit#gid=0