### PR TITLE
D&D 3.5 Str check fix, add options for attack and save.

### DIFF
--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -113,7 +113,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-base" value="10" title="str-base"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-misc" value="0" title="str-misc"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-temp" value="0" title="str-temp"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="str-macro (modify to modify roll macro)" name="attr_str-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Strength check:}} {{checkroll=[[1d20 + [[@{str-mod}]] ]] }}</textarea></span>
+								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="str-macro (modify to modify roll macro)" name="attr_str-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Strength check:}} {{checkroll=[[1d20 + [[@{str-mod}]] + [[@{specialattacksizemod}]] ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_strcheck" title='strcheck' value="@{str-macro}"></button></span>
 							</div>
 							<div class="sheet-table-row">
@@ -298,7 +298,14 @@
 													<span class="sheet-table-row-name" style="width: 60px;">Fortitude<br><div style="font-size: 0.65em;">(Constitution)</div></span>
 													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_fortitude" title="fortitude" value="(@{fortitudebase} +@{fortitudeability} +@{fortitudeepicsavemod} +@{fortitudemagicmod} +@{fortitudemiscmod} +@{fortitudetempmod} )" disabled="true"></span>
 													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_fortitudebase" title="fortitudebase" value="0"></span>
-													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudeability" title="fortitudeability" value="floor(@{con}/2-5) " disabled="true"></span>
+													<span  class="sheet-table-data-center"><select style="width: 35px; " name="attr_fortitudeability" title="fortitudeability">
+													<<option type="text" style="width: 45px;" value="@{str-mod} " >Str</option>
+													<option type="text" style="width: 45px;" value="@{dex-mod} " >Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} " selected >Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} " >Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													</select> </span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudeepicsavemod" title="fortitudeepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemagicmod" title="fortitudemagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemiscmod" title="fortitudemiscmod" value="0"></span>
@@ -313,7 +320,14 @@
 													<span class="sheet-table-row-name" style="width: 60px;">Reflex<br><div style="font-size: 0.65em;">(Dexterity)</div></span>
 													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_reflex" title="reflex" value="(@{reflexbase} +@{reflexability} +@{reflexepicsavemod} +@{reflexmagicmod} +@{reflexmiscmod} +@{reflextempmod} )" disabled="true"></span>
 													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_reflexbase" title="reflexbase" value="0"></span>
-													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexability" title="reflexability" value="floor(@{dex}/2-5) " disabled="true"></span>
+													<span  class="sheet-table-data-center"><select style="width: 35px; " name="attr_reflexability" title="reflexability">
+													<<option type="text" style="width: 45px;" value="@{str-mod} " >Str</option>
+													<option type="text" style="width: 45px;" value="@{dex-mod} " selected >Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} " >Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} " >Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													</select> </span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexepicsavemod" title="reflexepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmagicmod" title="reflexmagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmiscmod" title="reflexmiscmod" value="0"></span>
@@ -328,7 +342,14 @@
 													<span class="sheet-table-row-name" style="width: 60px;">Will<br><div style="font-size: 0.65em;">(Wisdom)</div></span>
 													<span class="sheet-table-data-center"><input type="text" style="width: 35px;" name="attr_will" title="will" value="(@{willbase} +@{willability} +@{willepicsavemod} +@{willmagicmod} +@{willmiscmod} +@{willtempmod} )" disabled="true"></span>
 													<span class="sheet-table-data-center">=<input type="text" style="width: 35px;" name="attr_willbase" title="willbase" value="0"></span>
-													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willability" title="willability" value="floor(@{wis}/2-5) " disabled="true"></span>
+													<span  class="sheet-table-data-center"><select style="width: 35px; " name="attr_willability" title="willability">
+													<option type="text" style="width: 45px;" value="@{str-mod} " >Str</option>
+													<option type="text" style="width: 45px;" value="@{dex-mod} " >Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} " >Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} " selected>Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													</select> </span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willepicsavemod" title="willepicsavemod (Epic Level Save Bonus)" value="@{epicsavebonus}" disabled="true"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmagicmod" title="willmagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmiscmod" title="willmiscmod" value="0"></span>
@@ -468,7 +489,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon1name" title="weapon1name" style="height: 24px; width: 120px;"></td>
@@ -482,24 +504,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon1stat" title="weapon1stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon1damagestat" title="weapon1damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon1specialproperties" title="weapon1specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon1specialproperties" title="weapon1specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon1powerattackmultiplier" title="weapon1powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon1attackcalc">1d20cs>@{weapon1critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon1stat}]][Ability] +@{size}[size] +@{weapon1enh}[Weapon Enh] +@{weapon1focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon1attackcalc">1d20cs>@{weapon1critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon1stat}]][Ability] +@{size}[size] +@{weapon1enh}[Weapon Enh] +@{weapon1focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon1attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=hitting AC[[@{weapon1attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon1attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon1damage}]] dmg}} {{critdmg1=+[[@{weapon1crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
 												<button type="roll" name="attr_weapon1attack" text="attack" title='weapon1attack' value="@{weapon1attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon1fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon1fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=A1:[[@{weapon1attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon1attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon1damage}]]}} {{critdmg1=+[[@{weapon1crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon1attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon1attackcalc}-5]]}} {{damage2=D2:[[@{weapon1damage}]]}} {{critdmg2=+[[@{weapon1crit}]]}} {{attack3=A3:[[@{weapon1attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon1attackcalc}-10]]}} {{damage3=D3:[[@{weapon1damage}]]}} {{critdmg3=+[[@{weapon1crit}]]}} {{attack4=A4:[[@{weapon1attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon1attackcalc}-15]]}} {{damage4=D4:[[@{weapon1damage}]]}} {{critdmg4=+[[@{weapon1crit}]]}} </textarea>
 													<button type="roll"name="attr_weapon1fullattack" text="Full Attack" title='weapon1fullattack' value="@{weapon1fullattackmacro}" style="width: 20px;" > </button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon1damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon1crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1crit (Edit this to adjust the critical calculation.)">[[(@{weapon1critmult}-1)]]d6 +[[(@{weapon1critmult}-1)]]*([[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon1damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon1powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon1crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1crit (Edit this to adjust the critical calculation.)">[[(@{weapon1critmult}-1)]]d6 +[[(@{weapon1critmult}-1)]]*([[@{weapon1damagestat}]][Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon1powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon1damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon1damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon1name} }} {{damage1=does [[@{weapon1damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon1damageroll" title='weapon1damageroll' style="width: 20px;" value="@{weapon1damagemacro}"></button></td>
 											</tr>
@@ -520,7 +563,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon2name" title="weapon2name" style="height: 24px; width: 120px;"></td>
@@ -534,24 +578,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon2stat" title="weapon2stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon2damagestat" title="weapon2damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon2specialproperties" title="weapon2specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon2specialproperties" title="weapon2specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon2powerattackmultiplier" title="weapon2powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon2attackcalc">1d20cs>@{weapon2critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon2stat}]][Ability] +@{size}[size] +@{weapon2enh}[Weapon Enh] +@{weapon2focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon2attackcalc">1d20cs>@{weapon2critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon2stat}]][Ability] +@{size}[size] +@{weapon2enh}[Weapon Enh] +@{weapon2focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon2attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=hitting AC[[@{weapon2attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon2attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon2damage}]] dmg}} {{critdmg1=+[[@{weapon2crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon2attack" text="attack" title='weapon2attack' value="@{weapon2attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon2attack" text="attack" title='weapon2attack' value="@{weapon2attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon2fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon2fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=A1:[[@{weapon2attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon2attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon2damage}]]}} {{critdmg1=+[[@{weapon2crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon2attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon2attackcalc}-5]]}} {{damage2=D2:[[@{weapon2damage}]]}} {{critdmg2=+[[@{weapon2crit}]]}} {{attack3=A3:[[@{weapon2attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon2attackcalc}-10]]}} {{damage3=D3:[[@{weapon2damage}]]}} {{critdmg3=+[[@{weapon2crit}]]}} {{attack4=A4:[[@{weapon2attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon2attackcalc}-15]]}} {{damage4=D4:[[@{weapon2damage}]]}} {{critdmg4=+[[@{weapon2crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon2fullattack" text="Full Attack" title='weapon2fullattack' value="@{weapon2fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon2damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon2crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2crit (Edit this to adjust the critical calculation.)">[[(@{weapon2critmult}-1)]]d6 +[[(@{weapon2critmult}-1)]]*([[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon2fullattack" text="Full Attack" title='weapon2fullattack' value="@{weapon2fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon2damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon2powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon2crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2crit (Edit this to adjust the critical calculation.)">[[(@{weapon2critmult}-1)]]d6 +[[(@{weapon2critmult}-1)]]*([[@{weapon2damagestat}]][Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon2powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon2damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon2damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon2name} }} {{damage1=does [[@{weapon2damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon2damageroll" title='weapon2damageroll' style="width: 20px;" value="@{weapon2damagemacro}"></button></td>
 											</tr>
@@ -572,7 +637,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon3name" title="weapon3name" style="height: 24px; width: 120px;"></td>
@@ -586,24 +652,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon3stat" title="weapon3stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon3damagestat" title="weapon3damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon3specialproperties" title="weapon3specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon3specialproperties" title="weapon3specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon3powerattackmultiplier" title="weapon3powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon3attackcalc">1d20cs>@{weapon3critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon3stat}]][Ability] +@{size}[size] +@{weapon3enh}[Weapon Enh] +@{weapon3focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon3attackcalc">1d20cs>@{weapon3critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon3stat}]][Ability] +@{size}[size] +@{weapon3enh}[Weapon Enh] +@{weapon3focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon3attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=hitting AC[[@{weapon3attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon3attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon3damage}]] dmg}} {{critdmg1=+[[@{weapon3crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon3attack" text="attack" title='weapon3attack' value="@{weapon3attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon3attack" text="attack" title='weapon3attack' value="@{weapon3attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon3fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon3fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=A1:[[@{weapon3attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon3attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon3damage}]]}} {{critdmg1=+[[@{weapon3crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon3attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon3attackcalc}-5]]}} {{damage2=D2:[[@{weapon3damage}]]}} {{critdmg2=+[[@{weapon3crit}]]}} {{attack3=A3:[[@{weapon3attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon3attackcalc}-10]]}} {{damage3=D3:[[@{weapon3damage}]]}} {{critdmg3=+[[@{weapon3crit}]]}} {{attack4=A4:[[@{weapon3attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon3attackcalc}-15]]}} {{damage4=D4:[[@{weapon3damage}]]}} {{critdmg4=+[[@{weapon3crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon3fullattack" text="Full Attack" title='weapon3fullattack' value="@{weapon3fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon3damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon3crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3crit (Edit this to adjust the critical calculation.)">[[(@{weapon3critmult}-1)]]d6 +[[(@{weapon3critmult}-1)]]*([[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon3fullattack" text="Full Attack" title='weapon3fullattack' value="@{weapon3fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon3damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon3powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon3crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3crit (Edit this to adjust the critical calculation.)">[[(@{weapon3critmult}-1)]]d6 +[[(@{weapon3critmult}-1)]]*([[@{weapon3damagestat}]][Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon3powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon3damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon3damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon3name} }} {{damage1=does [[@{weapon3damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon3damageroll" title='weapon3damageroll' style="width: 20px;" value="@{weapon3damagemacro}"></button></td>
 											</tr>
@@ -624,7 +711,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon4name" title="weapon4name" style="height: 24px; width: 120px;"></td>
@@ -638,24 +726,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon4stat" title="weapon4stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon4damagestat" title="weapon4damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon4specialproperties" title="weapon4specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon4specialproperties" title="weapon4specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon4powerattackmultiplier" title="weapon4powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon4attackcalc">1d20cs>@{weapon4critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon4stat}]][Ability] +@{size}[size] +@{weapon4enh}[Weapon Enh] +@{weapon4focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon4attackcalc">1d20cs>@{weapon4critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon4stat}]][Ability] +@{size}[size] +@{weapon4enh}[Weapon Enh] +@{weapon4focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon4attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=hitting AC[[@{weapon4attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon4attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon4damage}]] dmg}} {{critdmg1=+[[@{weapon4crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon4attack" text="attack" title='weapon4attack' value="@{weapon4attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon4attack" text="attack" title='weapon4attack' value="@{weapon4attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon4fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon4fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=A1:[[@{weapon4attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon4attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon4damage}]]}} {{critdmg1=+[[@{weapon4crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon4attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon4attackcalc}-5]]}} {{damage2=D2:[[@{weapon4damage}]]}} {{critdmg2=+[[@{weapon4crit}]]}} {{attack3=A3:[[@{weapon4attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon4attackcalc}-10]]}} {{damage3=D3:[[@{weapon4damage}]]}} {{critdmg3=+[[@{weapon4crit}]]}} {{attack4=A4:[[@{weapon4attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon4attackcalc}-15]]}} {{damage4=D4:[[@{weapon4damage}]]}} {{critdmg4=+[[@{weapon4crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon4fullattack" text="Full Attack" title='weapon4fullattack' value="@{weapon4fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon4damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon4crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4crit (Edit this to adjust the critical calculation.)">[[(@{weapon4critmult}-1)]]d6 +[[(@{weapon4critmult}-1)]]*([[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon4fullattack" text="Full Attack" title='weapon4fullattack' value="@{weapon4fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon4damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon4powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon4crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4crit (Edit this to adjust the critical calculation.)">[[(@{weapon4critmult}-1)]]d6 +[[(@{weapon4critmult}-1)]]*([[@{weapon4damagestat}]][Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon4powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon4damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon4damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon4name} }} {{damage1=does [[@{weapon4damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon4damageroll" title='weapon4damageroll' style="width: 20px;" value="@{weapon4damagemacro}"></button></td>
 											</tr>
@@ -676,7 +785,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon5name" title="weapon5name" style="height: 24px; width: 120px;"></td>
@@ -690,24 +800,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon5stat" title="weapon5stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon5damagestat" title="weapon5damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon5specialproperties" title="weapon5specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon5specialproperties" title="weapon5specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon5powerattackmultiplier" title="weapon5powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon5attackcalc">1d20cs>@{weapon5critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon5stat}]][Ability] +@{size}[size] +@{weapon5enh}[Weapon Enh] +@{weapon5focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon5attackcalc">1d20cs>@{weapon5critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon5stat}]][Ability] +@{size}[size] +@{weapon5enh}[Weapon Enh] +@{weapon5focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon5attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=hitting AC[[@{weapon5attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon5attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon5damage}]] dmg}} {{critdmg1=+[[@{weapon5crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon5attack" text="attack" title='weapon5attack' value="@{weapon5attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon5attack" text="attack" title='weapon5attack' value="@{weapon5attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon5fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon5fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=A1:[[@{weapon5attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon5attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon5damage}]]}} {{critdmg1=+[[@{weapon5crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon5attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon5attackcalc}-5]]}} {{damage2=D2:[[@{weapon5damage}]]}} {{critdmg2=+[[@{weapon5crit}]]}} {{attack3=A3:[[@{weapon5attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon5attackcalc}-10]]}} {{damage3=D3:[[@{weapon5damage}]]}} {{critdmg3=+[[@{weapon5crit}]]}} {{attack4=A4:[[@{weapon5attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon5attackcalc}-15]]}} {{damage4=D4:[[@{weapon5damage}]]}} {{critdmg4=+[[@{weapon5crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon5fullattack" text="Full Attack" title='weapon5fullattack' value="@{weapon5fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon5damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon5crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5crit (Edit this to adjust the critical calculation.)">[[(@{weapon5critmult}-1)]]d6 +[[(@{weapon5critmult}-1)]]*([[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon5fullattack" text="Full Attack" title='weapon5fullattack' value="@{weapon5fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon5damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon5powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon5crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5crit (Edit this to adjust the critical calculation.)">[[(@{weapon5critmult}-1)]]d6 +[[(@{weapon5critmult}-1)]]*([[@{weapon5damagestat}]][Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon5powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon5damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon5damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon5name} }} {{damage1=does [[@{weapon5damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon5damageroll" title='weapon5damageroll' style="width: 20px;" value="@{weapon5damagemacro}"></button></td>
 											</tr>
@@ -728,7 +859,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon6name" title="weapon6name" style="height: 24px; width: 120px;"></td>
@@ -742,24 +874,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon6stat" title="weapon6stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon6damagestat" title="weapon6damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon6specialproperties" title="weapon6specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon6specialproperties" title="weapon6specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon6powerattackmultiplier" title="weapon6powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon6attackcalc">1d20cs>@{weapon6critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon6stat}]][Ability] +@{size}[size] +@{weapon6enh}[Weapon Enh] +@{weapon6focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon6attackcalc">1d20cs>@{weapon6critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon6stat}]][Ability] +@{size}[size] +@{weapon6enh}[Weapon Enh] +@{weapon6focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon6attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=hitting AC[[@{weapon6attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon6attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon6damage}]] dmg}} {{critdmg1=+[[@{weapon6crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon6attack" text="attack" title='weapon6attack' value="@{weapon6attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon6attack" text="attack" title='weapon6attack' value="@{weapon6attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon6fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon6fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=A1:[[@{weapon6attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon6attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon6damage}]]}} {{critdmg1=+[[@{weapon6crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon6attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon6attackcalc}-5]]}} {{damage2=D2:[[@{weapon6damage}]]}} {{critdmg2=+[[@{weapon6crit}]]}} {{attack3=A3:[[@{weapon6attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon6attackcalc}-10]]}} {{damage3=D3:[[@{weapon6damage}]]}} {{critdmg3=+[[@{weapon6crit}]]}} {{attack4=A4:[[@{weapon6attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon6attackcalc}-15]]}} {{damage4=D4:[[@{weapon6damage}]]}} {{critdmg4=+[[@{weapon6crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon6fullattack" text="Full Attack" title='weapon6fullattack' value="@{weapon6fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon6damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon6crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6crit (Edit this to adjust the critical calculation.)">[[(@{weapon6critmult}-1)]]d6 +[[(@{weapon6critmult}-1)]]*([[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon6fullattack" text="Full Attack" title='weapon6fullattack' value="@{weapon6fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon6damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon6powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon6crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6crit (Edit this to adjust the critical calculation.)">[[(@{weapon6critmult}-1)]]d6 +[[(@{weapon6critmult}-1)]]*([[@{weapon6damagestat}]][Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon6powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon6damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon6damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon6name} }} {{damage1=does [[@{weapon6damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon6damageroll" title='weapon6damageroll' style="width: 20px;" value="@{weapon6damagemacro}"></button></td>
 											</tr>
@@ -780,7 +933,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon7name" title="weapon7name" style="height: 24px; width: 120px;"></td>
@@ -794,24 +948,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon7stat" title="weapon7stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon7damagestat" title="weapon7damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon7specialproperties" title="weapon7specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon7specialproperties" title="weapon7specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon7powerattackmultiplier" title="weapon7powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon7attackcalc">1d20cs>@{weapon7critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon7stat}]][Ability] +@{size}[size] +@{weapon7enh}[Weapon Enh] +@{weapon7focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon7attackcalc">1d20cs>@{weapon7critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon7stat}]][Ability] +@{size}[size] +@{weapon7enh}[Weapon Enh] +@{weapon7focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon7attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=hitting AC[[@{weapon7attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon7attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon7damage}]] dmg}} {{critdmg1=+[[@{weapon7crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon7attack" text="attack" title='weapon7attack' value="@{weapon7attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon7attack" text="attack" title='weapon7attack' value="@{weapon7attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon7fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon7fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=A1:[[@{weapon7attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon7attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon7damage}]]}} {{critdmg1=+[[@{weapon7crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon7attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon7attackcalc}-5]]}} {{damage2=D2:[[@{weapon7damage}]]}} {{critdmg2=+[[@{weapon7crit}]]}} {{attack3=A3:[[@{weapon7attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon7attackcalc}-10]]}} {{damage3=D3:[[@{weapon7damage}]]}} {{critdmg3=+[[@{weapon7crit}]]}} {{attack4=A4:[[@{weapon7attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon7attackcalc}-15]]}} {{damage4=D4:[[@{weapon7damage}]]}} {{critdmg4=+[[@{weapon7crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon7fullattack" text="Full Attack" title='weapon7fullattack' value="@{weapon7fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon7damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon7crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7crit (Edit this to adjust the critical calculation.)">[[(@{weapon7critmult}-1)]]d6 +[[(@{weapon7critmult}-1)]]*([[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon7fullattack" text="Full Attack" title='weapon7fullattack' value="@{weapon7fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon7damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon7powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon7crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7crit (Edit this to adjust the critical calculation.)">[[(@{weapon7critmult}-1)]]d6 +[[(@{weapon7critmult}-1)]]*([[@{weapon7damagestat}]][Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon7powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon7damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon7damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon7name} }} {{damage1=does [[@{weapon7damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon7damageroll" title='weapon7damageroll' style="width: 20px;" value="@{weapon7damagemacro}"></button></td>
 											</tr>
@@ -832,7 +1007,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon8name" title="weapon8name" style="height: 24px; width: 120px;"></td>
@@ -846,24 +1022,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon8stat" title="weapon8stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon8damagestat" title="weapon8damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon8specialproperties" title="weapon8specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon8specialproperties" title="weapon8specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon8powerattackmultiplier" title="weapon8powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon8attackcalc">1d20cs>@{weapon8critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon8stat}]][Ability] +@{size}[size] +@{weapon8enh}[Weapon Enh] +@{weapon8focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon8attackcalc">1d20cs>@{weapon8critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon8stat}]][Ability] +@{size}[size] +@{weapon8enh}[Weapon Enh] +@{weapon8focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon8attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=hitting AC[[@{weapon8attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon8attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon8damage}]] dmg}} {{critdmg1=+[[@{weapon8crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon8attack" text="attack" title='weapon8attack' value="@{weapon8attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon8attack" text="attack" title='weapon8attack' value="@{weapon8attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon8fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon8fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=A1:[[@{weapon8attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon8attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon8damage}]]}} {{critdmg1=+[[@{weapon8crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon8attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon8attackcalc}-5]]}} {{damage2=D2:[[@{weapon8damage}]]}} {{critdmg2=+[[@{weapon8crit}]]}} {{attack3=A3:[[@{weapon8attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon8attackcalc}-10]]}} {{damage3=D3:[[@{weapon8damage}]]}} {{critdmg3=+[[@{weapon8crit}]]}} {{attack4=A4:[[@{weapon8attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon8attackcalc}-15]]}} {{damage4=D4:[[@{weapon8damage}]]}} {{critdmg4=+[[@{weapon8crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon8fullattack" text="Full Attack" title='weapon8fullattack' value="@{weapon8fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon8damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon8crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8crit (Edit this to adjust the critical calculation.)">[[(@{weapon8critmult}-1)]]d6 +[[(@{weapon8critmult}-1)]]*([[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon8fullattack" text="Full Attack" title='weapon8fullattack' value="@{weapon8fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon8damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon8powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon8crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8crit (Edit this to adjust the critical calculation.)">[[(@{weapon8critmult}-1)]]d6 +[[(@{weapon8critmult}-1)]]*([[@{weapon8damagestat}]][Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon8powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon8damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon8damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon8name} }} {{damage1=does [[@{weapon8damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon8damageroll" title='weapon8damageroll' style="width: 20px;" value="@{weapon8damagemacro}"></button></td>
 											</tr>
@@ -884,7 +1081,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon9name" title="weapon9name" style="height: 24px; width: 120px;"></td>
@@ -898,24 +1096,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon9stat" title="weapon9stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon9damagestat" title="weapon9damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon9specialproperties" title="weapon9specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon9specialproperties" title="weapon9specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon9powerattackmultiplier" title="weapon9powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon9attackcalc">1d20cs>@{weapon9critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon9stat}]][Ability] +@{size}[size] +@{weapon9enh}[Weapon Enh] +@{weapon9focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon9attackcalc">1d20cs>@{weapon9critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon9stat}]][Ability] +@{size}[size] +@{weapon9enh}[Weapon Enh] +@{weapon9focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon9attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=hitting AC[[@{weapon9attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon9attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon9damage}]] dmg}} {{critdmg1=+[[@{weapon9crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon9attack" text="attack" title='weapon9attack' value="@{weapon9attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon9attack" text="attack" title='weapon9attack' value="@{weapon9attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon9fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon9fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=A1:[[@{weapon9attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon9attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon9damage}]]}} {{critdmg1=+[[@{weapon9crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon9attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon9attackcalc}-5]]}} {{damage2=D2:[[@{weapon9damage}]]}} {{critdmg2=+[[@{weapon9crit}]]}} {{attack3=A3:[[@{weapon9attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon9attackcalc}-10]]}} {{damage3=D3:[[@{weapon9damage}]]}} {{critdmg3=+[[@{weapon9crit}]]}} {{attack4=A4:[[@{weapon9attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon9attackcalc}-15]]}} {{damage4=D4:[[@{weapon9damage}]]}} {{critdmg4=+[[@{weapon9crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon9fullattack" text="Full Attack" title='weapon9fullattack' value="@{weapon9fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon9damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon9crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9crit (Edit this to adjust the critical calculation.)">[[(@{weapon9critmult}-1)]]d6 +[[(@{weapon9critmult}-1)]]*([[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon9fullattack" text="Full Attack" title='weapon9fullattack' value="@{weapon9fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon9damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon9powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon9crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9crit (Edit this to adjust the critical calculation.)">[[(@{weapon9critmult}-1)]]d6 +[[(@{weapon9critmult}-1)]]*([[@{weapon9damagestat}]][Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon9powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon9damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon9damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon9name} }} {{damage1=does [[@{weapon9damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon9damageroll" title='weapon9damageroll' style="width: 20px;" value="@{weapon9damagemacro}"></button></td>
 											</tr>
@@ -936,7 +1155,8 @@
 												<td class="sheet-statlabel" style="width: 59px;">Ammunition</td>
 												<td class="sheet-statlabel" style="width: 44px;">Attack Ability</td>
 												<td class="sheet-statlabel" style="width: 44px;">Damage Ability</td>
-												<td colspan="3" class="sheet-statlabel" style="width: 205px;">Special Properties</td>
+												<td colspan="2" class="sheet-statlabel" style="width: 145px;">Special Properties</td>
+												<td class="sheet-statlabel" style="width: 60px;">Power attack multiplier</td>
 											</tr>
 											<tr>
 												<td colspan="2"><input class="sheet-inputbox" type="text" name="attr_weapon10name" title="weapon10name" style="height: 24px; width: 120px;"></td>
@@ -950,24 +1170,45 @@
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon10stat" title="weapon10stat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="@{con-mod} ">Con</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="0 ">None</option>
 												</select></td>
 												<td><select class="sheet-inputbox" style="height: 24px; width: 44px; font-size: 0.75em;" name="attr_weapon10damagestat" title="weapon10damagestat">
 													<option type="text" style="width: 45px;" value="@{str-mod} " selected>Str</option>
 													<option type="text" style="width: 45px;" value="(floor(@{str-mod}/2))">1/2 Str</option>
-													<option type="text" style="width: 45px;" value="(@{str-mod} +floor(@{str-mod}/2))">Str+1/2Str</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{str-mod})">1.5xStr</option>
+													<option type="text" style="width: 45px;" value="2*@{str-mod}">2xStr</option>
+													<option type="text" style="width: 45px;" value="floor(@{dex-mod}/2) ">1/2xDex</option>
 													<option type="text" style="width: 45px;" value="@{dex-mod} ">Dex</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{dex-mod}) ">1.5xDex</option>
+													<option type="text" style="width: 45px;" value="@{int-mod} ">Int</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{int-mod}) ">1.5xInt</option>
+													<option type="text" style="width: 45px;" value="@{wis-mod} ">Wis</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{wis-mod}) ">1.5xWis</option>
+													<option type="text" style="width: 45px;" value="@{cha-mod} ">Cha</option>
+													<option type="text" style="width: 45px;" value="floor(1.5*@{cha-mod}) ">1.5xCha</option>
 													<option type="text" style="width: 45px;" value="0">None</option>
 												</select></td>
-												<td colspan="3"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 200px;" name="attr_weapon10specialproperties" title="weapon10specialproperties">0</textarea></td>
+												<td colspan="2"><textarea input class="sheet-inputbox" rows="1" cols="45" style="height: 20px; width: 140px;" name="attr_weapon10specialproperties" title="weapon10specialproperties">0</textarea></td>
+												<td><select class="sheet-inputbox" style="height: 24px; width: 60px; font-size: 0.75em;" name="attr_weapon10powerattackmultiplier" title="weapon10powerattackmultiplier">
+													<option type="text" style="width: 45px;" value="1 " >1</option>
+													<option type="text" style="width: 45px;" value="1.5 " >1.5</option>
+													<option type="text" style="width: 45px;" value="2 "selected>2</option>
+													<option type="text" style="width: 45px;" value="3 " >3</option>
+													<option type="text" style="width: 45px;" value="4 " >4</option>
+												</select></td>
 											</tr>
 											<tr>
-												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon10attackcalc">1d20cs>@{weapon10critmin} +@{bab} +@{epicattackbonus} [BAB] +[[@{weapon10stat}]][Ability] +@{size}[size] +@{weapon10enh}[Weapon Enh] +@{weapon10focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
+												<td colspan="6"><div style="font-size: 0.5em; text-align: left;">Attack Calc / Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon10attackcalc">1d20cs>@{weapon10critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] +[[@{weapon10stat}]][Ability] +@{size}[size] +@{weapon10enh}[Weapon Enh] +@{weapon10focus}[Weapon Focus] -?{Power Attack?|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon10attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=hitting AC[[@{weapon10attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon10attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=for [[@{weapon10damage}]] dmg}} {{critdmg1=+[[@{weapon10crit}]] crit dmg}} {{fullattackflag=[[0d1]]}} </textarea>
-												<button type="roll" name="attr_weapon10attack" text="attack" title='weapon10attack' value="@{weapon10attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="attr_weapon10attack" text="attack" title='weapon10attack' value="@{weapon10attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Full Attack Macro:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon10fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon10fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=A1:[[@{weapon10attackcalc}]]}} {{critconfirm1=Crit?:[[@{weapon10attackcalc}]]}} {{fumbleroll=Fumble:[[d20]]}} {{damage1=D1:[[@{weapon10damage}]]}} {{critdmg1=+[[@{weapon10crit}]]}} {{fullattackflag=[[?{Full Attack? (hit space for full attack else hit return) |0}d1]]}} {{attack2=A2:[[@{weapon10attackcalc}-5]]}} {{critconfirm2=Crit!:[[@{weapon10attackcalc}-5]]}} {{damage2=D2:[[@{weapon10damage}]]}} {{critdmg2=+[[@{weapon10crit}]]}} {{attack3=A3:[[@{weapon10attackcalc}-10]]}} {{critconfirm3=Crit!:[[@{weapon10attackcalc}-10]]}} {{damage3=D3:[[@{weapon10damage}]]}} {{critdmg3=+[[@{weapon10crit}]]}} {{attack4=A4:[[@{weapon10attackcalc}-15]]}} {{critconfirm4=Crit!:[[@{weapon10attackcalc}-15]]}} {{damage4=D4:[[@{weapon10damage}]]}} {{critdmg4=+[[@{weapon10crit}]]}} </textarea>
-													<button type="roll"name="attr_weapon10fullattack" text="Full Attack" title='weapon10fullattack' value="@{weapon10fullattackmacro}" style="width: 20px;" ></button></td>
-												<td colspan="3"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon10damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 +[[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
-												<textarea class="sheet-inputbox" type="text" name="attr_weapon10crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10crit (Edit this to adjust the critical calculation.)">[[(@{weapon10critmult}-1)]]d6 +[[(@{weapon10critmult}-1)]]*([[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
+													<button type="roll"name="attr_weapon10fullattack" text="Full Attack" title='weapon10fullattack' value="@{weapon10fullattackmacro}" style="width: 20px;" > </button></td>
+												<td colspan="5"><div style="font-size: 0.5em; text-align: left;">Damage Calc / Crit Calc / Damage Macro:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon10damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10damage (Edit this to adjust the damage calculation.)">1d6 +[[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon10powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
+												<textarea class="sheet-inputbox" type="text" name="attr_weapon10crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10crit (Edit this to adjust the critical calculation.)">[[(@{weapon10critmult}-1)]]d6 +[[(@{weapon10critmult}-1)]]*([[@{weapon10damagestat}]][Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +[[floor(?{Power Attack?|0}*@{weapon10powerattackmultiplier} )]] [Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon10damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon10damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon10name} }} {{damage1=does [[@{weapon10damage}]] damage}} {{fullattackflag=[[0d1]]}}</textarea>
 												<button type="roll" name="attr_weapon10damageroll" title='weapon10damageroll' style="width: 20px;" value="@{weapon10damagemacro}"></button></td>
 											</tr>


### PR DESCRIPTION
Added size modifiers to strenght checks, because I think you add your size bonus to most (if not all) strenght checks.

Added customization on what ability to use on the different saving throws. These can be changed by using feats and classes. Added all abilities just to have the options available.

Added additional customization on what abilities to use when calculating attack and damage. You can switch to these abilities fairly easy when using spells and different classes.
Added extra option for power attack multiplier, set standard to 2. Now it only asks you once on how much power attack you want, the damage is then calculated correctly based on the power attack multiplier. And you do not have to write it in with a minus sign. If you do power attack 5 you now substract 5 to hit, and add (power attack multiplier) x 5 to damage.
Removed to question flank. If you have flank just type it into additional to hit bonuses. You do not ask for higher ground, or any other thing that makes it easier for you to hit, so why ask for flanking. I think it is better the less things you have to type in before each attack.

Note that I just started learning HTML a couple of days ago, and I am am very bad at making things look good on screen :) I will try this in my own games a while and do additional changes if I find anything else to modify.