### PR TITLE
Fixed two bugs in WFRP 2e character sheet

### DIFF
--- a/WFRP-2nd-Ed/WFRP-2nd-Ed.html
+++ b/WFRP-2nd-Ed/WFRP-2nd-Ed.html
@@ -149,10 +149,10 @@
                             <label>Toughness</label> 
                         </div>
                         <div class="sheet-item sheet-tiny sheet-black">
-                            <input type="number" name="attr_Toughness-Bonus" value="floor(@{Toughness}/10)" disabled = "true">
+                            <input type="number" name="attr_Toughness-Bonus-Calculated" value="floor(@{Toughness}/10)" disabled = "true">
                         </div>
                         <div class="sheet-item sheet-tiny sheet-black sheet-hidden">
-                            <input type="number" name="attr_Toughness-Bonus-Calculated" value="@{Toughness-Bonus-Calculated}">
+                            <input type="number" name="attr_Toughness-Bonus" value="@{Toughness-Bonus-Calculated}">
                         </div>
                         <div class="sheet-item sheet-tiny sheet-black">
                             <button type="roll" name="roll_Toughness" value="/em rolls versus Toughness&#x00A;/roll d100<[[@{Toughness}]]"></button>

--- a/WFRP-2nd-Ed/WFRP-2nd-Ed.html
+++ b/WFRP-2nd-Ed/WFRP-2nd-Ed.html
@@ -246,13 +246,13 @@
                     <!-- Wounds -->
                     <div class="sheet-row">
                         <div class="sheet-item sheet-small sheet-halfblack">
-                            <input type="number" name="attr_Wounds-Max" value="1">
+                            <input type="number" name="attr_Wounds" value="1">
                         </div>
                         <div class="sheet-item sheet-large sheet-black">
                             <label>Wounds</label> 
                         </div>
                         <div class="sheet-item sheet-tiny sheet-black">
-                            <input type="number" name="attr_Wounds" value="1">
+                            <input type="number" name="attr_Wounds-Max" value="1">
                         </div>
                         <div class="sheet-item sheet-tiny sheet-black">
                         </div>


### PR DESCRIPTION
Two bugs quietly lurked in the WFRP 2e character sheet. One incorrectly referenced a calculated value that populated an underlying attribute used in macros.

The second reversed the values of the number of wounds that could impact health bar display.