### PR TITLE
Replaced repeating sections with fixed weapon slots for NPCs

### DIFF
--- a/Der Eine Ring/sheet.html
+++ b/Der Eine Ring/sheet.html
@@ -130,36 +130,68 @@
                 </table>
             </td>
         </tr>
-
-
         <tr>
-            <td colspan="2" class="sheet-section-heading"><label>Waffenfertigkeiten</label></td>
-        </tr>
-        <tr>
-            <td colspan="2" class="sheet-npc-weapon-labels">
-                <label class="sheet-name">Name</label>
-                <label class="sheet-rating">Stufe</label>
-                <label class="sheet-damage">Schad.</label>
-                <label class="sheet-edge">Schärfe</label>
-                <label class="sheet-injury">Verl.</label>
-                <label class="sheet-called-shot">Gez. Angriff</label>
+            <td colspan="2" class="sheet-center sheet-section-heading">
+                <label>Waffenfertigkeiten</label>
             </td>
         </tr>
         <tr>
-            <td colspan="2">
-                <fieldset class="repeating_npc-weapon-skills">
-                    <button type="roll" value="/me attackiert mit @{npc_weapon_skill_name}.\n/roll 1t[lm-feat] + @{npc_weapon_rating}t[@{weary}] + [[@{npc_weapon_skill_favoured} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="npc_weapon_check"></button>
-                    <input type="checkbox" name="attr_npc_weapon_skill_favoured" value="1">
-                    <input type="text" name="attr_npc_weapon_skill_name">
-                    <input type="number" name="attr_npc_weapon_rating" value="0">
-                    <input type="number" name="attr_npc_weapon_damage" value="0">
-                    <input type="text" name="attr_npc_weapon_edge" value="0">
-                    <input type="number" name="attr_npc_weapon_injury" value="0">
-                    <input type="text" name="attr_npc_weapon_called_shot">
-                </fieldset>
-            </td>
-        </tr>
+                    <table class="sheet-weapon-skills">
+                        <thead>
+                            <tr>
+                                <td></td>
+                                <td><label>Waffe</label></td>
+                                <td><label class="sheet-center">Stufe</label></td>
+                                <td><label class="sheet-center">Schad.</label></td>
+                                <td><label class="sheet-center">Schärfe</label></td>
+                                <td><label class="sheet-center">Verl.</label></td>
+                                <td><label class="sheet-center">Gez. Angriff</label></td>
+                            </tr>
+                        </thead>
 
+                        <tbody>
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_1} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[lm-feat] + @{weapon_rating_1}t[@{weary}] + [[@{weapon_favoured_1} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon1check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_1" value="1"><input name="attr_weapon_skill_name_1" type="text"></td>
+                                <td><input name="attr_weapon_rating_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_1" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_1" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_2} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[lm-feat] + @{weapon_rating_2}t[@{weary}] + [[@{weapon_favoured_2} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon2check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_2" value="1"><input name="attr_weapon_skill_name_2" type="text"></td>
+                                <td><input name="attr_weapon_rating_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_2" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_2" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_3} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[lm-feat] + @{weapon_rating_3}t[@{weary}] + [[@{weapon_favoured_3} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon3check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_3" value="1"><input name="attr_weapon_skill_name_3" type="text"></td>
+                                <td><input name="attr_weapon_rating_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_3" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_3" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_4} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[lm-feat] + @{weapon_rating_4}t[@{weary}] + [[@{weapon_favoured_4} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon4check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_4" value="1"><input name="attr_weapon_skill_name_4" type="text"></td>
+                                <td><input name="attr_weapon_rating_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_4" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_4" value="" type="text"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+        </tr>
 
         <tr>
             <td colspan="2" class="sheet-section-heading"><label>Spezialfähigkeiten</label></td>
@@ -216,7 +248,7 @@
                             <input type="number" value="0" name="attr_shield">
                         </td>
                         <td class="sheet-center">
-                            <button type="roll" value="/me würfelt auf Rüstung gegen SG ?{Verletzung|14}|14}.\n/roll 1t[feat] + @{armour}t[@{weary}] + @{head-gear} + [[@{armour_favoured} * @{attribute_level}]] > ?{Verletzung|14}" name="armourcheck"></button>
+                            <button type="roll" value="/me würfelt auf Rüstung gegen SG ?{Verletzung|14}.\n/roll 1t[feat] + @{armour}t[@{weary}] + @{head-gear} + [[@{armour_favoured} * @{attribute_level}]] > ?{Verletzung|14}" name="armourcheck"></button>
                             <input type="checkbox" name="attr_armour_favoured" value="1">
                             <input type="number" value="0" name="attr_armour">&nbsp;+&nbsp;
                             <input type="number" value="0" name="attr_head-gear">
@@ -299,32 +331,67 @@
         </tr>
 
 
-        <tr>
-            <td colspan="2" class="sheet-section-heading"><label>Waffenfertigkeiten</label></td>
-        </tr>
-        <tr>
-            <td colspan="2" class="sheet-npc-weapon-labels">
-                <label class="sheet-name">Name</label>
-                <label class="sheet-rating">Stufe</label>
-                <label class="sheet-damage">Schad.</label>
-                <label class="sheet-edge">Schärfe</label>
-                <label class="sheet-injury">Verl.</label>
-                <label class="sheet-called-shot">Gez. Angriff</label>
+                <tr>
+            <td colspan="2" class="sheet-center sheet-section-heading">
+                <label>Waffenfertigkeiten</label>
             </td>
         </tr>
         <tr>
-            <td colspan="2">
-                <fieldset class="repeating_npc-weapon-skills">
-                    <button type="roll" value="/me attackiert mit @{npc_weapon_skill_name}.\n/roll 1t[feat] + @{npc_weapon_rating}t[@{weary}] + [[@{npc_weapon_skill_favoured} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="npc_weapon_check"></button>
-                    <input type="checkbox" name="attr_npc_weapon_skill_favoured" value="1">
-                    <input type="text" name="attr_npc_weapon_skill_name">
-                    <input type="number" name="attr_npc_weapon_rating" value="0">
-                    <input type="number" name="attr_npc_weapon_damage" value="0">
-                    <input type="text" name="attr_npc_weapon_edge" value="0">
-                    <input type="number" name="attr_npc_weapon_injury" value="0">
-                    <input type="text" name="attr_npc_weapon_called_shot">
-                </fieldset>
-            </td>
+                    <table class="sheet-weapon-skills">
+                        <thead>
+                            <tr>
+                                <td></td>
+                                <td><label>Waffe</label></td>
+                                <td><label class="sheet-center">Stufe</label></td>
+                                <td><label class="sheet-center">Schad.</label></td>
+                                <td><label class="sheet-center">Schärfe</label></td>
+                                <td><label class="sheet-center">Verl.</label></td>
+                                <td><label class="sheet-center">Gez. Angriff</label></td>
+                            </tr>
+                        </thead>
+
+                        <tbody>
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_1} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_1}t[@{weary}] + [[@{weapon_favoured_1} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon1check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_1" value="1"><input name="attr_weapon_skill_name_1" type="text"></td>
+                                <td><input name="attr_weapon_rating_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_1" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_1" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_1" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_2} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_2}t[@{weary}] + [[@{weapon_favoured_2} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon2check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_2" value="1"><input name="attr_weapon_skill_name_2" type="text"></td>
+                                <td><input name="attr_weapon_rating_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_2" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_2" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_2" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_3} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_3}t[@{weary}] + [[@{weapon_favoured_3} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon3check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_3" value="1"><input name="attr_weapon_skill_name_3" type="text"></td>
+                                <td><input name="attr_weapon_rating_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_3" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_3" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_3" value="" type="text"></td>
+                            </tr>
+
+                            <tr>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_4} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_4}t[@{weary}] + [[@{weapon_favoured_4} * @{attribute_level}}]] > ?{Schwierigkeitsgrad|14}" name="weapon4check"></button></td>
+                                <td><input type="checkbox" name="attr_weapon_favoured_4" value="1"><input name="attr_weapon_skill_name_4" type="text"></td>
+                                <td><input name="attr_weapon_rating_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_damage_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_edge_4" value="0" class="center number" type="text" style="width: 46px;"></td>
+                                <td><input name="attr_weapon_injury_4" value="0" class="center number" type="text"></td>
+                                <td><input name="attr_weapon_called_shot_4" value="" type="text"></td>
+                            </tr>
+                        </tbody>
+                    </table>
         </tr>
 
 
@@ -895,7 +962,7 @@
 
                         <tbody>
                             <tr>
-                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_1}\n/roll 1t[feat] + @{weapon_rating_1}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon1check"></button></td>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_1} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_1}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon1check"></button></td>
                                 <td><input type="checkbox" name="attr_weapon_favoured_1" value="1"><input name="attr_weapon_skill_name_1" type="text"></td>
                                 <td><input name="attr_weapon_rating_1" value="0" class="center number" type="text"></td>
                                 <td><input name="attr_weapon_damage_1" value="0" class="center number" type="text"></td>
@@ -906,7 +973,7 @@
                             </tr>
 
                             <tr>
-                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_2}\n/roll 1t[feat] + @{weapon_rating_2}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon2check"></button></td>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_2} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_2}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon2check"></button></td>
                                 <td><input type="checkbox" name="attr_weapon_favoured_2" value="1"><input name="attr_weapon_skill_name_2" type="text"></td>
                                 <td><input name="attr_weapon_rating_2" value="0" class="center number" type="text"></td>
                                 <td><input name="attr_weapon_damage_2" value="0" class="center number" type="text"></td>
@@ -917,7 +984,7 @@
                             </tr>
 
                             <tr>
-                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_3}\n/roll 1t[feat] + @{weapon_rating_3}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon3check"></button></td>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_3} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_3}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon3check"></button></td>
                                 <td><input type="checkbox" name="attr_weapon_favoured_3" value="1"><input name="attr_weapon_skill_name_3" type="text"></td>
                                 <td><input name="attr_weapon_rating_3" value="0" class="center number" type="text"></td>
                                 <td><input name="attr_weapon_damage_3" value="0" class="center number" type="text"></td>
@@ -928,7 +995,7 @@
                             </tr>
 
                             <tr>
-                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_4}\n/roll 1t[feat] + @{weapon_rating_4}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon4check"></button></td>
+                                <td><button type="roll" value="/me attackiert mit @{weapon_skill_name_4} gegen SG ?{Schwierigkeitsgrad|14}.\n/roll 1t[feat] + @{weapon_rating_4}t[@{weary}] > ?{Schwierigkeitsgrad|14}" name="weapon4check"></button></td>
                                 <td><input type="checkbox" name="attr_weapon_favoured_4" value="1"><input name="attr_weapon_skill_name_4" type="text"></td>
                                 <td><input name="attr_weapon_rating_4" value="0" class="center number" type="text"></td>
                                 <td><input name="attr_weapon_damage_4" value="0" class="center number" type="text"></td>


### PR DESCRIPTION
Repeating sections didn't work with macros as macros needed numbered
attributes. So I replaced the repeating sections with a fixed weapon
list for NPCs. So they are identical to the PC sheets now. There is
place for 4 weapons which should be more than enough.

Furthermore I added call for target numbers to all sheet rolls and fixed
a small copy-paste error.