### PR TITLE
Adjustment of the base Characteristics rolls

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -106,7 +106,7 @@
                 <!-- WeaponSkill (WS) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_WS" type="roll" value="/me rolls Weapon Skill [[1d100]], Target: [[@{WeaponSkill} + @{advanceWS} + ?{Target Modifier|0} ]]"><label>Weapon Skill (WS)</label></button>
+                        <button name="roll_WS" type="roll" value="/me rolls Weapon Skill [[1d100]], Target: [[@{WeaponSkill} + ?{Target Modifier|0} ]]"><label>Weapon Skill (WS)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_WeaponSkill" type="text" value="0">
@@ -130,7 +130,7 @@
                 <!-- BallisticSkill (BS) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_BS" type="roll" value="/me rolls Ballistic Skill [[1d100]], Target: [[@{BallisticSkill} + @{advanceBS} + ?{Target Modifier|0} ]]"><label>Ballistic Skill (BS)</label></button>
+                        <button name="roll_BS" type="roll" value="/me rolls Ballistic Skill [[1d100]], Target: [[@{BallisticSkill} + ?{Target Modifier|0} ]]"><label>Ballistic Skill (BS)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_BallisticSkill" type="text" value="0">
@@ -154,7 +154,7 @@
                 <!-- Strength (S) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_S" type="roll" value="/me rolls Strength [[1d100]], Target: [[@{Strength} + @{advanceS} + ?{Target Modifier|0} ]]"><label>Strength (S)</label></button>
+                        <button name="roll_S" type="roll" value="/me rolls Strength [[1d100]], Target: [[@{Strength} + ?{Target Modifier|0} ]]"><label>Strength (S)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Strength" type="text" value="0">
@@ -178,7 +178,7 @@
                 <!-- Toughness (T) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_T" type="roll" value="/me rolls Toughness [[1d100]], Target: [[@{Toughness} + @{advanceT} + ?{Target Modifier|0} ]]"><label>Toughness (T)</label></button>
+                        <button name="roll_T" type="roll" value="/me rolls Toughness [[1d100]], Target: [[@{Toughness} + ?{Target Modifier|0} ]]"><label>Toughness (T)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Toughness" type="text" value="0">
@@ -202,7 +202,7 @@
                 <!-- Agility (Ag) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Ag" type="roll" value="/me rolls Agility [[1d100]], Target: [[@{Agility} + @{advanceAg} + ?{Target Modifier|0} ]]"><label>Agility (Ag)</label></button>
+                        <button name="roll_Ag" type="roll" value="/me rolls Agility [[1d100]], Target: [[@{Agility} + ?{Target Modifier|0} ]]"><label>Agility (Ag)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Agility" type="text" value="0">
@@ -230,7 +230,7 @@
                 <!-- Intelligence (Int) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Int" type="roll" value="/me rolls Intelligence [[1d100]], Target: [[@{Intelligence} + @{advanceInt} + ?{Target Modifier|0} ]]"><label>Intelligence (Int)</label></button>
+                        <button name="roll_Int" type="roll" value="/me rolls Intelligence [[1d100]], Target: [[@{Intelligence} + ?{Target Modifier|0} ]]"><label>Intelligence (Int)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Intelligence" type="text" value="0">
@@ -254,7 +254,7 @@
                 <!-- Perception (Per) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Per" type="roll" value="/me rolls Perception [[1d100]], Target: [[@{Perception} + @{advancePer} + ?{Target Modifier|0} ]]"><label>Perception (Per)</label></button>
+                        <button name="roll_Per" type="roll" value="/me rolls Perception [[1d100]], Target: [[@{Perception} + ?{Target Modifier|0} ]]"><label>Perception (Per)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Perception" type="text" value="0">
@@ -278,7 +278,7 @@
                 <!-- Willpower (WP) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_WP" type="roll" value="/me rolls Willpower [[1d100]], Target: [[@{Willpower} + @{advanceWP} + ?{Target Modifier|0} ]]"><label>Willpower (WP)</label></button>
+                        <button name="roll_WP" type="roll" value="/me rolls Willpower [[1d100]], Target: [[@{Willpower} + ?{Target Modifier|0} ]]"><label>Willpower (WP)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Willpower" type="text" value="0">
@@ -302,7 +302,7 @@
                 <!-- Fellowship (Fel) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Fel" type="roll" value="/me rolls Fellowship [[1d100]], Target: [[@{Fellowship} + @{advanceFel} + ?{Target Modifier|0} ]]"><label>Fellowship (Fel)</label></button>
+                        <button name="roll_Fel" type="roll" value="/me rolls Fellowship [[1d100]], Target: [[@{Fellowship} + ?{Target Modifier|0} ]]"><label>Fellowship (Fel)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Fellowship" type="text" value="0">
@@ -326,7 +326,7 @@
                 <!-- Influence (Ifl) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Inf" type="roll" value="/me rolls Influence [[1d100]], Target: [[@{Influence} + @{advanceInf} + ?{Target Modifier|0} ]]"><label>Influence (Inf)</label></button>
+                        <button name="roll_Inf" type="roll" value="/me rolls Influence [[1d100]], Target: [[@{Influence} + ?{Target Modifier|0} ]]"><label>Influence (Inf)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Influence" type="text" value="0">
@@ -335,16 +335,7 @@
                 
                 <div class="sheet-row">
                     <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceInf">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Proficient (+20)</option>
-                            <option value="25">Expert (+25)</option>
-                        </select>
-                    </div>    
+                    <div class="sheet-item" style="width:80%"><input name="attr_awardedInf" type="text"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Currently the base characteristics rolls were adding the value of the advance in that characteristic, but it wasn't reflected when using the skill rolls. This made this change necessary in order to align the sheet so both rolls have the correct target value.

Removed the advance from the Influence characteristic since it can't be upgraded this way like all other characteristics and this drop down menu is pointless.