### PR TITLE
Removed forced 100% opacity on input arrows - Mutant Year Zero

### DIFF
--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.css
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.css
@@ -68,11 +68,6 @@ Inputs
 
 /* General */
 
-input[type='number']::-webkit-inner-spin-button, 
-input[type='number']::-webkit-outer-spin-button { 
-   opacity: 1;
-}
-
 input[type='radio']{ 
    margin: 6px;  
 }
@@ -91,7 +86,7 @@ input[type='number']{
 }
 
 textarea {
-   resize:none;
+   resize:vertical;
 }
 
 select {
@@ -113,7 +108,7 @@ select {
 }
 
 .sheet-value-singledigit {
-   width:32px !important;
+   width:36px !important;
 }
 
 .sheet-value-doubledigit {
@@ -195,7 +190,7 @@ select {
    margin-bottom: 5px;
    margin-top: 5px; 
    width: 269px;
-   height:90px;
+   height:46px;
 }
 
 .sheet-text-talentmutations {

--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
@@ -1,6 +1,6 @@
-        <form>
+       <form>
             <input checked="checked" class="sheet-tab sheet-tab-character-sheet sheet-player-sheet" name="attr_pcgm" style="float:left;" title="Character Sheet" type="radio" value="1"> 
-			<input class="sheet-tab sheet-tab-ark-sheet sheet-player-sheet" name="attr_pcgm" style="float:left;" title="Ark Sheet" type="radio" value="2"> 
+            <input class="sheet-tab sheet-tab-ark-sheet sheet-player-sheet" name="attr_pcgm" style="float:left;" title="Ark Sheet" type="radio" value="2"> 
         </form>
         <div class="sheet-logo">
             <img alt="MUTANT YEAR ZERO" src="http://i.imgur.com/juUlixw.jpg">
@@ -19,13 +19,13 @@
                                 Strength
                             </td>
                             <td align="center" class="sheet-table-noleft" width="42">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_strength" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_strength" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
                                 Damage
                             </td>
                             <td align="center" class="sheet-table-noleft" width="86">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_damage" type="number"> / <input class="sheet-value sheet-value-singledigit" name="attr_damage_max" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_damage" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_damage_max" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
@@ -33,13 +33,13 @@
                                 Agility
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_agility" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_agility" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
                                 Fatigue
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_fatigue" type="number"> / <input class="sheet-value sheet-value-singledigit" name="attr_fatigue_max" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_fatigue" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_fatigue_max" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
@@ -47,13 +47,13 @@
                                 Wits
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_wits" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_wits" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
                                 Confusion
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_confusion" type="number"> / <input class="sheet-value sheet-value-singledigit" name="attr_confusion_max" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_confusion" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_confusion_max" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
@@ -61,13 +61,13 @@
                                 Empathy
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_empathy" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_empathy" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
                                 Doubt
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_doubt" type="number"> / <input class="sheet-value sheet-value-singledigit" name="attr_doubt_max" type="number">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_doubt" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_doubt_max" type="number" value='0' readonly />
                             </td>
                         </tr>
                     </table>
@@ -331,28 +331,28 @@
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
                             <td class=" sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/69HoHMG.jpg')">
-                                APPERANCE
+                                APPEARANCE
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
                                 Face: 
-                                <textarea class="sheet-text-apperance" name="attr_face">
-								</textarea>
+                                <textarea class="sheet-text-apperance" rows='2' name="attr_face">
+                                </textarea>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
                                 Body: 
-                                <textarea class="sheet-text-apperance" name="attr_body">
-								</textarea>
+                                <textarea class="sheet-text-apperance" rows='2' name="attr_body">
+                                </textarea>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
                                 Clothing: 
-                                <textarea class="sheet-text-apperance" name="attr_clothing">
-								</textarea>
+                                <textarea class="sheet-text-apperance" rows='2' name="attr_clothing">
+                                </textarea>
                             </td>
                         </tr>
                     </table>
@@ -988,3 +988,21 @@
                 </div>
             </div>
         </div>
+
+        <script type="text/worker">
+            on("change:strength change:agility change:wits change:empathy", function(eventInfo) {
+                var x = eventInfo.sourceAttribute;
+                var trauma = {
+                    strength:"damage_max", 
+                    agility:"fatigue_max", 
+                    wits:"confusion_max", 
+                    empathy:"doubt_max"
+                };                
+                getAttrs([x],function(values){
+                    var attrHash = attrHash || {};  
+                    var targetAttr = trauma[x];
+                    attrHash[targetAttr] = values[x];
+                    setAttrs(attrHash);
+                });
+            });
+        </script>

--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
@@ -990,19 +990,45 @@
         </div>
 
         <script type="text/worker">
+            //object reference matching core attribute with the associated trauma type
+            var trauma = {
+                strength:"damage_max", 
+                agility:"fatigue_max", 
+                wits:"confusion_max", 
+                empathy:"doubt_max"
+            };   
+
+            //Change max trauma when core attribute changes
             on("change:strength change:agility change:wits change:empathy", function(eventInfo) {
                 var x = eventInfo.sourceAttribute;
-                var trauma = {
-                    strength:"damage_max", 
-                    agility:"fatigue_max", 
-                    wits:"confusion_max", 
-                    empathy:"doubt_max"
-                };                
                 getAttrs([x],function(values){
-                    var attrHash = attrHash || {};  
                     var targetAttr = trauma[x];
+
+                    var attrHash = attrHash || {};  
                     attrHash[targetAttr] = values[x];
                     setAttrs(attrHash);
                 });
             });
+
+            //Ensure max trauma = core attribute when sheet is loaded
+            on("sheet:opened", function() {
+                //create array of attributes from trauma reference var
+                var fetchAttrs = _.keys(trauma).concat(_.values(trauma));
+
+                getAttrs(fetchAttrs, function(attrValues) {
+
+                    //pull values from attrValues, split in half, and compare for equality
+                    var attrArray = _.values(attrValues)
+                    var splitIndex = attrArray.length / 2;
+
+                    var i = attrArray.slice(0, splitIndex);
+                    var j = attrArray.slice(splitIndex);
+
+                    if (!_.isEqual(i,j)) {
+                        //Pass object to settAttrs where: keys = max trauma attr and values = core attr values
+                        var setTraumaHash = _.object(_.values(trauma),i);
+                        setAttrs(setTraumaHash);
+                    };
+                });
+            })
         </script>


### PR DESCRIPTION
Arrows on input boxes for core attributes and skills were set to 100% opacity and were hiding values once entered on some browsers.

Also, added sheet workers to auto-fill max trauma with changes to core attributes and test for incongruent max trauma values on sheet load. 

Made text areas vertically resizable.

