### PR TITLE
add attack options for all stats not just STR/DEX

### DIFF
--- a/13th Age Official/13th_Age_Official.html
+++ b/13th Age Official/13th_Age_Official.html
@@ -543,8 +543,12 @@
                         <span class="poption spacer"></span>
                     <input class="poption Attack" type="checkbox" name="attr_attack" value="{{attack=1}} {{attbonus=[[1d20+@{attack-type}+?{Modifiers|0}[MOD]+@{E-DIE}]]}} {{vstype=@{attack-vstype}}}"><span class="poption">Attack:</span>
                         <select class="suboption attackoptions" name="attr_attack-type">
-                            <option value="[[@{STR-mod}]][STR]+@{level}[LVL]">Melee</option>
-                            <option value="[[@{DEX-mod}]][DEX]+@{level}[LVL]">Ranged</option>
+                            <option value="[[@{STR-mod}]][STR]+@{level}[LVL]">Melee(STR)</option>
+                            <option value="[[@{DEX-mod}]][DEX]+@{level}[LVL]">Ranged(DEX)</option>
+                            <option value="[[@{INT-mod}]][INT]+@{level}[LVL]">Intelligence based</option>
+                            <option value="[[@{CHA-mod}]][CHA]+@{level}[LVL]">Charisma based</option>
+                            <option value="[[@{WIS-mod}]][WIS]+@{level}[LVL]">Wisdom based</option>
+                            <option value="[[@{CON-mod}]][CON]+@{level}[LVL]">Constitution based</option>
                             <option value="[[@{STR-mod}]][STR]+@{level}[LVL]+@{MWEAP-mod1}[WEAP]">Melee Weapon 1</option>
                             <option value="[[@{STR-mod}]][STR]+@{level}[LVL]+@{MWEAP-mod2}[WEAP]">Melee Weapon 2</option>
                             <option value="[[@{STR-mod}]][STR]+@{level}[LVL]+@{MWEAP-mod3}[WEAP]">Melee Weapon 3</option>


### PR DESCRIPTION
For use when people are adding spells, this change adds additional options to the Attack selector, letting people select which statistic to use.

Since this selector doesn't actually lookup which option people use for Melee attacks, I also changed the text to specify that Melee means STR and Ranged means DEX.  I feel it really should go look that up since players will have selected this earlier, but I can't currently work out how to do that.

(Apologies for the github fail in calling this branch the superdescriptive "patch-1", it's my first pull request.  You can see I got better on the second!)