### PR TITLE
D&D 5e OGL NPC HP Hiding

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -243,7 +243,7 @@
         <div class="row red">
             <span>Hit Points</span>
             <input class="num3" type="text" name="attr_npcd_hp">
-            <button type="roll" name="roll_npc_hpformula" value="&{template:npc} {{normal=1}} {{name=@{npc_name}}} {{rname=Hit Points}} {{mod=@{npc_hpformula}}} {{r1=[[@{npc_hpformula}]]}}">
+            <button type="roll" name="roll_npc_hpformula" value="@{wtype}&{template:npc} {{normal=1}} {{name=@{npc_name}}} {{rname=Hit Points}} {{mod=@{npc_hpformula}}} {{r1=[[@{npc_hpformula}]]}}">
                 <input class="parens" type="text" name="attr_npcd_hpformula" style="width: 200px; text-align: left;">
             </button>
         </div>


### PR DESCRIPTION
The NPC formula for rolling a NPC's health does not respect `wtype` and causes the result to always be printed global.  Added `wtype` to allow results to be whispered to GM.