### PR TITLE
PF_simple - HP|max fix, carried coin weight, crit damage roll query

### DIFF
--- a/pathfinder_simple/pathfinder.html
+++ b/pathfinder_simple/pathfinder.html
@@ -1,12 +1,21 @@
 <div>
 <b style="font-size:14px; font-weight:bold; color:red;">ATTENTION:</b>
-    <input type="checkbox" class="sheet-section-show" title="section-show" name="attr_section-show" value="1" style="opacity:1;width: 16px;height: 16px;position: relative;top: 0px;left: 0px;margin: 0px;cursor: pointer;z-index: 1;" checked/><span></span>
+    <input type="checkbox" class="sheet-section-show" title="section-show" name="attr_section-show" value="1" style="opacity: 0;width: 90px;height: 14px;top: 0px;left: 0px;margin: 0 0 4px -90px;cursor: help;z-index: 1;" checked/><input type="checkbox" class="sheet-section-show" title="section-show" name="attr_section-show" value="1" style="width:1em; height:1em; margin: 0 0 4px 0; cursor:help;" checked/>
+	
+	<span style="float:right;"><b>03/04/16' ver.</b>
+	<input type="text" style="width:2.5em; height:1.5em; border:none; margin-top:-2px;" name="attr_Sheet_Version" value="0" class="sheet-calc" readonly="readonly" title="A non-blank version indicates the sheet has been updated." /></span>
+	
 	<div class="sheet-section"style="background-color:#FFF; margin:0px 30px 0px 30px; padding: 10px;">
-	<li>The simple sheet has been updated for the new repeating section features recently added by Roll20. You can now drag/drop repeating row buttons to the quickbar as well as use the button's name directly from within other macros. You will need to update any existing macros that used the old repeating section naming schema. Instead of "repeating_foo_X..." where X is the row number, you must now include a "$" in front of the row number. You may also use a repeating attributes id in place of the row number.  Drag/drop a repeating button to the quickbar to learn a button's id.</li>
-	<li>Damage Stat has been expanded to cover the most common options.</li>
+	<li><b>Changes</b>		
+		<ol>	
+			<li>Total HP, @{HP|max} has been changed to @{HPCurrent_max} so that HP can be properly linked with token bars. This conversion is handled automatically using sheet workers to verify the version of the sheet and updating @{HPCurrent_max} with the value of @{HP|max}. Once the sheet has been updated, any changes made to @{HPCurrent_max} will also be reflected on @{HP|max} for backward compatibility.</li>
+			<li>Carried coins are now included in Total Weight and encumbrance.</li>
+			<li>The Critical damage roll has been changed from simply multiplying damage based off of the crit multiplier to rolling damage once(w/mods), and prompting for additional damage(w/mods), x2, x3, or x4 damage.</li>			
+		</ol>
+	</li>
 	</div>
+	
 </div>
-
 <table border="0" cellspacing="0" cellspacing="0" style="font-size: .75em;text-align: center;">
         <tbody>
             <tr><td rowspan=4 style="width: 10px;"> &nbsp; &nbsp; &nbsp; &nbsp; </td></tr>
@@ -137,9 +146,12 @@
           <tr>
             <td style="width:10px;"></td>
             <td class="sheet-label" style="width: 60px;">HP</td>
-            <td><input type="text"  name="attr_HP|max" title="HP|max" value="0" /></td>
+            <td>
+			<input type="text" name="attr_HPCurrent_max" title="@{HPCurrent_max}" value="0" />
+			<input type="text" name="attr_HP|max" title="@{HP|max}" value="0" style="display:none;"/>
+			</td>
             <td />
-            <td colspan="3"><input type="text"  name="attr_HPCurrent" title="HPCurrent" value="0" /></td>
+            <td colspan="3"><input type="text"  name="attr_HPCurrent" title="@{HPCurrent}" value="0" /></td>
             <td />
             <td colspan="3"><input type="text"  name="attr_HPSub" title="HPSub" value="0" /></td>
             <td />
@@ -244,7 +256,7 @@
         <table>   
             <tr>
                 <td style="width:10px;"></td>
-                <td><input type="text" style="width: 75px;" name="attr_TotalEncumb" title="TotalEncumb" value="@{wep1weight}+@{wep2weight}+@{wep3weight}+@{wep4weight}+@{armorwt}+@{shieldwt} +@{invwt}" disabled></td>
+                <td><input type="text" style="width: 75px;" name="attr_TotalEncumb" title="TotalEncumb" value="(@{wep1weight}+@{wep2weight}+@{wep3weight}+@{wep4weight}+@{armorwt}+@{shieldwt} + @{invwt})" disabled></td>
                 <td><input type="number" style="width: 75px;" name="attr_Lightload" title="Lightload" value="0"></td>
                 <td><input type="number" style="width: 75px;" name="attr_Medload" title="Medload" value="0"></td>
                 <td><input type="number" style="width: 75px;" name="attr_hvyload" title="hvyload" value="0"></td>
@@ -453,7 +465,7 @@
                         <td><input type="number" name="attr_wep1critmult" title="wep1critmult" value="0"></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep1attackroll" title="wep1attackroll" value="/em attacks with @{weapon1} hitting AC [[1d20+@{wep1mwk}+@{wep1enh}+@{wep1foc}+@{wep1attacktype} +?{Flank (1=yes)|0}*2 +?{Power Attack? (use negative sign i.e. -3|0}+?{Additional Hit Modifier?|0}]]"/></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep1dmgroll" title="wep1dmgroll" value="/em @{weapon1} Damage [[@{wep1dmg}+@{wep1enh}+@{wep1spc}+@{wep1dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0}]]"/></td>
-                        <td><button type="roll" name="attr_wep1critdmgroll" title="wep1critdmgroll" value="/em @{weapon1} Critical Damage [[(@{wep1dmg}+@{wep1enh}+@{wep1spc}+@{wep1dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0})*@{wep1critmult}]]"></button></td>
+                        <td><button type="roll" name="attr_wep1critdmgroll" title="wep1critdmgroll" value="/em @{weapon1} Critical Damage [[ [[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?|0} + ?{Additional Damage Modifier?|0} ]] [x1 DMG] + ?{Choose Crit Multiplier|x2,[[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125;]] [x2 DMG]|x3,[[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] |x4,[[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] + [[ @{wep1dmg} + @{wep1enh} + @{wep1spc} + @{wep1dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x4 DMG] }]]"></button></td>
                     </tr>
                     <tr>
                         <td colspan="3" class="sheet-statlabel">Special Properties</td>
@@ -531,7 +543,7 @@
                         <td><input type="number" name="attr_wep2critmult" title="wep2critmult" value="0"></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep2attackroll" title="wep2attackroll" value="/em attacks with @{weapon2} hitting AC [[1d20+@{wep2mwk}+@{wep2enh}+@{wep2foc}+@{wep2attacktype} +?{Flank (1=yes)|0}*2 +?{Power Attack? (use negative sign i.e. -3|0}+?{Additional Hit Modifier?|0}]]"/></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep2dmgroll" title="wep2dmgroll" value="/em @{weapon2} Damage [[@{wep2dmg}+@{wep2enh}+@{wep2spc}+@{wep2dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0}]]"/></td>
-                        <td><button type="roll" name="attr_wep2critdmgroll" title="wep2critdmgroll" value="/em @{weapon2} Critical Damage [[(@{wep2dmg}+@{wep2enh}+@{wep2spc}+@{wep2dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0})*@{wep2critmult}]]"></button></td>
+                        <td><button type="roll" name="attr_wep2critdmgroll" title="wep2critdmgroll" value="/em @{weapon2} Critical Damage [[ [[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?|0} + ?{Additional Damage Modifier?|0} ]] [x1 DMG] + ?{Choose Crit Multiplier|x2,[[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125;]] [x2 DMG]|x3,[[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] |x4,[[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] + [[ @{wep2dmg} + @{wep2enh} + @{wep2spc} + @{wep2dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x4 DMG] }]]"></button></td>
                     </tr>
                     <tr>
                         <td colspan="3" class="sheet-statlabel">Special Properties</td>
@@ -609,7 +621,7 @@
                         <td><input type="number" name="attr_wep3critmult" title="wep3critmult" value="0"></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep3attackroll" title="wep3attackroll" value="/em attacks with @{weapon3} hitting AC [[1d20+@{wep3mwk}+@{wep3enh}+@{wep3foc}+@{wep3attacktype} +?{Flank (1=yes)|0}*2 +?{Power Attack? (use negative sign i.e. -3|0}+?{Additional Hit Modifier?|0}]]"/></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep3dmgroll" title="wep3dmgroll" value="/em @{weapon3} Damage [[@{wep3dmg}+@{wep2enh}+@{wep3spc}+@{wep3dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0}]]"/></td>
-                        <td><button type="roll" name="attr_wep3critdmgroll" title="wep3critdmgroll" value="/em @{weapon3} Critical Damage [[(@{wep3dmg}+@{wep3enh}+@{wep2spc}+@{wep3dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0})*@{wep3critmult}]]"></button></td>
+                        <td><button type="roll" name="attr_wep3critdmgroll" title="wep3critdmgroll" value="/em @{weapon3} Critical Damage [[ [[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?|0} + ?{Additional Damage Modifier?|0} ]] [x1 DMG] + ?{Choose Crit Multiplier|x2,[[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125;]] [x2 DMG]|x3,[[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] |x4,[[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] + [[ @{wep3dmg} + @{wep3enh} + @{wep3spc} + @{wep3dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x4 DMG] }]]"></button></td>
                     </tr>
                     <tr>
                         <td colspan="3" class="sheet-statlabel">Special Properties</td>
@@ -687,7 +699,7 @@
                         <td><input type="number" name="attr_wep4critmult" title="wep4critmult" value="0"></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep4attackroll" title="wep4attackroll" value="/em attacks with @{weapon4} hitting AC [[1d20+@{wep4mwk}+@{wep4enh}+@{wep4foc}+@{wep4attacktype} +?{Flank (1=yes)|0}*2 +?{Power Attack? (use negative sign i.e. -3|0}+?{Additional Hit Modifier?|0}]]"/></td>
                         <td style="width: 50px;"><button type="roll" name="attr_wep4dmgroll" title="wep4dmgroll" value="/em @{weapon4} Damage [[@{wep4dmg}+@{wep2enh}+@{wep4spc}+@{wep4dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0}]]"/></td>
-                        <td><button type="roll" name="attr_wep4critdmgroll" title="wep4critdmgroll" value="/em @{weapon4} Critical Damage = [[(@{wep4dmg}+@{wep4enh}+@{wep2spc}+@{wep4dmgstat} +?{Power Attack?|0}+?{Additional Damage Modifier?|0})*@{wep4critmult}]]"></button></td>
+                        <td><button type="roll" name="attr_wep4critdmgroll" title="wep4critdmgroll" value="/em @{weapon4} Critical Damage [[ [[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?|0} + ?{Additional Damage Modifier?|0} ]] [x1 DMG] + ?{Choose Crit Multiplier|x2,[[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125;]] [x2 DMG]|x3,[[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] |x4,[[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x2 DMG] + [[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x3 DMG] + [[ @{wep4dmg} + @{wep4enh} + @{wep4spc} + @{wep4dmgstat} + ?{Power Attack?&amp;#124;0&amp;#125; + ?{Additional Damage Modifier?&amp;#124;0&amp;#125; ]] [x4 DMG] }]]"></button></td>
                     </tr>
                     <tr>
                         <td colspan="3" class="sheet-statlabel">Special Properties</td>
@@ -1826,8 +1838,8 @@
                                             <td><input type="text" name="attr_item38loc" title="item38loc" style="font-size: .9em; height: 20px;"></td>
                                         </tr>
                                         <tr>
-                                            <td colspan="2" style="font-size: .75em;">Total Weight of Inventory Items</td>
-                                            <td colspan="2" style="font-size: .75em;"><input type="text" name="attr_invwt" title="invwt" value="@{itemwt1}+@{itemwt2}+@{itemwt3}+@{itemwt4}+@{itemwt5}+@{itemwt6}+@{itemwt7}+@{itemwt8}+@{itemwt9}+@{itemwt10}+@{itemwt11}+@{itemwt12}+@{itemwt13}+@{itemwt14}+@{itemwt15}+@{itemwt16}+@{itemwt17}+@{itemwt18}+@{itemwt19}+@{itemwt20}+@{itemwt21}+@{itemwt22}+@{itemwt23}+@{itemwt24}+@{itemwt25}+@{itemwt26}+@{itemwt27}+@{itemwt28}+@{itemwt29}+@{itemwt30}+@{itemwt31}+@{itemwt32}+@{itemwt33}+@{itemwt34}+@{itemwt35}+@{itemwt36}+@{itemwt37}+@{itemwt38}" disabled></td>
+                                            <td colspan="2" style="padding-top: 10px;">Total Weight (Items/Coins)</td>
+                                            <td colspan="3" style="text-align:left;"><input style="width:5em; type="text" name="attr_invwt" title="invwt" value="( @{itemwt1}+@{itemwt2}+@{itemwt3}+@{itemwt4}+@{itemwt5}+@{itemwt6}+@{itemwt7}+@{itemwt8}+@{itemwt9}+@{itemwt10}+@{itemwt11}+@{itemwt12}+@{itemwt13}+@{itemwt14}+@{itemwt15}+@{itemwt16}+@{itemwt17}+@{itemwt18}+@{itemwt19}+@{itemwt20}+@{itemwt21}+@{itemwt22}+@{itemwt23}+@{itemwt24}+@{itemwt25}+@{itemwt26}+@{itemwt27}+@{itemwt28}+@{itemwt29}+@{itemwt30}+@{itemwt31}+@{itemwt32}+@{itemwt33}+@{itemwt34}+@{itemwt35}+@{itemwt36}+@{itemwt37}+@{itemwt38}+( ceil(@{gp_carried}+@{pp_carried}+@{cp_carried}+@{sp_carried})*.02) )" disabled>lbs.</td>
                                             </td>
                                         </tr>
                                     </table>
@@ -2363,16 +2375,16 @@
     <table style="width: 828px;">
         <tr>
             <td colspan="2"></td>
-                <table style="width: 50%;float: left;">
+                <table style="width: 49%;float: left;">
                     <tr>          
-                        <td colspan="5" style="sheet-label; width: 50%;">Currency</td>
+                        <td colspan="5" style="sheet-label; width: 50%;">Carried Currency</td>
                     </tr>
                     <tr>
-                        <td><input type="text" name="attr_cp" title="cp" value="0"></td>
-                        <td><input type="text" name="attr_sp" title="sp" value="0"></td>
-                        <td><input type="text" name="attr_gp" title="gp" value="0"></td>
-                        <td><input type="text" name="attr_pp" title="pp" value="0"></td>
-                        <td><input type="text" name="attr_wealth" title="wealth" value="@{gp}+(@{pp}*10)+(@{cp}*.01)+(@{sp}*.1)" disabled></td>
+                        <td><input type="text" name="attr_cp_carried" title="cp" value="0"></td>
+                        <td><input type="text" name="attr_sp_carried" title="sp" value="0"></td>
+                        <td><input type="text" name="attr_gp_carried" title="gp" value="0"></td>
+                        <td><input type="text" name="attr_pp_carried" title="pp" value="0"></td>
+                        <td><input type="text" name="attr_wealth" title="wealth" value="( @{gp_carried}+(@{pp_carried}*10)+(@{cp_carried}*.01)+(@{sp_carried}*.1) )" disabled></td>
                     </tr>
                     <tr>
                         <td style="font-size: .75em;">Copper</td>
@@ -2382,7 +2394,30 @@
                         <td style="font-size: .75em;">Total GP</td>
                     </tr>
                 </table>
-                <table style="width: 50%;float: right;">
+				<table style="width: 49%;float: right;">
+                    <tr>          
+                        <td colspan="5" style="sheet-label; width: 50%;">Total Currency</td>
+                    </tr>
+                    <tr>
+                        <td><input type="text" name="attr_cp" title="cp" value="0"></td>
+                        <td><input type="text" name="attr_sp" title="sp" value="0"></td>
+                        <td><input type="text" name="attr_gp" title="gp" value="0"></td>
+                        <td><input type="text" name="attr_pp" title="pp" value="0"></td>
+                        <td><input type="text" name="attr_wealth" title="wealth" value="( @{gp}+(@{pp}*10)+(@{cp}*.01)+(@{sp}*.1) )" disabled></td>
+                    </tr>
+                    <tr>
+                        <td style="font-size: .75em;">Copper</td>
+                        <td style="font-size: .75em;">Silver</td>
+                        <td style="font-size: .75em;">Gold</td>
+                        <td style="font-size: .75em;">Platinum</td>
+                        <td style="font-size: .75em;">Total GP</td>
+                    </tr>
+                </table>                
+            </td>
+        </tr>
+		<tr>
+			<td colspan="2">
+				<table style="width: 99.65%;">
                     <tr>
                         <td style="sheet-label; width: 50%;">Languages</td>
                     </tr>
@@ -2390,8 +2425,8 @@
                         <td><textarea name="attr_languages" title="languages" style="width: 100%, height: 7.5em;text-align: left;"></textarea></td>
                     </tr>
                 </table>
-            </td>
-        </tr>
+			</td>
+		</tr>
     </table>
     <table style="width: 828px;">
         <tr>
@@ -2426,3 +2461,100 @@
         </tr>
     </table>
 </div>
+
+<script type="text/worker">
+
+var Sheet = Sheet || (function(){
+
+	var version= 0.1,
+	Debug = false,
+
+	updateHP = function() {
+		getAttrs(["HP|max","HPCurrent_max"], function(values){
+			var HPmax=(parseInt(values["HP|max"],10));
+			var HPCurrent_max=(parseInt(values["HPCurrent_max"],10));
+			if ((parseInt(values["HP|max"],10)) === 0){
+				console.log("....No conversion necessary. HP|max = "+ (parseInt(values["HP|max"],10)) );
+				return(values);
+			}
+			else {
+				setAttrs({"HPCurrent_max": HPmax},{}, function(){
+					getAttrs(["HPCurrent_max"], function(values) {
+						var HPCurrent_max = (parseInt(values["HPCurrent_max"],10));
+							console.log("....HPCurrent_max now equals HP|max = " + HPCurrent_max);
+						setAttrs({"HP|max": HPCurrent_max});
+							console.log("....HPCurrent_max = " + HPCurrent_max);
+							console.log("...........HP|max = " + (parseInt(values["HP|max"],10)) );
+					});
+				});
+			}
+		});
+	},
+
+/* recalculateSheet */
+	recalculateSheet = function(oldversion) {
+		if (oldversion < 0.1) {
+		updateHP();
+		}
+	},	
+
+/* checkForUpdate looks at current version of page in
+ * Sheet_Version and compares to code Sheet.version calls
+ * recalulateSheet if versions don't match or if recalculate
+ * button was pressed. */
+	checkForUpdate = function(){
+		getAttrs(["Sheet_Version","Sheet_forcesync","recalc1"],function(v){
+			var setter={},currVer=0,setAny=0,recalc=false;
+			currVer=parseFloat(v["Sheet_Version"],10)||0;
+			console.log("Current sheet data version:"+currVer+", Sheet code version:" + version );
+			
+			if ( currVer!== version ) {
+				recalc=true;
+				setter["Sheet_Version"]= version;
+				setAny=1;
+			}
+			if (v["recalc1"] && v["recalc1"]!="0" ) {
+				currVer=-1;
+				recalc=true;
+				setter["recalc1"]=0;
+				setAny=1;
+			}
+			if (v["Sheet_forcesync"] && v["Sheet_forcesync"]!="0" ) {
+				currVer=-1;
+				recalc=true;
+				setter["Sheet_forcesync"]=0;
+				setAny=1;
+			}
+			if (setAny) {
+				 setAttrs( setter);
+			}
+			if (recalc) {
+				recalculateSheet(currVer);
+			}
+		});
+	};
+	return {
+		version:version,
+		checkForUpdate:checkForUpdate,
+		updateHP:updateHP
+	};
+}());
+
+//Sync HP|max with HPCurrent_max
+on("change:hpcurrent_max",function(){
+	getAttrs(["HPCurrent_max","HP|max"], function(values){
+		var HPCurrent_max=(parseInt(values["HPCurrent_max"],10));
+		setAttrs({"HP|max": HPCurrent_max},{}, function(){
+			getAttrs(["HPCurrent_max", "HP|max"], function(values) {
+				console.log("....HPCurrent_max = " + HPCurrent_max);
+				console.log("...........HP|max = " + (parseInt(values["HP|max"],10)) );
+			});
+		});
+	});
+});
+
+//sheet
+on("sheet:opened",function(){Sheet.checkForUpdate();});
+on("change:recalc1",function(){Sheet.checkForUpdate();});
+
+</script>


### PR DESCRIPTION
- Total HP, @{HP|max} has been changed to @{HPCurrent_max} so that HP
can be properly linked with token bars. This conversion is handled
automatically using sheet workers to verify the version of the sheet and
updating @{HPCurrent_max} with the value of @{HP|max}. Once the sheet
has been updated, any changes made to @{HPCurrent_max} will also be
reflected on @{HP|max} for backward compatibility.

- Added a Carried coins area and they will be included in Total Weight and encumbrance.

- The Critical damage roll has been changed from simply multiplying
damage based off of the crit multiplier to rolling damage once(w/mods),
and prompting for additional damage(w/mods), x2, x3, or x4 damage.