### PR TITLE
Removed Token Action

### DIFF
--- a/OVA/OVA.html
+++ b/OVA/OVA.html
@@ -710,7 +710,7 @@
 		<span style="margin-left: 300px; font-weight: bold;">Number of Dice to roll:</span>
 		<input type="number" name="attr_numdicetoroll" value=1 style='border: 1px solid #801421; background-color: #eee2e2; color: black; text-align: center;' />
 		<input type="text" name="attr_rollformula" style="display: none;" value="{{Die one=[[1d6]]}}" />
-		<button class="sheet-templatebutton tokenaction" type='roll' name='roll_Generic-Roll' title="@{Generic-Roll}" value='&{template:ova} {{name=@{character_name}}} @{rollformula}'></button>
+		<button class="sheet-templatebutton" type='roll' name='roll_Generic-Roll' title="@{Generic-Roll}" value='&{template:ova} {{name=@{character_name}}} @{rollformula}'></button>
 		<!--<button class="sheet-initiativebutton" type='roll' name='roll_initiative' title="@{initiative}" value='/roll @{numdicetoroll}d6 &{tracker}'>Initiative</button>-->
 		<span style="margin-left: 100px;">&nbsp;</span>
 		<input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Stats & Abilities" checked="checked"/> 


### PR DESCRIPTION
Due to a problem with Sheet Workers not updating the character sheet
via a token bubble, removed the token action roll button until that’s
fixed.