### PR TITLE
Massive IKRPG update

### DIFF
--- a/Iron Kingdoms RPG/IKPRG.html
+++ b/Iron Kingdoms RPG/IKPRG.html
@@ -1,4 +1,3 @@
-
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" style="width:120px;" title="Basic" checked="checked" id="radio1" /><label class="sheet-bob"  for="radio1">Basic</label>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Skills" id="radio2" /><label for="radio2">Skills</label>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Abilities" id="radio3" /><label for="radio3">Abilities</label>
@@ -9,28 +8,47 @@
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab8" value="8" title="Advancement" id="radio8" /><label for="radio8">Advancement</label>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9" title="Steamjack" id="radio9" /><label for="radio9">Steamjack</label>
 <input type="radio" name="attr_tab" class="sheet-tab sheet-tab10" value="10" title="NPC" id="radio10" /><label for="radio10">NPC</label>
-
 <div class="sheet-tab-br"></div> 
 
+<!--Top Bar -->
 <div class="sheet-top_half">
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
-            <div class="sheet-wrapper">
+            <div>
                 <table style="width:820px">
                     <tr>
-                        <th style="width:100px"><div class="sheet-tooltips"><h4>Defense</h4><span><div class="sheet-plain">Modify with 'Other Defenses' in the Combat Tab</div></span></div></th>
-                        <th style="width:100px"><div class="sheet-tooltips"><h4>Armor</h4><span><div class="sheet-plain">Modify with 'Other Defenses' in the Combat Tab</div></span></div></th> 
-                        <th style="width:100px"><button type='roll' class="sheet-roll" name="initiative_roll" value='/em @{character_name} rolls [[2d6 + [[@{initiative}]] + @{Preternatural_Awareness-switch} &{tracker}]] for initiative'><label><h4>Initative</h4></label></button></th>
-                        <th style="width:100px"><button type='roll' class="sheet-roll" name="willpower_roll" value='/em @{character_name} rolls [[2d6 + [[@{willpower}]] + ?{Extra Dice|0}d6]] for Willpower' /><label><h4>Willpower</h4></label></th>
+                        <th style="width:60px"><div class="sheet-tooltips"><h4>Defense</h4><span><div class="sheet-plain">Modify with 'Other Defenses' in the Combat Tab</div></span></div></th>
+                        <th style="width:60px"><div class="sheet-tooltips"><h4>Armor</h4><span><div class="sheet-plain">Modify with 'Other Defenses' in the Combat Tab</div></span></div></th> 
+                        <th style="width:80px"><button type='roll' class="sheet-btn" name="initiative_roll" value='/em @{character_name} rolls [[2d6 + [[@{initiative}]] + @{Preternatural_Awareness-switch} &{tracker}]] for Initiative'><label><h4>Initiative</h4></label></button></th>
+                        <th style="width:80px"><button type='roll' class="sheet-btn" name="willpower_roll" value='/em @{character_name} rolls [[2d6 + [[@{willpower}]] + ?{Extra Dice|0}d6]] for Willpower' /><label><h4>Willpower</h4></label></th>
                         <th style="width:160px"><div class="sheet-tooltips"><h4>Movement</h4><span><div class="sheet-plain">Increasing the modifier by +1 will increase the distance by +6ft</div></span></div></th>
-                        <th style="width:115px"><div class="sheet-tooltips-left"><h4>Command Range</h4><span><div class="sheet-plain">Increasing the modifier by +1 will increase the radius by +6ft</div></span></div></th>
-                        <th style="width:115px"><div class="sheet-tooltips-left"><h4>Control Area</h4><span><div class="sheet-plain">Increasing the modifier by +1 will increase the distance by +12ft</div></span></div></th>
+                        <th style="width:80px"><div class="sheet-tooltips-left"><h4>Command<br>Range</h4><span><div class="sheet-plain">Increasing the modifier by +1 will increase the radius by +6ft</div></span></div></th>
+                        <th style="width:80px"><div class="sheet-tooltips-left"><h4>Control<br>Area</h4><span><div class="sheet-plain">Increasing the modifier by +1 will increase the distance by +12ft</div></span></div></th>
+                        <th rowspan="3">
+                        <!-- ==== Feat Tracker ==== -->
+                            <div>
+                                <input type="checkbox" class="sheet-featup" name="attr_feat_up" value="1"><span></span><br>
+                                <input type="checkbox" class="sheet-featdown" name="attr_feat_down" value="1"><span></span>
+                            </div>
+                        </th>
+                        <th rowspan="3">
+                        <div class="sheet-feat">
+                            <input type="radio" class="sheet-feat sheet-zerofeat" name="attr_feat" value="0" checked/>
+                            <input type="radio" class="sheet-feat sheet-onefeat" name="attr_feat" value="1" />
+                            <input type="radio" class="sheet-feat sheet-twofeat" name="attr_feat" value="2" />
+                            <input type="radio" class="sheet-feat sheet-threefeat" name="attr_feat" value="3" />
+                            <span class="sheet-feat sheet-zerofeat"></span>
+                            <span class="sheet-feat sheet-onefeat"></span>
+                            <span class="sheet-feat sheet-twofeat"></span>
+                            <span class="sheet-feat sheet-threefeat"></span>
+                        </div>
+                        </th>
                     </tr>
                     <tr>
-                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_def" value="(@{speed} + @{agility} + @{perception} + @{worn_armor_def} + @{npc_def} + @{jack_def} + @{Gobber-toggle} - @{Crippled_Intellect})" disabled="true" /></div></th>
+                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_def" value="(@{speed} + @{agility} + @{perception} + @{worn_armor_def} + @{npc_def} + @{jack_def} + @{Gobber-toggle} + @{mounted} - @{Crippled_Intellect})" disabled="true" /></div></th>
                         <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_arm" value="([[@{physique} + @{worn_armor_arm} + @{hasshield}]] + @{npc_arm} + @{jack_arm})" disabled="true" /></div></th>
-                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_initiative" value="[[@{speed} + @{prowess} + @{perception} + @{initiative_mod}]] + [[@{jack_initiative} + @{npc_initiative}]]" disabled="true" /></div></th>
-                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_willpower" value="[[@{physique} + @{intellect} + @{willpower_mod}]] + [[@{npc_willpower}]]" disabled="true" /></div></th>
+                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_initiative" value="0" readonly  /></div></th>
+                        <th><div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_willpower" value="0" readonly /></div></th>
                         <th>
                             <div class = "sheet-stats-derived"><input type="number" class="sheet-stats-base" name="attr_movement" value="[[@{speed} + @{jack_movement} + @{npc_movement}]] + @{worn_armor_speed} + @{movement_mod}" disabled="true" />
                             <input type="number" class="sheet-stats-base" name="attr_movement_feet" value="(@{movement})*6" disabled="true" />ft</div>
@@ -54,7 +72,7 @@
 </div>
 
 <div class="sheet-tab-br"></div> 
-<!--Tab 1 -->
+<!--Tab 1 Basic -->
 <div class="sheet-tab-content sheet-tab1">
     <h2>Basic Info</h2>
     <div class="sheet-tabbed-panel">
@@ -78,14 +96,26 @@
                                 <td><div class="sheet-stats-weight"><input class="sheet-stats-base" type="text" value="" name="attr_weight" style="width:80px"  placeholder="100 lbs."/></div></td>
                             </tr>
                         </table>
-                        <div class="sheet-stats-height">Race</div>
-                        <div class="sheet-stats-race"><input class="sheet-stats-base" type="text" value="" name="attr_race" placeholder="Race"/></div>
                     </div>
                     <!-- ==== Damage Tracker ==== -->
                     <div class='sheet-col'>
-                        <div class='sheet-center'><div class="sheet-tooltips"><div style="font-family:Pictos; color:darkred">k</div>
-                            <span>After a short rest following an encounter, a character automatically regains a number of vitality points equal to his PHY.
-                                Characters who have suffered damage continue to recover over time. A character regains 1 vitality point each hour for the first three hours after being injured. After that he regains 1 Vitality point every six hours until he has regained all of his vitality points.</span></div></div>
+                        <table class="sheet-table_center">
+                            <tr>
+                                <td><input type="checkbox" class="sheet-reset" name="attr_wound_reset" value="1"/><span></span></td>
+                                <td>
+                                    <div class="sheet-center" style="width:100px;">
+                                        <div class="sheet-tooltips">
+                                            <div style="font-family:Pictos; color:darkred">k</div>
+                                            <span>After a short rest following an encounter, a character automatically regains a number of vitality points equal to his PHY.
+                                            Characters who have suffered damage continue to recover over time. A character regains 1 vitality point each hour for the first three hours after being injured. After that he regains 1 Vitality point every six hours until he has regained all of his vitality points.</span>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td><input type="checkbox" class="sheet-health" name="attr_health_refresh" value="1"/><span></span></td>
+                            </tr>
+                        </table>
+                        <div class='sheet-center'>
+                        </div>
                         <table class="sheet-table_center">
                             <tr>
                                 <th>1</th>
@@ -98,9 +128,9 @@
                             <tr>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl0" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl0" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy10" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy10" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy10" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -108,9 +138,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyr0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyr0" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyr0" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy9" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy9" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy9" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -118,9 +148,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll0" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll0" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl10" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl10" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl10" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -128,9 +158,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_aglr0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_aglr0" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_aglr0" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl9" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl9" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl9" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -138,9 +168,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl0" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl0" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int10" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int10" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int10" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -148,72 +178,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intr0" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intr0" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intr0" value="2" />
-                                        <span class="sheet-intbox sheet-blackdoti"></span>
-                                        <span class="sheet-intbox sheet-gredot"></span>
-                                        <span class="sheet-intbox sheet-xdoti"></span>
-                                    </div>
-                                </td>
-                            </tr>
-                            
-                            <tr>
-                                <td>
-                                    <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl1" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl1" value="2" />
-                                        <span class="sheet-phybox sheet-blackdot"></span>
-                                        <span class="sheet-phybox sheet-bluedot"></span>
-                                        <span class="sheet-phybox sheet-xdot"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyr1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyr1" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyr1" value="2" />
-                                        <span class="sheet-phybox sheet-blackdot"></span>
-                                        <span class="sheet-phybox sheet-bluedot"></span>
-                                        <span class="sheet-phybox sheet-xdot"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll1" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll1" value="2" />
-                                        <span class="sheet-aglbox sheet-blackdota"></span>
-                                        <span class="sheet-aglbox sheet-reddot"></span>
-                                        <span class="sheet-aglbox sheet-xdota"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_aglr1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_aglr1" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_aglr1" value="2" />
-                                        <span class="sheet-aglbox sheet-blackdota"></span>
-                                        <span class="sheet-aglbox sheet-reddot"></span>
-                                        <span class="sheet-aglbox sheet-xdota"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl1" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl1" value="2" />
-                                        <span class="sheet-intbox sheet-blackdoti"></span>
-                                        <span class="sheet-intbox sheet-gredot"></span>
-                                        <span class="sheet-intbox sheet-xdoti"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intr1" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intr1" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intr1" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int9" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int9" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int9" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -223,9 +190,9 @@
                             <tr>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl2" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl2" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy8" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy8" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy8" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -233,9 +200,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyr2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyr2" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyr2" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy7" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy7" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy7" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -243,9 +210,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll2" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll2" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl8" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl8" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl8" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -253,9 +220,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_aglr2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_aglr2" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_aglr2" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl7" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl7" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl7" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -263,9 +230,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl2" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl2" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int8" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int8" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int8" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -273,71 +240,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intr2" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intr2" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intr2" value="2" />
-                                        <span class="sheet-intbox sheet-blackdoti"></span>
-                                        <span class="sheet-intbox sheet-gredot"></span>
-                                        <span class="sheet-intbox sheet-xdoti"></span>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl3" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl3" value="2" />
-                                        <span class="sheet-phybox sheet-blackdot"></span>
-                                        <span class="sheet-phybox sheet-bluedot"></span>
-                                        <span class="sheet-phybox sheet-xdot"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyr3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyr3" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyr3" value="2" />
-                                        <span class="sheet-phybox sheet-blackdot"></span>
-                                        <span class="sheet-phybox sheet-bluedot"></span>
-                                        <span class="sheet-phybox sheet-xdot"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll3" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll3" value="2" />
-                                        <span class="sheet-aglbox sheet-blackdota"></span>
-                                        <span class="sheet-aglbox sheet-reddot"></span>
-                                        <span class="sheet-aglbox sheet-xdota"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_aglr3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_aglr3" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_aglr3" value="2" />
-                                        <span class="sheet-aglbox sheet-blackdota"></span>
-                                        <span class="sheet-aglbox sheet-reddot"></span>
-                                        <span class="sheet-aglbox sheet-xdota"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl3" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl3" value="2" />
-                                        <span class="sheet-intbox sheet-blackdoti"></span>
-                                        <span class="sheet-intbox sheet-gredot"></span>
-                                        <span class="sheet-intbox sheet-xdoti"></span>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intr3" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intr3" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intr3" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int7" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int7" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int7" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -347,9 +252,9 @@
                             <tr>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl4" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl4" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy6" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy6" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy6" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -357,9 +262,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyr4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyr4" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyr4" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy5" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy5" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy5" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -367,9 +272,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll4" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll4" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl6" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl6" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl6" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -377,9 +282,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_aglr4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_aglr4" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_aglr4" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl5" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl5" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl5" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -387,9 +292,9 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl4" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl4" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int6" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int6" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int6" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -397,9 +302,133 @@
                                 </td>
                                 <td>
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intr4" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intr4" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intr4" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int5" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int5" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int5" value="2" />
+                                        <span class="sheet-intbox sheet-blackdoti"></span>
+                                        <span class="sheet-intbox sheet-gredot"></span>
+                                        <span class="sheet-intbox sheet-xdoti"></span>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="sheet-phybox">
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy4" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy4" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy4" value="2" />
+                                        <span class="sheet-phybox sheet-blackdot"></span>
+                                        <span class="sheet-phybox sheet-bluedot"></span>
+                                        <span class="sheet-phybox sheet-xdot"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-phybox">
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy3" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy3" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy3" value="2" />
+                                        <span class="sheet-phybox sheet-blackdot"></span>
+                                        <span class="sheet-phybox sheet-bluedot"></span>
+                                        <span class="sheet-phybox sheet-xdot"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-aglbox">
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl4" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl4" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl4" value="2" />
+                                        <span class="sheet-aglbox sheet-blackdota"></span>
+                                        <span class="sheet-aglbox sheet-reddot"></span>
+                                        <span class="sheet-aglbox sheet-xdota"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-aglbox">
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl3" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl3" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl3" value="2" />
+                                        <span class="sheet-aglbox sheet-blackdota"></span>
+                                        <span class="sheet-aglbox sheet-reddot"></span>
+                                        <span class="sheet-aglbox sheet-xdota"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-intbox">
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int4" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int4" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int4" value="2" />
+                                        <span class="sheet-intbox sheet-blackdoti"></span>
+                                        <span class="sheet-intbox sheet-gredot"></span>
+                                        <span class="sheet-intbox sheet-xdoti"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-intbox">
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int3" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int3" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int3" value="2" />
+                                        <span class="sheet-intbox sheet-blackdoti"></span>
+                                        <span class="sheet-intbox sheet-gredot"></span>
+                                        <span class="sheet-intbox sheet-xdoti"></span>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="sheet-phybox">
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy2" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy2" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy2" value="2" />
+                                        <span class="sheet-phybox sheet-blackdot"></span>
+                                        <span class="sheet-phybox sheet-bluedot"></span>
+                                        <span class="sheet-phybox sheet-xdot"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-phybox">
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy1" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy1" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy1" value="2" />
+                                        <span class="sheet-phybox sheet-blackdot"></span>
+                                        <span class="sheet-phybox sheet-bluedot"></span>
+                                        <span class="sheet-phybox sheet-xdot"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-aglbox">
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl2" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl2" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl2" value="2" />
+                                        <span class="sheet-aglbox sheet-blackdota"></span>
+                                        <span class="sheet-aglbox sheet-reddot"></span>
+                                        <span class="sheet-aglbox sheet-xdota"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-aglbox">
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl1" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl1" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl1" value="2" />
+                                        <span class="sheet-aglbox sheet-blackdota"></span>
+                                        <span class="sheet-aglbox sheet-reddot"></span>
+                                        <span class="sheet-aglbox sheet-xdota"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-intbox">
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int2" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int2" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int2" value="2" />
+                                        <span class="sheet-intbox sheet-blackdoti"></span>
+                                        <span class="sheet-intbox sheet-gredot"></span>
+                                        <span class="sheet-intbox sheet-xdoti"></span>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="sheet-intbox">
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int1" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int1" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int1" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -409,9 +438,9 @@
                             <tr>
                                 <td colspan="2" align="center">
                                     <div class="sheet-phybox">
-                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phyl5" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phyl5" value="1" />
-                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phyl5" value="2" />
+                                        <input type="radio" class="sheet-phybox sheet-blackdot" name="attr_healthbox_phy0" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-phybox sheet-bluedot" name="attr_healthbox_phy0" value="1" />
+                                        <input type="radio" class="sheet-phybox sheet-xdot" name="attr_healthbox_phy0" value="2" />
                                         <span class="sheet-phybox sheet-blackdot"></span>
                                         <span class="sheet-phybox sheet-bluedot"></span>
                                         <span class="sheet-phybox sheet-xdot"></span>
@@ -419,9 +448,9 @@
                                 </td>
                                 <td colspan="2" align="center">
                                     <div class="sheet-aglbox">
-                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agll5" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agll5" value="1" />
-                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agll5" value="2" />
+                                        <input type="radio" class="sheet-aglbox sheet-blackdota" name="attr_healthbox_agl0" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-aglbox sheet-reddot" name="attr_healthbox_agl0" value="1" />
+                                        <input type="radio" class="sheet-aglbox sheet-xdota" name="attr_healthbox_agl0" value="2" />
                                         <span class="sheet-aglbox sheet-blackdota"></span>
                                         <span class="sheet-aglbox sheet-reddot"></span>
                                         <span class="sheet-aglbox sheet-xdota"></span>
@@ -429,9 +458,9 @@
                                 </td>
                                 <td colspan="2" align="center">
                                     <div class="sheet-intbox">
-                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_intl5" value="0" checked="checked"/>        
-                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_intl5" value="1" />
-                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_intl5" value="2" />
+                                        <input type="radio" class="sheet-intbox sheet-blackdoti" name="attr_healthbox_int0" value="0" checked="checked"/>        
+                                        <input type="radio" class="sheet-intbox sheet-gredot" name="attr_healthbox_int0" value="1" />
+                                        <input type="radio" class="sheet-intbox sheet-xdoti" name="attr_healthbox_int0" value="2" />
                                         <span class="sheet-intbox sheet-blackdoti"></span>
                                         <span class="sheet-intbox sheet-gredot"></span>
                                         <span class="sheet-intbox sheet-xdoti"></span>
@@ -579,30 +608,34 @@
                             </tr>
                         </table>
                     </div>
-                    <div class='sheet-col'>            
+                    <div class='sheet-col'>       
+                        <div class="sheet-stats-height">Race</div>
+                        <div class="sheet-stats-race"><input class="sheet-stats-base" type="text" value="" name="attr_race" placeholder="Race"/></div>     
                         <div class="sheet-stats-height">Archetype</div>
-                        <div class="sheet-stats-archetype"><input class="sheet-stats-base" type="text" value="" name="attr_archetype" placeholder="Archetype"/></div>    			
+                        <div class="sheet-stats-archetype"><input class="sheet-stats-base" type="text" value="" name="attr_archetype" placeholder="Archetype"/></div>                
                         <div class="sheet-stats-careers">Careers</div>
-                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career1" placeholder="Career"/></div>			
-                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career2" placeholder="Career"/></div>
-                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career3" placeholder="Career"/></div>    		
-                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career4" placeholder="Career"/></div>   
-                        <!-- ==== Feat Tracker ==== -->
-                        <div class="sheet-feat">
-                            <input type="radio" class="sheet-feat sheet-zerofeat" name="attr_feat" value="0" checked="checked" />
-                            <input type="radio" class="sheet-feat sheet-onefeat" name="attr_feat" value="1" />
-                            <input type="radio" class="sheet-feat sheet-twofeat" name="attr_feat" value="2" />
-                            <input type="radio" class="sheet-feat sheet-threefeat" name="attr_feat" value="3" />
-                            <span class="sheet-feat sheet-zerofeat"></span>
-                            <span class="sheet-feat sheet-onefeat"></span>
-                            <span class="sheet-feat sheet-twofeat"></span>
-                            <span class="sheet-feat sheet-threefeat"></span>
+                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career1" placeholder="First Career"/></div>            
+                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career2" placeholder="Second Career"/></div>
+                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career3" placeholder="Third Career"/></div>        	
+                        <div class="sheet-stats-careers"><input class="sheet-stats-base" type="text" value="" name="attr_career4" placeholder="Fourth Career"/></div>   
+
+                        <!--
+                        <div>
+                            <input type="radio" class="sheet-use" name="attr_feat_change" value="0"/><span></span>
+                            <br>
+                            <input type="radio" class="sheet-use" name="attr_feat_change" value="1"/><span></span>
+                            <br>
+                            <input type="radio" class="sheet-use" name="attr_feat_change" value="2"/><span></span>
+                            <br>
+                            <input type="radio" class="sheet-use" name="attr_feat_change" value="3"/><span></span>
                         </div>
+                        -->
                     </div>
 				</div>	
 			</div>
         </div>
     </div>
+    
     <h2>Character Stats</h2>
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
@@ -613,7 +646,7 @@
                     <div class='sheet-col'>
                         <table>
                             <tr>
-                                <td><div class="sheet-physstat"><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{physique} + ?{Extra Dice|0}d6 ]] for Physique'><h4 class="sheet-physfont">Physique</h4></button></div></td>
+                                <td><div class="sheet-physstat"><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{physique} + ?{Extra Dice|0}d6 ]] for Physique'><h4 class="sheet-physfont">Physique</h4></button></div></td>
                                 <td><div><input type="number" class="sheet-stats-base sheet-blue" name="attr_physique_base" value="0" /></div></td>
                             </tr>
                             <tr>
@@ -628,12 +661,12 @@
                                 <td>&nbsp;</td>
                             </tr>
                                 <div class="sheet-hidden">
-                                <input type="number" name="attr_physique" value='@{physique_base} + @{physique_misc_mod}' disabled="true" />
-                                <input type="number" name="attr_physique_health" value="@{physique}" />
+                                <input type="number" name="attr_physique" value='0' readonly/>
+                                <input type="number" name="attr_physique_health" value="@{physique}" disabled="true" />
                                 <input type="number" name="attr_physique_health_max" value="@{physique}" disabled="true" />
                                 </div>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{speed} + ?{Extra Dice|0}d6 ]] for Speed'><label><h4>Speed</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{speed} + ?{Extra Dice|0}d6 ]] for Speed'><label><h4>Speed</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_speed_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -645,7 +678,7 @@
                                 <td><div class = "sheet-skill-base"><input  type="number" name="attr_speed_misc_mod" value="0" /></div></td>
                             </tr>
                                 <div class="sheet-hidden">
-                                <input type="number" name="attr_speed" value='@{speed_base} + @{speed_misc_mod}' disabled="true" />
+                                <input type="number" name="attr_speed" value='0' />
                                 <input type="number" name="attr_speed_health" value="@{speed}" />
                                 <input type="number" name="attr_speed_health_max" value="@{speed}"  />
                                 </div>
@@ -653,7 +686,7 @@
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{strength} + ?{Extra Dice|0}d6 ]] for Strength'><label><h4>Strength</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{strength} + ?{Extra Dice|0}d6 ]] for Strength'><label><h4>Strength</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_strength_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -674,7 +707,7 @@
                     <div class='sheet-col'>
                         <table>
                             <tr>
-                                <td><div class="sheet-aglstat"><button type='roll' class="sheet-roll" value='/me rolls [[ [[2+@{Deft-switch}]]d6 + @{agility} + ?{Extra Dice|0}d6]] for Agility'><h4 class="sheet-aglfont">Agility</h4></button></div></td>
+                                <td><div class="sheet-aglstat"><button type='roll' class="sheet-btn" value='/me rolls [[ [[2+@{Deft-switch}]]d6 + @{agility} + ?{Extra Dice|0}d6]] for Agility'><h4 class="sheet-aglfont">Agility</h4></button></div></td>
                                 <td><input type="number" class="sheet-stats-base sheet-red" name="attr_agility_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -694,7 +727,7 @@
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{prowess} + ?{Extra Dice|0}d6 ]] for Prowess'><label><h4>Prowess</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{prowess} + ?{Extra Dice|0}d6 ]] for Prowess'><label><h4>Prowess</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_prowess_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -706,15 +739,15 @@
                                 <td><div class = "sheet-skill-base"><input  type="number" name="attr_prowess_misc_mod" value="0" /></div></td>
                             </tr>
                                 <div class="sheet-hidden">
-                                <input type="number" name="attr_prowess" value='@{prowess_base} + @{prowess_misc_mod}' disabled="true" />
-                                <input type="number" name="attr_prowess_health" value="@{prowess}" />
+                                <input type="number" name="attr_prowess" value='0'  />
+                                <input type="number" name="attr_prowess_health" value="@{prowess}"disabled="true"/>
                                 <input type="number" name="attr_prowess_health_max" value="@{prowess}" disabled="true" />
                                 </div>
                             <tr>
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{poise} + ?{Extra Dice|0}d6 ]] for Poise'><label><h4>Poise</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{poise} + ?{Extra Dice|0}d6 ]] for Poise'><label><h4>Poise</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_poise_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -735,7 +768,7 @@
                     <div class='sheet-col'>
                         <table>
                             <tr>
-                                <td><div class="sheet-intstat"><button type='roll' class="sheet-roll" value='/me rolls [[ [[2+@{Genius-switch}]]d6 + @{intellect} + ?{Extra Dice|0}d6]] for Intellect'><h4 class="sheet-intfont">Intellect</h4></button></div></td>
+                                <td><div class="sheet-intstat"><button type='roll' class="sheet-btn" value='/me rolls [[ [[2+@{Genius-switch}]]d6 + @{intellect} + ?{Extra Dice|0}d6]] for Intellect'><h4 class="sheet-intfont">Intellect</h4></button></div></td>
                                 <td><input type="number" class="sheet-stats-base sheet-green" name="attr_intellect_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -747,15 +780,15 @@
                                 <td><div class = "sheet-skill-base"><input  type="number" name="attr_intellect_misc_mod" value="0" /></div></td>
                             </tr>
                                 <div class="sheet-hidden">
-                                <input type="number" name="attr_intellect" value='@{intellect_base} + @{intellect_misc_mod}' disabled="true" />
-                                <input type="number" name="attr_intellect_health" value="@{intellect}" />
+                                <input type="number" name="attr_intellect" value='0' />
+                                <input type="number" name="attr_intellect_health" value="@{intellect}" disabled="true" />
                                 <input type="number" name="attr_intellect_health_max" value="@{intellect}" disabled="true" />
                                 </div>
                             <tr>
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[2d6 + @{arcane} + ?{Extra Dice|0}d6 ]] for Arcane'><label><h4>Arcane</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[2d6 + @{arcane} + ?{Extra Dice|0}d6 ]] for Arcane'><label><h4>Arcane</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_arcane_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -775,7 +808,7 @@
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><button type='roll' class="sheet-roll" value='/me rolls [[ [[2+@{Hyper_Perception-switch}]]d6 + @{perception} + ?{Extra Dice|0}d6 ]] for Perception'><label><h4>Perception</h4></label></button></td>
+                                <td><button type='roll' class="sheet-btn" value='/me rolls [[ [[2+@{Hyper_Perception-switch}]]d6 + @{perception} + ?{Extra Dice|0}d6 ]] for Perception'><label><h4>Perception</h4></label></button></td>
                                 <td><input type="number" class="sheet-stats-base" name="attr_perception_base" value="0" /></td>
                             </tr>
                             <tr>
@@ -787,7 +820,7 @@
                                 <td><div class = "sheet-skill-base"><input  type="number" name="attr_perception_misc_mod" value="0" /></div></td>
                             </tr>
                                 <div class="sheet-hidden">
-                                <input type="number" name="attr_perception" value='@{perception_base} + @{perception_misc_mod}' disabled="true" />
+                                <input type="number" name="attr_perception" value='0'/>
                                 <input type="number" name="attr_perception_health" value="@{perception}" />
                                 <input type="number" name="attr_perception_health_max" value="@{perception}" disabled="true" />
                                 </div>
@@ -811,6 +844,7 @@
                     <table style="width:820px">
                         <tr>
                             <td style="width:120px"><h5>Skill</h5></td>
+                            <th><h5>GM Roll</h5></th>
                             <td><h5>Stat</h5></td>
                             <td><h5>Total</h5></td>
                             <td><h5>Stat Value</h5></td>
@@ -818,100 +852,232 @@
                             <td><h5>Misc Modifier</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_archery_roll" value='/me shoots a bow. [[2d6 + ?{Extra Dice|0}d6 + [[@{archery_total}]] ]] to hit'>Archery</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_archery_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{archery_total}]] ]] }} {{Text= @{archery_text} (Archery) }}'>Archery</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_archery_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{archery_total}]] ]] }} {{Text= @{archery_text} (Archery) }}'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_archery_total" value="@{poise} + @{archery} + @{archery_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_archery_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_archery" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_archery_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_archery_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_crossbow_roll" value='/me shoots a crossbow. [[2d6 + ?{Extra Dice|0}d6 + [[@{crossbow_total}]] ]] to hit'>Crossbow</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_archery_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_archery_text" style="width:90%" value="@{character_name} shoots a bow!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_crossbow_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{crossbow_total}]] ]] }} {{Text= @{Crossbow_text} (Crossbow) }}'>Crossbow</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_crossbow_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{crossbow_total}]] ]] }} {{Text= @{Crossbow_text} (Crossbow) }}'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_crossbow_total" value="@{poise} + @{crossbow} + @{crossbow_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_crossbow_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_crossbow" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_crossbow_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_crossbow_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_greatweapon_roll" value='/me swings a great weapon. [[2d6 + ?{Extra Dice|0}d6 + [[@{greatweapon_total}]] ]] to hit'>Great Weapon</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_crossbow_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_crossbow_text" style="width:90%" value="@{character_name} shoots a crossbow!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_greatweapon_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{greatweapon_total}]] ]] }} {{Text= @{greatweapon_text} (Great Weapon) }}'>Great Weapon</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_greatweapon_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{greatweapon_total}]] ]] }} {{Text= @{greatweapon_text} (Great Weapon) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_greatweapon_total" value="@{prowess} + @{greatweapon} + @{greatweapon_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_greatweapon_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_greatweapon" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_greatweapon_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_greatweapon_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_handweapon_roll" value='/me swings a hand weapon. [[2d6 + ?{Extra Dice|0}d6 + [[@{handweapon_total}]] ]] to hit'>Hand Weapon</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_greatweapon_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_greatweapon_text" style="width:90%" value="@{character_name} swings a great weapon!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_handweapon_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{handweapon_total}]] ]] }} {{Text= @{handweapon_text} (Hand Weapon) }}'>Hand Weapon</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_handweapon_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{handweapon_total}]] ]] }} {{Text= @{handweapon_text} (Hand Weapon) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_handweapon_total" value="@{prowess} + @{handweapon} + @{handweapon_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_handweapon_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_handweapon" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_handweapon_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_handweapon_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_heavyartillery_roll" value='/me shoots...heavy artillery?  Holy freaking wow? No.  Just no.  I quit.  You got a [[2d6 + ?{Extra Dice|0}d6 + [[@{heavyartillery_total}]] ]] on the roll and I quit.'>Heavy Artillery</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_handweapon_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_handweapon_text" style="width:90%" value="@{character_name} swings a hand weapon!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_heavyartillery_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{heavyartillery_total}]] ]] }} {{Text= @{heavyartillery_text} (Heavy Artillery) }}'>Heavy Artillery</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_heavyartillery_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{heavyartillery_total}]] ]] }} {{Text= @{heavyartillery_text} (Heavy Artillery) }}'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_heavyartillery_total" value="@{poise} + @{heavyartillery} + @{heavyartillery_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_heavyartillery_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_heavyartillery" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_heavyartillery_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_heavyartillery_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lance_roll" value='/me plunges a lance in! [[2d6 + ?{Extra Dice|0}d6 + [[@{lance_total}]] ]] to hit'>Lance</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_heavyartillery_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_heavyartillery_text" style="width:90%" value="@{character_name} shoots...heavy artillery?  Holy freaking wow? No.  Just no.  I quit.  You got a" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_lance_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{lance_total}]] ]] }} {{Text= @{lance_text} (Lance) }}'>Lance</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lance_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{lance_total}]] ]] }} {{Text= @{lance_text} (Lance) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lance_total" value="@{prowess} + @{lance} + @{lance_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lance_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lance" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lance_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_lance_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lightartillery_roll" value='/me shoots...light artillery?  Really? Fine, go ahead. You got a [[2d6 + ?{Extra Dice|0}d6 + [[@{lightartillery_total}]] ]] on the roll.  Happy now?'>Light Artillery</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lance_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lance_text" style="width:90%" value="@{character_name} plunges a lance in!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_lightartillery_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{lightartillery_total}]] ]] }} {{Text= @{lightartillery_text} (Light Artillery) }}'>Light Artillery</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lightartillery_gm" value='/w gm @{lightartillery_text} [[2d6 + ?{Extra Dice|0}d6 + [[@{lightartillery_total}]] ]] (Light Artillery)'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lightartillery_total" value="@{poise} + @{lightartillery} + @{lightartillery_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lightartillery_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lightartillery" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lightartillery_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_lightartillery_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_pistol_roll" value='/me shoots a pistol. [[2d6 + ?{Extra Dice|0}d6 + [[@{pistol_total}]] ]] to hit'>Pistol</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lightartillery_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lightartillery_text" style="width:90%" value="@{character_name} shoots...light artillery?  Really? Fine, go ahead. Does that m ake you Happy?  I sure hope so.  Here, you got a" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_pistol_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{pistol_total}]] ]] }} {{Text= @{pistol_text} (Pistol) }}'>Pistol</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_pistol_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{pistol_total}]] ]] }} {{Text= @{pistol_text} (Pistol) }}'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pistol_total" value="@{poise} + @{pistol} +  @{pistol_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pistol_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pistol" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pistol_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_pistol_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_rifle_roll" value='/me shoots a rifle. [[2d6 + ?{Extra Dice|0}d6 + [[@{rifle_total}]] ]] to hit'>Rifle</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_pistol_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_pistol_text" style="width:90%" value="@{character_name} shoots a pistol!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_rifle_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{rifle_total}]] ]] }} {{Text= @{rifle_text} (Rifle) }}'>Rifle</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_rifle_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{rifle_total}]] ]] }} {{Text= @{rifle_text} (Rifle) }}'></button></th>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_rifle_total" value="@{poise} + @{rifle} + @{rifle_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_rifle_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_rifle" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_rifle_misc" value="0" /></div></td>
-                        </tr>                    
+                            <td><input type="checkbox" name="attr_rifle_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_shield_roll" value='/me bashes with a shield [[2d6 + ?{Extra Dice|0}d6 + [[@{shield_total}]] ]] to hit'>Shield</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_rifle_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_rifle_text" style="width:90%" value="@{character_name} shoots a rifle!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_shield_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{shield_total}]] ]] }} {{Text= @{shield_text} (Shield) }}'>Shield</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_shield_gm" value='/w gm  &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{shield_total}]] ]] }} {{Text= @{shield_text} (Shield) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_shield_total" value="@{prowess} + @{shield} + @{shield_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_shield_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_shield" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_shield_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_shield_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_thrownweapon_roll" value='/me throws an object [[2d6 + ?{Extra Dice|0}d6 + [[@{thrownweapon_total}]] ]] to hit'>Thrown Weapon</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_shield_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_shield_text" style="width:90%" value="@{character_name} bashes with  a shield!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_thrownweapon_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{thrownweapon_total}]] ]] }} {{Text= @{thrownweapon_text} (Thrown Weapon) }}'>Thrown Weapon</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_thrownweapon_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{thrownweapon_total}]] ]] }} {{Text= @{thrownweapon_text} (Thrown Weapon) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrownweapon_total" value="@{prowess} + @{thrownweapon} + @{thrownweapon_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrownweapon_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrownweapon" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrownweapon_misc" value="0" /></div></td>
-                        </tr>                    
+                            <td><input type="checkbox" name="attr_thrownweapon_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_unarmedcombat_roll" value='/me Punches, kicks, and bites. [[2d6 + ?{Extra Dice|0}d6 + [[@{unarmedcombat_total}]] ]] to hit'>Unarmed Combat</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_thrownweapon_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_thrownweapon_text" style="width:90%" value="@{character_name} throws an object!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_unarmedcombat_roll" value='&{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{unarmedcombat_total}]] ]] }} {{Text= @{unarmedcombat_text} (Unarmed Combat) }}'>Unarmed Combat</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_unarmedcombat_gm" value='/w gm &{template:skill} {{Roll= [[2d6 + ?{Extra Dice|0}d6 + [[@{unarmedcombat_total}]] ]] }} {{Text= @{unarmedcombat_text} (Unarmed Combat) }}'></button></th>
                             <td>Prowess</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_unarmedcombat_total" value="@{prowess} + @{unarmedcombat} + @{unarmedcombat_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_unarmedcombat_stat" value="@{prowess}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_unarmedcombat" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_unarmedcombat_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_unarmedcombat_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_unarmedcombat_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_unarmedcombat_text" style="width:90%" value="@{character_name} punches, kicks, and bites." />
+                                </div>
+                            </td>
                         </tr>
                     </table>
                 </div>
@@ -920,11 +1086,12 @@
         <div class="sheet-tabbed-panel">
             <div class="sheet-row-panel">
                 <input type="checkbox" name="attr_occupational_skill-toggle" class="sheet-arrow" /><span></span>
-            <h4>Occupational Skills</h4>
+                <h4>Occupational Skills</h4>
                 <div class="body">
                     <table style="width:820px">
                         <tr>
                             <td style="width:140px"><h5>Skill</h5></td>
+                            <th><h5>GM Roll</h5></th>
                             <td><h5>Type</h5></td>
                             <td><h5>Stat</h5></td>
                             <td><h5>Total</h5></td>
@@ -933,16 +1100,28 @@
                             <td><h5>Other Modifiers</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_alchemy_roll" value='/me brews up some stuff. [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{alchemy_total}]] + ?{Extra Dice|0}d6]]'>Alchemy</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_alchemy_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{alchemy_total}]] ]] }} {{Text= @{alchemy_text} (Alchemy) }}'>Alchemy</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_alchemyy_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{alchemy_total}]] ]] }} {{Text= @{Alchemy_text} (alchemy) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_alchemy_total" value="@{intellect} + @{alchemy} + @{alchemy_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_alchemy_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_alchemy" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_alchemy_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_alchemy_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_animalhandling_roll" value='/me says squeak squeaker squeaksquak! [[2d6 + [[@{animalhandling_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Animal Handling</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_alchemy_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_alchemy_text" style="width:90%" value="@{character_name} brews up the good stuff." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_animalhandling_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{animalhandling_total}]] ]] }} {{Text= @{animalhandling_text} (Animal Handling) }}'><div class="sheet-general">Animal Handling</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_animalhandling_gm" value='/w gm @{animalhandling_text} &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{animalhandling_total}]] ]] }} {{Text= @{animalhandling_text} (Animal Handling) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_animalhandling_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -959,9 +1138,20 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_animalhandling_stat" value="@{animalhandling_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_animalhandling" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_animalhandling_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_animalhandling_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_bribery_roll" value='/me greases the wheels. [[2d6 + [[@{bribery_total}]] + ?{Extra Dice|0}d6]]'>Bribery</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_animalhandling_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_animalhandling_text" style="width:90%" value="@{character_name} says squeak squeaker squeaksquak." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_bribery_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{bribery_total}]] ]] }} {{Text= @{bribery_text} (Bribery) }}'>Bribery</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_bribery_gm" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{bribery_total}]] ]] }} {{Text= @{bribery_text} (Bribery) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_bribery_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -978,18 +1168,40 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_bribery_stat" value="@{bribery_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_bribery" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_bribery_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_bribery_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_climbing_roll" value='/me ascends! [[ [[2+@{Deft-switch}]]d6 + [[@{climbing_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Climbing</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_bribery_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_bribery_text" style="width:90%" value="@{character_name} greases the wheels." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_climbing_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{climbing_total}]] ]] }} {{Text= @{climbing_text} (Climbing) }}'><div class="sheet-general">Climbing</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_climbing_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{climbing_total}]] ]] }} {{Text= @{climbing_text} (Climbing) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_climbing_total" value="@{agility} + @{climbing} + @{climbing_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_climbing_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_climbing" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_climbing_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_climbing_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_command_roll" value='/me takes charge! [[2d6 + [[@{command_total}]] + ?{Extra Dice|0}d6]]'>Command</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_climbing_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_climbing_text" style="width:90%" value="@{character_name} acends!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_command_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{command_total}]] ]] }} {{Text= @{command_text} (Command) }}'>Command</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_command_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{command_total}]] ]] }} {{Text= @{command_text} (Command) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_command_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1006,48 +1218,103 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_command_stat" value="@{command_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_command" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_command_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_command_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_command_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_command_text" style="width:90%" value="@{character_name} takes charge!" />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_craft1_roll" value='/me uses training in @{craft1_type} to build or repair something. [[[[2+@{Genius-switch}]]d6 + [[@{craft1_total}]] + ?{Extra Dice|0}d6}]]'>Craft</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_craft1_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft1_total}]] ]] }} {{Text= @{craft1_text} (Craft:@{craft1_type}) }}'>Craft</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_craft1y_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft1_total}]] ]] }} {{Text= @{craft1_text} (Craft: @{craft1_type}) }}'></button></th>
                             <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_craft1_type" value="" placeholder="Craft Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft1_total" value="@{intellect} + @{craft1} + @{craft1_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft1_stat" value="@{intellect}" disabled="true" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft1" value="0" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft1_misc" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft1" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft1_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_craft1_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
-                         <tr>
-                            <td><button type='roll' name="attr_craft2_roll" value='/me uses training in @{craft2_type} to build or repair something. [[[[2+@{Genius-switch}]]d6 + [[@{craft2_total}]] + ?{Extra Dice|0}d6]]'>Craft</button></td>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_craft1_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_craft1_text" style="width:90%" value="@{character_name} builds or repairs @{craft1_type}." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_craft2_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft2_total}]] ]] }} {{Text= @{craft2_text} (Craft:@{craft2_type}) }}'>Craft</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_craft2y_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft2_total}]] ]] }} {{Text= @{craft2_text} (Craft: @{craft2_type}) }}'></button></th>
                             <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_craft2_type" value="" placeholder="Craft Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft2_total" value="@{intellect} + @{craft2} + @{craft2_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft2_stat" value="@{intellect}" disabled="true" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft2" value="0" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft2_misc" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft2" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft2_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_craft2_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_craft3_roll" value='/me uses training in @{craft3_type} to build or repair something. [[[[2+@{Genius-switch}]]d6 + [[@{craft3_total}]] + ?{Extra Dice|0}d6}]]'>Craft</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_craft2_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_craft2_text" style="width:90%" value="@{character_name} builds or repairs @{craft2_type}." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_craft3_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft3_total}]] ]] }} {{Text= @{craft3_text} (Craft:@{craft3_type}) }}'>Craft</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_craft3_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{craft3_total}]] ]] }} {{Text= @{craft3_text} (Craft: @{craft3_type}) }}'></button></th>
                             <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_craft3_type" value="" placeholder="Craft Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft3_total" value="@{intellect} + @{craft3} + @{craft3_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_craft3_stat" value="@{intellect}" disabled="true" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft3" value="0" /></div></td>
-                            <td><div class="sheet-skill-base"><input type="number" name="attr_craft3_misc" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft3" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_craft3_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_craft3_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_cryptography_roll" value='/me puzzles over some code. [[ [[2+@{Genius-switch}]]d6 + [[@{cryptography_total}]] + ?{Extra Dice|0}d6]]'>Cryptography</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_craft3_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_craft3_text" style="width:90%" value="@{character_name} builds or repairs @{craft3_type}." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_cryptography_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{cryptography_total}]] ]] }} {{Text= @{cryptography_text} (Cryptography) }}'>Cryptography</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_cryptography_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{cryptography_total}]] ]] }} {{Text= @{cryptography_text} (Cryptography) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_cryptography_total" value="@{intellect} + @{cryptography} + @{cryptography_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_cryptography_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_cryptography" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_cryptography_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_cryptography_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_deception_roll" value='/me plays pretend! [[2d6 + [[@{deception_total}]] + ?{Extra Dice|0}d6]]'>Deception</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_cryptography_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_cryptography_text" style="width:90%" value="@{character_name} works on code." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_deception_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{deception_total}]] ]] }} {{Text= @{deception_text} (Deception) }}'>Deception</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_deception_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{deception_total}]] ]] }} {{Text= @{deception_text} (Deception) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_deception_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1064,48 +1331,103 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_deception_stat" value="@{deception_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_deception" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_deception_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_deception_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_deception_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_deception_text" style="width:90%" value="@{character_name} plays pretend!" />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_perception_roll" value='/me scans the area. [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{detection_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Detection</div></button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_perception_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{detection_total}]] ]] }} {{Text= @{detection_text} (Detection) }}'><div class="sheet-general">Detection</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_perception_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{detection_total}]] ]] }} {{Text= @{detection_text} (Detection) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_detection_total" value="@{perception} + @{detection} + @{detection_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_detection_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_detection" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_detection_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_detection_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_disguise_roll" value='/me tries look different! [[ [[2+Genius-switch}]]d6 + [[@{disguise_total}]] + ?{Extra Dice|0}d6]]'>Disguise</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_detection_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_detection_text" style="width:90%" value="@{character_name} scans the area." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_disguise_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{disguise_total}]] ]] }} {{Text= @{disguise_text} (Disguise) }}'>Disguise</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_disguise_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{disguise_total}]] ]] }} {{Text= @{disguise_text} (Disguise) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_disguise_total" value="@{intellect} + @{disguise} + @{disguise_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_disguise_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_disguise" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_disguise_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_disguise_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_driving_roll" value='/me drives! [[ [[2+@{Deft-switch}]]d6 + [[@{driving_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Driving</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_disguise_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_disguise_text" style="width:90%" value="@{character_name} tries to look different!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_driving_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{driving_total}]] ]] }} {{Text= @{driving_text} (Driving) }}'><div class="sheet-general">Driving</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_driving_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{driving_total}]] ]] }} {{Text= @{driving_text} (Driving) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_driving_total" value="@{agility} + @{driving} + @{driving_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_driving_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_driving" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_driving_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_driving_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_escapeartist_roll" value='/me tries to wriggle free! [[ [[2+@{Deft-switch}]]d6 + [[@{escapeartist_total}]] + ?{Extra Dice|0}d6 ]]'>Escape Artist</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_driving_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_driving_text" style="width:90%" value="@{character_name} drives!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_escapeartist_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{escapeartist_total}]] ]] }} {{Text= @{escapeartist_text} (Escape Artist) }}'>Escape Artist</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_escapeartist_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{escapeartist_total}]] ]] }} {{Text= @{escapeartist_text} (Escape Artist) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_escapeartist_total" value="@{agility} + @{escapeartist} + @{escapeartist_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_escapeartist_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_escapeartist" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_escapeartist_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_escapeartist_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_etiquette_roll" value='/me tries not to misbehave! [[2d6 + [[@{etiquette_total}]] + ?{Extra Dice|0}d6]]'>Etiquette</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_escapeartist_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_escapeartist_text" style="width:90%" value="@{character_name} wriggles free!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_etiquette_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{etiquette_total}]] ]] }} {{Text= @{etiquette_text} (Etiquette) }}'>Etiquette</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_etiquette_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{etiquette_total}]] ]] }} {{Text= @{etiquette_text} (Etiquette) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_etiquette_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1122,30 +1444,63 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_etiquette_stat" value="@{etiquette_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_etiquette" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_etiquette_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_etiquette_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_etiquette_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_etiquette_text" style="width:90%" value="@{character_name} tries not to misbehave! " />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_fellcalling_roll" value='/me practices screamo [[2d6 + [[@{fellcalling_total}]] + ?{Extra Dice|0}d6]] to hit'>Fell Calling</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_fellcalling_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{fellcalling_total}]] ]] }} {{Text= @{fellcalling_text} (Fell Calling) }}'>Fell Calling</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_fellcalling_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{fellcalling_total}]] ]] }} {{Text= @{fellcalling_text} (Fell Calling) }}'></button></th>
                             <td></td>
                             <td>Poise</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_fellcalling_total" value="@{poise} + @{fellcalling} + @{fellcalling_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_fellcalling_stat" value="@{poise}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_fellcalling" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_fellcalling_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_fellcalling_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_forensicccience_roll" value='/me gets all Bruce Wayne on it. [[ [[2+@{Genius-switch}]]d6 + [[@{forensicccience_total}]] + ?{Extra Dice|0}d6]]'>Forensic Science</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_fellcalling_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_fellcalling_text" style="width:90%" value="@{character_name} practices screamo! " />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_forensicccience_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{forensicccience_total}]] ]] }} {{Text= @{forensicccience_text} (Forensic Science) }}'>Forensic Science</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_forensicccience_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{forensicccience_total}]] ]] }} {{Text= @{forensicccience_text} (Forensic Science) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forensicccience_total" value="@{intellect} + @{forensicccience} + @{forensicccience_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forensicccience_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forensicccience" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forensicccience_misc" value="0" /></div></td>
-                        </tr>  
+                            <td><input type="checkbox" name="attr_forensicccience_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_forgery_roll" value='/me tries to buy beer! [[2d6 + [[@{forgery_total}]] + ?{Extra Dice|0}d6]]'>Forgery</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_forensicccience_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_forensicccience_text" style="width:90%" value="@{character_name} gets all Bruce Wayne on it." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_forgery_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{forgery_total}]] ]] }} {{Text= @{forgery_text} (Forgery) }}'>Forgery</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_forgery_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{forgery_total}]] ]] }} {{Text= @{forgery_text} (Forgery) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_forgery_select" value="0" style="width:100px">
                                     <option class="sheet-blackfont" value="0"> </option>
@@ -1155,18 +1510,40 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_forgery_stat" value="@{forgery_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forgery" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_forgery_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_forgery_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_gambling_roll" value='/me tries his luck! [[ [[(2+@{Hyper_Perception-switch})]]d6 + [[@{gambling_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Gambling</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_forgery_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_forgery_text" style="width:90%" value="@{character_name} tries to buy beer!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_gambling_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{gambling_total}]] ]] }} {{Text= @{gambling_text} (Gambling) }}'><div class="sheet-general">Gambling</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_gambling_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{gambling_total}]] ]] }} {{Text= @{gambling_text} (Gambling) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_gambling_total" value="@{perception} + @{gambling} + @{gambling_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_gambling_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_gambling" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_gambling_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_gambling_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_interrogation_roll" value='/me just wants to ask a few qestions... [[2d6 + [[@{interrogation_total}]] + ?{Extra Dice|0}d6]]'>Interrogation</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_gambling_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_gambling_text" style="width:90%" value="@{character_name} tries his luck!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_interrogation_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{interrogation_total}]] ]] }} {{Text= @{interrogation_text} (Interrogation) }}'>Interrogation</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_interrogation_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{interrogation_total}]] ]] }} {{Text= @{interrogation_text} (Interrogation) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_interrogation_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1183,12 +1560,23 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_interrogation_stat" value="@{interrogation_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_interrogation" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_interrogation_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_interrogation_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_interrogation_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_interrogation_text" style="width:90%" value="@{character_name} just wants to ask a few qestions..." />
+                                </div>
+                            </td>
+                        </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_intimidation_roll" value='/me adds a little menace to the situtation [[2d6 + [[@{intimidation_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Intimidation</div></button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_intimidation_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{intimidation_total}]] ]] }} {{Text= @{intimidation_text} (Intimidation) }}'><div class="sheet-general">Intimidation</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_intimidation_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{intimidation_total}]] ]] }} {{Text= @{intimidation_text} (Intimidation) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_intimidation_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1205,96 +1593,206 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_intimidation_stat" value="@{intimidation_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_intimidation" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_intimidation_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_intimidation_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_jumping_roll" value='/me jumps! [[2d6 + [[@{jumping_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Jumping</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_intimidation_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_intimidation_text" style="width:90%" value="@{character_name} adds a little menace to the situtation " />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_jumping_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{jumping_total}]] ]] }} {{Text= @{jumping_text} (Jumping) }}'><div class="sheet-general">Jumping</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_jumping_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{jumping_total}]] ]] }} {{Text= @{jumping_text} (Jumping) }}'></button></th>
                             <td></td>
                             <td>Physique</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_jumping_total" value="@{physique} + @{jumping} + @{jumping_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_jumping_stat" value="@{physique}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_jumping" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_jumping_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_jumping_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_law_roll" value='/me does (semi)legal stuff! [[ [[2+@{Genius-switch}]]d6 + [[@{law_total}]] + ?{Extra Dice|0}d6]]'>Law</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_jumping_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_jumping_text" style="width:90%" value="@{character_name} leaps small building in s a single bound!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_law_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{law_total}]] ]] }} {{Text= @{law_text} (Law) }}'>Law</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lawy_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{law_total}]] ]] }} {{Text= @{law_text} (Law) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_law_total" value="@{intellect} + @{law} + @{law_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_law_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_law" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_law_misc" value="0" /></div></td>
-                        </tr>  
+                            <td><input type="checkbox" name="attr_law_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lockpicking_roll" value='/me works the tumblers! [[ [[2+@{Deft-switch}]]d6 + [[@{lockpicking_total}]] + ?{Extra Dice|0}d6]]'>Lock Picking</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_law_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_law_text" style="width:90%" value="@{character_name} considers legal actions." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_lockpicking_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lockpicking_total}]] ]] }} {{Text= @{lockpicking_text} (Lock Picking) }}'>Lock Picking</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lockpicking_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lockpicking_total}]] ]] }} {{Text= @{lockpicking_text} (Lock Picking) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lockpicking_total" value="@{agility} + @{lockpicking} + @{lockpicking_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lockpicking_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lockpicking" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lockpicking_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_lockpicking_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lore1_roll" value='/me thinks about @{lore1_type}. [[ [[2+@{Genius-switch}]]d6 + [[@{lore1_total}]] + ?{Extra Dice|0}d6 ]]'><div class="sheet-general">Lore</div></button></td>
-                            <td><input class="sheet-clearbox " type="text" style="width:150px" name="attr_lore1_type" value="" placeholder="Lore Type" /></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lockpicking_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lockpicking_text" style="width:90%" value="@{character_name} works the tumblers!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_lore1_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lore1_total}]] ]] }} {{Text= @{lore1_text} (Lore:@{lore1_type}) }}'><div class="sheet-general">Lore</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lore1y_gm" value='/w gm&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{lore1_total}]] ]] }} {{Text= @{lore1_text} (Lore:@{lore1_type}) }}'></button></th>
+                            <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_lore1_type" value="" placeholder="lore Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore1_total" value="@{intellect} + @{lore1} + @{lore1_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore1_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore1" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore1_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_lore1_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lore1_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lore1_text" style="width:90%" value="@{character_name} thinks about @{lore1_type}." />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lore2_roll" value='/me thinks about @{lore2_type}. [[ [[2+@{Genius-switch}]]d6 + [[@{lore2_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Lore</div></button></td>
-                            <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_lore2_type" value="" placeholder="Lore Type" /></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_lore2_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lore2_total}]] ]] }} {{Text= @{lore2_text} (Lore:@{lore2_type}) }}'><div class="sheet-general">Lore</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lore2y_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{lore2_total}]] ]] }} {{Text= @{lore2_text} (Lore:@{lore2_type}) }}'></button></th>
+                            <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_lore2_type" value="" placeholder="lore Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore2_total" value="@{intellect} + @{lore2} + @{lore2_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore2_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore2" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore2_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_lore2_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_lore3_roll" value='/me thinks about @{lore3_type}. [[ [[2+@{Genius-switch}]]d6 + [[@{lore3_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Lore</div></button></td>
-                            <td><input class="sheet-clearbox " type="text" style="width:150px" name="attr_lore3_type" value="" placeholder="Lore Type" /></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lore2_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lore2_text" style="width:90%" value="@{character_name} thinks about @{lore2_type}." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_lore3_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lore3_total}]] ]] }} {{Text= @{lore3_text} (Lore:@{lore3_type}) }}'><div class="sheet-general">Lore</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_lore3_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{lore3_total}]] ]] }} {{Text= @{lore3_text} (Lore:@{lore3_type}) }}'></button></th>
+                            <td><input class="sheet-clearbox" type="text" style="width:150px" name="attr_lore3_type" value="" placeholder="lore Type" /></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore3_total" value="@{intellect} + @{lore3} + @{lore3_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore3_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore3" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_lore3_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_lore3_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_mechanikalengineering_roll" value='/me works some magic into the mechanics! [[ [[2+@{Genius-switch}]]d6 + [[@{mechanikalengineering_total}]] + ?{Extra Dice|0}d6]]'>Mechanikal Engineering</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_lore3_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_lore3_text" style="width:90%" value="@{character_name} thinks about @{lore3_type}." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_mechanikalengineering_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{mechanikalengineering_total}]] ]] }} {{Text= @{mechanikalengineering_text} (Mechanikal Engineering) }}'><div style="font-size:0.8em;">Mechanika Eengineering</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_mechanikalengineeringy_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{mechanikalengineering_total}]] ]] }} {{Text= @{mechanikalengineering_text} (Mechanikal Engineering) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_mechanikalengineering_total" value="@{intellect} + @{mechanikalengineering} + @{mechanikalengineering_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_mechanikalengineering_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_mechanikalengineering" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_mechanikalengineering_misc" value="0" /></div></td>
-                        </tr>  
+                            <td><input type="checkbox" name="attr_mechanikalengineering_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_medicine_roll" value='/me plays with needles! [[2d6 + [[@{medicine_total}]] + ?{Extra Dice|0}d6 + @{Genius-switch}d6]]'>Medicine</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_mechanikalengineering_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_mechanikalengineering_text" style="width:90%" value="@{character_name} puts some magic in the machine." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_medicine_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{medicine_total}]] ]] }} {{Text= @{medicine_text} (Medicine) }}'>Medicine</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_mediciney_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{medicine_total}]] ]] }} {{Text= @{medicine_text} (Medicine) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_medicine_total" value="@{intellect} + @{medicine} + @{medicine_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_medicine_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_medicine" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_medicine_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_medicine_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_medicine_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_medicine_text" style="width:90%" value="@{character_name} plays with needles." />
+                                </div>
+                            </td>
                         </tr>  
                         <tr>
-                            <td><button type='roll' name="attr_navigation_roll" value='/me tries not to get lost. [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{navigation_total}]] + ?{Extra Dice|0}d6]]'>Navigation</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_navigation_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{navigation_total}]] ]] }} {{Text= @{navigation_text} (Navigation) }}'>Navigation</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_navigation_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{navigation_total}]] ]] }} {{Text= @{navigation_text} (Navigation) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_navigation_total" value="@{perception} + @{navigation} + @{navigation_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_navigation_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_navigation" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_navigation_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_navigation_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_navigation_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_navigation_text" style="width:90%" value="@{character_name} tells you that they are not lost!" />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_negotiation_roll" value='/me tries to get the better deal. [[2d6 + [[@{negotiation_total}]] + ?{Extra Dice|0}d6]]'>Negotiation</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_negotiation_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{negotiation_total}]] ]] }} {{Text= @{negotiation_text} (Negotiation) }}'>Negotiation</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_negotiation_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{negotiation_total}]] ]] }} {{Text= @{negotiation_text} (Negotiation) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_negotiation_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1310,10 +1808,21 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_negotiation_total" value="@{negotiation_select} + @{negotiation} + @{negotiation_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-hidden"><input type="number" name="attr_negotiation_stat" value="@{negotiation_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_negotiation" value="0" /></div></td>
-                            <td><div class ="sheet-skill-base"><input type="number" name="attr_negotiation_misc" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_negotiation_misc" value="0" /></div>
+                            <td><input type="checkbox" name="attr_negotiation_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_oratory_roll" value='/me stirs the crowd! [[2d6 + [[@{oratory_total}]] + ?{Extra Dice|0}d6]]'>Oratory</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_negotiation_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_negotiation_text" style="width:90%" value="@{character_name} tries to get the better deal." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_oratory_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{oratory_total}]] ]] }} {{Text= @{oratory_text} (Oratory) }}'>Oratory</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_oratory_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{oratory_total}]] ]] }} {{Text= @{oratory_text} (Oratory) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_oratory_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1330,48 +1839,103 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_oratory_stat" value="@{oratory_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_oratory" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_oratory_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_oratory_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_pickpocket_roll" value='/me selects a cloth container! [[ [[2+@{Deft-switch}]]d6 + [[@{pickpocket_total}]] + ?{Extra Dice|0}d6]]'>Pickpocket</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_oratory_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_oratory_text" style="width:90%" value="@{character_name} stirs the crowd! " />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_pickpocket_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{pickpocket_total}]] ]] }} {{Text= @{pickpocket_text} (Pickpocket) }}'>Pickpocket</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_pickpocket_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{pickpocket_total}]] ]] }} {{Text= @{pickpocket_text} (Pickpocket) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pickpocket_total" value="@{agility} + @{pickpocket} + @{pickpocket_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pickpocket_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pickpocket" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_pickpocket_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_pickpocket_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_research_roll" value='/me looks up stuff! [[ [[2+@{Genius-switch}]]d6 + [[@{research_total}]] + ?{Extra Dice|0}d6]]'>Research</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_pickpocket_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_pickpocket_text" style="width:90%" value="@{character_name} selects a cloth container!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_research_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{research_total}]] ]] }} {{Text= @{research_text} (Research) }}'>Research</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_researchy_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{research_total}]] ]] }} {{Text= @{research_text} (Research) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_research_total" value="@{intellect} + @{research} + @{research_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_research_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_research" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_research_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_research_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_riding_roll" value='/me rides! [[ [[2+@{Deft-switch}]]d6 + [[@{riding_total}]] + ?{Extra Dice|0}d6]]'><div class="sheet-general">Riding</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_research_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_research_text" style="width:90%" value="@{character_name} digs through musty tomes" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_riding_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{riding_total}]] ]] }} {{Text= @{riding_text} (Riding) }}'><div class="sheet-general">Riding</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_riding_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{riding_total}]] ]] }} {{Text= @{riding_text} (Riding) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_riding_total" value="@{agility} + @{riding} + @{riding_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_riding_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_riding" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_riding_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_riding_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_riding_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_riding_text" style="width:90%" value="@{character_name} rides!" />
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_ropeuse_roll" value='/me ties a lot of knots! [[ [[2+@{Deft-switch}]]d6 +[[@{ropeuse_total}]] + ?{Extra Dice|0}d6]]'>Rope Use</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_ropeuse_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{ropeuse_total}]] ]] }} {{Text= @{ropeuse_text} (Rope Use) }}'>Rope Use</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_ropeuse_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{ropeuse_total}]] ]] }} {{Text= @{ropeuse_text} (Rope Use) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_ropeuse_total" value="@{agility} + @{ropeuse} + @{ropeuse_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_ropeuse_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_ropeuse" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_ropeuse_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_ropeuse_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_sailing_roll" value='/me says its a ship, not a boat! [[2d6 + [[@{sailing_total}]] + ?{Extra Dice|0}d6]]'>Sailing</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_ropeuse_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_ropeuse_text" style="width:90%" value="@{character_name} ties a lot of knots! " />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_sailing_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{sailing_total}]] ]] }} {{Text= @{sailing_text} (Sailing) }}'>Sailing</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_sailing_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{sailing_total}]] ]] }} {{Text= @{sailing_text} (Sailing) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_sailing_select" value="0" style="width:100px">
                                     <option class="sheet-blackfont" value="0"> </option>
@@ -1381,18 +1945,40 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_sailing_stat" value="@{sailing_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sailing" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sailing_misc" value="0" /></div></td>
-                        </tr>                      
+                            <td><input type="checkbox" name="attr_sailing_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_sneak_roll" value='/me slips away! [[ [[2+@{Deft-switch}]]d6 + @{sneak_total} + ?{Extra Dice|0}d6]]'>Sneak</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_sailing_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_sailing_text" style="width:90%" value="@{character_name} says its a ship, not a boat!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_sneak_roll" value='&{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{sneak_total}]] ]] }} {{Text= @{sneak_text} (Sneak) }}'>Sneak</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_sneak_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Deft-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{sneak_total}]] ]] }} {{Text= @{sneak_text} (Sneak) }}'></button></th>
                             <td></td>
                             <td>Agility</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sneak_total" value="@{agility} + [[@{sneak}]] + @{sneak_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sneak_stat" value="@{agility}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sneak" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_sneak_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_sneak_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_seduction_roll" value='/me gets the sexy on! [[2d6 + [[@{seduction_total}]] + ?{Extra Dice|0}d6]]'>Seduction</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_sneak_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_sneak_text" style="width:90%" value="@{character_name} slips away!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_seduction_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{seduction_total}]] ]] }} {{Text= @{seduction_text} (Seduction) }}'>Seduction</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_seduction_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{seduction_total}]] ]] }} {{Text= @{seduction_text} (Seduction) }}'></button></th>
                             <td></td>
                             <td><select class ="sheet-select sheet-clearbox" name="attr_seduction_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1409,64 +1995,140 @@
                             <td><div class ="sheet-hidden"><input type="number" name="attr_seduction_stat" value="@{seduction_select}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_seduction" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_seduction_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_seduction_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_streetwise_roll" value='/me throws up gang sign! [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{streetwise_total}]] + ?{Extra Dice|0}d6]]'>Streetwise</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_seduction_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_seduction_text" style="width:90%" value="@{character_name} gets the sexy on!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_streetwise_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{streetwise_total}]] ]] }} {{Text= @{streetwise_text} (Streetwise) }}'>Streetwise</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_streetwise_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{streetwise_total}]] ]] }} {{Text= @{streetwise_text} (Streetwise) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_streetwise_total" value="@{perception} + @{streetwise} + @{streetwise_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_streetwise_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_streetwise" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_streetwise_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_streetwise_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_streetwise_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" value="@{character_name} dominates the urban jungle!" name="attr_streetwise_text" style="width:90%"/>
+                                </div>
+                            </td>
                         </tr>
                         <tr>
                             <td><br></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_stormsmithing_roll" value='/me calls forth the power of the storm! [[ [[2+@{Hyper_Perception-switch}]]d6 +[[ @{stormsmithing_total}]] + ?{Extra Dice|0}d6]]'>Stormsmithing</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_stormsmithing_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{stormsmithing_total}]] ]] }} {{Text= @{stormsmithing_text} (Stormsmithing) }}'>Stormsmithing</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_stormsmithing_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{stormsmithing_total}]] ]] }} {{Text= @{stormsmithing_text} (Stormsmithing) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_stormsmithing_total" value="@{perception} + @{stormsmithing} + @{stormsmithing_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_stormsmithing_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_stormsmithing" value="0" /></div></td>
-                            <td><div class ="sheet-skill-base"><input type="number" name="attr_stormsmithing_misc" value="0" /></div></td>
+                            <td><div class ="sheet-skill-base"><input type="number" name="attr_stormsmithing_misc" value="0" /></div>
+                            <td><input type="checkbox" name="attr_stormsmithing_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_survival_roll" value='/me gets along in the wild. [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{survival_total}]] + ?{Extra Dice|0}d6]]'>Survival</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_stormsmithing_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_stormsmithing_text" style="width:90%" value="@{character_name} calls forth the power of the storm!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_survival_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{survival_total}]] ]] }} {{Text= @{survival_text} (Survival) }}'>Survival</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_survival_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{survival_total}]] ]] }} {{Text= @{survival_text} (Survival) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_survival_total" value="@{perception} + @{survival} + @{survival_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_survival_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_survival" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_survival_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_survival_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' name="attr_swimming_roll" value='/me swims! [[2d6 + @{swimming_total} + ?{Extra Dice|0}d6]]'><div class="sheet-general">Swimming</div></button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_survival_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_survival_text" style="width:90%" value="@{character_name} gets along in the wild." />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_swimming_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{swimming_total}]] ]] }} {{Text= @{swimming_text} (Swimming) }}'><div class="sheet-general">Swimming</div></button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_swimming_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{swimming_total}]] ]] }} {{Text= @{swimming_text} (Swimming) }}'></button></th>
                             <td></td>
                             <td>Strength</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_swimming_total" value="@{strength} + @{swimming} + @{swimming_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_swimming_stat" value="@{strength}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_swimming" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_swimming_misc" value="0" /></div></td>
-                        </tr> 
+                            <td><input type="checkbox" name="attr_swimming_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_thrallcrafting_roll" value='/me stitches some bodies up! [[ [[2+@{Genius-switch}]]d6 + [[@{thrallcrafting_total}]] + ?{Extra Dice|0}d6]]'>Thrall Crafting</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_swimming_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_swimming_text" style="width:90%" value="@{character_name} swims!" />
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_thrallcrafting_roll" value='&{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{thrallcrafting_total}]] ]] }} {{Text= @{thrallcrafting_text} (Thrall Crafting) }}'>Thrall Crafting</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_thrallcraftingy_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Genius-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{thrallcrafting_total}]] ]] }} {{Text= @{thrallcrafting_text} (Thrall Crafting) }}'></button></th>
                             <td></td>
                             <td>Intellect</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrallcrafting_total" value="@{intellect} + @{thrallcrafting} + @{thrallcrafting_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrallcrafting_stat" value="@{intellect}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrallcrafting" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_thrallcrafting_misc" value="0" /></div></td>
-                        </tr>   
+                            <td><input type="checkbox" name="attr_thrallcrafting_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
                         <tr>
-                            <td><button type='roll' name="attr_tracking_roll" value='/me follows the tracks. [[ [[2+@{Hyper_Perception-switch}]]d6 + [[@{tracking_total}]] + ?{Extra Dice|0}d6]]'>Tracking</button></td>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_thrallcrafting_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_thrallcrafting_text" style="width:90%" value="@{character_name} combines magic, thread, and flesh..." />
+                                </div>
+                            </td>
+                        </tr> 
+                        <tr>
+                            <td><button type='roll' class="sheet-btn" name="attr_tracking_roll" value='&{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{tracking_total}]] ]] }} {{Text= @{tracking_text} (Tracking) }}'>Tracking</button></td>
+                            <th><button type='roll' class="sheet-skill_button" name="attr_tracking_gm" value='/w gm &{template:skill} {{Roll= [[ [[2+@{Hyper_Perception-switch}]]d6 + ?{Extra Dice|0}d6 + [[@{tracking_total}]] ]] }} {{Text= @{tracking_text} (Tracking) }}'></button></th>
                             <td></td>
                             <td>Perception</td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_tracking_total" value="@{perception} + @{tracking} + @{tracking_misc}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_tracking_stat" value="@{perception}" disabled="true" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_tracking" value="0" /></div></td>
                             <td><div class ="sheet-skill-base"><input type="number" name="attr_tracking_misc" value="0" /></div></td>
+                            <td><input type="checkbox" name="attr_tracking_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
                         </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_tracking_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_tracking_text" style="width:90%" value="@{character_name} follows the tracks." />
+                                </div>
+                            </td>
+                        </tr> 
                     </table>
                 </div>
             </div>
@@ -1474,12 +2136,13 @@
         <div class="sheet-tabbed-panel">
             <div class="sheet-row-panel">
                 <input type="checkbox" name="attr_additional_skill-toggle" class="sheet-arrow" /><span></span>
-            <h4>Additional Skills</h4>
+                <h4>Additional Skills</h4>
                 <div class="body">
                     <fieldset class="repeating_additionalskills"> 
                         <table style="width:820px">
                             <tr>
                                 <td style="width:120px"><h5>Roll</h5></td>
+                                <td><h5>Gm Roll</h5></td>
                                 <td><h5>Name</h5></td>
                                 <td><h5>Stat</h5></td>
                                 <td><h5>Total</h5></td>
@@ -1489,7 +2152,8 @@
                                 <td><h5>Other Modifiers</h5></td>
                             </tr>
                             <tr>
-                                <td><button type='roll' name="attr_extraskill_roll" value='/me uses @{extraskill_name}! [[2d6 + [[@{extraskill_total}]] + ?{Extra Dice|0}d6]]'><input type="text" name="attr_extraskill_name_button"value="@{extraskill_name}" disabled="true"/></button></td>
+                                <td><button type='roll' class="sheet-btn" name="attr_extraskill_roll" value='&{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{extraskill_total}]] ]] }} {{Text= @{extraskill_text} (@{extraskill_name}) }}'><input type="text" name="attr_extraskill_name_button" style="color:white" value="@{extraskill_name}" disabled="true"/></button></td>
+                                <td><button type='roll' class="sheet-skill_button" name="attr_extraskill_gm" value='/w gm &{template:skill} {{Roll= [[ [[2]]d6 + ?{Extra Dice|0}d6 + [[@{extraskill_total}]] ]] }} {{Text= @{extraskill_text} (@{extraskill_name}) }}'></button></td>
                                 <td><input type="text" class="clearbox" name="attr_extraskill_name" value"" style="width:150px" placeholder="Skill Name"/></td>
                                 <td><select class ="sheet-select sheet-clearbox" name="attr_extraskill_select" value="0" style="width:100px">
                                     <option value="0"> </option>
@@ -1506,7 +2170,17 @@
                                 <td><div class ="sheet-hidden"><input type="number" name="attr_extraskill_stat" value="@{extraskill_select}" disabled="true" /></div></td>
                                 <td><div class ="sheet-skill-base"><input type="number" name="attr_extraskill" value="0" /></div></td>
                                 <td><div class ="sheet-skill-base"><input type="number" name="attr_extraskill_misc" value="0" /></div></td>
-                            </tr>
+                            <td><input type="checkbox" name="attr_extraskill_text-switch" class="sheet-gear sheet-hider" /><span></span></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td colspan="7">
+                                <input type="checkbox" name="attr_extraskill_text-switch" class="sheet-hidden sheet-hider" />
+                                <div class="sheet-body">
+                                    <input class="sheet-input-center-aligned" type="text" name="attr_extraskill_text" style="width:90%" value="@{character_name} uses training in @{extraskill_name}" />
+                                </div>
+                            </td>
+                        </tr> 
                         </table>
                     </fieldset>
                 </div>
@@ -1525,28 +2199,31 @@
             <div class="body">
                 <!-- Bog Troll -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Bog_trogs-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Bog_trogs-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Bog_trogs-toggle" value="1" class="sheet-aj"/><span></span>Bog Trogs</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 102</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_bog_trog-a" value="Unleashed, page 102" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Amphibious – Bog trogs treat water as open terrain and gain concealment while in water. Amphibious characters never make Swimming skill rolls and can always advance their full SPD while swimming (p. 194). A bog trog can remain submerged indefinitely.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_bog_trog-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Amphibious }} {{Text= @{bog_trog-1} }}">Amphibious</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_bog_trog-1" style="width:680px;height:60px" readonly>
+Bog trogs treat water as open terrain and gain concealment while in water. Amphibious characters never make Swimming skill rolls and can always advance their full SPD while swimming (Unleashed, page 194). A bog trog can remain submerged indefinitely.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Blending – Bog trog skin pigmentation naturally changes to enable them to blend into their surroundings. Provided his body is mostly uncovered and he is not wearing armor, a bog trog gains boosted Sneak skill rolls.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_bog_trog-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Blending }} {{Text= @{bog_trog-2} }}">Blending</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_bog_trog-2" style="width:680px;height:40px" readonly>
+Bog trog skin pigmentation naturally changes to enable them to blend into their surroundings. Provided his body is mostly uncovered and he is not wearing armor, a bog trog gains boosted Sneak skill rolls.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Natatorial – If a bog trog goes twenty-four hours without being able to fully immerse himself in water, he suffers a –2 penalty on all skill rolls from discomfort and impaired respiration. This penalty is removed immediately if the bog trog immerses itself in water but returns if he leaves the water before spending at least fifteen minutes submerged. Periodic immersion at more frequent intervals prevents this penalty.    
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_bog_trog-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Natatorial }} {{Text= @{bog_trog-3} }}">Natatorial</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_bog_trog-3" style="width:680px;height:80px" readonly>
+If a bog trog goes twenty-four hours without being able to fully immerse himself in water, he suffers a –2 penalty on all skill rolls from discomfort and impaired respiration. This penalty is removed immediately if the bog trog immerses itself in water but returns if he leaves the water before spending at least fifteen minutes submerged. Periodic immersion at more frequent intervals prevents this penalty.    
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1554,23 +2231,57 @@
                 </div>
                 <!-- Dwarf -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Dwarf-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Dwarf-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Dwarf-toggle" value="1" class="sheet-aj"/><span></span>Dwarf</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 109</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_rhul-a" value="Core book, page 109" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Load Bearing – Dwarf characters start the game with the Load Bearing ability (p. 164). This ability is in addition to any others the character gains from his starting career.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_rhul-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Load Bearing }} {{Text= @{rhul-1} }}">Load Bearing</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_rhul-1" style="width:680px;height:40px" readonly>
+Dwarf characters start the game with the Load Bearing ability (p. 164). This ability is in addition to any others the character gains from his starting career.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Connections (clan) – Dwarf characters begin with Connection (dwarven clan) (p. 169). This is in addition to any other connections the character starts with.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_rhul-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Connections (clan)}} {{Text= @{rhul-2} }}">Connections</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_rhul-2" style="width:680px;height:40px" readonly>
+Dwarf characters begin with Connection (dwarven clan) (p. 169). This is in addition to any other connections the character starts with.
+                                    </textarea></td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <!-- Efaarit -->
+               <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Efaarit-switch" class="sheet-gear sheet-hider" /><span></span>
+                        <h4><input type="checkbox" name="attr_Efaarit-toggle" value="1" class="sheet-aj"/><span></span>Efaarit</h4>
+                        <div class="body">
+                            <table style="width:800px">
+                                <tr>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Efaarit-a" value="No Quarter 61, page 68" readonly /></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Efaarit-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Adapted [Desert] }} {{Text= @{Efaarit-1} }}">Adapted [Desert]</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Efaarit-1" style="width:680px;height:40px" readonly>
+An efaarit gains the Pathfinder ability while in a desert environment. Additionally, an efaarit can reroll failed Survival and Tracking skill rolls while in a desert environment.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Efaarit-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Shallow Breathing }} {{Text= @{Efaarit-2} }}">Shallow Breathing</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Efaarit-2" style="width:680px;height:20px" readonly>
+An efaarit gains +2 to PHY rolls to resist inhaled toxins and is immune to gas effects.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Efaarit-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Bletcher Rider }} {{Text= @{Efaarit-3} }}">Bletcher Rider</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Efaarit-3" style="width:680px;height:20px" readonly>
+Efaarit start the game with Trained Rider (bletcher).
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1578,28 +2289,31 @@
                 </div>
                 <!-- Farrow -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Farrow-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Farrow-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Farrow-toggle" value="1" class="sheet-aj"/><span></span>Farrow</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 103</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_farrow-a" value="Unleashed, page 103" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Go to Ground – A farrow character starts the game with the Go to Ground ability. This ability is in addition to any others the character gains from his starting careers.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_farrow-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Go to Ground }} {{Text= @{farrow-1} }}">Load Bearing</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_farrow-1" style="width:680px;height:40px" readonly>
+A farrow character starts the game with the Go to Ground ability. This ability is in addition to any others the character gains from his starting careers.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Disease Resistance – A farrow character starts the game with the Disease Resistance ability. This ability is in addition to any others the character gains from his starting careers.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_farrow-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Disease Resistance }} {{Text= @{farrow-2} }}">Disease Resistance</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_farrow-2" style="width:680px;height:40px" readonly>
+A farrow character starts the game with the Disease Resistance ability. This ability is in addition to any others the character gains from his starting careers.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Heightened Olfactory Senses – A farrow character gains boosted Detection and Tracking skill rolls in situations in which his heightened sense of smell can be applied. 
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_farrow-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Heightened Olfactory Senses }} {{Text= @{farrow-3} }}">Heightened Senses</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_farrow-3" style="width:680px;height:40px" readonly>
+A farrow character gains boosted Detection and Tracking skill rolls in situations in which his heightened sense of smell can be applied. 
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1607,43 +2321,49 @@
                 </div>
                 <!-- Gatormen -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Gatormen-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Gatormen-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Gatormen-toggle" value="1" class="sheet-aj"/><span></span>Gatormen</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 104</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Gatormen-a" value="Unleashed, page 104" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Gatormen are medium-based characters.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Medium Size }} {{Text= @{Gatormen-1} }}">Medium Size</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-1" style="width:680px;height:20px" readonly>
+Gatormen are medium-based characters.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Amphibious – Gatormen treat water as open terrain and gain concealment while within water. Amphibious characters never make Swimming skill rolls and can always advance their full SPD while swimming (p. 194). A gatorman can remain submerged for a number of turns equal to twice his Physique stat.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Amphibious }} {{Text= @{Gatormen-2} }}">Amphibious</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-2" style="width:680px;height:60px" readonly>
+Gatormen treat water as open terrain and gain concealment while within water. Amphibious characters never make Swimming skill rolls and can always advance their full SPD while swimming (p. 194). A gatorman can remain submerged for a number of turns equal to twice his Physique stat.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Bite – In addition to his normal attacks, a gatorman can make one unarmed melee attack with his jaws during each of his turns. This attack uses the Unarmed Combat skill and is POW 5.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Bite }} {{Text= @{Gatormen-3} }}">Bite</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-3" style="width:680px;height:40px" readonly>
+In addition to his normal attacks, a gatorman can make one unarmed melee attack with his jaws during each of his turns. This attack uses the Unarmed Combat skill and is POW 5.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Flesh of Steel – A gatorman character starts the game with the Flesh of Steel ability (p. 161). This ability is in addition to any others the character gains from his starting careers. 
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-4" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Flesh of Steel }} {{Text= @{Gatormen-4} }}">Flesh of Steel</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-4" style="width:680px;height:40px" readonly>
+A gatorman character starts the game with the Flesh of Steel ability (p. 161). This ability is in addition to any others the character gains from his starting careers. 
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Gnawing Hunger – A gatorman must eat at least once every four waking hours. If a gatorman character goes more than four hours without eating, he suffers –1 to Willpower skill rolls until he eats again. Luckily gatormen are not picky eaters and will devour any meat they can chew and swallow.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-5" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Gnawing Hunger }} {{Text= @{Gatormen-5} }}">Bite</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-5" style="width:680px;height:60px" readonly>
+A gatorman must eat at least once every four waking hours. If a gatorman character goes more than four hours without eating, he suffers –1 to Willpower skill rolls until he eats again. Luckily gatormen are not picky eaters and will devour any meat they can chew and swallow.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Imitative Power – Gatormen often bedeck themselves in the trappings of rival races, believing such charms enable them to steal a portion of their enemies’ power. While wearing or holding at least one relic, tool, trinket, or piece of clothing that was once possessed by a member of another race, the gatorman character gains +1 on social rolls involving characters of that race.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gatormen-6" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Imitative Power }} {{Text= @{Gatormen-6} }}">Imitative Power</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gatormen-6" style="width:680px;height:70px" readonly>
+Gatormen often bedeck themselves in the trappings of rival races, believing such charms enable them to steal a portion of their enemies’ power. While wearing or holding at least one relic, tool, trinket, or piece of clothing that was once possessed by a member of another race, the gatorman character gains +1 on social rolls involving characters of that race.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1651,28 +2371,31 @@
                 </div>
                 <!-- Gobber -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Gobber-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Gobber-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Gobber-toggle" value="1" class="sheet-aj"/><span></span>Gobber</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 110</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Gobber-a" value="Core book, page 110" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Deft – Whether or not they have the Skilled archetype, gobber characters start the game with the Deft archetype benefit (p. 117). This benefit is in addition to any other archetype benefits the character starts with.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gobber-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Deft }} {{Text= @{Gobber-1} }}">Deft</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gobber-1" style="width:680px;height:40px" readonly>
+Whether or not they have the Skilled archetype, gobber characters start the game with the Deft archetype benefit (p. 117). This benefit is in addition to any other archetype benefits the character starts with.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Gobbers have a racial modifier of +1 DEF.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gobber-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Spry lil' bugger }} {{Text= @{Gobber-2} }}">Spry lil' bugger</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gobber-2" style="width:680px;height:20px" readonly>
+Gobbers have a racial modifier of +1 DEF.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Gobbers cannot use great weapons or rifles.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Gobber-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Small }} {{Text= @{Gobber-3} }}">Small</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Gobber-3" style="width:680px;height:20px" readonly>
+Gobbers cannot use great weapons or rifles. 
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1680,23 +2403,24 @@
                 </div>
                 <!-- Human -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Human-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Human-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Human-toggle" value="1" class="sheet-aj"/><span></span>Human</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 108</h5></div></td>
-                                </tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Distrusted – Humans are poorly trusted by the denizens of the wild. As a result, human characters suffer –1 on their non-Intimidation social rolls when dealing with characters of other races.
-                                    </h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Human-a" value="Core book, page 108 & Unleashed, page 105" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Exceptional Potential – Humans are extremely adaptable and talented individuals. Your character begins the game with your choice of +1 PHY, +1 AGL, or +1 INT. Add this bonus before spending Advancement Points. Note this bonus does not increase the character’s racial maximum, just the starting value.
-                                    <input type="text" class="sheet-input-center-aligned" type="text" name="attr_human-notes" style="color:#696969" placeholder="Selected Attribute" >
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Human-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Distrusted }} {{Text= @{Human-2} }}">Distrusted</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Human-2" style="width:680px" readonly>
+Humans are poorly trusted by the denizens of the wild. As a result, human characters suffer –1 on their non-Intimidation social rolls when dealing with characters of Unleashed races.                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Human-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Exceptional Potential }} {{Text= @{Human-1} }}">Exceptional Potential</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Human-1" style="width:680px;height:60px" readonly>
+Humans are extremely adaptable and talented individuals. Your character begins the game with your choice of +1 PHY, +1 AGL, or +1 INT. Add this bonus before spending Advancement Points. Note this bonus does not increase the character’s racial maximum, just the starting value. 
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1704,19 +2428,19 @@
                 </div>
                 <!-- Iosan -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Iosan-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Iosan-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Iosan-toggle" value="1" class="sheet-aj"/><span></span>Iosan</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 111</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Iosan-a" value="Core book, page 111" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Iosan characters begin the game with an additional ability selected from one of their careers. 
-                                    <input type="text" class="sheet-input-center-aligned" type="text" name="attr_Iosan-notes" style="color:#696969" placeholder="Selected Ability" >
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Iosan-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Talented }} {{Text= @{Iosan-1} }}">Talented</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Iosan-1" style="width:680px;height:20px" readonly>
+Iosan characters begin the game with an additional ability selected from one of their careers.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1724,62 +2448,113 @@
                 </div>
                 <!-- Nyss -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Nyss-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Nyss-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Nyss-toggle" value="1" class="sheet-aj"/><span></span>Nyss</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 112</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Nyss-a" value="Core book, page 112 & Unleashed, page 106" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Nyss with the Gifted archetype cannot have the Arcane Mechanik, Arcanist, Gun Mage, or Warcaster careers.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Limited Gift }} {{Text= @{Nyss-1} }}">Limited Gift</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-1" style="width:680px;height:20px" readonly>
+Nyss with the Gifted archetype cannot have the Arcane Mechanik, Arcanist, Gun Mage, or Warcaster careers.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Reduce the cost of Nyss bows (p. 262) and Nyss claymores (p. 256) by 10 gc during character creation.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Family Weapons }} {{Text= @{Nyss-2} }}">Family Weapons</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-2" style="width:680px;height:40px" readonly>
+Reduce the cost of Nyss bows (Core book, page 262) and Nyss claymores (Core book, page 256) by 10 gc during character creation.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    A Nyss character begins with the Specialization (Nyss bow) and Specialization (Nyss claymore) abilities.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Nyss Training }} {{Text= @{Nyss-3} }}">Nyss Training</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-3" style="width:680px;height:20px" readonly>
+A Nyss character begins with the Specialization (Nyss bow) and Specialization (Nyss claymore) abilities.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Nyss gain +1 on Initiative and PER rolls.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-4" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Keen Senses }} {{Text= @{Nyss-4} }}">Keen Senses</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-4" style="width:680px;height:20px" readonly>
+Nyss gain +1 on Initiative and PER rolls.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Nyss gain +3 ARM against cold damage.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-5" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Ice for Blood }} {{Text= @{Nyss-5} }}">Ice for Blood</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-5" style="width:680px;height:20px" readonly>
+Nyss gain +3 ARM against cold damage.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Nyss suffer –3 ARM against fire damage.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Nyss-6" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Flame Weakness }} {{Text= @{Nyss-6} }}">Flame Weakness</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Nyss-6" style="width:680px;height:20px" readonly>
+Nyss suffer –3 ARM against fire damage.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
                     </div>
                 </div>
                 <!-- Ogrun -->
-                <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Ogrun-switch" class="sheet-gear" /><span></span>
+               <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Ogrun-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Ogrun-toggle" value="1" class="sheet-aj"/><span></span>Ogrun</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 113</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Ogrun-a" value="Core book, page 112" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Huge Stature – An ogrun can wield a weapon in one hand that usually requires two hands to wield, but he suffers –2 on attack rolls with that weapon.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Ogrun-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Huge Stature }} {{Text= @{Ogrun-1} }}">Huge Stature</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Ogrun-1" style="width:680px;height:40px" readonly>
+An ogrun can wield a weapon in one hand that usually requires two hands to wield, but he suffers –2 on attack rolls with that weapon.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Ogrun-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Medium Size }} {{Text= @{Ogrun-2} }}">Medium Size</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Ogrun-2" style="width:680px;height:20px" readonly>
+Ogrun are medium-based characters.
+                                    </textarea></td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <!-- Blighted Ogrun -->
+               <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Blighted_Ogrun-switch" class="sheet-gear sheet-hider" /><span></span>
+                        <h4><input type="checkbox" name="attr_Blighted_Ogrun-toggle" value="1" class="sheet-aj"/><span></span>Ogrun, Blighted</h4>
+                        <div class="body">
+                            <table style="width:800px">
+                                <tr>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Blighted_Ogrun-a" value="Core book, page 112" readonly /></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Blighted_Ogrun-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Huge Stature }} {{Text= @{Blighted_Ogrun-1} }}">Huge Stature</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Blighted_Ogrun-1" style="width:680px;height:40px" readonly>
+An Blighted ogrun can wield a weapon in one hand that usually requires two hands to wield, but he suffers –2 on attack rolls with that weapon.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Blighted_Ogrun-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Medium Size }} {{Text= @{Blighted_Ogrun-2} }}">Medium Size</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Blighted_Ogrun-2" style="width:680px;height:20px" readonly>
+Blighted ogrun are medium-based characters.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Blighted_Ogrun-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Blight Gifts }} {{Text= @{Blighted_Ogrun-3} }}">Blight Gifts</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Blighted_Ogrun-3" style="width:680px;height:20px" readonly>
+Blighted ogrun are blighted characters and can receive blight gifts.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Blighted_Ogrun-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Blood Mad }} {{Text= @{Blighted_Ogrun-3} }}">Blood Mad</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Blighted_Ogrun-3" style="width:680px;height:20px" readonly>
+Blighted ogrun are compelled to slaughter. If a blighted ogrun goes 24 hours without inflicting damage, he suffers –1 to non-attack rolls until he does so.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1787,33 +2562,113 @@
                 </div>
                 <!-- Pygmy Troll -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Pygmy_Troll-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Pygmy_Troll-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Pygmy_Troll-toggle" value="1" class="sheet-aj"/><span></span>Pygmy Troll</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 107</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Pygmy_Troll-a" value="Unleashed, page 107" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Poison Resistance – A pyg character starts the game with the Poison Resistance ability. This ability is in addition to any others the character gains from his starting careers.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Pygmy_Troll-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Poison Resistance }} {{Text= @{Pygmy_Troll-1} }}">Poison Resistance</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Pygmy_Troll-1" style="width:680px;height:40px" readonly>
+A pyg character starts the game with the Poison Resistance ability. This ability is in addition to any others the character gains from his starting careers.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Spawn Whelps – If a pyg suffers a lost limb, he spawns a pyg whelp (see “Whelp Companion,” p. 169) that grows to full size in d6 rounds.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Pygmy_Troll-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Spawn Whelps }} {{Text= @{Pygmy_Troll-2} }}">Spawn Whelps</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Pygmy_Troll-2" style="width:680px;height:40px" readonly>
+If a pyg suffers a lost limb, he spawns a pyg whelp (see “Whelp Companion,” Unleashed, page 169) that grows to full size in [[d6]] rounds.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Troll Resilience – If a pyg suffers a lost eye or limb due to incapacitation (p. 217), he regenerates the eye or limb d6 + 3 days after fully recovering his vitality. A pyg that is grievously injured can sometimes self-stabilize. Every turn (or every five minutes out of combat) roll a d6. On a roll of 6, the character is stabilized. Pygs never suffer from slow recovery.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Pygmy_Troll-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Troll Resilience }} {{Text= @{Pygmy_Troll-3} }}">Troll Resilience</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Pygmy_Troll-3" style="width:680px" readonly>
+If a pyg suffers a lost eye or limb due to incapacitation (Unleashed, page 217), he regenerates the eye or limb [[d6 + 3]] days after fully recovering his vitality. A pyg that is grievously injured can sometimes self-stabilize. Every turn (or every five minutes out of combat) roll a d6 ([[d6]]. On a roll of 6, the character is stabilized. Pygs never suffer from slow recovery.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Tough – Whether or not they have the Mighty archetype, pyg characters start the game with the Tough archetype benefit (p. 111). This is in addition to any other archetype benefits selected for the character. 
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Pygmy_Troll-4" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Tough }} {{Text= @{Pygmy_Troll-4} }}">Tough</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Pygmy_Troll-4" style="width:680px;height:40px" readonly>
+Whether or not they have the Mighty archetype, pyg characters start the game with the Tough archetype benefit (Unleashed, page 111). This is in addition to any other archetype benefits selected for the character. 
+                                    </textarea></td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <!-- Satyxis -->
+               <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Satyxis-switch" class="sheet-gear sheet-hider" /><span></span>
+                        <h4><input type="checkbox" name="attr_Satyxis-toggle" value="1" class="sheet-aj"/><span></span>Satyxis</h4>
+                        <div class="body">
+                            <table style="width:800px">
+                                <tr>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Satyxis-a" value="Core book, page 112" readonly /></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Satyxis-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Limited Gift }} {{Text= @{Satyxis-1} }}">Limited Gift</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Satyxis-1" style="width:680px;height:20px" readonly>
+Satyxis with the Gifted archetype cannot have the Arcane Mechanik or Arcanist careers.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Satyxis-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Gender Inequality }} {{Text= @{Satyxis-2} }}">Gender Inequality</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Satyxis-2" style="width:680px;height:20px" readonly>
+A Satyxis must be female.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Satyxis-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Horns }} {{Text= @{Satyxis-3} }}">Horns</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Satyxis-3" style="width:680px;height:40px" readonly>
+In addition to her normal attacks, a Satyxis can make one unarmed melee attack with her horns during each of her turns. This attack uses the Unarmed Combat skill and is POW 3. On a critical hit, the target is knocked down. If a Satyxis uses her horns to make a knockout strike that damages her target, add +2 to the target number to avoid the knockout.
+                                    </textarea></td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <!-- Strider -->
+                <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Strider-switch" class="sheet-gear sheet-hider" /><span></span>
+                        <h4><input type="checkbox" name="attr_Strider-toggle" value="1" class="sheet-aj"/><span></span>Strider</h4>
+                        <div class="body">
+                            <table style="width:800px">
+                                <tr>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Strider-a" value="Core book, page 112 & Unleashed, page 106" readonly /></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Strider-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Blight Gifts }} {{Text= @{Strider-1} }}">Blight Gifts</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strider-1" style="width:680px;height:20px" readonly>
+Striders are blighted characters and can receive blight gifts.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Strider-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Pathfinder }} {{Text= @{Strider-2} }}">Pathfinder</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strider-2" style="width:680px;height:40px" readonly>
+Strider characters start the game with the Pathfinder ability. This ability is in addition to any others the character gains from his starting career.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Strider-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Nyss Training }} {{Text= @{Strider-3} }}">Strider Training</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strider-3" style="width:680px;height:20px" readonly>
+A Strider character begins with the Specialization (Nyss bow) and Specialization (Nyss claymore) abilities.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Strider-5" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Ice for Blood }} {{Text= @{Strider-5} }}">Ice for Blood</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strider-5" style="width:680px;height:20px" readonly>
+Strider gain +3 ARM against cold damage.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Strider-6" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Flame Weakness }} {{Text= @{Strider-6} }}">Flame Weakness</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strider-6" style="width:680px;height:20px" readonly>
+Strider suffer –3 ARM against fire damage.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1821,22 +2676,37 @@
                 </div>
                 <!-- Tharn -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Tharn-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Tharn-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Tharn-toggle" value="1" class="sheet-aj"/><span></span>Tharn</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 108</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Tharn-a" value="Unleashed, page 108" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Male Tharn are medium-based characters. Female Tharn are small-based characters.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Tharn-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Medium Size }} {{Text= @{Tharn-1} }}">Medium Size</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Tharn-1" style="width:680px;height:20px" readonly>
+Tharn males are medium-based characters.  Tharn females are small based creatures.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Transformation – A Tharn is able to tap into his primal connection to the Devourer Wurm at will, transforming himself into a predatory beast. During his turn, a Tharn can either spend a full action to transform slowly or spend 1 feat point to transform immediately.<br><br>When a male Tharn transforms, he gains the Flesh of Steel ability, +1 STR, and boosted PHY rolls, but he rolls one less die on INT and non-Intimidation social rolls. Because they actually grow physically larger when they transform, male Tharn are very limited in the armor and clothing they can wear. Most male Tharn wear the leather armor developed by their people to easily accommodate the rapid changes to their bodies brought about by transformation. A Tharn wearing other types of armor must remove it before transforming or risk its destruction.<br><br>When a female Tharn transforms, she gains stealth (p. 219) and boosted AGL and PER rolls, but she rolls one less die on INT and non-Intimidation social rolls.<br><br>While in bestial form, a Tharn can only communicate through short, clipped sentences and guttural growls. <br><br>Tharn must transform and remain transformed during lunar conjunctions. When Calder and either of Caen’s other moons are full, the Tharn cannot restrain their inner beast. For the duration of the lunar conjunction, the Tharn cannot revert to their human form for any reason.                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Tharn-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Transformation }} {{Text= @{Tharn-2} }}">Female</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Tharn-2" style="width:680px;height:160px" readonly>
+A Tharn is able to tap into her primal connection to the Devourer Wurm at will, transforming herself into a predatory beast. During her turn, a Tharn can either spend a full action to transform slowly or spend 1 feat point to transform immediately.
+When a female Tharn transforms, she gains stealth (p. 219) and boosted AGL and PER rolls, but she rolls one less die on INT and non-Intimidation social rolls.
+While in bestial form, a Tharn can only communicate through short, clipped sentences and guttural growls. 
+Tharn must transform and remain transformed during lunar conjunctions. When Calder and either of Caen’s other moons are full, the Tharn cannot restrain their inner beast. For the duration of the lunar conjunction, the Tharn cannot revert to their human form for any reason.
+                                    </textarea></td>
+                                </tr>
+                                <tr>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Tharn-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Transformation }} {{Text= @{Tharn-3} }}">Male</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Tharn-3" style="width:680px;height:235px" readonly>
+A Tharn is able to tap into her primal connection to the Devourer Wurm at will, transforming herself into a predatory beast. During her turn, a Tharn can either spend a full action to transform slowly or spend 1 feat point to transform immediately.
+When a male Tharn transforms, he gains the Flesh of Steel ability, +1 STR, and boosted PHY rolls, but he rolls one less die on INT and non-Intimidation social rolls. Because they actually grow physically larger when they transform, male Tharn are very limited in the armor and clothing they can wear. Most male Tharn wear the leather armor developed by their people to easily accommodate the rapid changes to their bodies brought about by transformation. A Tharn wearing other types of armor must remove it before transforming or risk its destruction.
+While in bestial form, a Tharn can only communicate through short, clipped sentences and guttural growls. 
+Tharn must transform and remain transformed during lunar conjunctions. When Calder and either of Caen’s other moons are full, the Tharn cannot restrain their inner beast. For the duration of the lunar conjunction, the Tharn cannot revert to their human form for any reason.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1844,28 +2714,31 @@
                 </div>
                 <!-- Trollkin -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Trollkin-switch" class="sheet-gear" /><span></span>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Trollkin-switch" class="sheet-gear sheet-hider" /><span></span>
                         <h4><input type="checkbox" name="attr_Trollkin-toggle" value="1" class="sheet-aj"/><span></span>Trollkin</h4>
                         <div class="body">
-                            <table style="width:97%">
+                            <table style="width:800px">
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 114</h5></div></td>
+                                    <td colspan="2"><input type="text" class="sheet-ability" name="attr_Trollkin-a" value="Core book, page 110" readonly /></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Trollkin with the Gifted archetype cannot have the Arcane Mechanik, Arcanist, or Warcaster careers.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Trollkin-1" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Limited Gift }} {{Text= @{Trollkin-1} }}">Limited Gift</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Trollkin-1" style="width:680px;height:40px" readonly>
+Trollkin with the Gifted archetype cannot have the Arcane Mechanik, Arcanist, or Warcaster  careers.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Tough – Whether or not they have the Mighty archetype, trollkin characters start the game with the Tough archetype benefit (p. 116). This is in addition to any other archetype benefits selected for the character.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Trollkin-2" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Tough }} {{Text= @{Trollkin-2} }}">Tough</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Trollkin-2" style="width:680px;height:20px" readonly>
+Whether or not they have the Mighty archetype, trollkin characters start the game with the Tough archetype benefit (p. 116). This is in addition to any other archetype benefits selected for the character.
+                                    </textarea></td>
                                 </tr>
                                 <tr>
-                                    <td><div class="sheet-ability"><h5 class="sheet-black">
-                                    Feat: Revitalize – Whether or not they have the Mighty archetype, trollkin characters start the game with the Feat: Revitalize archetype benefit (p. 116). This is in addition to any other archetype benefits selected for the character.
-                                    </h5></div></td>
+                                    <td><button type='roll' class="sheet-btn" name="roll_Trollkin-3" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Revitalize }} {{Text= @{Trollkin-3} }}">Revitalize</button></td>
+                                    <td><textarea wrap="soft" class="sheet-ability"  value="" name="attr_Trollkin-3" style="width:680px;height:20px" readonly>
+Whether or not they have the Mighty archetype, trollkin characters start the game with the Feat: Revitalize archetype benefit (p. 116). This is in addition to any other archetype benefits selected for the character.
+                                    </textarea></td>
                                 </tr>
                             </table>
                         </div>
@@ -1877,7 +2750,7 @@
                         <tr>
                             <td><button type="roll" class="sheet-skill_button" name ="attr_ability-racial" value="&{template:ability} {{Name= @{character_name} }} {{Ability= @{ability_racial_name} }} {{Text= @{ability_racial_text} }}"></button></td>
                             <td><div class="sheet-ability"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ability_racial_name"/></div></td>
-                            <td><input type="checkbox" name="attr_ability_racial-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_ability_racial-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_ability_racial-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -1901,965 +2774,697 @@
             <input type="checkbox" name="attr_archetypeability-toggle" class="sheet-arrow" /><span></span>
             <h4>Archetype Abilities</h4>
             <div class="body">
+                <!--Cunning -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Cunning-switch" class="sheet-sign" /><span></span>
-                        <h4><input type="checkbox" name="attr_Cunning-toggle" value="1" class="sheet-aj"/><span></span>Cunning</h4>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Cunning-toggle" class="sheet-sign sheet-hider" /><span></span>
+                        <input type="checkbox" name="attr_Cunning-show" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Cunning-switch" value="1" class="sheet-aj"/><span></span>
+                        <button type="roll" class="sheet-btn" name ="attr_Cunning" style="width:182px"value="&{template:ability} {{Name= @{character_name} }} {{Ability= Cunning }} {{Text= @{Cunning-1} }}"><h4>Cunning</h4></button>
                         <div class="body">
-                            <h5><button type="roll" class="sheet-skill_button" name ="attr_ability-career" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Cunning }} {{Text= Cunning characters possess a tactical genius and adaptability that gives them +1 on attack and damage rolls in combat. While in the command range of an Intellectual character, a friendly character listening to his orders also gains +1 on his attack and damage rolls. This bonus is non-cumulative, so a character can gain this bonus only from one Intellectual character at a time. }}"></button>Cunning characters possess a tactical genius and adaptability that gives them +1 on attack and damage rolls in combat. While in the command range of an Intellectual character, a friendly character listening to his orders also gains +1 on his attack and damage rolls. This bonus is non-cumulative, so a character can gain this bonus only from one Intellectual character at a time.</h5>
+                            <input type="checkbox" name="attr_Cunning-show" class="sheet-hidden sheet-hider" /><span></span>
+                            <div class="sheet-body">
+                                <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Cunning-1" style="height:70px;width:750px;" readonly>
+Cunning characters possess a tactical genius and adaptability that gives them +1 on attack and damage rolls in combat. While in the command range of an Intellectual character, a friendly character listening to his orders also gains +1 on his attack and damage rolls. This bonus is non-cumulative, so a character can gain this bonus only from one Intellectual character at a time
+    							</textarea>
+                            </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Battlefield_Coordination_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Battlefield_Coordination_c-switch" value="1" class="sheet-aj"/><span></span>Battlefield Coordination</h4>
+                                    <input type="checkbox" name="attr_Battlefield_Coordination-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Battlefield_Coordination-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Battlefield_Coordination-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Battlefield Coordination }} {{Text= @{Battlefield_Coordination-1} }}">Battlefield Coordination</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is a skilled battlefield commander. He is able to coordinate the movement and attacks of friendly forces to maximum effect. While in his command range, friendly characters do not suffer the firing into melee penalty for ranged attacks and spells and do not have a chance to hit friendly characters when they miss with ranged or magic attacks while firing into melee.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Battlefield_Coordination-1" style="height:70px;width:750px;" readonly>
+The character is a skilled battlefield commander. He is able to coordinate the movement and attacks of friendly forces to maximum effect. While in his command range, friendly characters do not suffer the firing into melee penalty for ranged attacks and spells and do not have a chance to hit friendly characters when they miss with ranged or magic attacks while firing into melee
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Flawless_Timing_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Flawless_Timing_c-switch" value="1" class="sheet-aj"/><span></span>Flawless Timing</h4>
+                                    <input type="checkbox" name="attr_Flawless_Timing-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Flawless_Timing-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Flawless_Timing-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Flawless Timing }} {{Text= @{Flawless_Timing-1} }}">Feat: Flawless Timing</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to use this benefit during his turn. When he uses Flawless Timing, the character names an enemy. The next time that enemy directly hits him with an attack that encounter, the attack is instead considered to be a miss
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Flawless_Timing-1" style="height:50px;width:750px;" readonly>
+The character can spend 1 feat point to use this benefit during his turn. When he uses Flawless Timing, the character names an enemy. The next time that enemy directly hits him with an attack that encounter, the attack is instead considered to be a miss
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Influence-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Influence-switch" value="1" class="sheet-aj"/><span></span>Influence</h4>
+                                    <input type="checkbox" name="attr_Influence-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Influence-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Influence-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Influence }} {{Text= @{Influence-1} }}">Feat: Influence</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to double his command range for one round.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Influence-1" style="height:20px;width:750px;" readonly>
+The character can spend 1 feat point to double his command range for one round.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Prescient_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Prescient_c-switch" value="1" class="sheet-aj"/><span></span>Prescient</h4>
+                                    <input type="checkbox" name="attr_Prescient-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Prescient-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Prescient-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Prescient }} {{Text= @{Prescient-1} }}">Feat: Prescient</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to win initiative automatically and take the first turn that combat. If two or more characters use this ability, they make initiative rolls to determine which of them goes first
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Prescient-1" style="height:40px;width:750px;" readonly>
+The character can spend 1 feat point to win initiative automatically and take the first turn that combat. If two or more characters use this ability, they make initiative rolls to determine which of them goes first
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Perfect_Plot_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Perfect_Plot_c-switch" value="1" class="sheet-aj"/><span></span>Perfect Plot</h4>
+                                    <input type="checkbox" name="attr_Perfect_Plot-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Perfect_Plot-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Perfect_Plot-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Perfect Plot }} {{Text= @{Perfect_Plot-1} }}">Feat: Perfect Plot</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is a flawless planner and allows nothing to escape his attention. Assuming he is able to oversee all aspects of his plan, scout out the related sites, and do his research in great detail, he is sure to succeed. Of course this degree of planning takes time and care, but perfection is not without its cost. The character must spend 1 feat point to use this ability. A character following this character’s plans gains an additional die on non-combat related rolls during the day in which the plan was enacted
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Perfect_Plot-1" style="height:90px;width:750px;" readonly>
+The character is a flawless planner and allows nothing to escape his attention. Assuming he is able to oversee all aspects of his plan, scout out the related sites, and do his research in great detail, he is sure to succeed. Of course this degree of planning takes time and care, but perfection is not without its cost. The character must spend 1 feat point to use this ability. A character following this character’s plans gains an additional die on non-combat related rolls during the day in which the plan was enacted
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Plan_of_Action_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Plan_of_Action_c-switch" value="1" class="sheet-aj"/><span></span>Plan of Action</h4>
+                                    <input type="checkbox" name="attr_Plan_of_Action-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Plan_of_Action-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Plan_of_Action-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Plan of Action }} {{Text= @{Plan_of_Action-1} }}">Feat: Plan of Action</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                At the start of combat, the character can spend 1 feat point to use this benefit. During that combat, he and friendly characters who follow his plan gain +2 to their initiative rolls and +2  to their attack rolls during the first round of combat.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Plan_of_Action-1" style="height:50px;width:750px;" readonly>
+At the start of combat, the character can spend 1 feat point to use this benefit. During that combat, he and friendly characters who follow his plan gain +2 to their initiative rolls and +2  to their attack rolls during the first round of combat.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Quick_Thinking_c-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Quick_Thinking_c-switch" value="1" class="sheet-aj"/><span></span>Quick Thinking</h4>
+                                    <input type="checkbox" name="attr_Quick_Thinking-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Quick_Thinking-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Quick_Thinking-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Quick Thinking }} {{Text= @{Quick_Thinking-1} }}">Feat: Quick Thinking</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character’s quick thinking enables him to act impossibly fast. Once per round, the character can spend 1 feat point to make one attack or quick action at the start of another character’s turn.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Quick_Thinking-1" style="height:30px;width:750px;" readonly>
+The character’s quick thinking enables him to act impossibly fast. Once per round, the character can spend 1 feat point to make one attack or quick action at the start of another character’s turn.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Genius-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Genius-switch" value="1" class="sheet-aj"/><span></span>Genius</h4>
+                                    <input type="checkbox" name="attr_Genius-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Genius-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Genius-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Genius }} {{Text= @{Genius-1} }}">Genius</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character possesses an incredible aptitude for intellectual pursuits. The character’s INT rolls are boosted.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Genius-1" style="height:20px;width:750px;" readonly>
+The character possesses an incredible aptitude for intellectual pursuits. The character’s INT rolls are boosted.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Hyper_Perception-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Hyper_Perception-switch" value="1" class="sheet-aj"/><span></span>Hyper Perception</h4>
+                                    <input type="checkbox" name="attr_Hyper_Perception-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Hyper_Perception-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Hyper_Perception-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Hyper Perception }} {{Text= @{Hyper_Perception-1} }}">Hyper Perception</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character’s keen senses miss few details. The character’s PER rolls are boosted.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Hyper_Perception-1" style="height:20px;width:750px;" readonly>
+The character’s keen senses miss few details. The character’s PER rolls are boosted.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Savant-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Savant-switch" value="1" class="sheet-aj"/><span></span>Savant</h4>
+                                    <input type="checkbox" name="attr_Savant-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Savant-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Savant-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Savant }} {{Text= @{Savant-1} }}">Savant</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Unleashed, page 110</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can attempt to use skills untrained that normally cannot be used untrained, but he suffers a –2 penalty to the skill roll.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Savant-1" style="height:30px;width:750px;" readonly>
+The character can attempt to use skills untrained that normally cannot be used untrained, but he suffers a –2 penalty to the skill roll.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
+                <!--Gifted -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Gifted-switch" class="sheet-sign" /><span></span>
-                        <h4><input type="checkbox" name="attr_gifted-toggle" value="1" class="sheet-aj"/><span></span>Gifted</h4>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Gifted-toggle" class="sheet-sign sheet-hider" /><span></span>
+                        <input type="checkbox" name="attr_Gifted-show" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Gifted-switch" value="1" class="sheet-aj"/><span></span>
+                        <button type="roll" class="sheet-btn" name ="attr_Gifted" style="width:182px"value="&{template:ability} {{Name= @{character_name} }} {{Ability= Gifted }} {{Text= @{Gifted-1} }}"><h4>Gifted</h4></button>
                         <div class="body">
-                            <h5>A character with the Gifted archetype starts the game with a tradition (Core, p. 228, or Unleashed, p. 110). There are three traditions: the will weaver, harnesser, and the focuser. If the character begins the game with the Warcaster career, he is a focuser; if the character begins the game with a Warlock career, he is a harnesser;  otherwise, he is a will weaver.</h5>
+                            <input type="checkbox" name="attr_Gifted-show" class="sheet-hidden sheet-hider" /><span></span>
+                            <div class="sheet-body">
+                                <textarea wrap="soft" class="sheet-ability" name="attr_Gifted-1" style="height:70px;width:750px;" readonly>
+A character with the Gifted archetype starts the game with a tradition (Core, p. 228, or Unleashed, p. 110). There are three traditions: the will weaver, harnesser, and the focuser. If the character begins the game with the Warcaster career, he is a focuser; if the character begins the game with a Warlock career, he is a harnesser;  otherwise, he is a will weaver.
+                                </textarea>
+                            </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Additional_Study-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Additional_Study-switch" value="1" class="sheet-aj"/><span></span>Additional Study</h4>
+                                    <input type="checkbox" name="attr_Additional_Study-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Additional_Study-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Additional_Study-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Additional Study }} {{Text= @{Additional_Study-1} }}">Additional Study</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character delves further into the mysteries of the arcane and is rewarded with a spell from one of his career spell lists. This benefit can be taken multiple times, but a character still cannot exceed twice his INT in spells known.
-                                                <textarea wrap="soft" class="sheet-input-center-aligned" type="text" name="attr_Additional_Study-notes" style="width:95%; margin-left:10px;margin-right:40px" ></textarea>
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Additional_Study-1" style="height:40px;width:750px;" readonly>
+The character delves further into the mysteries of the arcane and is rewarded with a spell from one of his career spell lists. This benefit can be taken multiple times, but a character still cannot exceed twice his INT in spells known.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Blood_Boon-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Blood_Boon-switch" value="1" class="sheet-aj"/><span></span>Blood Boon</h4>
+                                    <input type="checkbox" name="attr_Blood_Boon-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Blood_Boon-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Blood_Boon-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Blood Boon }} {{Text= @{Blood_Boon-1} }}">Blood Boon</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                Blood Boon – When this character destroys a living character with a melee attack, instead of gaining a feat point he can immediately cast a spell with a cost of 3 or lower without spending fury points or generating fatigue. This benefit does not require the expenditure of a quick action.                                               
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Blood_Boon-1" style="height:50px;width:750px;" readonly>
+When this character destroys a living character with a melee attack, instead of gaining a feat point he can immediately cast a spell with a cost of 3 or lower without spending fury points or generating fatigue. This benefit does not require the expenditure of a quick action.                                               
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Combat_Caster-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Combat_Caster-switch" value="1" class="sheet-aj"/><span></span>Combat Caster</h4>
+                                    <input type="checkbox" name="attr_Combat_Caster-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Combat_Caster-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Combat_Caster-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Combat Caster }} {{Text= @{Combat_Caster-1} }}">Combat Caster</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When this character makes a magic attack roll, he gains an additional die. Discard the lowest die of each roll.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Combat_Caster-1" style="height:20px;width:750px;" readonly>
+When this character makes a magic attack roll, he gains an additional die. Discard the lowest die of each roll.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Fast_Caster-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Fast_Caster-switch" value="1" class="sheet-aj"/><span></span>Fast Caster</h4>
+                                    <input type="checkbox" name="attr_Fast_Caster-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Fast_Caster-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Fast_Caster-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Fast Caster }} {{Text= @{Fast_Caster-1} }}">Fast Caster</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character gains one extra quick action each activation that can be used only to cast a spell.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Fast_Caster-1" style="height:20px;width:750px;" readonly>
+The character gains one extra quick action each activation that can be used only to cast a spell.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Dominator-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Dominator-switch" value="1" class="sheet-aj"/><span></span>Dominator</h4>
+                                    <input type="checkbox" name="attr_Dominator-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Dominator-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Dominator-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Dominator }} {{Text= @{Dominator-1} }}">Dominator</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point during his turn to double his control area for one round.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Dominator-1" style="height:20px;width:750px;" readonly>
+The character can spend 1 feat point during his turn to double his control area for one round.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Powerful_Caster-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Powerful_Caster-switch" value="1" class="sheet-aj"/><span></span>Powerful Caster</h4>
+                                    <input type="checkbox" name="attr_Powerful_Caster-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Powerful_Caster-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Powerful_Caster-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Powerful Caster }} {{Text= @{Powerful_Caster-1} }}">Powerful Caster</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point when he casts a spell to increase the RNG (range) of the spell by twelve feet (2˝). Spells with a range
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Powerful_Caster-1" style="height:30px;width:750px;" readonly>
+The character can spend 1 feat point when he casts a spell to increase the RNG (range) of the spell by twelve feet (2˝). Spells with a range
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Quick_Cast-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Quick_Cast-switch" value="1" class="sheet-aj"/><span></span>Quick Cast</h4>
+                                    <input type="checkbox" name="attr_Quick_Cast-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Quick_Cast-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Quick_Cast-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Quick Cast }} {{Text= @{Quick_Cast-1} }}">Quick Cast</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to immediately cast one upkeep spell at the start of combat before the first round. When casting a spell as a result of this benefit, the character is not required to pay the COST of the spell.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Quick_Cast-1" style="height:30px;width:750px;" readonly>
+The character can spend 1 feat point to immediately cast one upkeep spell at the start of combat before the first round. When casting a spell as a result of this benefit, the character is not required to pay the COST of the spell.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Strength_of_Will-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Strength_of_Will-switch" value="1" class="sheet-aj"/><span></span>Strength of Will</h4>
+                                    <input type="checkbox" name="attr_Strength_of_Will-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Strength_of_Will-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Strength_of_Will-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Strength of Will }} {{Text= @{Strength_of_Will-1} }}">Strength of Will</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                After failing a fatigue roll, the character can spend 1 feat point to instead automatically succeed on the roll. This benefit can be taken only by characters with the will weaver tradition.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Strength_of_Will-1" style="height:30px;width:750px;" readonly>
+After failing a fatigue roll, the character can spend 1 feat point to instead automatically succeed on the roll. This benefit can be taken only by characters with the will weaver tradition.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Magic_Sensitivity-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Magic_Sensitivity-switch" value="1" class="sheet-aj"/><span></span>Magic Sensitivity</h4>
+                                    <input type="checkbox" name="attr_Magic_Sensitivity-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Magic_Sensitivity-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Magic_Sensitivity-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Magic Sensitivity }} {{Text= @{Magic_Sensitivity-1} }}">Magic Sensitivity</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can automatically sense when another character casts a spell within fifty feet for each point of his ARC stat. Such characters can tune out this detection as background noise but are aware of particularly powerful magic. Additionally, a character with the focuser tradition can sense other focusers within their detection range.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Magic_Sensitivity-1" style="height:50px;width:750px;" readonly>
+The character can automatically sense when another character casts a spell within fifty feet for each point of his ARC stat. Such characters can tune out this detection as background noise but are aware of particularly powerful magic. Additionally, a character with the focuser tradition can sense other focusers within their detection range.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Rune_Reader-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Rune_Reader-switch" value="1" class="sheet-aj"/><span></span>Rune Reader</h4>
+                                    <input type="checkbox" name="attr_Rune_Reader-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Rune_Reader-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Rune_Reader-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Rune Reader }} {{Text= @{Rune_Reader-1} }}">Rune Reader</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can identify any spell cast in his line of sight by reading the accompanying spell runes (see the “Runes and Formulae” sidebar, p. 228). He can also learn the type of magic cast (the spell list it came from) and the tradition of the character casting the spell.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Rune_Reader-1" style="height:50px;width:750px;" readonly>
+The character can identify any spell cast in his line of sight by reading the accompanying spell runes (see the “Runes and Formulae” sidebar, p. 228). He can also learn the type of magic cast (the spell list it came from) and the tradition of the character casting the spell.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Warding_Circle-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Warding_Circle-switch" value="1" class="sheet-aj"/><span></span>Warding Circle</h4>
+                                    <input type="checkbox" name="attr_Warding_Circle-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Warding_Circle-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Warding_Circle-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Warding Circle }} {{Text= @{Warding_Circle-1} }}">Warding Circle</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend fifteen minutes to create a circle of warding runes around a small room or campsite. The names of the characters he intends to keep safe within the circle are incorporated into the runes. When any other character enters the circle, all named characters are alerted. While in the circle, non-named characters lose incorporeal, and non-named undead and infernal characters suffer –2 on attack rolls
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>    
-                <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Intellectual-switch" class="sheet-sign" /><span></span>
-                        <h4><input type="checkbox" name="attr_intellectual-toggle" value="1" class="sheet-aj"/><span></span>Intellectual</h4>
-                        <div class="body">
-                            <h5>Intellectual characters possess a tactical genius and adaptability that gives them +1 on attack and damage rolls in combat. While in the command range of an Intellectual character, a friendly character listening to his orders also gains +1 on his attack and damage rolls. This bonus is non-cumulative, so a character can gain this bonus only from one Intellectual character at a time.</h5>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Battlefield_Coordination-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Battlefield_Coordination-switch" value="1" class="sheet-aj"/><span></span>Battlefield Coordination</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is a skilled battlefield commander. He is able to coordinate the movement and attacks of friendly forces to maximum effect. While in his command range, friendly characters do not suffer the firing into melee penalty for ranged attacks and spells and do not have a chance to hit friendly characters when they miss with ranged or magic attacks while firing into melee.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Flawless_Timing-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Flawless_Timing-switch" value="1" class="sheet-aj"/><span></span>Flawless Timing</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 115</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to use this benefit during his turn. When he uses Flawless Timing, the character names an enemy. The next time that enemy directly hits him with an attack that encounter, the attack is instead considered to be a miss
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Prescient-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Prescient-switch" value="1" class="sheet-aj"/><span></span>Prescient</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point to win initiative automatically and take the first turn that combat. If two or more characters use this ability, they make initiative rolls to determine which of them goes first
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Perfect_Plot-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Perfect_Plot-switch" value="1" class="sheet-aj"/><span></span>Perfect Plot</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is a flawless planner and allows nothing to escape his attention. Assuming he is able to oversee all aspects of his plan, scout out the related sites, and do his research in great detail, he is sure to succeed. Of course this degree of planning takes time and care, but perfection is not without its cost. The character must spend 1 feat point to use this ability. A character following this character’s plans gains an additional die on non-combat related rolls during the day in which the plan was enacted
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Plan_of_Action-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Plan_of_Action-switch" value="1" class="sheet-aj"/><span></span>Plan of Action</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                At the start of combat, the character can spend 1 feat point to use this benefit. During that combat, he and friendly characters who follow his plan gain +2 to their initiative rolls and +2  to their attack rolls during the first round of combat.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Quick_Thinking-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Quick_Thinking-switch" value="1" class="sheet-aj"/><span></span>Quick Thinking</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character’s quick thinking enables him to act impossibly fast. Once per round, the character can spend 1 feat point to make one attack or quick action at the start of another character’s turn.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Unconventional_Warfare-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Unconventional_Warfare-switch" value="1" class="sheet-aj"/><span></span>Unconventional Warfare</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is quick thinking enough to assess any situation, see every potential angle and outcome, and use the environment itself as a weapon. He can use his attacks to off-balance foes and send them careening off ledges or into nearby vats of molten metal, cause them to stumble over terrain features, hit their weak spots to knock them to the ground, or otherwise maneuver them into a position of weakness and jeopardy. The character must spend 1 feat point to use this ability and explain to the Game Master how he is turning the environment against his enemy. The Game Master then determines the likely effect of the character’s action or attack. Outcomes include a boosted damage roll (see p. 197), knockdown, push, slam, or a fall from a height
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Genius-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Genius-switch" value="1" class="sheet-aj"/><span></span>Genius</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character possesses an incredible aptitude for intellectual pursuits. The character’s INT rolls are boosted.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Hyper_Perception-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Hyper_Perception-switch" value="1" class="sheet-aj"/><span></span>Hyper Perception</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character’s keen senses miss few details. The character’s PER rolls are boosted.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="sheet-tabbed-panel">
-                                <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Photographic_Memory-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Photographic_Memory-switch" value="1" class="sheet-aj"/><span></span>Photographic Memory</h4>
-                                    <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character has a photographic memory and can recall every event in perfect detail. During play  he can call upon his memory to ask the Game Master questions pertaining to anything he has seen or experienced.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Warding_Circle-1" style="height:70px;width:750px;" readonly>
+The character can spend fifteen minutes to create a circle of warding runes around a small room or campsite. The names of the characters he intends to keep safe within the circle are incorporated into the runes. When any other character enters the circle, all named characters are alerted. While in the circle, non-named characters lose incorporeal, and non-named undead and infernal characters suffer –2 on attack rolls
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
+                <!--Intellectual -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Mighty-switch" class="sheet-sign" /><span></span>
-                        <h4><input type="checkbox" name="attr_mighty-toggle" value="1" class="sheet-aj"/><span></span>Mighty</h4>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Intellectual-toggle" class="sheet-sign sheet-hider" /><span></span>
+                        <input type="checkbox" name="attr_Intellectual-show" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Intellectual-switch" value="1" class="sheet-aj"/><span></span>
+                        <button type="roll" class="sheet-btn" name ="attr_Intellectual" style="width:182px"value="&{template:ability} {{Name= @{character_name} }} {{Ability= Intellectual }} {{Text= @{Intellectual-1} }}"><h4>Intellectual</h4></button>
                         <div class="body">
-                            <h5>Mighty characters gain an additional die on their melee damage rolls.</h5>
+                            <input type="checkbox" name="attr_Intellectual-show" class="sheet-hidden sheet-hider" /><span></span>
+                            <div class="sheet-body">
+                                <textarea wrap="soft" class="sheet-ability" name="attr_Intellectual-1" style="height:70px;width:750px;" readonly>
+Intellectual characters possess a tactical genius and adaptability that gives them +1 on attack and damage rolls in combat. While in the command range of an Intellectual character, a friendly character listening to his orders also gains +1 on his attack and damage rolls. This bonus is non-cumulative, so a character can gain this bonus only from one Intellectual character at a time.
+                                </textarea>
+                            </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Beat_Back-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Beat_Back-switch" value="1" class="sheet-aj"/><span></span>Beat Back</h4>
+                                    <input type="checkbox" name="attr_Battlefield_Coordination-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Battlefield_Coordination-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Battlefield_Coordination-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Battlefield Coordination }} {{Text= @{Battlefield_Coordination-1} }}">Battlefield Coordination</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Beat Back</h5></div></td>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td colspan="2"><div class="sheet-ability"><h5 class="sheet-black">
-                                                When this character hits a target with a melee attack, he can immediately push his target 1˝ directly away. After the target is pushed, this character can advance up to 1˝                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Battlefield_Coordination-1" style="height:70px;width:750px;" readonly>
+The character is a skilled battlefield commander. He is able to coordinate the movement and attacks of friendly forces to maximum effect. While in his command range, friendly characters do not suffer the firing into melee penalty for ranged attacks and spells and do not have a chance to hit friendly characters when they miss with ranged or magic attacks while firing into melee
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Back_Swing-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Back_Swing-switch" value="1" class="sheet-aj"/><span></span>Back Swing</h4>
+                                    <input type="checkbox" name="attr_Flawless_Timing-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Flawless_Timing-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Flawless_Timing-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Flawless Timing }} {{Text= @{Flawless_Timing-1} }}">Feat: Flawless Timing</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                Once per turn, this character can spend 1 feat point to gain one additional melee attack.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Flawless_Timing-1" style="height:50px;width:750px;" readonly>
+The character can spend 1 feat point to use this benefit during his turn. When he uses Flawless Timing, the character names an enemy. The next time that enemy directly hits him with an attack that encounter, the attack is instead considered to be a miss
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Bounding_Leap-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Bounding_Leap-switch" value="1" class="sheet-aj"/><span></span>Bounding Leap</h4>
+                                    <input type="checkbox" name="attr_Prescient-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Prescient-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Prescient-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Prescient }} {{Text= @{Prescient-1} }}">Feat: Prescient</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is capable of preternatural feats of athleticism. Once during each of his turns in which the character does not run or charge, he can spend 1 feat point to pitch himself over the heads of his enemies into the heart of battle. When the character uses this benefit, place him anywhere within 5˝ of his current location.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Prescient-1" style="height:40px;width:750px;" readonly>
+The character can spend 1 feat point to win initiative automatically and take the first turn that combat. If two or more characters use this ability, they make initiative rolls to determine which of them goes first
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Counter_Charge-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Counter_Charge-switch" value="1" class="sheet-aj"/><span></span>Counter Charge</h4>
+                                    <input type="checkbox" name="attr_Perfect_Plot-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Perfect_Plot-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Perfect_Plot-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Perfect Plot }} {{Text= @{Perfect_Plot-1} }}">Feat: Perfect Plot</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When an enemy advances and ends its movement within thirty-six feet (6˝) of this character and in his line of sight, this character can immediately spend 1 feat point to charge the enemy. The character cannot make a counter charge while engaged.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Perfect_Plot-1" style="height:90px;width:750px;" readonly>
+The character is a flawless planner and allows nothing to escape his attention. Assuming he is able to oversee all aspects of his plan, scout out the related sites, and do his research in great detail, he is sure to succeed. Of course this degree of planning takes time and care, but perfection is not without its cost. The character must spend 1 feat point to use this ability. A character following this character’s plans gains an additional die on non-combat related rolls during the day in which the plan was enacted
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Invulnerable-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Invulnerable-switch" value="1" class="sheet-aj"/><span></span>Invulnerable</h4>
+                                    <input type="checkbox" name="attr_Plan_of_Action-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Plan_of_Action-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Plan_of_Action-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Plan of Action }} {{Text= @{Plan_of_Action-1} }}">Feat: Plan of Action</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point during his turn to gain +3 ARM for one round. 
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Plan_of_Action-1" style="height:50px;width:750px;" readonly>
+At the start of combat, the character can spend 1 feat point to use this benefit. During that combat, he and friendly characters who follow his plan gain +2 to their initiative rolls and +2  to their attack rolls during the first round of combat.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Revitalize-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Revitalize-switch" value="1" class="sheet-aj"/><span></span>Revitalize</h4>
+                                    <input type="checkbox" name="attr_Quick_Thinking-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Quick_Thinking-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Quick_Thinking-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Quick Thinking }} {{Text= @{Quick_Thinking-1} }}">Feat: Quick Thinking</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point during his turn to regain a number of vitality points equal to his PHY stat immediately. If a character suffers damage during his turn, the damage must be resolved before a character can use this feat. An incapacitated character cannot use Revitalize.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Quick_Thinking-1" style="height:30px;width:750px;" readonly>
+The character’s quick thinking enables him to act impossibly fast. Once per round, the character can spend 1 feat point to make one attack or quick action at the start of another character’s turn.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Shield_Breaker-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Shield_Breaker-switch" value="1" class="sheet-aj"/><span></span>Shield Breaker</h4>
+                                    <input type="checkbox" name="attr_Unconventional_Warfare-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Unconventional_Warfare-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="attr_Unconventional_Warfare-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Feat: Unconventional Warfare }} {{Text= @{Unconventional_Warfare-1} }}">Feat: Unconventional Warfare</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When this character hits a target that has a shield with a melee attack, the character can spend 1 feat point to use this benefit. When the character uses this benefit, after damage has been dealt the other character’s shield is completely destroyed as a result of the attack.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Unconventional_Warfare-1" style="height:130px;width:750px;" readonly>
+The character is quick thinking enough to assess any situation, see every potential angle and outcome, and use the environment itself as a weapon. He can use his attacks to off-balance foes and send them careening off ledges or into nearby vats of molten metal, cause them to stumble over terrain features, hit their weak spots to knock them to the ground, or otherwise maneuver them into a position of weakness and jeopardy. The character must spend 1 feat point to use this ability and explain to the Game Master how he is turning the environment against his enemy. The Game Master then determines the likely effect of the character’s action or attack. Outcomes include a boosted damage roll (see p. 197), knockdown, push, slam, or a fall from a height
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Vendetta-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Vendetta-switch" value="1" class="sheet-aj"/><span></span>Vendetta</h4>
+                                    <input type="checkbox" name="attr_Genius-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Genius-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Genius-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Genius }} {{Text= @{Genius-1} }}">Genius</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point during his turn to use this benefit. When this ability is used the character names one enemy. For the rest of the encounter, this character gains boosted attack rolls against that enemy. A character can use this benefit only once per encounter unless the original subject of his vendetta is destroyed, at which point the character can spend a feat point to use this benefit again.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Genius-1" style="height:20px;width:750px;" readonly>
+The character possesses an incredible aptitude for intellectual pursuits. The character’s INT rolls are boosted.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Righteous_Anger-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Righteous_Anger-switch" value="1" class="sheet-aj"/><span></span>Righteous Anger</h4>
+                                    <input type="checkbox" name="attr_Hyper_Perception-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Hyper_Perception-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Hyper_Perception-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Hyper Perception }} {{Text= @{Hyper_Perception-1} }}">Hyper Perception</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When one or more characters who are friendly to this character are damaged by an enemy attack while in this character’s command range, this character gains +2 STR and ARM for one round.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Hyper_Perception-1" style="height:20px;width:750px;" readonly>
+The character’s keen senses miss few details. The character’s PER rolls are boosted.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Tough-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Tough-switch" value="1" class="sheet-aj"/><span></span>Tough</h4>
+                                    <input type="checkbox" name="attr_Photographic_Memory-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Photographic_Memory-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Photographic_Memory-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Photographic Memory }} {{Text= @{Photographic_Memory-1} }}">Photographic Memory</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 116</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character is incredibly hardy. When this character is disabled, roll a d6. On a 5 or 6, the character heals 1 vitality point, is no longer disabled, and is knocked down.                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Photographic_Memory-1" style="height:40px;width:750px;" readonly>
+The character has a photographic memory and can recall every event in perfect detail. During play he can call upon his memory to ask the Game Master questions pertaining to anything he has seen or experienced.
+                                        </textarea>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
+                <!--Mighty -->
                 <div class="sheet-tabbed-panel">
-                    <div class="sheet-row-panel">
-                        <input type="checkbox" name="attr_Skilled-switch" class="sheet-sign" /><span></span>
-                        <h4><input type="checkbox" name="attr_skilled-toggle" value="1" class="sheet-aj"/><span></span>Skilled</h4>
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Mighty-switch" class="sheet-sign sheet-hider" /><span></span>
+                        <input type="checkbox" name="attr_Mighty-show" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Mighty-toggle" value="1" class="sheet-aj"/><span></span>
+                        <button type="roll" class="sheet-btn" name ="attr_Mighty" style="width:182px"value="&{template:ability} {{Name= @{character_name} }} {{Ability= Mighty }} {{Text= @{Mighty-1} }}"><h4>Mighty</h4></button>
                         <div class="body">
-                            <h5>
-                            A Skilled character gains an additional attack during his Activation Phase if he chooses to attack that turn.</h5>
+                            <input type="checkbox" name="attr_Mighty-show" class="sheet-hidden sheet-hider" /><span></span>
+                            <div class="sheet-body">
+                                <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Mighty-1" style="height:20px;width:750px;" readonly>
+Mighty characters gain an additional die on their melee damage rolls.
+                                </textarea>
+                            </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Ambidextrous-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Ambidextrous-switch" value="1" class="sheet-aj"/><span></span>Ambidextrous</h4>
+                                    <input type="checkbox" name="attr_Beat_Back-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Beat_Back-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Beat_Back-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Beat Back }} {{Text= @{Beat_Back-1} }}">Beat Back</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character does not suffer the normal attack roll penalty with a second weapon while using the Two-Weapon Fighting ability.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Beat_Back-1" style="height:40px;width:750px;" readonly>
+When this character hits a target with a melee attack, he can immediately push his target 1˝ directly away. After the target is pushed, this character can advance up to 1˝.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Cagey-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Cagey-switch" value="1" class="sheet-aj"/><span></span>Cagey</h4>
+                                    <input type="checkbox" name="attr_Back_Swing-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Back_Swing-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Back_Swing-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Back Swing }} {{Text= @{Back_Swing-1} }}">Back Swing</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When this character becomes knocked down, he can immediately move up to twelve feet (2˝) and cannot be targeted by free strikes during this movement. This benefit has no effect while this character is mounted. While knocked down, this character is not automatically hit by melee attacks and his DEF is not reduced. The character can stand up during his turn without forfeiting his movement or action.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Back_Swing-1" style="height:20px;width:750px;" readonly>
+Once per turn, this character can spend 1 feat point to gain one additional melee attack.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Deft-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Deft-switch" value="1" class="sheet-aj"/><span></span>Deft</h4>
+                                    <input type="checkbox" name="attr_Bounding_Leap-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Bounding_Leap-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Bounding_Leap-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Bounding Leap }} {{Text= @{Bounding_Leap-1} }}">Bounding Leap</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character has nimble fingers and steady hands. The character gains boosted AGL rolls.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Bounding_Leap-1" style="height:70px;width:750px;" readonly>
+The character is capable of preternatural feats of athleticism. Once during each of his turns in which the character does not run or charge, he can spend 1 feat point to pitch himself over the heads of his enemies into the heart of battle. When the character uses this benefit, place him anywhere within 5˝ of his current location.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Defensive_Strike-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Defensive_Strike-switch" value="1" class="sheet-aj"/><span></span>Defensive Strike</h4>
+                                    <input type="checkbox" name="attr_Counter_Charge-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Counter_Charge-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Counter_Charge-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Counter Charge }} {{Text= @{Counter_Charge-1} }}">Counter Charge</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When an enemy advances into and ends its movement in this character’s melee range, this character can spend 1 feat point to immediately make one melee attack targeting it.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Counter_Charge-1" style="height:70px;width:750px;" readonly>
+When an enemy advances and ends its movement within thirty-six feet (6˝) of this character and in his line of sight, this character can immediately spend 1 feat point to charge the enemy. The character cannot make a counter charge while engaged.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Disarm-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Disarm-switch" value="1" class="sheet-aj"/><span></span>Disarm</h4>
+                                    <input type="checkbox" name="attr_Invulnerable-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Invulnerable-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Invulnerable-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Invulnerable }} {{Text= @{Invulnerable-1} }}">Invulnerable</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                After directly hitting an enemy with a non-spray, non-AOE (area of effect) ranged or melee attack, instead of making a damage roll, the character can spend 1 feat point to disarm his opponent. When this benefit is used, the enemy’s weapon, or any object in his hand, flies from his grasp. He suffers no damage from the attack.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Invulnerable-1" style="height:20px;width:750px;" readonly>
+The character can spend 1 feat point during his turn to gain +3 ARM for one round.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Swashbuckler-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Swashbuckler-switch" value="1" class="sheet-aj"/><span></span>Swashbuckler</h4>
+                                    <input type="checkbox" name="attr_Revitalize-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Revitalize-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Revitalize-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Revitalize }} {{Text= @{Revitalize-1} }}">Revitalize</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                Once during each of his turns, this character can spend 1 feat point to use Swashbuckler. The next time this character makes an attack with a hand weapon after using this benefit, his front arc extends to 360°, and he can make one melee attack against each enemy in his line of sight in his melee range. Regardless of the number of characters hit, Swashbuckler can trigger the Sidestep benefit only once (see below).
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Revitalize-1" style="height:60px;width:750px;" readonly>
+The character can spend 1 feat point during his turn to regain a number of vitality points equal to his PHY stat immediately. If a character suffers damage during his turn, the damage must be resolved before a character can use this feat. An incapacitated character cannot use Revitalize.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Untouchable-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Untouchable-switch" value="1" class="sheet-aj"/><span></span>Untouchable</h4>
+                                    <input type="checkbox" name="attr_Shield_Breaker-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Shield_Breaker-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Shield_Breaker-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Shield Breaker }} {{Text= @{Shield_Breaker-1} }}">Shield Breaker</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character can spend 1 feat point during his turn to gain +3 DEF for one round.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Shield_Breaker-1" style="height:60px;width:750px;" readonly>
+When this character hits a target that has a shield with a melee attack, the character can spend 1 feat point to use this benefit. When the character uses this benefit, after damage has been dealt the other character’s shield is completely destroyed as a result of the attack.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Preternatural_Awareness-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Preternatural_Awareness-switch" value="[[1d6]]" class="sheet-aj"/><span></span>Preternatural Awareness</h4>
+                                    <input type="checkbox" name="attr_Vendetta-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Vendetta-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Vendetta-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Vendetta }} {{Text= @{Vendetta-1} }}">Vendetta</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                The character’s uncanny perception keeps him constantly aware of his surroundings. The character gains boosted Initiative rolls. Additionally, enemies never gain back strike bonuses against this character.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Vendetta-1" style="height:70px;width:750px;" readonly>
+The character can spend 1 feat point during his turn to use this benefit. When this ability is used the character names one enemy. For the rest of the encounter, this character gains boosted attack rolls against that enemy. A character can use this benefit only once per encounter unless the original subject of his vendetta is destroyed, at which point the character can spend a feat point to use this benefit again.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Sidestep-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Sidestep-switch" value="1" class="sheet-aj"/><span></span>Sidestep</h4>
+                                    <input type="checkbox" name="attr_Righteous_Anger-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Righteous_Anger-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Righteous_Anger-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Righteous Anger }} {{Text= @{Righteous_Anger-1} }}">Righteous Anger</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">
-                                                When this character hits an enemy character with a melee weapon, he can advance up to 2˝ after the attack is resolved. This character cannot be targeted by free strikes during this movement.
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Righteous_Anger-1" style="height:40px;width:750px;" readonly>
+When one or more characters who are friendly to this character are damaged by an enemy attack while in this character’s command range, this character gains +2 STR and ARM for one round.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
                             <div class="sheet-tabbed-panel">
                                 <div class="sheet-row-panel">
-                                    <input type="checkbox" name="attr_Virtuoso-toggle" class="sheet-gear" /><span></span>
-                                    <h4><input type="checkbox" name="attr_Virtuoso-switch" value="1" class="sheet-aj"/><span></span>Virtuoso</h4>
+                                    <input type="checkbox" name="attr_Tough-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Tough-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Tough-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Tough }} {{Text= @{Tough-1} }}">Tough</button>
                                     <div class="sheet-body">
-                                        <table style="width:97%">
-                                            <tr>
-                                                <td><div class="sheet-ability"><h5 class="sheet-black">Core book, page 117</h5></div></td>
-                                            </tr>
-                                            <tr>
-                                                <td colspan="2"><div class="sheet-ability"><h5 class="sheet-black">
-                                                Choose a military skill. When making a non-AOE attack with a weapon that uses that skill, this character gains an additional die on his attack and damage rolls. Discard the lowest die of each roll. This benefit can be taken more than once, each time specifying a different military skill.
-                                                <input type="text" class="sheet-input-center-aligned" type="text" name="attr_Virtuoso-notes" style="color:#696969" placeholder="Selected Weapon Skill(s)" >
-                                                </h5></div></td>
-                                            </tr>
-                                        </table>
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Tough-1" style="height:40px;width:750px;" readonly>
+The character is incredibly hardy. When this character is disabled, roll a d6. On a 5 or 6, the character heals 1 vitality point, is no longer disabled, and is knocked down. 
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!--Skilled -->
+                <div class="sheet-tabbed-panel">
+                    <div class="sheet-wrapper">
+                        <input type="checkbox" name="attr_Skilled-switch" class="sheet-sign sheet-hider" /><span></span>
+                        <input type="checkbox" name="attr_Skilled-show" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Skilled-toggle" value="1" class="sheet-aj"/><span></span>
+                        <button type="roll" class="sheet-btn" name ="attr_Skilled" style="width:182px"value="&{template:ability} {{Name= @{character_name} }} {{Ability= Skilled }} {{Text= @{Skilled-1} }}"><h4>Skilled</h4></button>
+                        <div class="body">
+                            <input type="checkbox" name="attr_Skilled-show" class="sheet-hidden sheet-hider" /><span></span>
+                            <div class="sheet-body">
+                                <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Skilled-1" style="height:70px;width:750px;" readonly>
+A Skilled character gains an additional attack during his Activation Phase if he chooses to attack that turn.
+                                </textarea>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Ambidextrous-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Ambidextrous-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Ambidextrous-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Ambidextrous }} {{Text= @{Ambidextrous-1} }}">Ambidextrous</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Ambidextrous-1" style="height:40px;width:750px;" readonly>
+The character does not suffer the normal attack roll penalty with a second weapon while using the Two-Weapon Fighting ability.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Cagey-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Cagey-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Cagey-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Cagey }} {{Text= @{Cagey-1} }}">Cagey</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Cagey-1" style="height:70px;width:750px;" readonly>
+When this character becomes knocked down, he can immediately move up to twelve feet (2˝) and cannot be targeted by free strikes during this movement. This benefit has no effect while this character is mounted. While knocked down, this character is not automatically hit by melee attacks and his DEF is not reduced. The character can stand up during his turn without forfeiting his movement or action.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Deft-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Deft-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Deft-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Deft }} {{Text= @{Deft-1} }}">Deft</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Deft-1" style="height:20px;width:750px;" readonly>
+The character has nimble fingers and steady hands. The character gains boosted AGL rolls.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Defensive_Strike-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Defensive_Strike-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Defensive_Strike-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Defensive Strike }} {{Text= @{Defensive_Strike-1} }}">Defensive Strike</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Defensive_Strike-1" style="height:40px;width:750px;" readonly>
+When an enemy advances into and ends its movement in this character’s melee range, this character can spend 1 feat point to immediately make one melee attack targeting it.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Disarm-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Disarm-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Disarm-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Disarm }} {{Text= @{Disarm-1} }}">Disarm</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Disarm-1" style="height:70px;width:750px;" readonly>
+After directly hitting an enemy with a non-spray, non-AOE (area of effect) ranged or melee attack, instead of making a damage roll, the character can spend 1 feat point to disarm his opponent. When this benefit is used, the enemy’s weapon, or any object in his hand, flies from his grasp. He suffers no damage from the attack.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Swashbuckler-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Swashbuckler-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Swashbuckler-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Swashbuckler }} {{Text= @{Swashbuckler-1} }}">Swashbuckler</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Swashbuckler-1" style="height:70px;width:750px;" readonly>
+Once during each of his turns, this character can spend 1 feat point to use Swashbuckler. The next time this character makes an attack with a hand weapon after using this benefit, his front arc extends to 360°, and he can make one melee attack against each enemy in his line of sight in his melee range. Regardless of the number of characters hit, Swashbuckler can trigger the Sidestep benefit only once (see below).
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Untouchable-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Untouchable-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Untouchable-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Untouchable }} {{Text= @{Untouchable-1} }}">Untouchable</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Untouchable-1" style="height:20px;width:750px;" readonly>
+The character can spend 1 feat point during his turn to gain +3 DEF for one round.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Preternatural_Awareness-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Preternatural_Awareness-switch" value="[[1d6]]" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Preternatural_Awareness-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Preternatural Awareness }} {{Text= @{Preternatural_Awareness-1} }}">Preternatural Awareness</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Preternatural_Awareness-1" style="height:40px;width:750px;" readonly>
+The character’s uncanny perception keeps him constantly aware of his surroundings. The character gains boosted Initiative rolls. Additionally, enemies never gain back strike bonuses against this character.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Sidestep-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Sidestep-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Sidestep-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Sidestep }} {{Text= @{Sidestep-1} }}">Sidestep</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Sidestep-1" style="height:40px;width:750px;" readonly>
+When this character hits an enemy character with a melee weapon, he can advance up to 2˝ after the attack is resolved. This character cannot be targeted by free strikes during this movement.
+                                        </textarea></td>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="sheet-tabbed-panel">
+                                <div class="sheet-row-panel">
+                                    <input type="checkbox" name="attr_Virtuoso-toggle" class="sheet-gear sheet-hider" /><span></span>
+                                    <input type="checkbox" name="attr_Virtuoso-switch" value="1" class="sheet-aj"/><span></span>
+                                    <button type='roll' class="sheet-btn" name="roll_Virtuoso-1" style="width:200px;" value="&{template:ability} {{Name= @{character_name} }} {{Ability= Virtuoso }} {{Text= @{Virtuoso-1} }}">Virtuoso</button>
+                                    <div class="sheet-body">
+                                        <textarea wrap="soft" class="sheet-ability"  value="" name="attr_Virtuoso-1" style="height:70px;width:750px;" readonly>
+Choose a military skill. When making a non-AOE attack with a weapon that uses that skill, this character gains an additional die on his attack and damage rolls. Discard the lowest die of each roll. This benefit can be taken more than once, each time specifying a different military skill.
+                                        </textarea></td>
                                     </div>
                                 </div>
                             </div>
@@ -2871,7 +3476,7 @@
                         <tr>
                             <td><button type="roll" class="sheet-skill_button" name ="attr_ability-archetype" value="&{template:ability} {{Name= @{character_name} }} {{Ability= @{ability_archetype_name} }} {{Text= @{ability_archetype_text} }}"></button></td>
                             <td><div class="sheet-ability"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ability_archetype_name"/></div></td>
-                            <td><input type="checkbox" name="attr_ability_archetype-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_ability_archetype-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_ability_archetype-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -2902,7 +3507,7 @@
                                 <tr>
                                     <td><button type="roll" class="sheet-skill_button" name ="attr_ability-career" value="&{template:ability} {{Name= @{character_name} }} {{Ability= @{ability_career_name} }} {{Text= @{ability_Career_text} }}"></button></td>
                                     <td><div class="sheet-ability"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ability_career_name"/></div></td>
-                                    <td><input type="checkbox" name="attr_ability-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                    <td><input type="checkbox" name="attr_ability-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                                 </tr>
                             </table>
                             <input type="checkbox" name="attr_ability-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -2925,7 +3530,7 @@
                                 <tr>
                                     <td><button type="roll" class="sheet-skill_button" name ="attr_ability-career_roll" value="&{template:ability} {{Name= @{character_name} }} {{Ability= @{ability_career_a_name} }} {{Text= @{ability_career_a_text} }}"></button></td>
                                     <td><div class="sheet-ability"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ability_career_a_name"/></div></td>
-                                    <td><input type="checkbox" name="attr_abilitya-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                    <td><input type="checkbox" name="attr_abilitya-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                                 </tr>
                             </table>
                             <input type="checkbox" name="attr_abilitya-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -2956,7 +3561,7 @@
                         <tr>
                             <td><button type="roll" class="sheet-skill_button" name ="attr_ability-career" value="&{template:ability} {{Name= @{character_name} }} {{Ability= @{ability_company_name} }} {{Text= @{ability_company_text} }}"></button></td>
                             <td><div class="sheet-ability"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ability_company_name"/></div></td>
-                            <td><input type="checkbox" name="attr_ability_company-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_ability_company-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_ability_company-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -2986,10 +3591,10 @@
                     <table>
                         <tr>
                             <th></th>
-                            <th><h4>Fatgiue/Focus</h4></th>
+                            <th><h4>Fatigue/Focus</h4></th>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" name="attr_roll_fatigue" value='&{template:fury} {{name= @{character_name} }} {{roll= [[2d6]] }} {{fatigue= [[@{fatigue}]] }}'>Fatigue</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_roll_fatigue" value='&{template:fury} {{name= @{character_name} }} {{roll= [[2d6]] }} {{fatigue= [[@{fatigue}]] }}'><h4>Fatigue</h4></button></td>
                             <td>                
                                 <input type="radio" class="sheet-normal sheet-zero" name="attr_fatigue" value="0" checked="checked" /><span></span>
                                 <input type="radio" class="sheet-normal" name="attr_fatigue" value="1" /><span></span>
@@ -3017,7 +3622,7 @@
                             <th><h4>Fury</h4></th>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_roll_Threshold" value='&{template:fury} {{name= @{character_name} }} {{roll= [[2d6+@{fury}]] }} {{threshold= [[@{Threshold}]] }}'>Threshold</button></td>
+                            <td><button type='roll' class="sheet-btn" name="attr_roll_Threshold" value='&{template:fury} {{name= @{character_name} }} {{roll= [[2d6+@{fury}]] }} {{threshold= [[@{Threshold}]] }}'><h4>Threshold</h4></button></td>
                             <td><input type="number" class="sheet-stats-base" name="attr_Threshold" value="0" /></td>
                             <td>                
                                 <input type="radio" class="sheet-normal sheet-zero" name="attr_fury" value="0" checked="checked" /><span></span>
@@ -3043,95 +3648,337 @@
     <br>
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
-        <input type="checkbox" name="attr_spell-toggle" class="sheet-arrow" /><span></span>
-        <h4>Spells</h4>
+            <input type="checkbox" name="attr_spell-toggle" class="sheet-arrow" /><span></span>
+            <h4>Spells</h4>
             <div class="body">
-                <table style="width:420px;">
-                    <tr>
-                        <td style="width:70px"><h5>Combat Caster?</h5></td>
-                        <td style="width:40px"><h5>Roll</h5></td>
-                        <td style="width:70px"><h5>Targeted<br>Roll</h5></td>
-                        <td style="width:200px"><h5>Spell</h5></td>
-                    </tr>
-                </table>
-                <fieldset class="repeating_spells"> 
-                    <table style="width:420px;margin-left:10px;">
-                        <tr>
-                            <td style="width:70px;"><input type="checkbox" class="sheet-bigcheck" name="attr_Combat_Caster-toggle" value="1" /><span></span></td>
-                            <td style="width:40px">
-                                <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Combat_Caster-toggle" value="1" />
-                                <div class="sheet-one_block">
-                                    <button type='roll' class="sheet-skill_button" name="roll_spell_attack" value='&{template:spell}  {{character= @{character_name} }} {{spell= @{spell_name} }} {{cost= @{spell_cost} }} {{range= @{spell_range} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell_att_mod} ]] }} {{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell_pow}]] }} {{notes= @{spell_details} }} {{aoe= @{spell_aoe} }}  {{location= [[  @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}'></button>
-                                </div>
-                                <div class="sheet-two_block">
-                                    <div class="sheet-tooltips"><button type='roll' class="sheet-combatstatic_button" name="roll_spell_attack-combatstatic_button" value='&{template:spell} {{spell= @{spell_name} }} {{cost= @{spell_cost} }} {{character= @{character_name} }} {{range= @{spell_range} }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell_att_mod}]] }} {{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell_pow}]] }}{{target-armor= Armor}}{{target-def= Defence} {{notes= @{spell_details} }} {{aoe= @{spell_aoe} }} {{location= [[ @{hit-loc} ]]}}' /><span><div class="sheet-plain">You may spend a focus or gain a fatgue point to boost either the attack or effect</div></span></div>
-                                </div>
-                            </td>
-                            <td style="width:70px;">
-                                <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Combat_Caster-toggle" value="1" />
-                                <div class="sheet-one_block">
-                                    <div class="sheet-tooltips"><button type='roll' class="sheet-skill_button" name="roll_spell_attack-tgt" value='&{template:spell} {{spell= @{spell_name} }} {{cost= @{spell_cost} }} {{character= @{character_name} }} {{range= @{spell_range} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell_att_mod} ]] }} {{target-token_name= at @{target|character_name} }} {{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell_pow}]] }} {{target-def= [[ [[@{target|def}]] ]] }} {{target-armor=[[ [[@{target|arm}]]]] }} {{notes= @{spell_details} }} {{aoe= @{spell_aoe} }} {{location= [[@{hit-loc} ]]}} '/><span><div class="sheet-plain">You may spend a focus or gain a fatgue point to boost either the attack or effect</div></span></div>
-                                </div>
-                                <div class="sheet-two_block">
-                                    <div class="sheet-tooltips"><button type='roll' class="sheet-combatcaster_button" name="roll_spell_attack-combatcaster" value='&{template:spell} {{spell= @{spell_name} }} {{cost= @{spell_cost} }} {{character= @{character_name} }} {{range= @{spell_range} }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell_att_mod}]] }} {{target-token_name= at @{target|character_name} }} {{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell_pow}]] }} {{target-def= [[ [[@{target|def}]] ]] }} {{target-armor= [[ [[@{target|arm}]] ]] }} {{notes= @{spell_details} }} {{aoe= @{spell_aoe} }} {{location= [[ @{hit-loc} ]]}}' /><span><div class="sheet-plain">You may spend a focus or gain a fatgue point to boost either the attack or effect</div></span></div>
-                                </div>
-                            </td>
-                            <td style="width:200px"><div class="sheet-spell_select_text"><input class="sheet-input-center-aligned" type="text" name="attr_spell_name" value="" /></div></td>
-                            <td><input type="checkbox" name="attr_spelldetails-toggle" class="sheet-gear" value="1"/><span></span></td>
-                        </tr>
-                    </table>
-                    <input type="checkbox" name="attr_spelldetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
-                    <div class="body">
-                        <table style="width:820px">
-                            <tr>
-                                <td><h5>Cost</h5></td>
-                                <td><h5>Range</h5></td>
-                                <td><h5>Area of Effect?</h5></td>
-                                <td><h5>Static Attack Mod</h5></td>
-                                <td><h5>POW</h5></td>
-                                <td><h5>AoE<br>POW</h5></td>
-                                <td><h5>Upkeep</h5></td>
-                                <td><h5>Offensive?</h5></td>
-                                
-                            </tr>
-                            <tr>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_cost" type="number" style="width:50px">
-                                    <option value="1" selected>1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                    <option value="4">4</option></select></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_range" value="Self" style="width:120px">
-                                    <option value="Base to Base">Base to Base</option>
-                                    <option value="Spray 8 (48 ft.)">Spray 8</option>
-                                    <option value="Ctrl">Ctrl</option>
-                                    <option value="Self">Self</option>
-                                    <option value="6 (36 ft.)">6 (36 ft.)</option>
-                                    <option value="8 (48 ft.)">8 (48 ft.)</option>
-                                    <option value="10 (60 ft.)">10 (60 ft.)</option>
-                                    <option value="12 (72 ft.)">12 (72 ft.)</option></select></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_aoe" style="width:60px">
-                                    <option value="None" selected>None</option>
-                                    <option value="*">*</option>
-                                    <option value="Ctrl">Ctrl</option>
-                                    <option value="3 (18ft) [[2d6 + @{spell_aoe_damage}]] damage">3 (18ft)</option>
-                                    <option value="4 (24ft) [[2d6 + @{spell_aoe_damage}]] damage">4 (24ft)</option>
-                                    <option value="5 (30ft) [[2d6 + @{spell_aoe_damage}]] damage">5 (30ft)</option></select></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_att_mod" value="0" /></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_pow" value="0" /></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_aoe_damage" value="0"/>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_upkeep" style="width:65px">
-                                    <option value="Yes">Yes</option>
-                                    <option value="No" selected>No</option></select></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_offensive" style="width:65px">
-                                    <option value="Yes">Yes</option>
-                                    <option value="No" selected>No</option></select></td>
-                            </tr>
-                            <tr>
-                                <td colspan="8"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" style="width:99%" value="" name="attr_spell_details" placeholder="Spell Text" /></textarea></td>
-                            </tr>
-                        </table>
-                    </div>
-                </fieldset>
+                <div class='sheet-2colrow'>
+                    <div class='sheet-col'>
+						<table style="width:420px;">
+							<tr>
+								<th style="width:40px"><h5>Roll</h5></th>
+								<td style="width:70px"><h5>Targeted<br>Roll</h5></td>
+								<td style="width:180px"><h5>Spell</h5></td>
+							</tr>
+						</table>
+						<fieldset class="repeating_spells"> 
+							<table style="width:420px;margin-left:10px;">
+								<tr>
+									<th style="width:40px">
+										<button type='roll' class="sheet-combatstatic_button" name="roll_spell_attack" value='@{include-spell_fx} \\n &{template:spell} {{character= @{character_name} }} {{spell= @{spell_name} }} {{target-def= Defence}}{{target-armor= Armor}} @{include-spell_offensive} @{include-spell_range} @{include-spell_cost} @{include-spell_aoe} @{include-spell_upkeep} @{include-location} @{include-spell_details} @{include-spell_upkeep} @{include-spell_damage}'></button>
+									</th>
+                                    <td style="width:40px">
+										<div class="sheet-tooltips">
+                                        <button type='roll' class="sheet-combatcaster_button" name="roll_spell_attack-combatcaster" value='@{include-spell_fx} \\n &{template:spell}{{character= @{character_name} }}{{spell= @{spell_name} }} {{target-token_name= at @{target|character_name} }}{{target-def= [[ [[@{target|def}]] ]] }}{{target-armor= [[ [[@{target|arm}]] ]] }} @{include-spell_offensive} @{include-spell_range} @{spell_cost} @{include-spell_aoe} @{include-spell_upkeep} @{include-location} @{include-spell_details} @{include-spell_upkeep} @{include-spell_damage}'></button><span><div class="sheet-plain">You may spend a focus or gain a fatgue point to boost either the attack or effect</div></span></div>
+									</td>
+									<td style="width:180px"><div class="sheet-spell_select_text"><input class="sheet-input-center-aligned" type="text" name="attr_spell_name" value="" /></div></td>
+                                    <th style="width:40px">
+										<button type='roll' class="sheet-skill_button" name="roll_gm-spell" value='/w gm @{include-spell_fx} \\n &{template:spell}  {{character= @{character_name} }} {{spell= @{spell_name} }} {{target-def= Defence}}{{target-armor= Armor}} @{include-spell_offensive} @{include-spell_range} @{include-spell_cost} @{include-spell_aoe} @{include-spell_upkeep} @{include-location} @{include-spell_details} @{spell_upkeep} @{include-spell_damage}'></button>
+									</th>
+                                    <td><input type="checkbox" name="attr_spelldetails-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
+								</tr>
+							</table>
+							<input type="checkbox" name="attr_spelldetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
+							<div class="body">
+								<table style="width:390px">
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_cost" value=" "/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_cost" value="{{cost= [[@{spell_cost} + ?{Extra Attack Dice|0} + ?{Extra Effect Dice|0} ]] }}" checked /><span></span></th>
+										<td><h5>Cost</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_cost" type="number" style="width:60px">
+											<option value="1" selected>1</option>
+											<option value="2">2</option>
+											<option value="3">3</option>
+											<option value="4">4</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_range" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_range" value="{{range= @{spell_range} }}" checked/><span></span></th>
+										<td><h5>Range</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_range" value="Self" style="width:120px">
+                                            <option value="*">*</option>
+											<option value="Base to Base">Base to Base</option>
+											<option value="Spray 8 (48 ft.)">Spray 8</option>
+											<option value="Ctrl">Ctrl</option>
+											<option value="Self">Self</option>
+											<option value="6 (36 ft.)">6 (36 ft.)</option>
+											<option value="8 (48 ft.)">8 (48 ft.)</option>
+											<option value="10 (60 ft.)">10 (60 ft.)</option>
+											<option value="12 (72 ft.)">12 (72 ft.)</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_aoe" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_aoe" value=" {{aoe= @{spell_aoe} }}" checked/><span></span></th>
+										<td><h5>Area of Effect?</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_aoe" style="width:60px">
+											<option value="None" selected>None</option>
+											<option value="*">*</option>
+											<option value="Ctrl">Ctrl</option>
+											<option value="3 (18ft) [[2d6 + @{spell_aoe_damage}]] damage">3 (18ft)</option>
+											<option value="4 (24ft) [[2d6 + @{spell_aoe_damage}]] damage">4 (24ft)</option>
+											<option value="5 (30ft) [[2d6 + @{spell_aoe_damage}]] damage">5 (30ft)</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th></th>
+                                        <th></th>
+										<td><h5>Static Attack Mod</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_att_mod" value="0"  style="width:60px"/></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_damage" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_damage" value="{{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell_pow}]] }}" checked /><span></span></th>
+										<td><h5>POW</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_pow" value="0" style="width:60px" /></td>
+                                    </tr> 
+									<tr>
+                                        <th></th>
+                                        <th></th>
+                                        <td><h5>AoE POW</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell_aoe_damage" value="0" style="width:60px"/></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_upkeep" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_upkeep" value="@{spell_upkeep}" checked/><span></span></th>
+										<td><h5>Upkeep</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_upkeep" style="width:60px">
+											<option value="{{upkeep= Yes}}">Yes</option>
+											<option value="{{upkeep= No}}" selected>No</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_offensive" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_offensive" value="{{{{offensive= @{spell_offensive} }}" checked/><span></span></th>
+										<td><h5>Offensive</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell_offensive" style="width:60px">
+											<option value="{{offensive= [[(2 + @{Combat_Caster-switch})d6k2 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell_att_mod} ]] }}">Yes</option>
+											<option value="{{offensive= No" selected>No</option></select></td>
+									</tr>
+                                    <tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-location" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-location" value=" {{location= [[@{hit-loc}]] }}" checked/><span></span></th>
+                                        <td><h5>Location</h5></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_details" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_details" value="{{notes= @{spell_details} }}" checked/><span></span></th>
+										<td colspan="2"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" style="width:99%" value="" name="attr_spell_details" placeholder="Spell Text" /></textarea></td>
+									</tr>
+                                </table>
+                                <table style="width:390px">
+                                    <tr>
+                                        <th></th>
+                                        <th></th>
+                                        <td></td>
+                                        <td>Type</td>
+                                        <td>Color</td>
+                                        <td>Source</td>
+                                        <td>Target</td>
+                                    </tr>
+                                    <tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_fx" value="" checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_fx" value="/fx @{fx_type}-@{fx_color} @{fx_source} @{fx_target} " /><span></span></th>
+                                        <td><h5>F/X</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_type" style="width:80px">
+											<option value="beam">Beam</option>
+											<option value="bomb">Bomb</option>
+											<option value="breath">Breath</option>
+											<option value="bubbling">Bubbling</option>
+											<option value="burn">Burn</option>
+                                            <option value="burst">Burst</option>
+											<option value="explode">Explosion</option>
+											<option value="glow">Glow</option>
+											<option value="missile">Missile</option>
+											<option value="nova">Nova</option>
+                                            <option value="splatter">Splatter</option>
+										</select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_color" style="width:60px">
+											<option value="acid">Acid</option>
+											<option value="blood">Blood</option>
+											<option value="charm">Charm</option>
+											<option value="death">Death</option>
+											<option value="fire">Fire</option>
+                                            <option value="frost">Frost</option>
+											<option value="holy">Holy</option>
+											<option value="magic">Magic</option>
+											<option value="slime">Slime</option>
+											<option value="smoke">Smoke</option>
+                                            <option value="water">Water</option>
+										</select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_source" style="width:80px">
+                                            <option value="@{selected|token_id}">Selected</option>
+                                            <option value="@{target|token_id}">Target</option>
+                                        </select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_target" style="width:80px">
+                                            <option value="@{selected|token_id}">Selected</option>
+                                            <option value="@{target|token_id}">Target</option>
+                                        </select></td>
+                                    </tr>
+								</table>
+							</div>
+						</fieldset>
+					</div>
+                    <div class='sheet-col'>
+                        <table style="width:420px;">
+							<tr>
+								<th style="width:40px"><h5>Roll</h5></th>
+								<td style="width:70px"><h5>Targeted<br>Roll</h5></td>
+								<td style="width:180px"><h5>Spell</h5></td>
+							</tr>
+						</table>
+						<fieldset class="repeating_spell2s"> 
+							<table style="width:420px;margin-left:10px;">
+								<tr>
+									<th style="width:40px">
+										<button type='roll' class="sheet-combatstatic_button" name="roll_spell2_attack" value='@{include-spell_fx2} \\n &{template:spell}  {{character= @{character_name} }} {{spell= @{spell2_name} }} {{target-def= Defence}}{{target-armor= Armor}} @{include-spell2_offensive} @{include-spell2_range} @{include-spell2_cost} @{include-spell2_aoe} @{include-spell2_upkeep} @{include-location} @{include-spell2_details} @{include-spell2_upkeep} @{include-spell2_damage}'></button>
+									</th>
+                                    <td style="width:40px">
+										<div class="sheet-tooltips">
+                                        <button type='roll' class="sheet-combatcaster_button" name="roll_spell2_attack-combatcaster" value='@{include-spell_fx2} \\n &{template:spell}{{character= @{character_name} }}{{spell= @{spell2_name} }} {{target-token_name= at @{target|character_name} }}{{target-def= [[ [[@{target|def}]] ]] }}{{target-armor= [[ [[@{target|arm}]] ]] }} @{include-spell2_offensive} @{include-spell2_range} @{include-spell2_cost} @{include-spell2_aoe} @{include-spell2_upkeep} @{include-location} @{include-spell2_details} @{include-spell2_upkeep} @{include-spell2_damage}'></button><span><div class="sheet-plain">You may spend a focus or gain a fatgue point to boost either the attack or effect</div></span></div>
+									</td>
+									<td style="width:180px"><div class="sheet-spell2_select_text"><input class="sheet-input-center-aligned" type="text" name="attr_spell2_name" value="" /></div></td>
+                                    <th style="width:40px">
+                                        <button type='roll' class="sheet-skill_button" name="roll_gm-spell" value='/w gm &{template:spell}  {{character= @{character_name} }} {{spell= @{spell2_name} }} {{target-def= Defence}}{{target-armor= Armor}} @{include-spell2_offensive} @{include-spell2_range} @{include-spell2_cost} @{include-spell2_aoe} @{include-spell2_upkeep} @{include-location} @{include-spell2_details} @{include-spell2_upkeep} @{include-spell2_damage}'></button>
+									</th>
+									<td><input type="checkbox" name="attr_spell2details-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
+								</tr>
+							</table>
+							<input type="checkbox" name="attr_spell2details-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
+							<div class="body">
+                                <table style="width:390px">
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_cost" value=" "/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_cost" value="{{cost= [[@{spell2_cost} + ?{Extra Attack Dice|0} + ?{Extra Effect Dice|0} ]] }}" checked /><span></span></th>
+										<td><h5>Cost</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell2_cost" type="number" style="width:60px">
+											<option value="1" selected>1</option>
+											<option value="2">2</option>
+											<option value="3">3</option>
+											<option value="4">4</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_range" value=" " checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_range" value="{{range= @{spell2_range} }}" checked/><span></span></th>
+										<td><h5>Range</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell2_range" value="Self" style="width:120px">
+                                            <option value="*">*</option>
+											<option value="Base to Base">Base to Base</option>
+											<option value="Spray 8 (48 ft.)">Spray 8</option>
+											<option value="Ctrl">Ctrl</option>
+											<option value="Self">Self</option>
+											<option value="6 (36 ft.)">6 (36 ft.)</option>
+											<option value="8 (48 ft.)">8 (48 ft.)</option>
+											<option value="10 (60 ft.)">10 (60 ft.)</option>
+											<option value="12 (72 ft.)">12 (72 ft.)</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_aoe" value=" " checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_aoe" value=" {{aoe= @{spell2_aoe} }}" checked/><span></span></th>
+										<td><h5>Area of Effect?</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell2_aoe" style="width:60px">
+											<option value="None" selected>None</option>
+											<option value="*">*</option>
+											<option value="Ctrl">Ctrl</option>
+											<option value="3 (18ft) [[2d6 + @{spell2_aoe_damage}]] damage">3 (18ft)</option>
+											<option value="4 (24ft) [[2d6 + @{spell2_aoe_damage}]] damage">4 (24ft)</option>
+											<option value="5 (30ft) [[2d6 + @{spell2_aoe_damage}]] damage">5 (30ft)</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th></th>
+                                        <th></th>
+										<td><h5>Static Attack Mod</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell2_att_mod" value="0"  style="width:60px"/></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_damage" value=" " checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_damage" value="{{damage= [[2d6+?{Extra Effect Dice|0}d6 +@{spell2_pow}]] }}" checked /><span></span></th>
+										<td><h5>POW</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell2_pow" value="0" style="width:60px" /></td>
+                                    </tr> 
+									<tr>
+                                        <th></th>
+                                        <th></th>
+                                        <td><h5>AoE POW</h5></td>
+                                        <td><input type="number" class="sheet-input-center-aligned" name="attr_spell2_aoe_damage" value="0" style="width:60px"/></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_upkeep" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_upkeep" value="@{spell2_upkeep}" checked/><span></span></th>
+										<td><h5>Upkeep</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_spell2_upkeep" style="width:60px">
+											<option value="{{upkeep= Yes}}">Yes</option>
+											<option value="{{upkeep= No}}" selected>No</option></select></td>
+                                    </tr>
+									<tr>
+                                        <th></th>
+                                        <th></th>
+										<td><h5>Offensive</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_include-spell2_offensive" style="width:60px">
+											<option value="{{offensive= [[(2 + @{Combat_Caster-switch})d6k2 + ?{Extra Attack Dice|0}d6 + @{arcane} + @{spell2_att_mod} ]] }}">Yes</option>
+											<option value="No" selected>No</option></select></td>
+									</tr>
+                                    <tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-location" value=" " /><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-location" value=" {{location= [[@{hit-loc}]] }}" checked/><span></span></th>
+                                        <td><h5>Location</h5></td>
+                                    </tr>
+									<tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell2_details" value=" " checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell2_details" value="{{notes= @{spell2_details} }}" checked/><span></span></th>
+										<td colspan="2"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" style="width:99%" value="" name="attr_spell2_details" placeholder="spell2 Text" /></textarea></td>
+									</tr>
+                                </table>
+                                <table style="width:390px">
+                                    <tr>
+                                        <th></th>
+                                        <th></th>
+                                        <td></td>
+                                        <td>Type</td>
+                                        <td>Color</td>
+                                        <td>Source</td>
+                                        <td>Target</td>
+                                    </tr>
+                                    <tr>
+                                        <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-spell_fx2" value="" checked/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-spell_fx2" value="/fx @{fx_type2}-@{fx_color2} @{fx_source2} @{fx_target2} " /><span></span></th>
+                                        <td><h5>F/X</h5></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_type2" style="width:80px">
+    										<option value="beam">Beam</option>
+											<option value="bomb">Bomb</option>
+											<option value="breath">Breath</option>
+											<option value="bubbling">Bubbling</option>
+											<option value="burn">Burn</option>
+                                            <option value="burst">Burst</option>
+											<option value="explode">Explosion</option>
+											<option value="glow">Glow</option>
+											<option value="missile">Missile</option>
+											<option value="nova">Nova</option>
+                                            <option value="splatter">Splatter</option>
+										</select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_color2" style="width:60px">
+											<option value="acid">Acid</option>
+											<option value="blood">Blood</option>
+											<option value="charm">Charm</option>
+											<option value="death">Death</option>
+											<option value="fire">Fire</option>
+                                            <option value="frost">Frost</option>
+											<option value="holy">Holy</option>
+											<option value="magic">Magic</option>
+											<option value="slime">Slime</option>
+											<option value="smoke">Smoke</option>
+                                            <option value="water">Water</option>
+										</select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_source2" style="width:80px">
+                                            <option value="@{selected|token_id}">Selected</option>
+                                            <option value="@{target|token_id}">Target</option>
+                                        </select></td>
+                                        <td><select class="sheet-select sheet-input-center-aligned" name="attr_fx_target2" style="width:80px">
+                                            <option value="@{selected|token_id}">Selected</option>
+                                            <option value="@{target|token_id}">Target</option>
+                                        </select></td>
+                                    </tr>
+								</table>
+							</div>
+						</fieldset>
+					</div>
+                </div>
             </div>
         </div>
     </div>
@@ -3151,28 +3998,26 @@
                 <fieldset class="repeating_fellcall"> 
                     <table>
                         <tr>
-                            <td style="width:40px"><button type='roll' name="attr_fellcall_attack_roll" class="sheet-skill_button" value='&{template:fellcall} {{character= @{character_name} }} {{fellcall= @{fellcall_name} }} {{range= @{fellcall_range}}} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[ @{fellcalling_total} + @{fellcall_attack-mod}]] ]] }} {{damage= [[2d6 + ?{Extra Effect Dice|0}d6 + [[@{fellcall_pow}+ @{fellcall_pow-mod} ]] ]] }} {{notes= @{fellcall_details} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' /></td>
+                            <td style="width:40px"><button type='roll' name="attr_fellcall_attack_roll" class="sheet-skill_button" value='&{template:fellcall} {{character= @{character_name} }} {{fellcall= @{fellcall_name} }} {{damage= [[2d6 + ?{Extra Effect Dice|0}d6 + [[@{fellcall_pow} + @{fellcall_pow-mod} ]] ]] }} @{include-fellcall_range} @{include-fellcall_offensive}  @{include-fellcall_details} {{target-def= Defence}}{{target-armor= Armor}} @{include-location} @{include-fellcall_aoe}' /></td>
                             <td style="width:70px"><button type='roll' name="attr_fellcall_attack_roll_tgt" class="sheet-skill_button" value='&{template:fellcall} {{character= @{character_name} }} {{target-token_name= at @{target|token_name} }} {{target-def= [[ [[@{target|def}]] ]] }} {{target-armor= [[ [[@{target|arm}]] ]] }} {{fellcall= @{fellcall_name} }} {{range= @{fellcall_range}}} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 +[[ @{fellcalling_total} + @{fellcall_attack-mod}]] ]] }} {{damage= [[2d6 + ?{Extra Effect Dice|0}d6 + [[@{fellcall_pow} + @{fellcall_pow-mod} ]] ]] }} {{notes= @{fellcall_details} }}  {{location= [[ @{hit-loc} ]]}}' /></td>
                             <td style="width:40px"><div class="sheet-spell_select_text"><input class="sheet-input-center-aligned" type="text" name="attr_fellcall_name" value="" /></div></td>
-                            <td><input type="checkbox" name="attr_fellcalldetails-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_fellcalldetails-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_fellcalldetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
                     <div class="body">
-                        <table style="width:820px">
-                            <tr>
-                                <td style="width:20px"></td>
-                                <td><h5>Attack Mod</h5></td>
-                                <td><h5>Range</h5></td>
-                                <td><h5>Area of Effect?</h5></td>
-                                <td><h5>POW</h5></td>
-                                <td><h5>POW Mod</h5></td>
-                                <td><h5>Offensive?</h5></td>
-                            </tr>
+                        <table style="width:390px">
                             <tr>
                                 <td></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_attack-mod" value="0" /></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_range" style="width:120px">
+                                <td></td>
+                                <td><h5>Attack Mod</h5></td>
+                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_attack-mod" value="0"  style="width:100px"/></td>
+                            </tr>
+                            <tr>
+                                <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-fellcall_range" value=" "/><span></span></th>
+                                        <th><input type="radio" class="sheet-grate" name="attr_include-fellcall_range" value="{{range= @{fellcall_range} }}" checked /><span></span></th>
+                                <td><h5>Range</h5></td>
+                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_range" style="width:100px">
                                     <option value="Base to Base">Base to Base</option>
                                     <option value="Spray 8 (48 ft.)">Spray 8</option>
                                     <option value="Ctrl">Ctrl</option>
@@ -3181,22 +4026,48 @@
                                     <option value="8">8 (48 ft.)</option>
                                     <option value="10">10 (60 ft.)</option>
                                     <option value="12">12 (72 ft.)</option></select></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_aoe" style="width:65px">
+                            </tr>
+                            <tr>
+                                <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-fellcall_aoe" value=" "/><span></span></th>
+                                <th><input type="radio" class="sheet-grate" name="attr_include-fellcall_aoe" value="{{aoe= @{fellcall_aoe} }}" checked /><span></span></th>
+                                <td><h5>Area of Effect?</h5></td>
+                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_aoe" style="width:100px">
                                     <option value="—">—</option>
                                     <option value="*">*</option>
                                     <option value="Ctrl">Ctrl</option>
                                     <option value="3">3</option>
                                     <option value="4">4</option>
                                     <option value="5">5</option></select></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_pow" value="0" /></td>
-                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_pow-mod" value="0" /></td>
-                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_offensive" style="width:65px">
-                                    <option value="Yes">Yes</option>
-                                    <option value="No" selected>No</option></select></td>
                             </tr>
                             <tr>
-                                <td></td>
-                                <td colspan="6"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" value="" name="attr_fellcall_details" style="width:99%" placeholder="Fell Call Text" /></textarea></td>
+                                <th></th>
+                                <th></th>
+                                <td><h5>POW</h5></td>
+                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_pow" value="0" style="width:100px"/></td>
+                            </tr>
+                            <tr>
+                                <th></th>
+                                <th></th>
+                                <td><h5>POW Mod</h5></td>
+                                <td><input type="number" class="sheet-input-center-aligned" name="attr_fellcall_pow-mod" value="0" style="width:100px"/></td>
+                            </tr>
+                            <tr>
+                                <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-fellcall_offensive" value=" "/><span></span></th>
+                                <th><input type="radio" class="sheet-grate" name="attr_include-fellcall_offensive" value="@{fellcall_offensive}" /><span></span></th>
+                                <td><h5>Offensive</h5></td>
+                                <td><select class="sheet-select sheet-input-center-aligned" name="attr_fellcall_offensive" style="width:100px">
+                                    <option value="{{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[ @{fellcalling_total} + @{fellcall_attack-mod}]] ]] }}">Yes</option>
+                                    <option value="No" selected>No</option></select></td>
+                            </tr>
+                                <tr>
+                                <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-location" value=" " checked/><span></span></th>
+                                <th><input type="radio" class="sheet-grate" name="attr_include-location" value=" {{location= [[@{hit-loc}]] }}" /><span></span></th>
+                                <td><h5>Location</h5></td>
+                                </tr>
+                            <tr>
+                                <th><input type="radio" class="sheet-grate sheet-x" name="attr_include-fellcall_details" value=" "/><span></span></th>
+                                <th><input type="radio" class="sheet-grate" name="attr_include-fellcall_details" value="{{notes= @{fellcall_details} }}" checked /><span></span></th>
+                                <td colspan="2"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" value="" name="attr_fellcall_details" style="width:99%" placeholder="Fell Call Text" /></textarea></td>
                             </tr>
                         </table>
                     </div>
@@ -3222,7 +4093,7 @@
                                 <td style="width:40px"><button type='roll' class="sheet-skill_button" name="roll_runeshot" value='&{template:runeshot}  {{character= @{character_name} }} {{weapon= @{runeshot_weapon_name} }} {{range= @{runeshot_effectiverange} }} {{extreme-range= @{runeshot_extremerange} }} {{attack= [[ [[(2 + @{runeshot-Accuracy})]]d6 + ?{Extra Attack Dice|0}d6 + [[@{runeshot_RAT_total} ]] ]] }} {{damage= [[ [[(2 + @{runeshot-Brutal})]]d6 + ?{Extra Damage Dice|0}d6 + [[@{runeshot_damage_total}]] ]] }}{{target-def= Defence}}{{target-armor= Armor}}{{notes= @{note-runeshot}}} {{location= [[ @{hit-loc} ]]}} {{Black_Penny= @{runeshot-Black_Penny}}} {{Detonator= @{runeshot-Detonator}}} {{Earth_Shaker= @{runeshot-Earth_Shaker}}}{{Fire_Beacon= @{runeshot-Fire_Beacon}}}{{Freeze_Fire= @{runeshot-Freeze_Fire}}}{{Heart_Stopper= @{runeshot-Heart_Stopper}}}{{Iron_Rot= @{runeshot-Iron_Rot} }}{{Molten_Shot= @{runeshot-Molten_Shot} }}{{Momentum= @{runeshot-Momentum}}}{{Phantom_Seeker= @{runeshot-Phantom_Seeker} }}{{Shadow_Fire= @{runeshot-Shadow_Fire} }}{{Silencer= @{runeshot-Silencer}}}{{Spell_Cracker= @{runeshot-Spell_Cracker} }}{{Spontaneous_Combustion= @{runeshot-Spontaneous_Combustion}}}{{Thunderbolt= @{runeshot-Thunderbolt} }}{{Trick_Shot= @{runeshot-Trick_Shot} }} ' /></td>
                                 <td style="width:70px"><button type='roll' class="sheet-skill_button" name="roll_runeshot_tgt" value='&{template:runeshot}  {{character= @{character_name} }} {{weapon= @{runeshot_weapon_name} }} {{range= @{runeshot_effectiverange} }} {{extreme-range= @{runeshot_extremerange} }} {{attack= [[ [[(2 + @{runeshot-Accuracy})]]d6 + ?{Extra Attack Dice|0}d6 + [[@{runeshot_RAT_total}]] ]] }} {{damage= [[ [[(2 + @{runeshot-Brutal})]]d6 + ?{Extra Damage Dice|0}d6 + [[@{runeshot_damage_total}]] ]] }}  {{target-def= [[ [[@{target|def}]] ]] }} {{target-armor= [[ [[@{target|arm}]] ]] }} {{notes= @{note-runeshot}}} {{location= [[ @{hit-loc} ]]}} {{Black_Penny= @{runeshot-Black_Penny}}} {{Detonator= @{runeshot-Detonator}}} {{Earth_Shaker= @{runeshot-Earth_Shaker}}}{{Fire_Beacon= @{runeshot-Fire_Beacon}}}{{Freeze_Fire= @{runeshot-Freeze_Fire}}}{{Heart_Stopper= @{runeshot-Heart_Stopper}}}{{Iron_Rot= @{runeshot-Iron_Rot} }}{{Molten_Shot= @{runeshot-Molten_Shot} }}{{Momentum= @{runeshot-Momentum}}}{{Phantom_Seeker= @{runeshot-Phantom_Seeker} }}{{Shadow_Fire= @{runeshot-Shadow_Fire} }}{{Silencer= @{runeshot-Silencer}}}{{Spell_Cracker= @{runeshot-Spell_Cracker} }}{{Spontaneous_Combustion= @{runeshot-Spontaneous_Combustion}}}{{Thunderbolt= @{runeshot-Thunderbolt} }}{{Trick_Shot= @{runeshot-Trick_Shot}}} {{target-token_name= at @{target|token_name} }} ' /></td>
                                 <td style="width:200px"><input class="sheet-input-center-aligned" type="text" name="attr_runeshot_weapon_name"/></td>
-                                <td><input type="checkbox" name="attr_runeshot1details-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                <td><input type="checkbox" name="attr_runeshot1details-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                             </tr>
                         </table>
                         <input type="checkbox" name="attr_runeshot1details-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -3321,7 +4192,7 @@
                                 <td style="width:40px"><button type='roll' class="sheet-skill_button" name="roll_runeshot2" value='&{template:runeshot}  {{character= @{character_name} }} {{weapon= @{runeshot2_weapon_name} }} {{range= @{runeshot2_effectiverange} }} {{extreme-range= @{runeshot2_extremerange} }} {{attack= [[ [[(2 + @{runeshot2-Accuracy})]]d6 + ?{Extra Attack Dice|0}d6 + [[@{runeshot2_RAT_total}]] ]] }} {{damage= [[ [[(2 + @{runeshot2-Brutal})]]d6 + ?{Extra Damage Dice|0}d6 + @{runeshot2_damage_total}]] }}{{target-def= Defence}}{{target-armor= Armor}}{{notes= @{note-runeshot2}}} {{location= [[ @{hit-loc} ]]}} {{Black_Penny= @{runeshot2-Black_Penny}}} {{Detonator= @{runeshot2-Detonator}}} {{Earth_Shaker= @{runeshot2-Earth_Shaker}}}{{Fire_Beacon= @{runeshot2-Fire_Beacon}}}{{Freeze_Fire= @{runeshot2-Freeze_Fire}}}{{Heart_Stopper= @{runeshot2-Heart_Stopper}}}{{Iron_Rot= @{runeshot2-Iron_Rot} }}{{Molten_Shot= @{runeshot2-Molten_Shot} }}{{Momentum= @{runeshot2-Momentum}}}{{Phantom_Seeker= @{runeshot2-Phantom_Seeker} }}{{Shadow_Fire= @{runeshot2-Shadow_Fire} }}{{Silencer= @{runeshot2-Silencer}}}{{Spell_Cracker= @{runeshot2-Spell_Cracker} }}{{Spontaneous_Combustion= @{runeshot2-Spontaneous_Combustion}}}{{Thunderbolt= @{runeshot2-Thunderbolt} }}{{Trick_Shot= @{runeshot2-Trick_Shot} }} ' /></td>
                                 <td style="width:70px"><button type='roll' class="sheet-skill_button" name="roll_runeshot2_tgt" value='&{template:runeshot}  {{character= @{character_name} }} {{weapon= @{runeshot2_weapon_name} }} {{range= @{runeshot2_effectiverange} }} {{extreme-range= @{runeshot2_extremerange} }} {{attack= [[ [[(2 + @{runeshot2-Accuracy})]]d6 + ?{Extra Attack Dice|0}d6 + [[@{runeshot2_RAT_total}]] ]] }} {{damage= [[ [[(2 + @{runeshot2-Brutal})]]d6 + ?{Extra Damage Dice|0}d6 + @{runeshot2_damage_total}]] }}  {{target-def= [[[[@{target|def}]]]] }} {{target-armor=[[[[@{target|arm}]]]] }} {{notes= @{note-runeshot2}}} {{location= [[ @{hit-loc} ]]}} {{Black_Penny= @{runeshot2-Black_Penny}}} {{Detonator= @{runeshot2-Detonator}}} {{Earth_Shaker= @{runeshot2-Earth_Shaker}}}{{Fire_Beacon= @{runeshot2-Fire_Beacon}}}{{Freeze_Fire= @{runeshot2-Freeze_Fire}}}{{Heart_Stopper= @{runeshot2-Heart_Stopper}}}{{Iron_Rot= @{runeshot2-Iron_Rot} }}{{Molten_Shot= @{runeshot2-Molten_Shot} }}{{Momentum= @{runeshot2-Momentum}}}{{Phantom_Seeker= @{runeshot2-Phantom_Seeker} }}{{Shadow_Fire= @{runeshot2-Shadow_Fire} }}{{Silencer= @{runeshot2-Silencer}}}{{Spell_Cracker= @{runeshot2-Spell_Cracker} }}{{Spontaneous_Combustion= @{runeshot2-Spontaneous_Combustion}}}{{Thunderbolt= @{runeshot2-Thunderbolt} }}{{Trick_Shot= @{runeshot2-Trick_Shot}}} {{target-token_name= at @{target|token_name} }} ' /></td>
                                 <td style="width:200px"><input class="sheet-input-center-aligned" type="text" name="attr_runeshot2_weapon_name"/></td>
-                                <td><input type="checkbox" name="attr_runeshot2details-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                <td><input type="checkbox" name="attr_runeshot2details-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                             </tr>
                         </table>
                         <input type="checkbox" name="attr_runeshot2details-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -3428,32 +4299,34 @@
                 <table style="width:100%">
                     <tr>
                         <td><h5>Location</h5></td>
-                        <td><input type="text" class="sheet-input-center-aligned" name="attr_hit-loc" value="1t[Hit-Location]" /></td>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_hit-loc" value="1d6" /></td>
                     </tr>
                 </table>
             </div>
         </div>
     </div>
+    <!--weapons -->
     <div class="sheet-tabbed-panel">
+    <!--melee -->
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_melee-toggle" class="sheet-arrow" /><span></span>
             <h4>Melee Weapons</h4>
             <div class="body">
-                <table style="width:420px">
+                <table style="width:500px">
                     <tr>
-                        <td style="width:60px;"><div class="sheet-virtioso">Virtuoso?</div></td>
-                        <td style="width:60px;"><h5>Roll</h5></td>
-                        <td style="width:100px;"><h5>Targeted<br>Roll</h5></td>
+                        <th style="width:80px;"><div class="sheet-virtioso">Virtuoso?</div></th>
+                        <th style="width:60px;"><h5>Roll</h5></th>
+                        <th style="width:100px;"><h5>Targeted<br>Roll</h5></th>
                         <td style="width:200px;"><h5>Weapon</h5></td>
                         <td style="width:40px;"></td>
                     </tr>
                 </table>
                 <fieldset class="repeating_melee"> 
                     <div class="sheet-rasied_border">
-                        <table style="width:420px;margin-left:10px;">
+                        <table style="width:500px;margin-left:10px;">
                             <tr>
-                                <td style="width:60px;"><input type="checkbox" class="sheet-bigcheck" name="attr_Virtuoso-toggle" value="1" /><span></span></td>
-                                <td>
+                                <td style="width:80px;"><input type="checkbox" class="sheet-bigcheck" name="attr_Virtuoso-toggle" value="1" /><span></span></td>
+                                <th style="width:60px;">
                                     <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Virtuoso-toggle" value="1" />
                                     <div class="sheet-one_block">
                                         <button type='roll' class="sheet-skill_button" name="roll_melee" value='&{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' />
@@ -3461,8 +4334,8 @@
                                     <div class="sheet-two_block">
                                         <button type='roll' class="sheet-combatstatic_button" name="roll_melee-v" value='&{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[3d6k2 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee}}} {{target-def= Defence}} {{target-armor= Armor }} {{location= [[ @{hit-loc} ]]}}' />
                                     </div>
-                                </td>
-                                <td style="width:60px;">
+                                </th>
+                                <th style="width:100px;">
                                     <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Virtuoso-toggle" value="1" />
                                     <div class="sheet-one_block">
                                         <button type='roll' class="sheet-skill_button" name="roll_melee_tgt" value='&{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee}}} {{target-token_name= at @{target|token_name} }}  {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' /></td>
@@ -3470,9 +4343,19 @@
                                     <div class="sheet-two_block">
                                         <button type='roll' class="sheet-virtioso_button" name="roll_melee-virtuoso" value='&{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[3d6k2 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee}}} {{target-token_name= at @{target|token_name} }} {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' />
                                     </div>
-                                </td>
+                                </th>
                                 <td style="width:200px;"><input class="sheet-input-center-aligned" type="text" value="" name="attr_melee_weapon_name"/></td>
-                                <td style="width:40px;"><input type="checkbox" name="attr_meleedetails-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                <!--gm buttons -->
+                                <th>
+                                    <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Virtuoso-toggle" value="1" />
+                                    <div class="sheet-one_block">
+                                        <button type='roll' class="sheet-skill_button" name="roll_meleegm" value='/w gm &{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' />
+                                    </div>
+                                    <div class="sheet-two_block">
+                                        <button type='roll' class="sheet-combatstatic_button" name="roll_melee-vggm" value='/w gm &{template:melee}  {{character= @{character_name} }} {{weapon= @{melee_weapon_name} }} {{strength= [[@{strength}]] }} {{POW= [[@{melee_pow} + @{melee_pow_mod}]] }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{melee_MAT_total}]] }} {{damage= [[3d6k2 + ?{Extra Damage Dice|0}d6 + @{mighty-toggle}d6 + @{melee_damage_total}]] }} {{notes= @{note-melee}}} {{target-def= Defence}} {{target-armor= Armor }} {{location= [[ @{hit-loc} ]]}}' />
+                                    </div>
+                                 </th>
+                                <td style="width:40px;"><input type="checkbox" name="attr_meleedetails-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                             </tr>
                         </table>
                         <input type="checkbox" name="attr_meleedetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -3510,8 +4393,7 @@
                 </fieldset>
             </div>
         </div>
-    </div>
-    <div class="sheet-tabbed-panel">
+        <!--range -->
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_ranged-toggle" class="sheet-arrow" /><span></span>
             <h4>Ranged Weapons</h4>
@@ -3549,7 +4431,16 @@
                                     </div>
                                 </td>
                                 <td style="width:200px;"><input class="sheet-input-center-aligned" type="text" value="" name="attr_ranged_weapon_name"/></td>
-                                <td style="width:40px;"><input type="checkbox" name="attr_rangedetails-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                <th>
+                                    <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Virtuoso-toggle" value="1" />
+                                    <div class="sheet-one_block">
+                                        <button type='roll' class="sheet-skill_button" name="roll_rangedgm" value='/w gm &{template:weapon}  {{character= @{character_name} }} {{weapon= @{ranged_weapon_name} }} {{range= @{ranged_effectiverange} }} {{extreme-range= @{ranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{ranged_RAT_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{ranged_damage_total}]] }} {{notes= @{note-ranged}}} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' />
+                                    </div>
+                                    <div class="sheet-two_block">
+                                        <button type='roll' class="sheet-combatstatic_button" name="roll_ranged_vgm" value='/w gm &{template:weapon}  {{character= @{character_name} }} {{weapon= @{ranged_weapon_name} }} {{range= @{ranged_effectiverange} }} {{extreme-range= @{ranged_extremerange} }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + @{ranged_RAT_total}]] }} {{damage= [[3d6k2 + ?{Extra Damage Dice|0}d6 + @{ranged_damage_total}]] }} {{target-def= Defence}} {{target-armor= Armor }} {{notes= @{note-ranged}}} {{location= [[ @{hit-loc} ]]}}' /> 
+                                    </div>
+                                </th>
+                                <td style="width:40px;"><input type="checkbox" name="attr_rangedetails-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                             </tr>
                         </table>
                         <input type="checkbox" name="attr_rangedetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -3595,8 +4486,7 @@
                 </fieldset>
             </div>
         </div>
-    </div>    
-    <div class="sheet-tabbed-panel">
+    <!--artillery -->
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_explosive-toggle" class="sheet-arrow" /><span></span>
             <h4>Artillery and Explosive Weapons</h4>
@@ -3634,7 +4524,16 @@
                                     </div>
                                 </td>
                                 <td style="width:200px;"><input class="sheet-input-center-aligned" type="text" value="" name="attr_explosive_weapon_name"/></td>
-                                <td style="width:40px;"><input type="checkbox" name="attr_explosivedetails-toggle" class="sheet-gear" value="1"/><span></span></td>
+                                <td>
+                                    <input type="checkbox" class="sheet-hidden sheet-showhide" name="attr_Virtuoso-toggle" value="1" />
+                                    <div class="sheet-one_block">
+                                        <button type='roll' class="sheet-skill_button" name="roll_explosivegm" value='/w gm  &{template:boom}  {{character= @{character_name} }} {{weapon= @{explosive_weapon_name} }} {{range= @{explosive_effectiverange} }} {{extreme-range= @{explosive_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{explosive_RAT_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{explosive_damage_total}]] ]] }} {{notes= @{note-explosive} }} {{aoe= @{explosive_aoe} }} {{aoe-damage= [[2d6+ ([[@{explosive_damage_total}]]/2) ]] }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' />
+                                    </div>
+                                    <div class="sheet-two_block">
+                                        <button type='roll' class="sheet-combatstatic_button" name="roll_explosive-virtuosogm"  value='/w gm &{template:boom}  {{character= @{character_name} }} {{weapon= @{explosive_weapon_name} }} {{range= @{explosive_effectiverange} }} {{extreme-range= @{explosive_extremerange} }} {{attack= [[3d6k2 + ?{Extra Attack Dice|0}d6 + [[ @{explosive_RAT_total}]] ]] }} {{damage= [[3d6k2 + ?{Extra Damage Dice|0}d6 + [[ @{explosive_damage_total}]] ]] }} {{notes= @{note-explosive} }} {{aoe= @{explosive_aoe} }} {{aoe-damage= [[2d6+ ([[@{explosive_damage_total}]]/2)]] }} {{target-def= Defence}} {{target-armor= Armor }} {{location= [[ @{hit-loc} ]]}}' />
+                                    </div>
+                                </td>
+                                <td style="width:40px;"><input type="checkbox" name="attr_explosivedetails-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                             </tr>
                         </table>
                         <input type="checkbox" name="attr_explosivedetails-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -3688,19 +4587,8 @@
             </div>
         </div>
     </div>
-    
+    <!--Armor -->
     <h4>Armor</h4>
-    <div class="sheet-tabbed-panel">
-        <div class="sheet-row-panel">
-            <table style="width:820px">
-                <tr>
-                    <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_speed" value="@{armor_speed_mod} + @{shield_speed_mod} + @{otherarmor_speed_mod}" disabled="true" /></th>
-                    <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_def" value="@{armor_def_mod} + @{shield_def_mod} + @{otherarmor_def_mod}" disabled="true" /></th>
-                    <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_arm" value="@{armor_arm_mod} + @{shield_arm_mod} + @{otherarmor_arm_mod}" disabled="true" /></th>
-                </tr>
-            </table>
-        </div>
-    </div>
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_armor-toggle" class="sheet-arrow" /><span></span>
@@ -3708,6 +4596,23 @@
             <div class="body">
                 <table style="width:820px">
                     <tr>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_a" value="@{worn_armor_speed} + @{shield_speed_mod} + @{otherarmor_speed_mod}" disabled="true" /></th>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_b" value="@{worn_armor_def} + @{shield_def_mod} + @{otherarmor_def_mod}" disabled="true"/></th>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_c" value="@{worn_armor_arm} + @{shield_arm_mod} + @{otherarmor_arm_mod}" disabled="true"/></th>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_speed" value="" /></th>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_def" value="" /></th>
+                        <th><input type="hidden" class="sheet-input-center-aligned" name="attr_worn_armor_arm" value="" /></th>
+                    </tr>
+                    <tr>
+                        <td></td>
                         <td><h5>Armor</h5></td>
                         <th><h5>Type</h5></th>
                         <th><h5>SPD Modifier</h5></th>
@@ -3715,25 +4620,81 @@
                         <th><h5>ARM Modifier</h5></th>
                     </tr>
                     <tr>
-                        <td><input type="text" class="sheet-input-center-aligned" name="attr_armor_name" value="" placeholder="Armor Name" /></td>
-                        <td style="width:20%"><select name="attr_armortype" class="sheet-input-center-aligned sheet-select" style="width:120px">
+                        <th><input type="radio" class="sheet-use" name="attr_armor_select" value="0"/><span></span></th>
+                        <td><h5>Flesh of Steel</h5></td>
+                    </tr>
+                    <tr>
+                        <th><input type="radio" class="sheet-use" name="attr_armor_select" value="1" checked/><span></span></th>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_armor_name_1" value="" placeholder="Armor Name" /></td>
+                        <td><select name="attr_armor_type_1" class="sheet-input-center-aligned sheet-select" style="width:120px">
                             <option value="None">None</option>
                             <option value="Light">Light</option>
                             <option value="Medium">Medium</option>
                             <option value="Heavy">Heavy</option>
                             </select></td>
-                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_speed_mod" value="0" /></th>
-                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_def_mod" value="0" /></th>
-                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_arm_mod" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_speed_mod_1" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_def_mod_1" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_arm_mod_1" value="0" /></th>
+                        <th><input type="checkbox" class="sheet-gear sheet-hider" name="attr_armor_details-toggle_1" value="1"/><span></span></th>
                     </tr>
                     <tr>
-                        <td colspan="5"><textarea class="sheet-input-center-aligned" wrap="soft" class="sheet-input-center-aligned" type="text" value="" name="attr_armor_note" style="width:99%" placeholder="Armor Notes" /></textarea></td>
+                        <td></td>
+                        <td colspan="5">
+                            <input type="checkbox" name="attr_armor_details-toggle_1" class="sheet-hidden sheet-hider" value="1"/><span></span>
+                            <div class="sheet-body">
+                                <textarea class="sheet-input-center-aligned" wrap="soft" class="sheet-input-center-aligned" type="text" value="" name="attr_armor_note_1" style="width:99%" placeholder="Armor Notes" /></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><input type="radio" class="sheet-use" name="attr_armor_select" value="2" /><span></span></th>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_armor_name_2" value="" placeholder="Armor Name" /></td>
+                        <td style="width:20%"><select name="attr_armor_type_2" class="sheet-input-center-aligned sheet-select" style="width:120px">
+                            <option value="None">None</option>
+                            <option value="Light">Light</option>
+                            <option value="Medium">Medium</option>
+                            <option value="Heavy">Heavy</option>
+                            </select></td>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_speed_mod_2" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_def_mod_2" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_arm_mod_2" value="0" /></th>
+                        <th><input type="checkbox" class="sheet-gear sheet-hider" name="attr_armor_details-toggle_2" value="1"/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td colspan="5">
+                            <input type="checkbox" name="attr_armor_details-toggle_2" class="sheet-hidden sheet-hider" value="1"/><span></span>
+                            <div class="sheet-body">
+                                <textarea class="sheet-input-center-aligned" wrap="soft" class="sheet-input-center-aligned" type="text" value="" name="attr_armor_note_2" style="width:99%" placeholder="Armor Notes" /></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><input type="radio" class="sheet-use" name="attr_armor_select" value="3" /><span></span></th>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_armor_name_3" value="" placeholder="Armor Name" /></td>
+                        <td style="width:20%"><select name="attr_armor_type_3" class="sheet-input-center-aligned sheet-select" style="width:120px">
+                            <option value="None">None</option>
+                            <option value="Light">Light</option>
+                            <option value="Medium">Medium</option>
+                            <option value="Heavy">Heavy</option>
+                            </select></td>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_speed_mod_3" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_def_mod_3" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_armor_arm_mod_3" value="0" /></th>
+                        <th><input type="checkbox" class="sheet-gear sheet-hider" name="attr_armor_details-toggle_3" value="1"/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td colspan="5">
+                            <input type="checkbox" name="attr_armor_details-toggle_3" class="sheet-hidden sheet-hider" value="1"/><span></span>
+                            <div class="sheet-body">
+                                <textarea class="sheet-input-center-aligned" wrap="soft" class="sheet-input-center-aligned" type="text" value="" name="attr_armor_note_3" style="width:99%" placeholder="Armor Notes" /></textarea>
+                            </div>
+                        </td>
                     </tr>
                 </table>
             </div>
         </div>
-    </div>
-    <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_worn_shield-toggle" class="sheet-arrow" /><span></span>
             <h4>Shield</h4>
@@ -3757,8 +4718,6 @@
                 </table>
             </div>
         </div>
-    </div>
-    <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_worn_other-toggle" class="sheet-arrow" /><span></span>
             <h4>Other Defenses</h4>
@@ -3780,6 +4739,80 @@
                         <td colspan="4"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" value="" name="attr_shield_note" style="width:99%" placeholder="Shield" /></textarea></td>
                     </tr>
                 </table>
+            </div>
+        </div>
+    </div> 
+    <!--Mounts --> 
+    <h4>Mount</h4>
+    <div class="sheet-tabbed-panel">
+        <div class="sheet-row-panel">
+            <input type="checkbox" name="attr_mount-toggle" class="sheet-arrow" /><span></span>
+            <h4>Mount Stats</h4>
+            <div class="body">
+                <table style="width:820px">
+                    <tr>
+                        <td><h5>Mounted?</h5></td>
+                        <th><h5>Name</h5></th>
+                        <th><h5>Type</h5></th>
+                        <th><h5>PHY</h5></th>
+                        <th><h5>SPD</h5></th>
+                        <th><h5>STR</h5></th>
+                        <th><h5>DEF</h5></th>
+                        <th><h5>ARM</h5></th>
+                        <th><h5>MaT</h5></th>
+                    </tr>
+                    <tr>
+                        <th><div class= "sheet-derived-button"><input type='checkbox' value="[[-4 + @{riding}]]" name="attr_mounted" class="sheet-bigcheck"/><span></span></div></th>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_mount_name" value="" placeholder="Mount Name" /></td>
+                        <td><input type="text" class="sheet-input-center-aligned" name="attr_mount_type" value="" placeholder="Mount Type" /></td>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_physique" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_speed" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_strength" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_def" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_arm" value="0" /></th>
+                        <th><input type="number" class="sheet-input-center-aligned" name="attr_mount_mat" value="0" /></th>
+                    </tr>
+                    <tr>
+                        <td colspan="9"><textarea class="sheet-input-center-aligned" wrap="soft" class="sheet-input-center-aligned" type="text" value="" name="attr_mount_note" style="width:99%" placeholder="Mount Notes" /></textarea></td>
+                    </tr>
+                </table>
+                <div class="sheet-wrapper">
+                <table>
+                    <tr>
+                        <td><button type='roll' class="sheet-btn" name="attr_riding_roll" value='/me rides! [[ [[2+@{Deft-switch}]]d6 + [[@{riding_total}]] + ?{Extra Dice|0}d6]]'>Riding</button></td>
+                        <td><button type='roll' class="sheet-btn" name="attr_stay_in_saddle_roll" value='/me attempts to stay in the saddle! [[2d6 + [[@{agility} + @{Deft-switch}d6 + @{riding} + @{riding_misc}]] + ?{Extra Dice|0}d6]]'>AGL + Ridin</button></td>
+                        <td><button type='roll' class="sheet-btn" name="attr_land_safely_roll" value='/me tries not to land on their head! [[2d6 + [[@{agility} + @{Deft-switch}d6 + @{jumping} + @{jumping_misc}]] + ?{Extra Dice|0}d6]]'>AGL + Jumping</button></td>
+                        <td><button type='roll' class="sheet-btn" name="attr_under_mount_roll" value='/me tries shift his mount [[2d6 + [[@{strength} + @{agility} + @{Deft-switch}d6]] + ?{Extra Dice|0}d6]]'>STR + AGL</button></td>
+                    </tr>
+                </table>
+                </div>
+                <fieldset class="repeating_mount"> 
+                    <table style="width:100%">
+                        <tr>
+                            <td><h5>Roll</h5></td>
+                            <td><h5>Targeted<br>Roll</h5></td>
+                            <td><h5>Weapon</h5></td>
+                            <td><h5>MAT</h5></td>
+                            <td><h5>Attack Modifier</h5></td>
+                            <td><h5>POW</h5></td>
+                            <td><h5>Weapon POW</h5></td>
+                            <td><h5>Damage Modifier</h5></td>
+                        </tr>
+                        <tr>
+                            <td><button type='roll' class="sheet-skill_button" name="attr_mount_wpn_roll" value='&{template:npcmelee}  {{character= @{mount_name} }} {{weapon= @{mount_wpn_name} }} {{strength= [[@{mount_strength}]] }} {{POW= [[@{mount_pow} + @{mount_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{mount_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{mount_wpn_damage_total}]] }} {{notes= @{mount_text} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' /></td>
+                            <td><button type='roll' class="sheet-skill_button" name="attr_mount_tgt" value='&{template:npcmelee}  {{character= @{mount_name} }} {{weapon= @{mount_wpn_name} }} {{strength= [[@{mount_strength}]] }} {{POW= [[@{mount_pow} + @{mount_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{mount_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{mount_wpn_damage_total}]] }} {{notes= @{mount_text}}} {{target-token_name= at @{target|token_name} }}  {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' /></td>                           
+                            <td><input class="sheet-input-center-aligned" type="text" value="" name="attr_mount_wpn_name"/></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_mount_mat_total" value="@{prowess} + @{riding} + @{mount_att_mod}" disabled="true" /></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_mount_att_mod" value="0" /></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_mount_wpn_damage_total" value="@{mount_pow} + @{mount_strength} + @{mount_pow_mod} " disabled="true" /></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_mount_pow" value="0" /></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_mount_pow_mod" value="0" /></td>
+                        </tr>
+                        <tr>
+                            <td colspan="8"><textarea class="sheet-input-center-aligned" wrap="soft" value="" name="attr_mount_text" style="width:99%" placeholder="Weapon Description" /></textarea></td>
+                        </tr>
+                    </table>
+                </fieldset>
             </div>
         </div>
     </div>
@@ -3830,6 +4863,178 @@
             <input type="checkbox" name="attr_language-toggle" class="sheet-arrow" /><span></span>
             <h4>Spoken Languages</h4>
             <div class="body">
+                <div class='sheet-2colrow'>
+                    <div class='sheet-col'>
+    					<table style="width:400px">
+							<tr>
+								<td></td>
+								<td><h5>Langauges</h5></td>
+								<td><h5>Book & Page Reference</h5></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Caspian" class="sheet-bigcheck" value="Caspian" /><span></span></th>
+								<td><div class="sheet-ability">Caspian (extinct)</div></td>
+								<td><div class="sheet-ability">FMF, page 67</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Caspian" class="sheet-bigcheck" value="Cygnaran" /><span></span></th>
+								<td><div class="sheet-ability">Cygnaran</div></td>
+								<td><div class="sheet-ability">FMF, page 67</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Sulese" class="sheet-bigcheck" value="Sulese" /><span></span></th>
+								<td><div class="sheet-ability">Sulese</div></td>
+								<td><div class="sheet-ability">FMF, page 67</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Llaelese" class="sheet-bigcheck" value="Llaelese" /><span></span></th>
+								<td><div class="sheet-ability">Llaelese</div></td>
+								<td><div class="sheet-ability">FMF, page 67</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Ordic" class="sheet-bigcheck" value="Ordic" /><span></span></th>
+								<td><div class="sheet-ability">Ordic</div></td>
+								<td><div class="sheet-ability">FMF, page 68</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Scharde" class="sheet-bigcheck" value="Scharde" /><span></span></th>
+								<td><div class="sheet-ability">Scharde</div></td>
+								<td><div class="sheet-ability">FMF, page 68</div></td>
+							</tr>
+							<tr>
+								<td><br></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Khurzic" class="sheet-bigcheck" value="Khurzic" /><span></span></th>
+								<td><div class="sheet-ability">Khurzic (extinct)</div></td>
+								<td><div class="sheet-ability">FMF, page 68</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Khadoran" class="sheet-bigcheck" value="Khadoran" /><span></span></th>
+								<td><div class="sheet-ability">Khadoran</div></td>
+								<td><div class="sheet-ability">FMF, page 68</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Kossite" class="sheet-bigcheck" value="Kossite" /><span></span></th>
+								<td><div class="sheet-ability">Kossite</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Umbrean" class="sheet-bigcheck" value="Umbrean" /><span></span></th>
+								<td><div class="sheet-ability">Umbrean</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<td><br></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Morridane" class="sheet-bigcheck" value="Morridane" /><span></span></th>
+								<td><div class="sheet-ability">Morridane (extinct)</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Idrian" class="sheet-bigcheck" value="Idrian" /><span></span></th>
+								<td><div class="sheet-ability">Idrian</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Thurian" class="sheet-bigcheck" value="Thurian" /><span></span></th>
+								<td><div class="sheet-ability">Thurian</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<td><br></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Satyx" class="sheet-bigcheck" value="Satyx" /><span></span></th>
+								<td><div class="sheet-ability">Satyx</div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Thrallspeak" class="sheet-bigcheck" value="Thrallspeak" /><span></span></th>
+								<td><div class="sheet-ability">Thrallspeak</div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Telgesh" class="sheet-bigcheck" value="Telgesh" /><span></span></th>
+								<td><div class="sheet-ability">Telgesh</div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+						</table>
+                    </div>
+                    <div class='sheet-col'>
+                        <table style="width:400px">
+							<tr>
+								<td></td>
+								<td><h5>Langauges</h5></td>
+								<td><h5>Book & Page Reference</h5></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Rhulic" class="sheet-bigcheck" value="Rhulic" /><span></span></th>
+								<td><div class="sheet-ability">Rhulic</div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Shyr" class="sheet-bigcheck" value="Shyr" /><span></span></th>
+								<td><div class="sheet-ability">Shyr</div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+							<tr>
+								<td><br></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Aeric" class="sheet-bigcheck" value="Aeric" /><span></span></th>
+								<td><div class="sheet-ability">Aeric (Nyss)</nyss></div></td>
+								<td><div class="sheet-ability">FMF, page 70</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Molgur" class="sheet-bigcheck" value="Molgur" /><span></span></th>
+								<td><div class="sheet-ability">Molgur</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Gobberish" class="sheet-bigcheck" value="Gobberish" /><span></span></th>
+								<td><div class="sheet-ability">Gobberish (Gobbers)</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Molgur_Og" class="sheet-bigcheck" value="Molgur_Og" /><span></span></th>
+								<td><div class="sheet-ability">Molgur-Og</div></td>
+								<td><div class="sheet-ability">FMF, page 69</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Molgur_Trul" class="sheet-bigcheck" value="Molgur_Trulrish" /><span></span></th>
+								<td><div class="sheet-ability">Molgur-Trul (Trollkin)</div></td>
+								<td><div class="sheet-ability">FMF, page 69<br>Unleashed, page 43</div></td>
+							</tr>
+        					<tr>
+								<td><br></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Quor_og" class="sheet-bigcheck" value="Quor_og" /><span></span></th>
+								<td><div class="sheet-ability">Quor-og (Bog Trog)</div></td>
+								<td><div class="sheet-ability">Unleashed, page 67</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Grun" class="sheet-bigcheck" value="Grun" /><span></span></th>
+								<td><div class="sheet-ability">Grun (Farrow)</div></td>
+								<td><div class="sheet-ability">Unleashed, page 51</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Quor_gar" class="sheet-bigcheck" value="Quor_gar" /><span></span></th>
+								<td><div class="sheet-ability">Quor-gar (Gatorman)</div></td>
+								<td><div class="sheet-ability">Unleashed, page 57</div></td>
+							</tr>
+							<tr>
+								<th><input type='checkbox' name="attr_Molgur_Tharn" class="sheet-bigcheck" value="Molgur_Tharn" /><span></span></th>
+								<td><div class="sheet-ability">Molgur-Tharn (Tharn)</div></td>
+								<td><div class="sheet-ability">Unleashed, page 67</div></td>
+							</tr>
+						</table>
+
+                        
+                    </div>
+                </div>
                 <fieldset class="repeating_languages"> 
                     <table style="width:100%">
                         <tr>
@@ -3876,14 +5081,14 @@
             <input type="checkbox" name="attr_history-toggle" class="sheet-arrow" /><span></span>
             <h4>History</h4>
             <div class="body">
-                <input type="checkbox" name="attr_characterhistory-toggle" class="sheet-gear" /><span></span>
+                <input type="checkbox" name="attr_characterhistory-toggle" class="sheet-gear sheet-hider" /><span></span>
                 <h5>Character History</h5>
                 <div class="body">
                     <textarea wrap="soft" class="sheet-input-center-aligned" value="" name="attr_character_history" style="width:99%" placeholder="Character History" /></textarea>
                 </div>
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row">
-                        <input type="checkbox" name="attr_recenthistory-toggle" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_recenthistory-toggle" class="sheet-gear sheet-hider" /><span></span>
                         <h5>Recent History</h5>
                         <div class="body">
                             <fieldset class="repeating_recenthistory"> 
@@ -3918,7 +5123,7 @@
             <div class="body">
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row-panel"> 
-                        <input type="checkbox" name="attr_Coin-Cygnar" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Coin-Cygnar" class="sheet-gear sheet-hider" /><span></span>
                         <h4>Cygnar Coin</h4>
                         <div class="body">
                             <table style="width:75%">
@@ -3977,7 +5182,7 @@
                 </div>
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row-panel"> 
-                        <input type="checkbox" name="attr_Coin-Khador" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Coin-Khador" class="sheet-gear sheet-hider" /><span></span>
                         <h4>Khador Coin</h4>
                         <div class="body">
                             <table style="width:75%">
@@ -4015,7 +5220,7 @@
                 </div>
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row-panel"> 
-                        <input type="checkbox" name="attr_Coin-Llael" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Coin-Llael" class="sheet-gear sheet-hider" /><span></span>
                         <h4>Llael Coin</h4>
                         <div class="body">
                             <table style="width:75%">
@@ -4053,7 +5258,7 @@
                 </div>
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row-panel"> 
-                        <input type="checkbox" name="attr_Coin-Ord" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Coin-Ord" class="sheet-gear sheet-hider" /><span></span>
                         <h4>Ord Coin</h4>
                         <div class="body">
                             <table style="width:75%">
@@ -4105,7 +5310,7 @@
                 </div>
                 <div class="sheet-tabbed-panel">
                     <div class="sheet-row-panel"> 
-                        <input type="checkbox" name="attr_Coin-PoM" class="sheet-gear" /><span></span>
+                        <input type="checkbox" name="attr_Coin-PoM" class="sheet-gear sheet-hider" /><span></span>
                         <h4>Protectorate of Menoth Coin</h4>
                         <div class="body">
                             <table style="width:75%">
@@ -4266,16 +5471,32 @@
     <h2>Advancement</h2>
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel"> 
-        <h4>Experince Points<input class="sheet-input-center-aligned" type="number" value="0" name="attr_xp" /></h4>
+            <table style="width:700px">
+            </table>
+            <h4>Experince Points<input class="sheet-input-center-aligned" type="number" value="0" name="attr_xp" /></h4>
             <input type="checkbox" name="attr_herolevel-toggle" class="sheet-arrow" /><span></span>
             <!-- Hero -->
             <h4>Hero Level</h4>
             <div class="body">
-                <table style="width:75%">
+                <table style="width:750px">
                     <tr>
-                        <td><h5>XP Total</h5></td>
-                        <td><h5>Character Advancement</h5></td>
-                        <td><h5>Spent On</h5></td>
+                        <td style="width:50px"><h5>XP Total</h5></td>
+                        <td style="width:400px"><h5>Character Advancement</h5></td>
+                        <td style="width:300px"><h5>Spent On</h5></td>
+                    </tr>
+                    <tr>
+                        <td>0</td>
+                        <td>3 advancement points</td>
+                        <td>
+                            <div class="sheet-xp-level">
+                                <input class="sheet-input-center-aligned" type="text" value="" name="attr_ap_1" style="width:100%" /><br>
+                                <input class="sheet-input-center-aligned" type="text" value="" name="attr_ap_2" style="width:100%" /><br>
+                                <input class="sheet-input-center-aligned" type="text" value="" name="attr_ap_2" style="width:100%" />
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><br></td>
                     </tr>
                     <tr>
                         <td>2</td>
@@ -4372,11 +5593,11 @@
             <!-- Veteran -->
             <h4>Veteran Level</h4>
             <div class="body">
-                <table style="width:75%">
+                <table style="width:750px">
                     <tr>
-                        <td><h5>XP Total</h5></td>
-                        <td><h5>Character Advancement</h5></td>
-                        <td><h5>Spent On</h5></td>
+                        <td style="width:50px"><h5>XP Total</h5></td>
+                        <td style="width:400px"><h5>Character Advancement</h5></td>
+                        <td style="width:300px"><h5>Spent On</h5></td>
                     </tr>
                     <tr>
                         <td>50</td>
@@ -4438,11 +5659,11 @@
             <!-- Epic -->
             <h4>Epic Level</h4>
             <div class="body">
-                <table style="width:75%">
-                        <tr>
-                        <td><h5>XP Total</h5></td>
-                        <td><h5>Character Advancement</h5></td>
-                        <td><h5>Spent On</h5></td>
+                <table style="width:750px">
+                    <tr>
+                        <td style="width:50px"><h5>XP Total</h5></td>
+                        <td style="width:400px"><h5>Character Advancement</h5></td>
+                        <td style="width:300px"><h5>Spent On</h5></td>
                     </tr>
                     <tr>
                         <td>100</td>
@@ -4615,6 +5836,9 @@
         <div class='sheet-col'>
             <table class="sheet-grid">
                 <tr>
+                    <th colspan="8"><input type="checkbox" class="sheet-reset" name="attr_damage_reset" value="1"/><span></span></th>
+                </tr>
+                <tr>
                     <th colspan="8"><h4>Damage Grid</h4></th>
                 </tr>
                 <tr>
@@ -4681,9 +5905,9 @@
                     </td>
                     <td>
                         <div class="sheet-jackbox">
-                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightrm1" value="0" checked="checked"/>
-                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightrm1" value="1" />
-                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightrm1" value="2" />
+                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightarm1" value="0" checked="checked"/>
+                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightarm1" value="1" />
+                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightarm1" value="2" />
                             <span class="sheet-jackbox sheet-blackbox"></span>
                             <span class="sheet-jackbox sheet-whitebox"></span>
                             <span class="sheet-jackbox sheet-redbox"></span>
@@ -4745,9 +5969,9 @@
                     </td>
                     <td>
                         <div class="sheet-jackbox">
-                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightrm2" value="0" checked="checked"/>
-                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightrm2" value="1" />
-                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightrm2" value="2" />
+                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightarm2" value="0" checked="checked"/>
+                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightarm2" value="1" />
+                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightarm2" value="2" />
                             <span class="sheet-jackbox sheet-blackbox"></span>
                             <span class="sheet-jackbox sheet-whitebox"></span>
                             <span class="sheet-jackbox sheet-redbox"></span>
@@ -4809,9 +6033,9 @@
                     </td>
                     <td>
                         <div class="sheet-jackbox">
-                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightrm3" value="0" checked="checked"/>
-                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightrm3" value="1" />
-                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightrm3" value="2" />
+                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightarm3" value="0" checked="checked"/>
+                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_righatrm3" value="1" />
+                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightarm3" value="2" />
                             <span class="sheet-jackbox sheet-blackbox"></span>
                             <span class="sheet-jackbox sheet-whitebox"></span>
                             <span class="sheet-jackbox sheet-redbox"></span>
@@ -4873,9 +6097,9 @@
                     </td>
                     <td>
                         <div class="sheet-jackbox">
-                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightrm4" value="0" checked="checked"/>
-                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightrm4" value="1" />
-                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightrm4" value="2" />
+                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightarm4" value="0" checked="checked"/>
+                        <input type="radio" class="sheet-jackbox sheet-whitebox" name="attr_jackbox_rightarm4" value="1" />
+                        <input type="radio" class="sheet-jackbox sheet-redbox" name="attr_jackbox_rightarm4" value="2" />
                             <span class="sheet-jackbox sheet-blackbox"></span>
                             <span class="sheet-jackbox sheet-whitebox"></span>
                             <span class="sheet-jackbox sheet-redbox"></span>
@@ -4937,9 +6161,9 @@
                     </td>
                     <td>
                         <div class="sheet-jackbox">
-                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightrm5" value="0" checked="checked"/>
-                        <input type="radio" class="sheet-jackbox sheet-whiteboxl" name="attr_jackbox_rightrm5" value="1" />
-                        <input type="radio" class="sheet-jackbox sheet-redboxl" name="attr_jackbox_rightrm5" value="2" />
+                        <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_rightarm5" value="0" checked="checked"/>
+                        <input type="radio" class="sheet-jackbox sheet-whiteboxl" name="attr_jackbox_rightarm5" value="1" />
+                        <input type="radio" class="sheet-jackbox sheet-redboxl" name="attr_jackbox_rightarm5" value="2" />
                             <span class="sheet-jackbox sheet-blackbox"></span>
                             <span class="sheet-jackbox sheet-whiteboxl"></span>
                             <span class="sheet-jackbox sheet-redboxl"></span>
@@ -4949,9 +6173,7 @@
                 </tr>
                 <tr>
                     <td></td>
-                    <td>
-                        
-                    </td>
+                    <td></td>
                     <td>
                         <div class="sheet-jackbox">
                         <input type="radio" class="sheet-jackbox sheet-blackbox" name="attr_jackbox_leftside6" value="0" checked="checked"/>
@@ -5012,14 +6234,14 @@
             <h4>'jack Stat Block</h4>
                 <table class="sheet-grid" style="width:70%">
                     <tr>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_phy}]] for Physique' ><div class="sheet-center">Phy</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_str}]] for Strength' ><div class="sheet-center">Str</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_spd}]] for Speed' ><div class="sheet-center">Spd</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_agl}]] for Agility'><div class="sheet-center">Agl</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_prw}]] for Prowess' ><div class="sheet-center">Prw</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_poi}]] for Poise' ><div class="sheet-center">Poi</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_int}]] for Intelect' ><div class="sheet-center">Int</div></button></div></td>
-                        <td><div class = "sheet-stats-button"><button type='roll' value='/em @{jack_name} rolls [[2d6 +@{jack_per}]] for Perception' ><div class="sheet-center">Per</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_phy}]] for Physique' ><div class="sheet-center">Phy</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_str}]] for Strength' ><div class="sheet-center">Str</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_spd}]] for Speed' ><div class="sheet-center">Spd</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_agl}]] for Agility'><div class="sheet-center">Agl</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_prw}]] for Prowess' ><div class="sheet-center">Prw</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_poi}]] for Poise' ><div class="sheet-center">Poi</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_int}]] for Intelect' ><div class="sheet-center">Int</div></button></div></td>
+                        <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" value='/em @{jack_name} rolls [[2d6 +@{jack_per}]] for Perception' ><div class="sheet-center">Per</div></button></div></td>
                     </tr>
                     <tr>
                         <th><div class="sheet-skill-base"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_jack_phy"/></div></th>
@@ -5035,9 +6257,9 @@
                 <table class="sheet-grid" style="width:70%">
                     <tr>
                         <td></td>
-                        <td><div class= "sheet-jack-button"><button type='roll' name="jack_initiative_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_initiative} &{tracker}]] for initiative'>Initiative</button></div></td>
-                        <td><div class= "sheet-jack-button"><button type='roll' name="jack_mat_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_mat}]] for Melee Attack Total' >MAT</button></div></td>
-                        <td><div class= "sheet-jack-button"><button type='roll' name="jack_rat_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_rat}]] for Ranged Attack Total' >RAT</button></div></td>
+                        <td><div class= "sheet-jack-button"><button type='roll' class="sheet-btn" name="jack_initiative_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_initiative} &{tracker}]] for initiative'>Initiative</button></div></td>
+                        <td><div class= "sheet-jack-button"><button type='roll' class="sheet-btn" name="jack_mat_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_mat}]] for Melee Attack Total' >MAT</button></div></td>
+                        <td><div class= "sheet-jack-button"><button type='roll' class="sheet-btn" name="jack_rat_roll" value='/em @{jack_name} rolls [[2d6 + @{jack_rat}]] for Ranged Attack Total' >RAT</button></div></td>
                         <td><h5>DEF</h5></td>
                         <td><h5>ARM</h5></td>
                         <td><h5>Movement</h5></td>
@@ -5062,7 +6284,7 @@
                     </tr>
                     <tr>
                         <td>Total</td>
-                        <td><div class="sheet-skill-base"><input type="number" class="sheet-input-center-aligned" name="attr_jack_initiative" value='@{jack_initiative_base} + @{jack_initiative_mod}' disabled="true" /></div></td>
+                        <td><div class="sheet-skill-base"><input type="number" class="sheet-input-center-aligned" name="attr_jack_initiative" value='0' /></div></td>
                         <td><div class="sheet-skill-base"><input type="number" class="sheet-input-center-aligned" name="attr_jack_mat" value='@{jack_mat_base} + @{jack_mat_mod}' disabled="true" /></div></td>
                         <td><div class="sheet-skill-base"><input type="number" class="sheet-input-center-aligned" name="attr_jack_rat" value='@{jack_rat_base} + @{jack_rat_mod}' disabled="true" /></div></td>
                         <td><div class="sheet-skill-base"><input type="number" class="sheet-input-center-aligned" name="attr_jack_def" value='@{jack_def_base} + @{jack_def_mod}' disabled="true" /></div></td>
@@ -5101,7 +6323,7 @@
                             <td><button type='roll' class="sheet-skill_button" name="attr_jackmelee_wpn_roll" value='&{template:jackmelee}  {{character= @{jack_name} }} {{weapon= @{jackmelee_wpn_name} }} {{strength= [[@{jack_str}]] }} {{POW= [[@{jackmelee_pow} + @{jackmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{jackmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{jackmelee_wpn_damage_total}]] }} {{notes= @{jack_melee_text} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' /></td>
                             <td><button type='roll' class="sheet-skill_button" name="attr_jackmelee_tgt" value='&{template:jackmelee}  {{character= @{jack_name} }} {{weapon= @{jackmelee_wpn_name} }} {{strength= [[@{jack_str}]] }} {{POW= [[@{jackmelee_pow} + @{jackmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{jackmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{jackmelee_wpn_damage_total}]] }} {{notes= @{jack_melee_text}}} {{target-token_name= at @{target|token_name} }}  {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' /></td>                           
                             <td><input type="text" class="sheet-input-center-aligned" value="" name="attr_jackmelee_wpn_name"/></td>
-                            <td><input type="checkbox" name="attr_jackmelee-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_jackmelee-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_jackmelee-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -5150,7 +6372,7 @@
                             <td><button type='roll' class="sheet-skill_button" name="attr_jackranged_wpn_roll" value='&{template:jackrange}  {{character= @{jack_name} }} {{weapon= @{jackranged_wpn_name} }} {{range= @{jackranged_effectiverange} }} {{extreme-range= @{jackranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{jackranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{jackranged_damage_total}]] ]] }} {{notes= @{jack_ranged_text} }} {{aoe= @{jackranged_aoe} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' /></td>
                             <td><button type='roll' class="sheet-skill_button" name="attr_jackranged_wpn_roll-tgt" value='&{template:jackrange}  {{character= @{jack_name} }} {{weapon= @{jackranged_wpn_name} }} {{range= @{jackranged_effectiverange} }} {{extreme-range= @{jackranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{jackranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{jackranged_damage_total}]] ]] }} {{notes= @{jack_ranged_text} }} {{aoe= @{jackranged_aoe} }}  {{target-token_name= at @{target|token_name} }} {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }}  {{location= [[ @{hit-loc} ]]}}' /></td>
                             <td><input class="sheet-input-center-aligned" type="text" value="" name="attr_jackranged_wpn_name"/></td>
-                            <td><input type="checkbox" name="attr_jackranged-toggle" class="sheet-gear" value="1"/><span></span></td>
+                            <td><input type="checkbox" name="attr_jackranged-toggle" class="sheet-gear sheet-hider" value="1"/><span></span></td>
                         </tr>
                     </table>
                     <input type="checkbox" name="attr_jackranged-toggle" class="sheet-hidden sheet-hider" value="1"/><span></span>
@@ -5246,12 +6468,13 @@
         <h4>NPC Stat Block</h4>
             <table style="width:70%">
                 <tr>
-                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-skill_button" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_spd}]] for Speed'>Spd</button></div></td>
-                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-skill_button" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_str}]] for Strength'>Str</button></div></td>
-                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-skill_button" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_mat}]] for Melee Attack '>MAT</button></div></td>
-                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-skill_button" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_rat}]] for Ranged Attack'>RAT</button></div></td>
+                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" class="sheet-btn" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_spd}]] for Speed'>Spd</button></div></td>
+                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" class="sheet-btn" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_str}]] for Strength'>Str</button></div></td>
+                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" class="sheet-btn" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_mat}]] for Melee Attack '>MAT</button></div></td>
+                    <td><div class = "sheet-stats-button"><button type='roll' class="sheet-btn" class="sheet-btn" style="width:45px;" value='/em @{npc_name} rolls [[2d6 +@{npc_rat}]] for Ranged Attack'>RAT</button></div></td>
                     <td><h5>DEF</h5></td>
                     <td><h5>ARM</h5></td>
+                    <td>Shield</td>
                 </tr>
                 <tr>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_spd_base"/></div></td>
@@ -5260,6 +6483,7 @@
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_rat_base"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_def_base"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_arm_base"/></div></td>
+                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_shield_base"/></div></td>
                 </tr>
                 <tr>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_spd_mod"/></div></td>
@@ -5268,26 +6492,23 @@
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_rat_mod"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_def_mod"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_arm_mod"/></div></td>
+                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_shield_mod"/></div></td>
                 </tr>
                 <tr>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_spd" value='@{npc_spd_base} + @{npc_spd_mod}' disabled="true" /></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_spd" value='0' readonly/></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_str" value='@{npc_str_base} + @{npc_str_mod}' disabled="true" /></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_mat" value='@{npc_mat_base} + @{npc_mat_mod}' disabled="true" /></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_rat" value='@{npc_rat_base} + @{npc_rat_mod}' disabled="true" /></td>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_def" value='@{npc_def_base} + @{npc_def_mod}' disabled="true" /></td>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_arm" value='@{npc_arm_base} + @{npc_arm_mod} + @{npchasshield}' disabled="true" /></td>
-                </tr>
-                <tr>
-                    <th colspan="4"></th>
-                    <td>Shield?</td>
-                    <td><input type='checkbox' value="2" name="attr_npchasshield" class="sheet-bigcheck"/><span></span></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_def" value='0' readonly/></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_arm" value='0' /></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_shield" value='0' /></td>
                 </tr>
                 <tr>
                     <td></td>
-                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-skill_button" style="width:70px;" name="npc_willpower_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_willpower}]] for willpower'>Willpower</button></div></td>
-                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-skill_button" style="width:70px;" name="npc_initiative_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_initiative} &{tracker}]] for initiative'>Initiative</button></div></td>
-                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-skill_button" style="width:45px;" name="npc_detect_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_detect}]] for detect'>Detect</button></div></td>
-                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-skill_button" style="width:45px;" name="npc_sneak_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_sneak}]] for sneak'>Sneak</button></div></td>
+                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-btn" class="sheet-skill_button" style="width:70px;" name="npc_willpower_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_willpower}]] for willpower'>Willpower</button></div></td>
+                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-btn" class="sheet-skill_button" style="width:70px;" name="npc_initiative_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_initiative} &{tracker}]] for initiative'>Initiative</button></div></td>
+                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-btn" class="sheet-skill_button" style="width:45px;" name="npc_detect_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_detect}]] for detect'>Detect</button></div></td>
+                    <td><div class= "sheet-npc-button"><button type='roll' class="sheet-btn" class="sheet-skill_button" style="width:45px;" name="npc_sneak_roll" value='/em @{npc_name} rolls [[2d6 + @{npc_sneak}]] for sneak'>Sneak</button></div></td>
                     <td><h5>Movement</h5></td>
                     <td><h5>Vitality</h5></td>
                 </tr>
@@ -5296,8 +6517,8 @@
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_willpower_base"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_initiative_base"/></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_detect_base"/></div></td>
-                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_sneak_base"/></div></td> 
-                    <td></td>
+                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_sneak_base"/></div></td>
+                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_movement_mod" /></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_vitality"/></div></td>
                 </tr>
                 <tr>
@@ -5306,18 +6527,14 @@
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_initiative_mod" /></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_detect_mod" /></div></td>
                     <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_sneak_mod" /></div></td>
-                    <td><div class="sheet-stats-npc"><input class="sheet-input-center-aligned" type="number" value="0" name="attr_npc_movement_mod" /></div></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_movement" value='@{npc_spd} + @{npc_movement_mod}' disabled="true" /></td>
                 </tr>
                 <tr>
                     <td>Total</td>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_willpower"  value='@{npc_willpower_base} + @{npc_willpower_mod}'    disabled="true" /></td>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_initiative" value='@{npc_initiative_base} + @{npc_initiative_mod}'  disabled="true" /></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_willpower" value='0' readonly /></td>
+                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_initiative" value='0' readonly /></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_detect"     value='@{npc_detect_base} + @{npc_detect_mod}'          disabled="true" /></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_sneak"      value='@{npc_sneak_base} + @{npc_sneak_mod}'            disabled="true" /></td>
-                    <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_movement"   value='@{npc_spd} + @{npc_movement_mod}'                disabled="true" /></td>
-                </tr>
-                <tr>
-                    <td colspan="5"></td>
                     <td><input type="number" class="sheet-input-center-aligned" name="attr_npc_movement_feet" value="(@{npc_movement})*6" disabled="true" />feet</td>
                 </tr>
                 <tr>
@@ -5326,9 +6543,7 @@
             </table>
         </div>
     </div>
-    <!-- NPC Attacks -->
     <h4>NPC Attacks</h4>
-    <!-- Melee Attacks -->
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_npcmelee-toggle" class="sheet-arrow" /><span></span>
@@ -5347,8 +6562,8 @@
                             <td><h5>Damage Modifier</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcmelee_wpn_roll" value='&{template:npcmelee}  {{character= @{npc_name} }} {{weapon= @{npcmelee_wpn_name} }} {{strength= [[@{npc_str}]] }} {{POW= [[@{npcmelee_pow} + @{npcmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{npcmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{npcmelee_wpn_damage_total}]] }} {{notes= @{npc_melee_text} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' /></td>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcmelee_tgt" value='&{template:npcmelee}  {{character= @{npc_name} }} {{weapon= @{npcmelee_wpn_name} }} {{strength= [[@{npc_str}]] }} {{POW= [[@{npcmelee_pow} + @{npcmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{npcmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{npcmelee_wpn_damage_total}]] }} {{notes= @{npc_melee_text}}} {{target-token_name= at @{target|token_name} }}  {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' /></td>                           
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcmelee_wpn_roll" value='&{template:npcmelee}  {{character= @{npc_name} }} {{weapon= @{npcmelee_wpn_name} }} {{strength= [[@{npc_str}]] }} {{POW= [[@{npcmelee_pow} + @{npcmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{npcmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{npcmelee_wpn_damage_total}]] }} {{notes= @{npc_melee_text} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence }} {{target-armor= Armor }}' /></td>
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcmelee_tgt" value='&{template:npcmelee}  {{character= @{npc_name} }} {{weapon= @{npcmelee_wpn_name} }} {{strength= [[@{npc_str}]] }} {{POW= [[@{npcmelee_pow} + @{npcmelee_pow_mod}]] }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + @{npcmelee_mat_total}]] }} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + @{npcmelee_wpn_damage_total}]] }} {{notes= @{npc_melee_text}}} {{target-token_name= at @{target|token_name} }}  {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }} {{location= [[ @{hit-loc} ]]}}' /></td>                           
                             <td><input class="sheet-input-center-aligned" type="text" value="" name="attr_npcmelee_wpn_name"/></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcmelee_mat_total" value="@{npc_mat} + @{npcmelee_att_mod}" disabled="true" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcmelee_att_mod" value="0" /></td>
@@ -5364,7 +6579,6 @@
             </div>
         </div>
     </div>
-    <!-- Ranged Attacks -->
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
             <input type="checkbox" name="attr_npcranged-toggle" class="sheet-arrow" /><span></span>
@@ -5387,8 +6601,8 @@
                             <td><h5>Area of<br>Effect</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcranged_wpn_roll" value='&{template:npcrange}  {{character= @{npc_name} }} {{weapon= @{npcranged_wpn_name} }} {{range= @{npcranged_effectiverange} }} {{extreme-range= @{npcranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{npcranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{npcranged_damage_total}]] ]] }} {{notes= @{npc_ranged_text} }} {{aoe= @{npcranged_aoe} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' /></td>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcranged_wpn_roll-tgt" value='&{template:npcrange}  {{character= @{npc_name} }} {{weapon= @{npcranged_wpn_name} }} {{range= @{npcranged_effectiverange} }} {{extreme-range= @{npcranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{npcranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{npcranged_damage_total}]] ]] }} {{notes= @{npc_ranged_text} }} {{aoe= @{npcranged_aoe} }}  {{target-token_name= at @{target|token_name} }} {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }}  {{location= [[ @{hit-loc} ]]}}' /></td>
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcranged_wpn_roll" value='&{template:npcrange}  {{character= @{npc_name} }} {{weapon= @{npcranged_wpn_name} }} {{range= @{npcranged_effectiverange} }} {{extreme-range= @{npcranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{npcranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{npcranged_damage_total}]] ]] }} {{notes= @{npc_ranged_text} }} {{aoe= @{npcranged_aoe} }} {{location= [[ @{hit-loc} ]]}} {{target-def= Defence}}{{target-armor= Armor}}' /></td>
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcranged_wpn_roll-tgt" value='&{template:npcrange}  {{character= @{npc_name} }} {{weapon= @{npcranged_wpn_name} }} {{range= @{npcranged_effectiverange} }} {{extreme-range= @{npcranged_extremerange} }} {{attack= [[2d6 + ?{Extra Attack Dice|0}d6 + [[@{npcranged_rat_total}]] ]]}} {{damage= [[2d6 + ?{Extra Damage Dice|0}d6 + [[@{npcranged_damage_total}]] ]] }} {{notes= @{npc_ranged_text} }} {{aoe= @{npcranged_aoe} }}  {{target-token_name= at @{target|token_name} }} {{target-def= [[ [[@{target|def}]] ]]}} {{target-armor= [[ [[@{target|arm}]] ]] }}  {{location= [[ @{hit-loc} ]]}}' /></td>
                             <td><input type="text" class="sheet-input-center-aligned" value="" name="attr_npcranged_wpn_name"/></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcranged_ammo" value="0" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcranged_effectiverange" value="0" /></td>
@@ -5416,7 +6630,6 @@
             </div>
         </div>
     </div>
-    <!-- Special -->
     <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
         <input type="checkbox" name="attr_spells-toggle" class="sheet-arrow" /><span></span>
@@ -5439,8 +6652,8 @@
                             <td><h5>Off?</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcpower_roll" value='/em @{npc_name} attacks with @{npcpower_name}. [[2d6 + @{npcpower_att_total}]] to hit and dealing [[2d6 + @{npcpower_effect_total}]] points of damage.' /></td>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcpower_tgt" value='/em @{npc_name} attacks with @{npcpower_name} at @{target|token_name}! Attack roll beats the defense by [[2d6 + @{npcpower_att_total} + ?{Extra Attack Dice|0}d6 -@{target|def}]] and deals [[2d6 + @{npcpower_effect_total} + ?{Extra Damag Dice|0}d6 - @{target|arm}]] points of damage!' /></td>
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcpower_roll" value='/em @{npc_name} attacks with @{npcpower_name}. [[2d6 + @{npcpower_att_total}]] to hit and dealing [[2d6 + @{npcpower_effect_total}]] points of damage.' /></td>
+                            <td><button type='roll' class="sheet-skill_button" class="sheet-skill_button" name="attr_npcpower_tgt" value='/em @{npc_name} attacks with @{npcpower_name} at @{target|token_name}! Attack roll beats the defense by [[2d6 + @{npcpower_att_total} + ?{Extra Attack Dice|0}d6 -@{target|def}]] and deals [[2d6 + @{npcpower_effect_total} + ?{Extra Damag Dice|0}d6 - @{target|arm}]] points of damage!' /></td>
                             <td><input type="text" class="sheet-input-center-aligned" value="" name="attr_npcpower_name" placeholder="Ability Name" style="width:100px" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcpower_att" value="0" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcpower_att_mod" value="0" /></td>
@@ -5502,9 +6715,9 @@
                             <td><h5>Modifier</h5></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-skill_button" name="attr_npcskill_roll" value='/em @{npc_name} uses the @{npcskill_name}! [[2d6 + @{npcskill_total} + ?{Extra Dice|0}d6]]' /></td>
+                            <td><button type='roll' class="sheet-btn" class="sheet-skill_button" name="attr_npcskill_roll" value='/em @{npc_name} uses the @{npcskill_name}! [[2d6 + @{npcskill_total} + ?{Extra Attack Dice|0}d6]]' /></td>
                             <td><input type="text" class="sheet-input-center-aligned" value="" name="attr_npcskill_name" /></td>
-                            <td><input type="number" class="sheet-input-center-aligned" name="attr_npcskill_total" value="@{npcskill_stat_value} + @{npcskill} + @{npcskill_mod}" disabled="true" /></td>
+                            <td><input type="number" class="sheet-input-center-aligned" name="attr_npcskill_total" value="@{npcskill_stat} + @{npcskill} + @{npcskill_mod}" disabled="true" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcskill_stat_value" value="0" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcskill" value="0" /></td>
                             <td><input type="number" class="sheet-input-center-aligned" name="attr_npcskill_mod" value="0" /></td>
@@ -5516,280 +6729,753 @@
     </div>
 </div>
 
-
+<!-- Roll Templates -->
 <div class="sheet-hidden">
 
-<rolltemplate class="sheet-rolltemplate-melee">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Strength</b>{{strength}}</td></tr>
-        <tr><td><b>POW</b>{{POW}}</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-    	{{#damage}}
-    		<tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+    <rolltemplate class="sheet-rolltemplate-melee">
+		<table>
+			<tr>
+                <th colspan="3">{{weapon}}</th>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-weapon">
-    <table>
-    	<tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}} feet</td></tr>
-        <tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
-		</tr>
-    	<tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-boom">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}} feet</td></tr>
-        <tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
-        <tr>
-			<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
-		</tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-		{{#damage}}
-            <tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+			<tr>
+                <td colspan="3"><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
+			<tr>
+                <td></td>
+                <td><b>Strength</b></td>
+                <td><b>POW</b></td>
+			</tr>
+			<tr>
+                <td></td>
+                <td>{{strength}}</td>
+                <td>{{POW}}</td>
+            </tr>
+			<tr>
+                <td colspan="3"><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td>
+            </tr>
+			{{#damage}}
+				<tr>
+					<td colspan="3"><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
 
-<rolltemplate class="sheet-rolltemplate-spell">
-    <table>
-        <tr><th>{{spell}}</th></tr>
-        <tr><td><i><b>{{character}}</b> casts {{spell}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Cost</b>{{cost}}</td></tr>
-        <tr><td><b>Range</b>{{range}}</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-		{{#damage}}
+	<rolltemplate class="sheet-rolltemplate-weapon">
+		<table>
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr><td><b>Range</b>{{range}} feet</td></tr>
+			<tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
+			<tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
 			<tr>
 				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
 			</tr>
-        <tr>
-            <td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
-		</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Effect:</b> </span>{{notes}}</td>
-		</tr>
-    </table>
-</rolltemplate>
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
 
-<rolltemplate class="sheet-rolltemplate-fellcall">
-    <table class="sheet-round_border">
-        <tr><th>{{fellcall}}</th></tr>
-        <tr><td><i><b>{{character}}</b> croaks out {{fellcall}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}}</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-        {{#damage}}
+	<rolltemplate class="sheet-rolltemplate-boom">
+		<table>
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr><td><b>Range</b>{{range}} feet</td></tr>
+			<tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
+			</tr>
+			<tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-spell">
+		<table>
+			<tr><th>{{spell}}</th></tr>
+			<tr><td><i><b>{{character}}</b> casts {{spell}} {{target-token_name}}</i></td></tr>
+			{{#cost}}
+			<tr><td><b>Cost</b>{{cost}}</td></tr>
+			{{/cost}}
+			{{#range}}
+			<tr><td><b>Range</b>{{range}}</td></tr>
+			{{/range}}
+			{{#offensive}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Attack:</b> </span>{{offensive}} vs. {{target-def}}</td>
+			</tr>
+            {{/offensive}}
+			{{#damage}}
 			<tr>
 				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Effect:</b> </span>{{notes}}</td>
-		</tr>
-    </table>
-</rolltemplate>
+            {{/damage}}
+            {{#location}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+            {{/location}}
+			{{#aoe}}
+			<tr>
+				<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
+			</tr>
+			{{/aoe}}
+			{{#upkeep}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Upkeep:</b> </span><i>{{upkeep}}</i></td>
+			</tr>
+			{{/upkeep}}
+			{{#notes}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Effect:</b> </span>{{notes}}</td>
+			</tr>
+			{{/notes}}
+		</table>
+        {{fx}}
+	</rolltemplate>
 
-<rolltemplate class="sheet-rolltemplate-runeshot">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}} feet</td></tr>
-        <tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-        {{#damage}}
-        	<tr>
+	<rolltemplate class="sheet-rolltemplate-fellcall">
+		<table class="sheet-round_border">
+			<tr><th>{{fellcall}}</th></tr>
+			<tr>
+				<td><i><b>{{character}}</b> croaks out {{fellcall}} {{target-token_name}}</i></td>
+			</tr>
+			{{#range}}
+			<tr><td><b>Range</b>{{range}}</td></tr>
+			{{/range}}
+			{{#attack}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td>
+			</tr>
+			{{#damage}}
+			<tr>
 				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><b>Location:</b><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><b>Notes:</b><i style="font-size:0.9em">{{notes}}</i></td>
-		</tr>
-        <tr>
-            <td><b>Effects:</b><div style="font-size:0.9em"><i><p style="font-size:0.9em">{{Black_Penny}}<p style="font-size:0.9em">{{Detonator}}<p style="font-size:0.9em">{{Earth_Shaker}}<p style="font-size:0.9em">{{Fire_Beacon}}<p style="font-size:0.9em">{{Freeze_Fire}}<p style="font-size:0.9em">{{Heart_Stopper}}<p style="font-size:0.9em">{{Iron_Rot}}<p style="font-size:0.9em">{{Molten_Shot}}<p style="font-size:0.9em">{{Momentum}}<p style="font-size:0.9em">{{Phantom_Seeker}}<p style="font-size:0.9em">{{Shadow_Fire}}<p style="font-size:0.9em">{{Silencer}}<p style="font-size:0.9em">{{Spell_Cracker}}<p style="font-size:0.9em">{{Spontaneous_Combustion}}<p style="font-size:0.9em">{{Thunderbolt}}<p style="font-size:0.9em">{{Trick_Shot}}</i></div></td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-ability">
-    <table class="sheet-round_border">
-        <tr><th>{{Ability}}</th></tr>
-        <tr><td><i><b>{{Name}}</b> uses/has {{Ability}}</i></td></tr>
-			<td><span class="sheet-tcat"><b>Effect:</b> </span>{{Text}}</td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-npc">
-    <table class="sheet-round_border">
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{name}}</b> attacks with {{weapon}} {{target}}</i></td></tr>
-    		<td><span class="sheet-tcat"><b>Effect:</b> </span>{{Text}}</td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-jackmelee">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Strength</b>{{strength}}</td></tr>
-        <tr><td><b>POW</b>{{POW}}</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-        {{#damage}}
-    		<tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+			{{#location}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
+			{{/location}}
+			{{/damage}}
+			{{/attack}}
+			{{#aoe}}
+			<tr>
+				<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
+			</tr>
+			{{/aoe}}
+			{{#notes}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Effect:</b> </span>{{notes}}</td>
+			</tr>
+			{{/notes}}
+		</table>
+	</rolltemplate>
 
-<rolltemplate class="sheet-rolltemplate-jackrange">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}} feet</td></tr>
-        <tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
-        <tr>
-    		<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
-		</tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-		{{#damage}}
+	<rolltemplate class="sheet-rolltemplate-runeshot">
+		<table>
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr><td><b>Range</b>{{range}} feet</td></tr>
+			<tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
+			<tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td><b>Location:</b><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td><b>Notes:</b><i style="font-size:0.9em">{{notes}}</i></td>
+			</tr>
+			<tr>
+				<td><b>Effects:</b><div style="font-size:0.9em"><i><p style="font-size:0.9em">{{Black_Penny}}<p style="font-size:0.9em">{{Detonator}}<p style="font-size:0.9em">{{Earth_Shaker}}<p style="font-size:0.9em">{{Fire_Beacon}}<p style="font-size:0.9em">{{Freeze_Fire}}<p style="font-size:0.9em">{{Heart_Stopper}}<p style="font-size:0.9em">{{Iron_Rot}}<p style="font-size:0.9em">{{Molten_Shot}}<p style="font-size:0.9em">{{Momentum}}<p style="font-size:0.9em">{{Phantom_Seeker}}<p style="font-size:0.9em">{{Shadow_Fire}}<p style="font-size:0.9em">{{Silencer}}<p style="font-size:0.9em">{{Spell_Cracker}}<p style="font-size:0.9em">{{Spontaneous_Combustion}}<p style="font-size:0.9em">{{Thunderbolt}}<p style="font-size:0.9em">{{Trick_Shot}}</i></div></td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-ability">
+		<table class="sheet-round_border">
+			<tr><th>{{Ability}}</th></tr>
+			<tr><td><i><b>{{Name}}</b> uses/has {{Ability}}</i></td></tr>
+				<td><span class="sheet-tcat"><b>Effect:</b> </span>{{Text}}</td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+    <rolltemplate class="sheet-rolltemplate-skill">
+		<table>
+			<tr>
+                <td>
+                    <div class="sheet-skill_number">{{Roll}}</div><i>{{Text}}</i>
+                </td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-npc">
+		<table class="sheet-round_border">
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{name}}</b> attacks with {{weapon}} {{target}}</i></td></tr>
+				<td><span class="sheet-tcat"><b>Effect:</b> </span>{{Text}}</td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-jackmelee">
+		<table>
+			<tr><th colspan="3">{{weapon}}</th></tr>
+			<tr><td colspan="3"><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr>
+                <td></td> 
+                <td><b>Strength</b></td>
+                <td><b>POW</b></td>
+            </tr>
+			<tr>
+                <td></td> 
+                <td>{{strength}}</td> 
+                <td>{{POW}}</td>    		    
+			</tr>
+			<tr><td colspan="3"><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td colspan="3"><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-jackrange">
+		<table>
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr><td><b>Range</b>{{range}} feet</td></tr>
+			<tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
+			</tr>
+			<tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
+
+	<rolltemplate class="sheet-rolltemplate-npcmelee">
+		<table>
+			<tr><th colspan="3">{{weapon}}</th></tr>
+			<tr><td colspan="3"><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
             <tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+                <td><div style="width:10px;"></div></td> 
+                <td><b>Strength</b></td>
+                <td><b>POW</b></td>
+            </tr>
+			<tr>
+                <td></td> 
+                <td>{{strength}}</td> 
+                <td>{{POW}}</td>    		    
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-npcmelee">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Strength</b>{{strength}}</td></tr>
-        <tr><td><b>POW</b>{{POW}}</td></tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-        {{#damage}}
-        	<tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+			<tr><td colspan="3"><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td colspan="3"><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-npcrange">
-    <table>
-        <tr><th>{{weapon}}</th></tr>
-        <tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
-        <tr><td><b>Range</b>{{range}} feet</td></tr>
-        <tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
-        <tr>
-    		<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
-		</tr>
-        <tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
-		{{#damage}}
-            <tr>
-				<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+			<tr>
+				<td colspan="3"><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
 			</tr>
-		{{/damage}}
-        <tr>
-			<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
-		</tr>
-		<tr>
-			<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
-		</tr>
-    </table>
-</rolltemplate>
+		</table>
+	</rolltemplate>
 
-<rolltemplate class="sheet-rolltemplate-fury">
-    <table class="sheet-round_border">
-        {{#fatigue}}        
-        <tr>
-            <th colspan="2" class="sheet-background"><i><b>{{name}}</b> fights off fatigue</i></th>
-        </tr>
-        <tr>
-            <th>Roll</th>
-            <th>Meet or Exceed</th>
-    	</tr>
-        <tr>
-        	<th><span class="sheet-tcat">{{roll}}</span></th>
-            <th><span class="sheet-tcat">{{fatigue}}</span></th>
-		</tr>
-        {{/fatigue}}
-        {{#threshold}}   
-        <tr>
-            <th colspan="2" class="sheet-background"><i><b>{{name}}</b> struggles for control</i></th>
-        </tr>
-        <tr>
-            <th>Roll</th>
-            <th>Meet or Below</th>
-    	</tr>
-        <tr>
-        	<th><span class="sheet-tcat">{{roll}}</span></th>
-            <th><span class="sheet-tcat">{{threshold}}</span></th>
-		</tr>
-        {{/threshold}}
-    </table>
-</rolltemplate>
+	<rolltemplate class="sheet-rolltemplate-npcrange">
+		<table>
+			<tr><th>{{weapon}}</th></tr>
+			<tr><td><i><b>{{character}}</b> attacks with {{weapon}} {{target-token_name}}</i></td></tr>
+			<tr><td><b>Range</b>{{range}} feet</td></tr>
+			<tr><td><b>Extreme Range</b>{{extreme-range}} feet</td></tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>AoE:</b> </span>{{aoe}}</td>
+			</tr>
+			<tr><td><span class="sheet-tcat"><b>Attack:</b> </span>{{attack}} vs. {{target-def}}</td></tr>
+			{{#damage}}
+				<tr>
+					<td><span class="sheet-tcat"><b>Damage:</b> </span>{{damage}} vs. {{target-armor}}</td>
+				</tr>
+			{{/damage}}
+			<tr>
+				<td><span class="sheet-tcat"><b>Location:</b> </span><i>{{location}}</i></td>
+			</tr>
+			<tr>
+				<td><span class="sheet-tcat"><b>Notes:</b> </span><i>{{notes}}</i></td>
+			</tr>
+		</table>
+	</rolltemplate>
 
-</div>    
+	<rolltemplate class="sheet-rolltemplate-fury">
+		<table class="sheet-round_border">
+			{{#fatigue}}        
+			<tr>
+				<th colspan="2" class="sheet-background"><i><b>{{name}}</b> fights off fatigue</i></th>
+			</tr>
+			<tr>
+				<th>Roll</th>
+				<th>Meet or Exceed</th>
+			</tr>
+			<tr>
+				<th><span class="sheet-tcat">{{roll}}</span></th>
+				<th><span class="sheet-tcat">{{fatigue}}</span></th>
+			</tr>
+			{{/fatigue}}
+			{{#threshold}}   
+			<tr>
+				<th colspan="2" class="sheet-background"><i><b>{{name}}</b> struggles for control</i></th>
+			</tr>
+			<tr>
+				<th>Roll</th>
+				<th>Meet or Below</th>
+			</tr>
+			<tr>
+				<th><span class="sheet-tcat">{{roll}}</span></th>
+				<th><span class="sheet-tcat">{{threshold}}</span></th>
+			</tr>
+			{{/threshold}}
+		</table>
+	</rolltemplate>
 
+</div>  
+
+<!-- Sheet Worker Scripts -->
+<script type="text/worker">
+// Basic Math
+    //Willpower
+on("change:physique change:intellect change:willpower_mod change:npc_willpower sheet:opened", function() {
+        getAttrs(["physique", "intellect", "willpower_mod", "npc_willpower"], function(values) {
+            setAttrs({
+                willpower: (+values.physique + +values.intellect + +values.willpower_mod + +values.npc_willpower)
+            });
+        });
+    });
+    //Physique
+on("change:physique_base change:physique_misc_mod sheet:opened", function() {
+        getAttrs(["physique_base", "physique_misc_mod"], function(values) {
+            setAttrs({
+                physique: (+values.physique_base + +values.physique_misc_mod)
+            });
+        });
+    });
+
+    //Intellect
+on("change:intellect_base change:intellect_misc_mod sheet:opened", function() {
+        getAttrs(["intellect_base", "intellect_misc_mod"], function(values) {
+            setAttrs({
+                intellect: (+values.intellect_base + +values.intellect_misc_mod)
+            });
+        });
+    });
+    
+    //Prowess
+on("change:prowess_base change:prowess_misc_mod sheet:opened", function() {
+        getAttrs(["prowess_base", "prowess_misc_mod"], function(values) {
+            setAttrs({
+                prowess: (+values.prowess_base + +values.prowess_misc_mod)
+            });
+        });
+    });
+    
+    //Perception
+on("change:perception_base change:perception_misc_mod sheet:opened", function() {
+        getAttrs(["perception_base", "perception_misc_mod"], function(values) {
+            setAttrs({
+                perception: (+values.perception_base + +values.perception_misc_mod)
+            });
+        });
+    });
+    
+    //Speed
+on("change:speed_base change:speed_misc_mod sheet:opened", function() {
+        getAttrs(["speed_base", "speed_misc_mod"], function(values) {
+            setAttrs({
+                speed: (+values.speed_base + +values.speed_misc_mod)
+            });
+        });
+    });
+
+    //npc_shield
+on("change:npc_shield_base change:npc_shield_mod sheet:opened", function() {
+        getAttrs(["npc_shield_base", "npc_shield_mod"], function(values) {
+            setAttrs({
+                npc_shield: (+values.npc_shield_base + +values.npc_shield_mod)
+            });
+        });
+    });
+
+    //npc_arm
+on("change:npc_arm_base change:npc_arm_mod change:npc_shield sheet:opened", function() {
+        getAttrs(["npc_arm_base", "npc_arm_mod", "npc_shield"], function(values) {
+            setAttrs({
+                npc_arm: (+values.npc_arm_base + +values.npc_arm_mod + +values.npc_shield)
+            });
+        });
+    });
+    
+    //npc_def
+on("change:npc_def_base change:npc_def_mod sheet:opened", function() {
+        getAttrs(["npc_def_base", "npc_def_mod"], function(values) {
+            setAttrs({
+                npc_def: (+values.npc_def_base + +values.npc_def_mod)
+            });
+        });
+    });
+    
+    //npc_spd
+on("change:npc_spd_base change:npc_spd_mod sheet:opened", function() {
+        getAttrs(["npc_spd_base", "npc_spd_mod"], function(values) {
+            setAttrs({
+                npc_spd: (+values.npc_spd_base + +values.npc_spd_mod)
+            });
+        });
+    });
+    
+    //npc_willpower
+on("change:npc_willpower_base change:npc_willpower_mod sheet:opened", function() {
+        getAttrs(["npc_willpower_base", "npc_willpower_mod"], function(values) {
+            setAttrs({
+                npc_willpower: (+values.npc_willpower_base + +values.npc_willpower_mod)
+            });
+        });
+    });
+    
+    //initiative
+on("change:speed change:prowess change:perception change:initiative_mod change:npc_initiative change:jack_initiative sheet:opened", function() {
+        getAttrs(["speed", "prowess", "perception", "initiative_mod", "npc_initiative", "jack_initiative"], function(values) {
+            setAttrs({
+                initiative: (+values.speed + +values.prowess + +values.perception + +values.initiative_mod + +values.npc_initiative + +values.jack_initiative)
+            });
+        });
+    });
+
+    //jack_initiative
+on("change:jack_initiative_base change:jack_initiative_mod sheet:opened", function() {
+        getAttrs(["jack_initiative_base", "jack_initiative_mod"], function(values) {
+            setAttrs({
+                jack_initiative: (+values.jack_initiative_base + +values.jack_initiative_mod)
+            });
+        });
+    });
+    
+    //npc_initiative
+on("change:npc_initiative_base change:npc_initiative_mod sheet:opened", function() {
+        getAttrs(["npc_initiative_base", "npc_initiative_mod"], function(values) {
+            setAttrs({
+                npc_initiative: (+values.npc_initiative_base + +values.npc_initiative_mod)
+            });
+        });
+    });
+
+// Advanced
+    //Armor Selection
+on("change:armor_select sheet:opened", function() {
+    getAttrs(["armor_select", "physique", "armor_speed_mod_1", "armor_def_mod_1", "armor_arm_mod_1", "armor_speed_mod_2", "armor_def_mod_2", "armor_arm_mod_2", "armor_speed_mod_3", "armor_def_mod_3", "armor_arm_mod_3"], function(values) {
+        var attrs = {},
+            armor_select = parseInt(values.armor_select);
+
+        switch (armor_select) {
+            case 0: // Use appropriate values for the radio buttons
+                attrs.worn_armor_arm = values.physique; // Use appropriate numbers for armor/defense/speed
+                attrs.worn_armor_def = 0;
+                attrs.worn_armor_speed = 0;
+                break;
+            case 1:
+                attrs.worn_armor_arm = values.armor_arm_mod_1;
+                attrs.worn_armor_def = values.armor_def_mod_1;
+                attrs.worn_armor_speed = values.armor_speed_mod_1;
+                break;
+            case 2:
+                attrs.worn_armor_arm = values.armor_arm_mod_2;
+                attrs.worn_armor_def = values.armor_def_mod_2;
+                attrs.worn_armor_speed = values.armor_speed_mod_2;
+                break;
+            case 3:
+                attrs.worn_armor_arm = values.armor_arm_mod_3;
+                attrs.worn_armor_def = values.armor_def_mod_3;
+                attrs.worn_armor_speed = values.armor_speed_mod_3;
+                break;
+        }
+
+        setAttrs(attrs);
+    });
+});
+
+on("change:feat_up", function() {
+    getAttrs(["feat_up", "feat"], function(values) {
+        setAttrs({
+            feat: Math.max(Math.min(parseInt(values.feat, 10) + 1, 3), 0)
+        });
+    });
+});
+        
+on("change:feat_down", function() {
+    getAttrs(["feat_down", "feat"], function(values) {
+        setAttrs({
+            feat: Math.max(Math.min(parseInt(values.feat, 10) - 1, 3), 0)
+        });
+    });
+});
+        
+on("change:wound_reset", function() {
+    getAttrs(['wound_reset', 'healthbox_phyl0', 'healthbox_phyr0', 'healthbox_phyl1', 'healthbox_phyr1', 'healthbox_phyl2', 'healthbox_phyr2', 'healthbox_phyl3', 'healthbox_phyr3', 'healthbox_phyl4', 'healthbox_phyr4', 'healthbox_phyl5', 'healthbox_phyr5', 'healthbox_intl0', 'healthbox_intr0', 'healthbox_intl1', 'healthbox_intr1', 'healthbox_intl2', 'healthbox_intr2', 'healthbox_intl3', 'healthbox_intr3', 'healthbox_intl4', 'healthbox_intr4', 'healthbox_intl5', 'healthbox_intr5', 'healthbox_agll0', 'healthbox_aglr0', 'healthbox_agll1', 'healthbox_aglr1', 'healthbox_agll2', 'healthbox_aglr2', 'healthbox_agll3', 'healthbox_aglr3', 'healthbox_agll4', 'healthbox_aglr4', 'healthbox_agll5', 'healthbox_aglr5'], function(values) {
+        setAttrs({
+            healthbox_phy0: 0,
+            healthbox_phy1: 0,
+            healthbox_phy2: 0,
+            healthbox_phy3: 0,
+            healthbox_phy4: 0,
+            healthbox_phy5: 0,
+            healthbox_phy6: 0,
+            healthbox_phy7: 0,
+            healthbox_phy8: 0,
+            healthbox_phy9: 0,
+            healthbox_phy10: 0,
+            healthbox_agl0: 0,
+            healthbox_agl1: 0,
+            healthbox_agl2: 0,
+            healthbox_agl3: 0,
+            healthbox_agl4: 0,
+            healthbox_agl5: 0,
+            healthbox_agl6: 0,
+            healthbox_agl7: 0,
+            healthbox_agl8: 0,
+            healthbox_agl9: 0,
+            healthbox_agl10: 0,
+            healthbox_int0: 0,
+            healthbox_int1: 0,
+            healthbox_int2: 0,
+            healthbox_int3: 0,
+            healthbox_int4: 0,
+            healthbox_int5: 0,
+            healthbox_int6: 0,
+            healthbox_int7: 0,
+            healthbox_int8: 0,
+            healthbox_int9: 0,
+            healthbox_int10: 0
+        });
+    });
+});
+on("change:damage_reset", function() {
+    getAttrs(['damage_reset', 'jackbox_leftarm1', 'jackbox_leftside1', 'jackbox_leftcenter1', 'jackbox_rightcenter1', 'jackbox_rightside1', 'jackbox_rightarm1', 'jackbox_leftarm2', 'jackbox_leftside2', 'jackbox_leftcenter2', 'jackbox_rightcenter2', 'jackbox_rightside2', 'jackbox_rightarm2', 'jackbox_leftarm3', 'jackbox_leftside3', 'jackbox_leftcenter3', 'jackbox_rightcenter3', 'jackbox_rightside3', 'jackbox_rightarm3', 'jackbox_leftarm4', 'jackbox_leftside4', 'jackbox_leftcenter4', 'jackbox_rightcenter4', 'jackbox_rightside4', 'jackbox_rightarm4', 'jackbox_leftarm5', 'jackbox_leftside5', 'jackbox_leftcenter5', 'jackbox_rightcenter5', 'jackbox_rightside5', 'jackbox_rightarm5', 'jackbox_leftarm6', 'jackbox_leftside6', 'jackbox_leftcenter6', 'jackbox_rightcenter6', 'jackbox_rightside6', 'jackbox_rightarm6'], function(values) {
+        setAttrs({
+    		jackbox_leftarm1: 0,
+			jackbox_leftside1: 0,
+			jackbox_leftcenter1: 0,
+			jackbox_rightcenter1: 0,
+			jackbox_rightside1: 0,
+			jackbox_rightarm1: 0,
+			jackbox_leftarm2: 0,
+			jackbox_leftside2: 0,
+			jackbox_leftcenter2: 0,
+			jackbox_rightcenter2: 0,
+			jackbox_rightside2: 0,
+			jackbox_rightarm2: 0,
+			jackbox_leftarm3: 0,
+			jackbox_leftside3: 0,
+			jackbox_leftcenter3: 0,
+			jackbox_rightcenter3: 0,
+			jackbox_rightside3: 0,
+			jackbox_rightarm3: 0,
+			jackbox_leftarm4: 0,
+			jackbox_leftside4: 0,
+			jackbox_leftcenter4: 0,
+			jackbox_rightcenter4: 0,
+			jackbox_rightside4: 0,
+			jackbox_rightarm4: 0,
+			jackbox_leftarm5: 0,
+			jackbox_leftside5: 0,
+			jackbox_leftcenter5: 0,
+			jackbox_rightcenter5: 0,
+			jackbox_rightside5: 0,
+			jackbox_rightarm5: 0,
+			jackbox_leftside6: 0,
+			jackbox_leftcenter6: 0,
+			jackbox_rightcenter6: 0,
+			jackbox_rightside6: 0
+        });
+    });
+});
+    //Health Refresh, Phy
+on("change:health_refresh", function() {
+    getAttrs(["health_refresh", "physique_base", "healthbox_phy0", "healthbox_phy1", "healthbox_phy2", "healthbox_phy3", "healthbox_phy4", "healthbox_phy5", "healthbox_phy6", "healthbox_phy7", "healthbox_phy8", "healthbox_phy9", "healthbox_phy10"], function(values) {
+
+        if (values.physique_base == 3) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 0, healthbox_phy3: 0, healthbox_phy4: 0, healthbox_phy5: 0, healthbox_phy6: 0, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+    		})
+        }
+		else if (values.physique_base == 4) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 0, healthbox_phy4: 0, healthbox_phy5: 0, healthbox_phy6: 0, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+    	else if (values.physique_base == 5) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 0, healthbox_phy5: 0, healthbox_phy6: 0, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+    	else if (values.physique_base == 6) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 0, healthbox_phy6: 0, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 7) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 0, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 8) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 1, healthbox_phy7: 0, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 9) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 1, healthbox_phy7: 1, healthbox_phy8: 0, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 10) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 1, healthbox_phy7: 1, healthbox_phy8: 1, healthbox_phy9: 0, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 11) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 1, healthbox_phy7: 1, healthbox_phy8: 1, healthbox_phy9: 1, healthbox_phy10: 0
+            })
+        }
+        else if (values.physique_base == 12) {
+            setAttrs({ healthbox_phy0: 1, healthbox_phy1: 1, healthbox_phy2: 1, healthbox_phy3: 1, healthbox_phy4: 1, healthbox_phy5: 1, healthbox_phy6: 1, healthbox_phy7: 1, healthbox_phy8: 1, healthbox_phy9: 1, healthbox_phy10: 1
+            })
+        }
+    });
+});
+//Health Refresh, Agl
+on("change:health_refresh", function() {
+    getAttrs(["health_refresh", "agility_base", "healthbox_agl0", "healthbox_agl1", "healthbox_agl2", "healthbox_agl3", "healthbox_agl4", "healthbox_agl5", "healthbox_agl6", "healthbox_agl7", "healthbox_agl8", "healthbox_agl9", "healthbox_agl10"], function(values) {
+
+        if (values.agility_base == 3) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 0, healthbox_agl3: 0, healthbox_agl4: 0, healthbox_agl5: 0, healthbox_agl6: 0, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+    		})
+        }
+		else if (values.agility_base == 4) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 0, healthbox_agl4: 0, healthbox_agl5: 0, healthbox_agl6: 0, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+    	else if (values.agility_base == 5) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 0, healthbox_agl5: 0, healthbox_agl6: 0, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+    	else if (values.agility_base == 6) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 0, healthbox_agl6: 0, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 7) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 0, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 8) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 1, healthbox_agl7: 0, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 9) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 1, healthbox_agl7: 1, healthbox_agl8: 0, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 10) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 1, healthbox_agl7: 1, healthbox_agl8: 1, healthbox_agl9: 0, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 11) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 1, healthbox_agl7: 1, healthbox_agl8: 1, healthbox_agl9: 1, healthbox_agl10: 0
+            })
+        }
+        else if (values.agility_base == 12) {
+            setAttrs({ healthbox_agl0: 1, healthbox_agl1: 1, healthbox_agl2: 1, healthbox_agl3: 1, healthbox_agl4: 1, healthbox_agl5: 1, healthbox_agl6: 1, healthbox_agl7: 1, healthbox_agl8: 1, healthbox_agl9: 1, healthbox_agl10: 1
+            })
+        }
+    });
+});
+//Health Refresh, Int
+on("change:health_refresh", function() {
+    getAttrs(["health_refresh", "intellect_base", "healthbox_int0", "healthbox_int1", "healthbox_int2", "healthbox_int3", "healthbox_int4", "healthbox_int5", "healthbox_int6", "healthbox_int7", "healthbox_int8", "healthbox_int9", "healthbox_int10"], function(values) {
+
+        if (values.intellect_base == 3) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 0, healthbox_int3: 0, healthbox_int4: 0, healthbox_int5: 0, healthbox_int6: 0, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+    		})
+        }
+		else if (values.intellect_base == 4) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 0, healthbox_int4: 0, healthbox_int5: 0, healthbox_int6: 0, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+    	else if (values.intellect_base == 5) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 0, healthbox_int5: 0, healthbox_int6: 0, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+    	else if (values.intellect_base == 6) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 0, healthbox_int6: 0, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 7) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 0, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 8) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 1, healthbox_int7: 0, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 9) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 1, healthbox_int7: 1, healthbox_int8: 0, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 10) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 1, healthbox_int7: 1, healthbox_int8: 1, healthbox_int9: 0, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 11) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 1, healthbox_int7: 1, healthbox_int8: 1, healthbox_int9: 1, healthbox_int10: 0
+            })
+        }
+        else if (values.intellect_base == 12) {
+            setAttrs({ healthbox_int0: 1, healthbox_int1: 1, healthbox_int2: 1, healthbox_int3: 1, healthbox_int4: 1, healthbox_int5: 1, healthbox_int6: 1, healthbox_int7: 1, healthbox_int8: 1, healthbox_int9: 1, healthbox_int10: 1
+            })
+        }
+    });
+});
+</script>
 


### PR DESCRIPTION
Adds: 

Sheet workers!  Some, not all.
Button to set health to what is listed in base physique, agility, and health.  And a button to reset all health boxes to empty
Power field easier to see.  
Moved the feat tracker to the top bar.
Put arrows in the top bar to control the the feat tracker.
All skills are no roll templates, plus the ability to edit the text of the roll template.
Whisper to GM rolls for all skills, attack rolls and spells.
Added Efraarit, Blighted Orgrun, Satyxis,and Striders to racial selection.  
All racial and Archetype abilities can now be displayed in chat.
Spells & Fell calls will only display what you want to when rolled
F/X on spells!  You will need a pro subscription to use them, and they are 'off' by default.  
Cleaned up the weapons a bit
Multiple armor selection!
Mount stats!
More space for each entry on the advancement tab
Reset button on the Steamjack damage grid.