### PR TITLE
DragonQuest v1.1

### DIFF
--- a/DragonQuest/DQSheet.css
+++ b/DragonQuest/DQSheet.css
@@ -36,6 +36,33 @@
     flex: 1;
 }
 
+.sheet-headers span {
+    font-weight: bold;
+}
+
+.sheet-headers, .sheet-summary {
+    display: -webkit-flex;
+    display: flex; 
+}
+
+.sheet-headers span, .sheet-summary > span, .sheet-summary button[type="roll"].sheet-btn {
+    border: solid brown;
+    border-width: 0 0 1px 0;
+    line-height: 19px;
+    height: 20px;
+}
+
+.sheet-summary button[type="roll"].sheet-btn {
+    width: calc(100% - 17em);
+    border-radius: 0;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.sheet-hidden {
+    display:none;
+}
+
 /* CSS for main DIVs */
 
 .sheet-chardets, .sheet-chars, .sheet-weapons, .sheet-armours, .sheet-shields, 
@@ -106,6 +133,10 @@ input, span, select {
     -webkit-align-self: center;
     align-self: center;
     margin: 0;
+}
+
+textarea {
+    resize: vertical;
 }
 
 * {
@@ -314,57 +345,35 @@ input, span, select {
 
 /* Weapons (weapons) */
 
-/* Headers & Summary (wheaders, wsummary) */
+/* Headers & Summary (headers, summary) */
 
-.sheet-wheaders, .sheet-wsummary {
-    display: -webkit-flex;
-    display: flex; 
-}
-
-.sheet-wheaders span {
-    font-weight: bold;
-}
-
-.sheet-wheaders span, .sheet-wsummary > span, .sheet-wsummary button.sheet-btn {
-    border: solid brown;
-    border-width: 0 0 1px 0;
-    min-height: 19px;
-}
-
-.sheet-wheaders span:first-of-type {    
+.sheet-weapons .sheet-headers span:first-of-type {    
     width: calc(100% - 17em);
     padding-left: 10px;
 }
 
-.sheet-wsummary button.sheet-btn {
-    width: calc(100% - 17em);
-    border-radius: 0;
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.sheet-wheaders span:nth-of-type(2), .sheet-wheaders span:nth-last-of-type(2), 
-.sheet-wsummary > span:nth-of-type(1), .sheet-wsummary > span:nth-last-of-type(2) {
+.sheet-weapons .sheet-headers span:nth-of-type(2), .sheet-weapons .sheet-headers span:nth-last-of-type(2), 
+.sheet-weapons .sheet-summary > span:nth-of-type(1), .sheet-weapons .sheet-summary > span:nth-last-of-type(2) {
     width:3.5em;
     display: block;
     text-align: center;
 }
 
-.sheet-wheaders span:last-of-type, .sheet-wsummary > span:last-of-type {
+.sheet-weapons .sheet-headers span:last-of-type, .sheet-weapons .sheet-summary > span:last-of-type {
     width: 18px;
 }
 
-.sheet-wheaders span:nth-of-type(3), .sheet-wheaders span:nth-of-type(4), 
-.sheet-wheaders span:nth-of-type(5), .sheet-wheaders span:nth-of-type(6), 
-.sheet-wheaders span:nth-of-type(7), .sheet-wsummary > span:nth-of-type(2), 
-.sheet-wsummary > span:nth-of-type(3), .sheet-wsummary > span:nth-of-type(4), 
-.sheet-wsummary > span:nth-of-type(5), .sheet-wsummary > span:nth-of-type(6) {
+.sheet-weapons .sheet-headers span:nth-of-type(3), .sheet-weapons .sheet-headers span:nth-of-type(4), 
+.sheet-weapons .sheet-headers span:nth-of-type(5), .sheet-weapons .sheet-headers span:nth-of-type(6), 
+.sheet-weapons .sheet-headers span:nth-of-type(7), .sheet-weapons .sheet-summary > span:nth-of-type(2), 
+.sheet-weapons .sheet-summary > span:nth-of-type(3), .sheet-weapons .sheet-summary > span:nth-of-type(4), 
+.sheet-weapons .sheet-summary > span:nth-of-type(5), .sheet-weapons .sheet-summary > span:nth-of-type(6) {
     width: 2em;
     display: block;
     text-align: center;
 }
 
-.repitem:nth-child(odd) .sheet-repeating-weapon .sheet-wsummary {
+.repitem:nth-child(odd) .sheet-repeating-weapon .sheet-summary {
     background-color: rgba(255,255,0,0.3);
 }
 
@@ -389,7 +398,7 @@ input, span, select {
         display: inherit;
     }
     
-    /* Weapon (weapon) - weapondets, weaponstats, wuse */
+    /* Weapon (weapon) - weapondets, weaponstats, use */
     
     /* Weaponstats options-flag settings -- see generic options flag settings */
     
@@ -452,7 +461,7 @@ input, span, select {
         height: 104px;
     }
     
-    /* Weaponstats - wuse */
+    /* Weaponstats - use */
     
     .sheet-weaponstats {
         border-top: 1px dashed black;
@@ -464,17 +473,17 @@ input, span, select {
         padding: 0 10px;
     }
     
-    .sheet-weaponstats .sheet-wuse > ul > li {
+    .sheet-weaponstats .sheet-use > ul > li {
         margin: 0;
         padding-left: 10px;
         display: block; // Override usual flex setting
     }
     
-    .sheet-weaponstats .sheet-wuse > ul > li > span {
+    .sheet-weaponstats .sheet-use > ul > li > span {
         padding-left: 5px;
     }
     
-    .sheet-wuse {
+    .sheet-use {
         width: 100%;
     }
     
@@ -498,57 +507,41 @@ input, span, select {
 
 /* Armours (armours) & Shields (shields) */
 
-/* Armour headers & summary (aheaders, asummary) 
-& Shield headers & summary (sheaders, ssummary) */
+/* Armour headers & summary (headers, summary) 
+& Shield headers & summary (headers, summary) */
 
-.sheet-aheaders, .sheet-asummary, .sheet-sheaders, .sheet-ssummary {
-    display: -webkit-flex;
-    display: flex; 
-}
-
-.sheet-aheaders span, .sheet-sheaders span {
-    font-weight: bold;
-}
-
-.sheet-aheaders span, .sheet-asummary span, 
-.sheet-sheaders span, .sheet-ssummary span {
-    border: solid brown;
-    border-width: 0 0 1px 0;
-    min-height: 19px;
-}
-
-.sheet-aheaders span:first-of-type, .sheet-asummary span:first-of-type {
+.sheet-armours .sheet-headers span:first-of-type, .sheet-armours .sheet-summary span:first-of-type {
     width: calc(100% - 14em - 18px);
     padding-left: 10px;
 }
 
-.sheet-aheaders span:not(:first-of-type), .sheet-asummary span:not(:first-of-type) {
+.sheet-armours .sheet-headers span:not(:first-of-type), .sheet-armours .sheet-summary span:not(:first-of-type) {
     width:3.5em;
     display: block;
     text-align: center;
 }
 
-.sheet-aheaders span:last-of-type, .sheet-asummary span:last-of-type {
+.sheet-armours .sheet-headers span:last-of-type, .sheet-armours .sheet-summary span:last-of-type {
     width: 18px;
 }
 
-.sheet-sheaders span:first-of-type, .sheet-ssummary span:first-of-type {
+.sheet-shields .sheet-headers span:first-of-type, .sheet-shields .sheet-summary span:first-of-type {
     width: calc(100% - 10.5em);
     padding-left: 10px;
 }
 
-.sheet-sheaders span:not(:first-of-type), .sheet-ssummary span:not(:first-of-type) {
+.sheet-shields .sheet-headers span:not(:first-of-type), .sheet-shields .sheet-summary span:not(:first-of-type) {
     width:3.5em;
     display: block;
     text-align: center;
 }
 
-.sheet-sheaders span:last-of-type, .sheet-ssummary span:last-of-type {
+.sheet-shields .sheet-headers span:last-of-type, .sheet-shields .sheet-summary span:last-of-type {
     width: 18px;
 }
 
-.repitem:nth-child(even) .sheet-repeating-armour .sheet-asummary, 
-.repitem:nth-child(even) .sheet-repeating-shield .sheet-ssummary {
+.repitem:nth-child(even) .sheet-repeating-armour .sheet-summary, 
+.repitem:nth-child(even) .sheet-repeating-shield .sheet-summary {
     background-color: rgba(255,255,0,0.3);
 }
 
@@ -610,28 +603,26 @@ input, span, select {
         width: 100%;
     }
     
-/* Armour totals (atotal) */
+/* Armour & Shield totals (total) */
 
-.sheet-atotal, .sheet-stotal {
+.sheet-total {
     padding-top: 5px;
     display: flex;
     justify-content: flex-end;
     align-items: center;
 }
 
-.sheet-atotal span, .sheet-stotal span {
+.sheet-total span {
     padding-right: 5px;
 }
 
-.sheet-atotal input[type=number]::-webkit-inner-spin-button,
-.sheet-atotal input[type=number]::-webkit-outer-spin-button,
-.sheet-stotal input[type=number]::-webkit-inner-spin-button,
-.sheet-stotal input[type=number]::-webkit-outer-spin-button {
+.sheet-total input[type=number]::-webkit-inner-spin-button,
+.sheet-total input[type=number]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-.sheet-atotal input[type=number], .sheet-stotal input[type=number] {
+.sheet-total input[type=number] {
     -moz-appearance:textfield;
 }
 
@@ -640,31 +631,27 @@ input, span, select {
 
 /* Possessions (possessions) & Money (money) */
 
-/* Possessions headers and summary (pheaders, psummary) & Possession repeats (possession) & Money rows (mrow) */
+/* Possessions headers and summary (headers, summary) & Possession repeats (possession) & Money rows (mrow) */
 
-.sheet-pheaders span {
-    font-weight: bold;
-}
-
-.sheet-pheaders, .sheet-psummary, .sheet-possession, .sheet-mrow {
+.sheet-possession, .sheet-mrow {
     display: -webkit-flex;
     display: flex; 
 }
 
-.sheet-pheaders span, .sheet-psummary span, .sheet-possession input, 
+.sheet-possession input, 
 .sheet-mrow span, .sheet-mrow input {
     border: solid brown;
     border-width: 0 0 1px 0;
     min-height: 19px;
 }
 
-.sheet-pheaders span:first-of-type, .sheet-psummary span:first-of-type, 
+.sheet-possessions .sheet-headers span:first-of-type, .sheet-possessions .sheet-summary span:first-of-type, 
 .sheet-possession input:first-of-type {
     width: 80%;
     padding-left: 10px;
 }
 
-.sheet-pheaders span:last-of-type, .sheet-psummary span:last-of-type, 
+.sheet-possessions .sheet-headers span:last-of-type, .sheet-possessions .sheet-summary span:last-of-type, 
 .sheet-possession input:last-of-type, .sheet-mrow input:first-of-type {
     width: 20%;
     text-align: center;
@@ -698,7 +685,7 @@ input, span, select {
     min-width: 14em;
 }
 
-.sheet-possessions > div.sheet-psummary:not(:last-of-type):nth-of-type(even),
+.sheet-possessions > div.sheet-summary:not(:last-of-type):nth-of-type(even),
 .sheet-possessions .repcontainer .repitem:nth-of-type(even) .sheet-possession input,
 .sheet-mrow:nth-of-type(odd) span, .sheet-mrow:nth-of-type(odd) input {
     background-color: rgba(255,255,0,0.3);
@@ -789,31 +776,9 @@ input, span, select {
 
 /* Spells summary (summary) */
 
-.sheet-headers span {
-    font-weight: bold;
-}
-
-.sheet-headers, .sheet-summary {
-    display: -webkit-flex;
-    display: flex; 
-}
-
-.sheet-headers span, .sheet-summary > span, .sheet-summary button.sheet-btn {
-    border: solid brown;
-    border-width: 0 0 1px 0;
-    min-height: 19px;
-}
-
 .sheet-spells .sheet-headers span:first-of-type {
     width: calc(100% - 17em);
     padding-left: 10px;
-}
-
-.sheet-spells .sheet-summary button.sheet-btn {
-    width: calc(100% - 17em);
-    border-radius: 0;
-    white-space: nowrap;
-    overflow: hidden;
 }
 
 .sheet-spells .sheet-headers span:nth-of-type(2), .sheet-spells .sheet-headers span:nth-of-type(3), 
@@ -908,9 +873,9 @@ input, span, select {
         margin-left: 10px;
     }
     
-        /* Spell resistances (spres) */
+        /* Spell resistances (res) */
             
-        .sheet-spres li {
+        .sheet-res li {
             margin: 0;
             justify-content: flex-start;
             padding-left: 10px;
@@ -920,31 +885,25 @@ input, span, select {
 
 /* Skills (skills) */
 
-/* Skill headers & data (skheaders, skdata) */
+/* Skill headers & data (headers, skdata) */
 
-.sheet-skheaders {
-    display: -webkit-flex;
-    display: flex;
+.sheet-skills .sheet-headers {
     flex: 0 0 100%;
-    font-weight: bold;
-    border: solid brown;
-    border-width: 0 0 1px 0;
-    min-height: 18px;
 }
 
-.sheet-skheaders span:first-of-type {
+.sheet-skills .sheet-headers span:first-of-type {
     padding-left: 10px;
 }
 
-.sheet-skheaders span:first-of-type, .sheet-skdata div {
+.sheet-skills .sheet-headers span:first-of-type, .sheet-skdata div {
     width: 11em;
 }
 
-.sheet-skheaders span:nth-of-type(2), .sheet-skdata input[type="text"] {
+.sheet-skills .sheet-headers span:nth-of-type(2), .sheet-skdata input[type="text"] {
     width: calc(100% - 14.5em);
 }
 
-.sheet-skheaders span:nth-of-type(3) {
+.sheet-skills .sheet-headers span:nth-of-type(3) {
     width:3.5em;
 }
 

--- a/DragonQuest/DQSheet.html
+++ b/DragonQuest/DQSheet.html
@@ -1,28 +1,20 @@
 <script type="text/worker">
 
+// Scripts for first section - description and characteristics
+
 // Populating description
 
-on("change:gender change:hand change:race", function() {
-    getAttrs(["gender","hand","race"], function(obj) {
-        var hand = obj.hand;
-        hand = hand.charAt(0).toUpperCase() + hand.slice(1).toLowerCase();
-        var gender = obj.gender;
-        gender = gender.toLowerCase();
-        var race = obj.race;
-        race  = race.toLowerCase();
-        setAttrs({
-            "descrip": hand + " " + gender + " " + race
-        });
-    });
-});
-
-on("change:height change:weight change:age change:pb", function() {
-    getAttrs(["height","weight","age","pb"], function(obj) {
+on("change:hist-options-flag", function() {
+    getAttrs(["gender","hand","race","aspect","status","legit","order","height","weight","age","pb"], function(obj) {
+        var attrs = {};
+        var hand = obj.hand.charAt(0).toUpperCase() + obj.hand.slice(1).toLowerCase();
+        var gender = obj.gender.toLowerCase();
+        var race = obj.race.toLowerCase();
+        attrs["descrip"] = hand + " " + gender + " " + race;
         var height = obj.height;
         var weight = obj.weight;
         var age = obj.age;
         var pb = obj.pb;
-        attrs = {};
         attrs["stat-height"] = "";
         attrs["stat-weight"] = "";
         attrs["stat-age"] = "";
@@ -41,23 +33,14 @@ on("change:height change:weight change:age change:pb", function() {
                 attrs["stat-pb"] = "PB: " + pb;
             }
         }
-        setAttrs(attrs);
-    });
-});
-
-// Populate history
-
-on("change:aspect change:status change:legit change:order", function() {
-    getAttrs(["aspect","status","legit","order"], function(obj) {
         var order = obj["order"];
         if (order != undefined) { order = "You are your parents' " + order + " child."; }
         else { order = ""; }
-        setAttrs({
-            "hsum-aspect": obj["aspect"],
-            "hsum-status": obj["status"],
-            "hsum-legit": obj["legit"],
-            "hsum-order": order
-        });
+        attrs["hsum-aspect"] = obj["aspect"];
+        attrs["hsum-status"] = obj["status"];
+        attrs["hsum-legit"] = obj["legit"];
+        attrs["hsum-order"] = order;
+        setAttrs(attrs);
     });
 });
 
@@ -118,14 +101,13 @@ var updateIsmage = function() {
  
 on("change:repeating_college:college", function() {
     getAttrs(["repeating_college_college", "ismage"], function(obj) {
-        console.log(obj);
         if((obj.ismage=="1") && (obj.repeating_college_college==undefined)) {
             updateIsmage();
         }
         else if((obj.ismage=="0") && (obj.repeating_college_college!=undefined)) {
             updateIsmage();
         }
-    })
+    });
 });
 
 on("remove:repeating_college", function() {
@@ -139,37 +121,6 @@ on("change:wp change:ismage", function() {
             wp += 20;
         }
         setAttrs({"mr":wp});
-    });
-});
-
-// Calculating shield MD total
-
-on("change:repeating_shield:smd change:repeating_shield:sequip", function() {
-    getAttrs(["repeating_shield_smd", "repeating_shield_sequip"], function(obj) {
-        var smdact = 0;
-        var smd = obj.repeating_shield_smd;
-        var sequip = obj.repeating_shield_sequip;
-        if (sequip == "on") {
-            sequip = 1;
-        }
-        smdact = smd * sequip;
-        setAttrs({"repeating_shield_smdact":smdact});
-    });
-});
-
-on("change:repeating_shield:smdact remove:repeating_shield", function() {
-    var tot = 0;
-    getSectionIDs("repeating_shield", function(idArray) {
-        var IDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_shield_" + idArray[i] + "_smdact");
-        }
-        getAttrs(IDs, function(obj) {
-            _.each(obj, function(value, key) {
-                tot += value*1;
-            });
-            setAttrs({"smdtot":tot})
-        });
     });
 });
 
@@ -203,27 +154,287 @@ on("change:en", function() {
     });
 });
 
-// Calculating aagtot, pagcalc & agcurr
+//Calculating agcurr
 
-on("change:repeating_armour:aag change:repeating_armour:aequip", function() {
-    getAttrs(["repeating_armour_aag", "repeating_armour_aequip"], function(obj) {
-        var aagact = 0;
-        var aag = obj.repeating_armour_aag;
-        var aequip = obj.repeating_armour_aequip;
-        if (aequip == "on") {
-            aequip = 1;
+on("change:aagtot change:ag change:pagcalc", function() {
+    getAttrs(["ag","aagtot","pagcalc"], function(obj) {
+        if ((obj.pagcalc*1) == -99) {
+            obj.pagcalc = (obj.ag*-1) + (obj.aagtot*-1)
         }
-        aagact = aag * aequip;
-        setAttrs({"repeating_armour_aagact":aagact});
+        setAttrs({
+            "agcurr": (obj.ag*1) + (obj.aagtot*1) + (obj.pagcalc*1)
+        });
     });
 });
 
-on("change:repeating_armour:aagact remove:repeating_armour", function() {
+
+
+
+
+
+
+
+
+
+// Scripts for second section - weapons etc.
+
+
+
+// Calculating Unarmed combat base & damage
+
+on("change:agcurr change:ps", function() {
+    getAttrs(["agcurr","ps"], function(obj) {
+        var ps = obj.ps * 1;
+        var psbonus = (ps > 15) ? ps - 15 : 0;
+        var dmbonus = Math.floor(psbonus/3) - 4;
+        setAttrs({
+            "wuc-base": (obj.agcurr * 2) + psbonus,
+            "wuc-dm": dmbonus,
+            "wuc-sum-dm": dmbonus
+        });
+    });
+});
+
+// Calculating Unarmed Combat IV
+
+on("change:wuc-rank change:ib", function() {
+    getAttrs(["wuc-rank","ib"], function(obj) {
+        var rank = obj["wuc-rank"];
+        if (rank == undefined || rank == "") { rank = 0; }
+        var iv = (obj.ib*1) + (rank*1);
+        setAttrs({
+            "wuc-iv": iv,
+            "wuc-sum-iv": iv
+        });
+    });
+});
+
+// Calculating Unarmed Combat SC
+
+on("change:wuc-rank change:wuc-base change:mdcurr", function() {
+    getAttrs(["wuc-rank","wuc-base","mdcurr"], function(obj) {
+        var rank = obj["wuc-rank"];
+        if (rank == "") { rank = undefined; }
+        if (rank != undefined) { rank = rank*1; }
+        var sc = ((obj["wuc-base"]*1) + ((rank != undefined) ? (rank*4) + (obj.mdcurr*1) : 0));
+        setAttrs({
+            "wuc-sc": sc,
+            "wuc-sum-sc": sc
+        });
+    });
+});
+
+// Updating Unarmed combat weapon summary
+
+on("change:wuc-rank", function() {
+    getAttrs(["wuc-rank"], function(obj) {
+        var rank = obj["wuc-rank"];
+        if (rank == undefined || rank == "") { rank = "-"; }
+        setAttrs({ "wuc-sum-rank": rank });
+    });
+});
+
+// Calculating weapon IV
+
+on("change:repeating_weapon:rank", function() {
+    getAttrs(["repeating_weapon_rank", "ib"], function(obj) {
+        var rank = obj.repeating_weapon_rank;
+        if (rank==undefined) { rank = 0; }
+        var iv = (rank*1)+(obj.ib*1);
+        setAttrs({
+            "repeating_weapon_iv": iv
+        });
+    });
+});
+
+on("change:ib", function() {
+    // Trigger recalc of IV for all weapons
+    getSectionIDs("repeating_weapon", function(idArray) {
+        var IDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            IDs.push("repeating_weapon_" + idArray[i] + "_rank");
+        }
+        IDs.push("ib");
+        getAttrs(IDs, function(objAttrs) {
+            var ib = objAttrs.ib*1;
+            delete objAttrs.ib;
+            var attrs = {};
+            _.each(objAttrs, function(value, key) {
+                var ivID = key.slice(0, -5);
+                if (value == undefined || value == "") { value=0; }
+                var iv = ib + (value*1);
+                attrs[ivID + "iv"] = iv;
+                attrs[ivID + "sum-iv"] = iv;
+            });
+            setAttrs(attrs);
+        });
+    });
+});
+
+// Calculating weapon SC
+
+on("change:repeating_weapon:base change:repeating_weapon:rank", function() {
+    getAttrs(["repeating_weapon_base","repeating_weapon_rank","mdcurr"], function(obj) {
+        var rank = obj.repeating_weapon_rank;
+        if (rank == "") { rank = undefined; }
+        if (rank != undefined) { rank = rank*1; }
+        var sc =  ((obj.repeating_weapon_base*1)+((rank != undefined) ? rank*4 + (obj.mdcurr*1) : 0));
+        setAttrs({
+            "repeating_weapon_sc": sc
+        });
+    });
+});
+
+on("change:mdcurr", function() {
+    // Trigger recalc of SC for all weapons
+    getSectionIDs("repeating_weapon", function(idArray) {
+        var IDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            IDs.push("repeating_weapon_" + idArray[i] + "_base");
+            IDs.push("repeating_weapon_" + idArray[i] + "_rank");
+        }
+        IDs.push("mdcurr");
+        getAttrs(IDs, function(objAttrs) {
+            var mdcurr = objAttrs.mdcurr;
+            delete objAttrs.mdcurr;
+            var objBase = {};
+            var objRank = {};
+            var keys = [];
+            var attrs = {};
+            _.each(objAttrs, function(value, key) {
+                if (key.slice(-4) == "base") {
+                    key = key.slice(0, -5);
+                    objBase[key] = value;
+                    keys.push(key);
+                }
+                else if (key.slice(-4) == "rank") {
+                    key = key.slice(0, -5);
+                    objRank[key] = value;
+                }
+            });
+            for (var i = 0; i < keys.length; i++) {
+                var rank = objRank[keys[i]];
+                if (rank == "") { rank = undefined; }
+                if (rank != undefined) { rank = rank*1; }
+                var sc = (objBase[keys[i]]*1) + ((rank != undefined) ? (rank*4) + mdcurr : 0);
+                attrs[keys[i] + "_sc"] = sc;
+                attrs[keys[i] + "_sum-sc"] = sc;
+            }
+            setAttrs(attrs);
+        });
+    });    
+});
+
+// Calculating weights for multiples of weapons
+
+on("change:repeating_weapon:num change:repeating_weapon:wgt", function() {
+    getAttrs(["repeating_weapon_num", "repeating_weapon_wgt"], function(obj) {
+        setAttrs({
+            "repeating_weapon_wgtact": ((obj.repeating_weapon_num*(obj.repeating_weapon_wgt*10000))/10000)
+        });
+    });
+});
+
+// Updating weapon summary
+
+on("change:repeating_weapon:options-flag", function() {
+    getAttrs(["repeating_weapon_options-flag"], function(flag) {
+        // When closing the options display, update the summary
+        if(flag["repeating_weapon_options-flag"] == 0) {
+            getAttrs([
+                "repeating_weapon_name",
+                "repeating_weapon_num",
+                "repeating_weapon_user",
+                "repeating_weapon_usem",
+                "repeating_weapon_usec",
+                "repeating_weapon_rg",
+                "repeating_weapon_iv",
+                "repeating_weapon_sc",
+                "repeating_weapon_dm",
+                "repeating_weapon_cl",
+                "repeating_weapon_rank",
+                "repeating_weapon_rankmax"],
+                function(obj) {
+                    var attrs = {};
+                    var count = "";
+                    var num = obj.repeating_weapon_num*1;
+                    if (num > 1) {
+                        count = " (" + num + ")";
+                    }
+                    else if(num == 0) {
+                        count = " - unavailable";
+                    }
+                    attrs["repeating_weapon_sum-name"] = obj.repeating_weapon_name + count;
+                    attrs["repeating_weapon_sum-use"] = (obj.repeating_weapon_user=="0" ? "" : "R") + (obj.repeating_weapon_usem=="0" ? "" : "M") + (obj.repeating_weapon_usec=="0" ? "" : "C");
+                    attrs["repeating_weapon_sum-range"] = obj.repeating_weapon_rg;
+                    attrs["repeating_weapon_sum-iv"] = obj.repeating_weapon_iv;
+                    attrs["repeating_weapon_sum-sc"] = obj.repeating_weapon_sc;
+                    attrs["repeating_weapon_sum-dm"] = obj.repeating_weapon_dm;
+                    attrs["repeating_weapon_sum-cl"] = obj.repeating_weapon_cl;
+                    var rank = obj.repeating_weapon_rank;
+                    var rankmax = obj.repeating_weapon_rankmax;
+                    if (rank == undefined || rank == "") { rank = "-"; }
+                    if (rankmax == undefined || rankmax == "") { rankmax = "-"; }
+                    attrs["repeating_weapon_sum-rank"] = rank + "/" + rankmax;
+                    setAttrs(attrs);
+                }  
+            );
+        }
+    });
+});
+
+// Getting total protection from armour
+
+on("change:repeating_armour:pro change:repeating_armour:equip", function(log) {
+    getAttrs(["repeating_armour_pro", "repeating_armour_equip"], function(obj) {
+        var proact = 0;
+        var pro = obj.repeating_armour_pro;
+        var equip = obj.repeating_armour_equip;
+        if (equip == "on") {
+            equip = 1;
+        }
+        proact = pro * equip;
+        setAttrs({"repeating_armour_proact":proact});
+    });
+});
+
+on("change:repeating_armour:proact remove:repeating_armour", function() {
     var tot = 0;
     getSectionIDs("repeating_armour", function(idArray) {
         var IDs = [];
         for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_armour_" + idArray[i] + "_aagact");
+            IDs.push("repeating_armour_" + idArray[i] + "_proact");
+        }
+        getAttrs(IDs, function(obj) {
+            _.each(obj, function(value, key) {
+                tot += value*1;
+            });
+            setAttrs({"pro":tot})
+        });
+    });
+});
+
+// Calculating agility modifier from armour, aagtot
+
+on("change:repeating_armour:ag change:repeating_armour:equip", function() {
+    getAttrs(["repeating_armour_ag", "repeating_armour_equip"], function(obj) {
+        var agact = 0;
+        var ag = obj.repeating_armour_ag;
+        var equip = obj.repeating_armour_equip;
+        if (equip == "on") {
+            equip = 1;
+        }
+        agact = ag * equip;
+        setAttrs({"repeating_armour_agact":agact});
+    });
+});
+
+on("change:repeating_armour:agact remove:repeating_armour", function() {
+    var tot = 0;
+    getSectionIDs("repeating_armour", function(idArray) {
+        var IDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            IDs.push("repeating_armour_" + idArray[i] + "_agact");
         }
         getAttrs(IDs, function(obj) {
             _.each(obj, function(value, key) {
@@ -233,6 +444,204 @@ on("change:repeating_armour:aagact remove:repeating_armour", function() {
         });
     });
 });
+
+// Updating armour summary
+
+on("change:repeating_armour:options-flag", function() {
+    getAttrs(["repeating_armour_options-flag"], function(flag) {
+        // When closing the options display, update the summary
+        if(flag["repeating_armour_options-flag"] == 0) {
+            getAttrs(["repeating_armour_type","repeating_armour_pro",
+            "repeating_armour_ag","repeating_armour_sth",
+            "repeating_armour_equip"], function(obj) {
+                var attrs = {};
+                attrs["repeating_armour_sum-type"] = obj.repeating_armour_type;
+                attrs["repeating_armour_sum-pro"] = obj.repeating_armour_pro;
+                attrs["repeating_armour_sum-ag"] = obj.repeating_armour_ag;
+                attrs["repeating_armour_sum-sth"] = obj.repeating_armour_sth;
+                var equip = "N";
+                if(obj.repeating_armour_equip=="on") {
+                    equip = "Y";
+                }
+                attrs["repeating_armour_sum-equip"] = equip;
+                setAttrs(attrs);
+            });
+        }
+    });
+});
+
+// Getting total defence from shields
+
+on("change:repeating_shield:rank change:repeating_shield:dfpr change:repeating_shield:equip", function() {
+    getAttrs(["repeating_shield_rank", "repeating_shield_dfpr", "repeating_shield_equip"], function(obj) {
+        var df = 0;
+        var def = 0;
+        var rank = obj.repeating_shield_rank;
+        var dfpr = obj.repeating_shield_dfpr;
+        var equip = obj.repeating_shield_equip;
+        if (equip == "on") {
+            equip = 1;
+        }
+        df = rank * dfpr * equip;
+        def = rank * dfpr;
+        setAttrs({"repeating_shield_df":df, "repeating_shield_def":def});
+    });
+});
+
+on("change:repeating_shield:df remove:repeating_shield", function() {
+    var tot = 0;
+    getSectionIDs("repeating_shield", function(idArray) {
+        var IDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            IDs.push("repeating_shield_" + idArray[i] + "_df");
+        }
+        getAttrs(IDs, function(obj) {
+            _.each(obj, function(value, key) {
+                tot += value*1;
+            });
+            setAttrs({"sdftot":tot})
+        });
+    });
+});
+
+// Calculating shield MD total
+
+on("change:repeating_shield:md change:repeating_shield:equip", function() {
+    getAttrs(["repeating_shield_md", "repeating_shield_equip"], function(obj) {
+        var mdact = 0;
+        var md = obj.repeating_shield_md;
+        var equip = obj.repeating_shield_equip;
+        if (equip == "on") {
+            equip = 1;
+        }
+        mdact = md * equip;
+        setAttrs({"repeating_shield_mdact":mdact});
+    });
+});
+
+on("change:repeating_shield:mdact remove:repeating_shield", function() {
+    var tot = 0;
+    getSectionIDs("repeating_shield", function(idArray) {
+        var IDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            IDs.push("repeating_shield_" + idArray[i] + "_mdact");
+        }
+        getAttrs(IDs, function(obj) {
+            _.each(obj, function(value, key) {
+                tot += value*1;
+            });
+            setAttrs({"smdtot":tot})
+        });
+    });
+});
+
+// Updating shield summary
+
+on("change:repeating_shield:options-flag", function() {
+    getAttrs(["repeating_shield_options-flag"], function(flag) {
+        // When closing the options display, update the summary
+        if(flag["repeating_shield_options-flag"] == 0) {
+            getAttrs(["repeating_shield_type","repeating_shield_rank",
+            "repeating_shield_def","repeating_shield_md","repeating_shield_equip"], 
+                function(obj) {
+                    var attrs = {};
+                    attrs["repeating_shield_sum-type"] = obj.repeating_shield_type;
+                    attrs["repeating_shield_sum-rank"] = obj.repeating_shield_rank;
+                    attrs["repeating_shield_sum-df"] = obj.repeating_shield_def;
+                    attrs["repeating_shield_sum-md"] = obj.repeating_shield_md;
+                    var equip = "N";
+                    if(obj.repeating_shield_equip=="on") {
+                        equip = "Y";
+                    }
+                    attrs["repeating_shield_sum-equip"] = equip;
+                    setAttrs(attrs);
+                }
+            );
+        }
+    });
+});
+
+// Calculating all the weight totals
+
+on("change:repeating_weapon:wgtact remove:repeating_weapon", function() {
+    var wgttot = 0;
+    getSectionIDs("repeating_weapon", function(idArray) {
+        var wgtIDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            wgtIDs.push("repeating_weapon_" + idArray[i] + "_wgtact");
+        }
+        getAttrs(wgtIDs, function(objWgts) {
+            _.each(objWgts, function(value) {
+                wgttot += value*10000;
+            });
+            wgttot = wgttot/10000;
+            setAttrs({"wwgttot":wgttot});
+        });
+    });
+});
+
+on("change:repeating_armour:wgt remove:repeating_armour", function() {
+    var wgttot = 0;
+    getSectionIDs("repeating_armour", function(idArray) {
+        var wgtIDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            wgtIDs.push("repeating_armour_" + idArray[i] + "_wgt");
+        }
+        getAttrs(wgtIDs, function(objWgts) {
+            _.each(objWgts, function(value) {
+                wgttot += value*10000;
+            });
+            wgttot = wgttot/10000;
+            setAttrs({"awgttot":wgttot});
+        });
+    });
+});
+
+on("change:repeating_shield:wgt remove:repeating_shield", function() {
+    var wgttot = 0;
+    getSectionIDs("repeating_shield", function(idArray) {
+        var wgtIDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            wgtIDs.push("repeating_shield_" + idArray[i] + "_wgt");
+        }
+        getAttrs(wgtIDs, function(objWgts) {
+            _.each(objWgts, function(value) {
+                wgttot += value*10000;
+            });
+            wgttot = wgttot/10000;
+            setAttrs({"swgttot":wgttot});
+        });
+    });
+});
+
+on("change:repeating_possession:wgt remove:repeating_possession", function() {
+    var wgttot = 0;
+    getSectionIDs("repeating_possession", function(idArray) {
+        var wgtIDs = [];
+        for (var i = 0; i < idArray.length; i++) {
+            wgtIDs.push("repeating_possession_" + idArray[i] + "_wgt");
+        }
+        getAttrs(wgtIDs, function(objWgts) {
+            _.each(objWgts, function(value) {
+                wgttot += value*10000;
+            });
+            wgttot = wgttot/10000;
+            setAttrs({"pwgttot":wgttot});
+        });
+    });
+});
+
+// Calculating wgttot
+
+on("change:wwgttot change:awgttot change:swgttot change:monwgt change:pwgttot", function() {
+    getAttrs(["wwgttot", "awgttot", "swgttot", "monwgt", "pwgttot"], function(values) {
+        setAttrs( {
+            "wgttot": ((values.wwgttot*1)+(values.awgttot*1)+(values.swgttot*1)+(values.monwgt*1)+(values.pwgttot*1))
+        });
+    });
+});
+
+// Calculating pagcalc
 
 on("change:ps change:wgttot", function(info) {
     getAttrs(["ps", "wgttot"], function(values) {
@@ -267,24 +676,6 @@ on("change:ps change:wgttot", function(info) {
     });
 });
 
-on("change:aagtot change:ag change:pagcalc", function() {
-    getAttrs(["ag","aagtot","pagcalc"], function(obj) {
-        console.log("%cAgility or Agility Modifier changed","color:red");
-        console.log(obj);
-        console.log((obj.ag*1) + (obj.aagtot*1) + (obj.pagcalc*1));
-        console.log(obj.ag*1);
-        console.log(obj.aagtot*1);
-        console.log(obj.pagcalc*1);
-        if ((obj.pagcalc*1) == -99) {
-            obj.pagcalc = (obj.ag*-1) + (obj.aagtot*-1)
-        }
-        console.log(obj.pagcalc);
-        setAttrs({
-            "agcurr": (obj.ag*1) + (obj.aagtot*1) + (obj.pagcalc*1)
-        });
-    });
-});
-
 // Calculating total sp value & weight of money
 
 on("change:cf change:sp change:gs change:tg", function() {
@@ -296,540 +687,207 @@ on("change:cf change:sp change:gs change:tg", function() {
     });
 });
 
-// Calculating weights for multiples of weapons
-
-on("change:repeating_weapon:wnum change:repeating_weapon:wwgt", function() {
-    getAttrs(["repeating_weapon_wnum", "repeating_weapon_wwgt"], function(obj) {
-        setAttrs({
-            "repeating_weapon_wwgtact": ((obj.repeating_weapon_wnum*(obj.repeating_weapon_wwgt*10000))/10000)
-        });
-    });
-});
-
-// Calculating weapon IV
-
-on("change:repeating_weapon:wrank", function() {
-    getAttrs(["repeating_weapon_wrank", "ib"], function(obj) {
-        var wrank = obj.repeating_weapon_wrank;
-        if (wrank==undefined) { wrank = 0; }
-        var wiv = (wrank*1)+(obj.ib*1);
-        setAttrs({
-            "repeating_weapon_wiv": wiv,
-            "repeating_weapon_wsum-iv": wiv
-        });
-    });
-});
-
-on("change:ib", function() {
-    // Trigger recalc of IV for all weapons
-    getSectionIDs("repeating_weapon", function(idArray) {
-        var IDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_weapon_" + idArray[i] + "_wrank");
-        }
-        IDs.push("ib");
-        getAttrs(IDs, function(objAttrs) {
-            var ib = objAttrs.ib*1;
-            delete objAttrs.ib;
-            var attrs = {};
-            _.each(objAttrs, function(value, key) {
-                var wivID = key.slice(0, -5);
-                if (value == undefined || value == "") { value=0; }
-                var wiv = ib + (value*1);
-                attrs[wivID + "wiv"] = wiv;
-                attrs[wivID + "wsum-iv"] = wiv;
-            });
-            setAttrs(attrs);
-        });
-    });
-});
-
-// Calculating Unarmed Combat IV
-
-on("change:wuc-wrank change:ib", function() {
-    getAttrs(["wuc-wrank","ib"], function(obj) {
-        var wrank = obj["wuc-wrank"];
-        if (wrank == undefined || wrank == "") { wrank = 0; }
-        var iv = (obj.ib*1) + (wrank*1);
-        setAttrs({
-            "wuc-wiv": iv,
-            "wuc-wsum-iv": iv
-        });
-    });
-});
-
-// Calculating weapon SC
-
-on("change:repeating_weapon:wbase change:repeating_weapon:wrank", function() {
-    getAttrs(["repeating_weapon_wbase","repeating_weapon_wrank","mdcurr"], function(obj) {
-        var wrank = obj.repeating_weapon_wrank;
-        var rank = undefined;
-        if (wrank != undefined && wrank != "") { rank = obj.repeating_weapon_wrank*1; }
-        var wsc =  ((obj.repeating_weapon_wbase*1)+((rank != undefined) ? rank*4 + (obj.mdcurr*1) : 0));
-        setAttrs({
-            "repeating_weapon_wsc": wsc,
-            "repeating_weapon_wsum-sc": wsc
-        });
-    });
-});
-
-on("change:mdcurr", function() {
-    // Trigger recalc of SC for all weapons
-    getSectionIDs("repeating_weapon", function(idArray) {
-        var IDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_weapon_" + idArray[i] + "_wbase");
-            IDs.push("repeating_weapon_" + idArray[i] + "_wrank");
-        }
-        IDs.push("mdcurr");
-        getAttrs(IDs, function(objAttrs) {
-            var mdcurr = objAttrs.mdcurr;
-            delete objAttrs.mdcurr;
-            var objWbase = {};
-            var objWrank = {};
-            var keys = [];
-            var attrs = {};
-            _.each(objAttrs, function(value, key) {
-                if (key.slice(-4) == "base") {
-                    key = key.slice(0, -6);
-                    objWbase[key] = value;
-                    keys.push(key);
-                }
-                else if (key.slice(-4) == "rank") {
-                    key = key.slice(0, -6);
-                    objWrank[key] = value;
-                }
-            });
-            for (var i = 0; i < keys.length; i++) {
-                var wrank = objWrank[keys[i]];
-                var rank = undefined;
-                if (wrank != undefined && wrank != "") { rank = objWrank[keys[i]]*1; }
-                var sc = (objWbase[keys[i]]*1) + ((rank != undefined) ? (rank*4) + mdcurr : 0);
-                attrs[keys[i] + "_wsc"] = sc;
-                attrs[keys[i] + "_wsum-sc"] = sc;
-            }
-            setAttrs(attrs);
-        });
-    });    
-});
-
-// Calculating Unarmed Combat SC
-
-on("change:wuc-wrank change:wuc-wbase change:mdcurr", function() {
-    getAttrs(["wuc-wrank","wuc-wbase","mdcurr"], function(obj) {
-        var wrank = obj["wuc-wrank"];
-        var rank = undefined;
-        if (wrank != undefined && wrank != "") { rank = obj["wuc-wrank"]*1; }
-        var sc = ((obj["wuc-wbase"]*1) + ((rank != undefined) ? (rank*4) + (obj.mdcurr*1) : 0));
-        setAttrs({
-            "wuc-wsc": sc,
-            "wuc-wsum-sc": sc
-        });
-    });
-});
-
-// Calculating Unarmed combat base & damage
-
-on("change:agcurr change:ps", function() {
-    getAttrs(["agcurr","ps"], function(obj) {
-        var ps = obj.ps * 1;
-        var psbonus = (ps > 15) ? ps - 15 : 0;
-        var dmbonus = Math.floor(psbonus/3) - 4;
-        setAttrs({
-            "wuc-wbase": (obj.agcurr * 2) + psbonus,
-            "wuc-wdm": dmbonus,
-            "wuc-wsum-dm": dmbonus
-        });
-    });
-});
-
-// Calculating all the weight totals
-
-on("change:repeating_weapon:wwgtact remove:repeating_weapon", function() {
-    var wgttot = 0;
-    getSectionIDs("repeating_weapon", function(idArray) {
-        var wgtIDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            wgtIDs.push("repeating_weapon_" + idArray[i] + "_wwgtact");
-        }
-        getAttrs(wgtIDs, function(objWgts) {
-            _.each(objWgts, function(value) {
-                wgttot += value*10000;
-            });
-            wgttot = wgttot/10000;
-            setAttrs({"wwgttot":wgttot});
-        });
-    });
-});
-
-on("change:repeating_armour:awgt remove:repeating_armour", function() {
-    var wgttot = 0;
-    getSectionIDs("repeating_armour", function(idArray) {
-        var wgtIDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            wgtIDs.push("repeating_armour_" + idArray[i] + "_awgt");
-        }
-        getAttrs(wgtIDs, function(objWgts) {
-            _.each(objWgts, function(value) {
-                wgttot += value*10000;
-            });
-            wgttot = wgttot/10000;
-            setAttrs({"awgttot":wgttot});
-        });
-    });
-});
-
-on("change:repeating_shield:swgt remove:repeating_shield", function() {
-    var wgttot = 0;
-    getSectionIDs("repeating_shield", function(idArray) {
-        var wgtIDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            wgtIDs.push("repeating_shield_" + idArray[i] + "_swgt");
-        }
-        getAttrs(wgtIDs, function(objWgts) {
-            _.each(objWgts, function(value) {
-                wgttot += value*10000;
-            });
-            wgttot = wgttot/10000;
-            setAttrs({"swgttot":wgttot});
-        });
-    });
-});
-
-on("change:repeating_possession:pwgt remove:repeating_possession", function() {
-    var wgttot = 0;
-    getSectionIDs("repeating_possession", function(idArray) {
-        var wgtIDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            wgtIDs.push("repeating_possession_" + idArray[i] + "_pwgt");
-        }
-        getAttrs(wgtIDs, function(objWgts) {
-            _.each(objWgts, function(value) {
-                wgttot += value*10000;
-            });
-            wgttot = wgttot/10000;
-            setAttrs({"pwgttot":wgttot});
-        });
-    });
-});
-
-// Calculating wgttot
-
-on("change:wwgttot change:awgttot change:swgttot change:monwgt change:pwgttot", function() {
-    getAttrs(["wwgttot", "awgttot", "swgttot", "monwgt", "pwgttot"], function(values) {
-        setAttrs( {
-            "wgttot": ((values.wwgttot*1)+(values.awgttot*1)+(values.swgttot*1)+(values.monwgt*1)+(values.pwgttot*1))
-        });
-    });
-});
-
-// Getting total protection from armour
-
-on("change:repeating_armour:apro change:repeating_armour:aequip", function(log) {
-    getAttrs(["repeating_armour_apro", "repeating_armour_aequip"], function(obj) {
-        var aproact = 0;
-        var apro = obj.repeating_armour_apro;
-        var aequip = obj.repeating_armour_aequip;
-        if (aequip == "on") {
-            aequip = 1;
-        }
-        aproact = apro * aequip;
-        setAttrs({"repeating_armour_aproact":aproact});
-    });
-});
-
-on("change:repeating_armour:aproact remove:repeating_armour", function() {
-    var tot = 0;
-    getSectionIDs("repeating_armour", function(idArray) {
-        var IDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_armour_" + idArray[i] + "_aproact");
-        }
-        getAttrs(IDs, function(obj) {
-            _.each(obj, function(value, key) {
-                tot += value*1;
-            });
-            setAttrs({"pro":tot})
-        });
-    });
-});
-
-// Getting total defence from shields
-
-on("change:repeating_shield:srank change:repeating_shield:sdfpr change:repeating_shield:sequip", function() {
-    getAttrs(["repeating_shield_srank", "repeating_shield_sdfpr", "repeating_shield_sequip"], function(obj) {
-        var sdf = 0;
-        var sdef = 0;
-        var srank = obj.repeating_shield_srank;
-        var sdfpr = obj.repeating_shield_sdfpr;
-        var sequip = obj.repeating_shield_sequip;
-        if (sequip == "on") {
-            sequip = 1;
-        }
-        sdf = srank * sdfpr * sequip;
-        sdef = srank * sdfpr;
-        setAttrs({"repeating_shield_sdf":sdf, "repeating_shield_sdef":sdef});
-    });
-});
-
-on("change:repeating_shield:sdf remove:repeating_shield", function() {
-    var tot = 0;
-    getSectionIDs("repeating_shield", function(idArray) {
-        var IDs = [];
-        for (var i = 0; i < idArray.length; i++) {
-            IDs.push("repeating_shield_" + idArray[i] + "_sdf");
-        }
-        getAttrs(IDs, function(obj) {
-            _.each(obj, function(value, key) {
-                tot += value*1;
-            });
-            setAttrs({"sdftot":tot})
-        });
-    });
-});
-
-// Calculating Main SC% for spells
-
-
-
-// Updating weapon summary
-
-on("change:repeating_weapon:wname change:repeating_weapon:wnum", function() {
-    getAttrs(["repeating_weapon_wname", "repeating_weapon_wnum"], function(obj) {
-        var num = "";
-        var wnum = obj.repeating_weapon_wnum*1;
-        if (wnum > 1) {
-            num = " (" + wnum + ")";
-        }
-        else if(wnum == 0) {
-            num = " - unavailable"
-        }
-        setAttrs({
-            "repeating_weapon_wsum-name": obj.repeating_weapon_wname + num
-        });
-    });
-});
-
-on("change:repeating_weapon:wuser change:repeating_weapon:wusem change:repeating_weapon:wusec", function() {
-    getAttrs(["repeating_weapon_wuser","repeating_weapon_wusem","repeating_weapon_wusec"], function(obj) {
-        setAttrs({
-            "repeating_weapon_wsum-use": (obj.repeating_weapon_wuser=="0" ? "" : "R") + (obj.repeating_weapon_wusem=="0" ? "" : "M") + (obj.repeating_weapon_wusec=="0" ? "" : "C")
-        });
-    });
-});
-
-on("change:repeating_weapon:wrg", function() {
-    getAttrs(["repeating_weapon_wrg"], function(obj) {
-        setAttrs({
-            "repeating_weapon_wsum-range": obj.repeating_weapon_wrg
-        });
-    });
-});
-
-on("change:repeating_weapon:wdm", function() {
-    getAttrs(["repeating_weapon_wdm"], function(obj) {
-        setAttrs({
-            "repeating_weapon_wsum-dm": obj.repeating_weapon_wdm
-        });
-    });
-});
-
-on("change:repeating_weapon:wcl", function() {
-    getAttrs(["repeating_weapon_wcl"], function(obj) {
-        setAttrs({
-            "repeating_weapon_wsum-cl": obj.repeating_weapon_wcl
-        });
-    });
-});
-
-on("change:repeating_weapon:wrank change:repeating_weapon:wrankmax", function() {
-    getAttrs(["repeating_weapon_wrank","repeating_weapon_wrankmax"], function(obj) {
-        var wrank = obj.repeating_weapon_wrank;
-        var wrankmax = obj.repeating_weapon_wrankmax;
-        if (wrank == undefined || wrank == "") { wrank = "-"; }
-        if (wrankmax == undefined || wrankmax == "") { wrankmax = "-"; }
-        setAttrs({
-            "repeating_weapon_wsum-rank": wrank + "/" + wrankmax
-        });
-    });
-});
-
-// Updating Unarmed combat weapon summary
-
-on("change:wuc-wrank", function() {
-    getAttrs(["wuc-wrank"], function(obj) {
-        var wrank = obj["wuc-wrank"];
-        if (wrank == undefined || wrank == "") { wrank = "-"; }
-        setAttrs({
-            "wuc-wsum-rank": wrank
-        });
-    });
-});
-
-// Updating armour summary
-
-on("change:repeating_armour:atype", function() {
-    getAttrs(["repeating_armour_atype"], function(obj) {
-        setAttrs({
-            "repeating_armour_asum-type": obj.repeating_armour_atype
-        });
-    });
-});
-
-on("change:repeating_armour:apro", function() {
-    getAttrs(["repeating_armour_apro"], function(obj) {
-        setAttrs({
-            "repeating_armour_asum-pro": obj.repeating_armour_apro
-        });
-    });
-});
-
-on("change:repeating_armour:aag", function() {
-    getAttrs(["repeating_armour_aag"], function(obj) {
-        setAttrs({
-            "repeating_armour_asum-ag": obj.repeating_armour_aag
-        });
-    });
-});
-
-on("change:repeating_armour:asth", function() {
-    getAttrs(["repeating_armour_asth"], function(obj) {
-        setAttrs({
-            "repeating_armour_asum-sth": obj.repeating_armour_asth
-        });
-    });
-});
-
-on("change:repeating_armour:aequip", function() {
-    getAttrs(["repeating_armour_aequip"], function(obj) {
-        var equip = "N";
-        if(obj.repeating_armour_aequip=="on") {
-            equip = "Y";
-        }
-        setAttrs({
-            "repeating_armour_asum-equip": equip
-        });
-    });
-});
-
-// Updating shield summary
-
-on("change:repeating_shield:stype", function() {
-    getAttrs(["repeating_shield_stype"], function(obj) {
-        setAttrs({
-            "repeating_shield_ssum-type": obj.repeating_shield_stype
-        });
-    });
-});
-
-on("change:repeating_shield:srank", function() {
-    getAttrs(["repeating_shield_srank"], function(obj) {
-        setAttrs({
-            "repeating_shield_ssum-rank": obj.repeating_shield_srank
-        });
-    });
-});
-
-on("change:repeating_shield:sdef", function() {
-    getAttrs(["repeating_shield_sdef"], function(obj) {
-        setAttrs({
-            "repeating_shield_ssum-df": obj.repeating_shield_sdef
-        });
-    });
-});
-
-on("change:repeating_shield:smd", function() {
-    getAttrs(["repeating_shield_smd"], function(obj) {
-        setAttrs({
-            "repeating_shield_ssum-md": obj.repeating_shield_smd
-        });
-    });
-});
-
-on("change:repeating_shield:sequip", function() {
-    getAttrs(["repeating_shield_sequip"], function(obj) {
-        var equip = "N";
-        if(obj.repeating_shield_sequip=="on") {
-            equip = "Y";
-        }
-        setAttrs({
-            "repeating_shield_ssum-equip": equip
-        });
-    });
-});
-
 // Updating spell summary
 
-on("change:repeating_spell:spname", function() {
-    getAttrs(["repeating_spell_spname"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-name": obj.repeating_spell_spname
-        });
+on("change:repeating_spell:options-flag", function() {
+    getAttrs(["repeating_spell_options-flag"], function(flag) {
+        // When closing the options display, update the summary
+        if(flag["repeating_spell_options-flag"] == 0) {
+           getAttrs(["repeating_spell_name","repeating_spell_type","repeating_spell_rank",
+           "repeating_spell_main","repeating_spell_rg","repeating_spell_dur",
+           "repeating_spell_resp","repeating_spell_resa","repeating_spell_rit"], 
+               function(obj) {
+                    var res = "";
+                    if (obj.repeating_spell_resp == "P") { res += "P"; }
+                    if (obj.repeating_spell_resa == "A") { res += "A"; }
+                    if (res == "") { res = "N"; }
+                    var rit = obj.repeating_spell_rit;
+                    if (rit == "on") { rit = "Y"; }
+                    else {rit = "N"; }
+                    setAttrs({
+                        "repeating_spell_sum-name": obj.repeating_spell_name,
+                        "repeating_spell_sum-type": obj.repeating_spell_type,
+                        "repeating_spell_sum-rank": obj.repeating_spell_rank,
+                        "repeating_spell_sum-main": obj.repeating_spell_main,
+                        "repeating_spell_sum-rg": obj.repeating_spell_rg,
+                        "repeating_spell_sum-dur": obj.repeating_spell_dur,
+                        "repeating_spells_sum-res": res,
+                        "repeating_spell_sum-rit": rit
+                    });
+                }
+           );
+        }
     });
 });
 
-on("change:repeating_spell:sptype", function() {
-    getAttrs(["repeating_spell_sptype"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-type": obj.repeating_spell_sptype
-        });
-    });
-});
+// Check version and update
 
-on("change:repeating_spell:sprank", function() {
-    getAttrs(["repeating_spell_sprank"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-rank": obj.repeating_spell_sprank
-        });
-    });
-});
-
-/* Remove and place update into calculation if/when SC is calculated */
-
-on("change:repeating_spell:spmain", function() {
-    getAttrs(["repeating_spell_spmain"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-main": obj.repeating_spell_spmain
-        });
-    });
-});
-
-on("change:repeating_spell:sprg", function() {
-    getAttrs(["repeating_spell_sprg"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-rg": obj.repeating_spell_sprg
-        });
-    });
-});
-
-on("change:repeating_spell:spdur", function() {
-    getAttrs(["repeating_spell_spdur"], function(obj) {
-        setAttrs({
-            "repeating_spell_sum-dur": obj.repeating_spell_spdur
-        });
-    });
-});
-
-on("change:repeating_spell:spresp change:repeating_spell:spresa", function() {
-    getAttrs(["repeating_spell_spresp","repeating_spell_spresa"], function(obj) {
-        var res = "";
-        if (obj.repeating_spell_spresp == "P") { res += "P"; }
-        if (obj.repeating_spell_spresa == "A") { res += "A"; }
-        if (res == "") { res = "N"; }
-        setAttrs({
-            "repeating_spells_sum-res": res
-        });
-    });
-});
-
-on("change:repeating_spell:sprit", function() {
-    getAttrs(["repeating_spell_sprit"], function(obj) {
-        var rit = obj.repeating_spell_sprit;
-        if (rit == "on") { rit = "Y"; }
-        else {rit = "N"; }
-        setAttrs({
-            "repeating_spell_sum-rit": rit
-        });
+on("sheet:opened", function() {
+    getAttrs(["version"], function(obj) {
+        // For no previous version given (i.e. version 1)
+        if (obj.version == undefined || obj.version == "") {
+            // Update Unarmed combat attributes
+            getAttrs(["wuc-wsum-iv","wuc-wsum-sc","wuc-wsum-dm","wuc-wsum-rank", "wuc-wrank","wuc-wnotes","wuc-wiv","wuc-wsc","wuc-wbase","wuc-wdm"],
+                function(wucObj) {
+                    var attrs = {};
+                    for (var attr in wucObj) {
+                        var newAttr = attr.slice(0, attr.lastIndexOf("w")) + attr.slice(attr.lastIndexOf("w")+1);
+                        attrs[newAttr] = wucObj[attr];
+                    }
+                    setAttrs(attrs);
+                }
+            );
+            //Update the various repeating sections
+            getSectionIDs("repeating_weapon", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_weapon_"+idArray[i]+"_wsum-name",
+                        "repeating_weapon_"+idArray[i]+"_wsum-use",
+                        "repeating_weapon_"+idArray[i]+"_wsum-range",
+                        "repeating_weapon_"+idArray[i]+"_wsum-iv",
+                        "repeating_weapon_"+idArray[i]+"_wsum-sc",
+                        "repeating_weapon_"+idArray[i]+"_wsum-dm",
+                        "repeating_weapon_"+idArray[i]+"_wsum-cl",
+                        "repeating_weapon_"+idArray[i]+"_wsum-rank",
+                        "repeating_weapon_"+idArray[i]+"_wname",
+                        "repeating_weapon_"+idArray[i]+"_wrank",
+                        "repeating_weapon_"+idArray[i]+"_wrankmax",
+                        "repeating_weapon_"+idArray[i]+"_wnum",
+                        "repeating_weapon_"+idArray[i]+"_wnotes",
+                        "repeating_weapon_"+idArray[i]+"_wiv",
+                        "repeating_weapon_"+idArray[i]+"_wsc",
+                        "repeating_weapon_"+idArray[i]+"_wwgt",
+                        "repeating_weapon_"+idArray[i]+"_wwgtact",
+                        "repeating_weapon_"+idArray[i]+"_wbase",
+                        "repeating_weapon_"+idArray[i]+"_wdm",
+                        "repeating_weapon_"+idArray[i]+"_wrg",
+                        "repeating_weapon_"+idArray[i]+"_wps",
+                        "repeating_weapon_"+idArray[i]+"_wmd",
+                        "repeating_weapon_"+idArray[i]+"_wcl",
+                        "repeating_weapon_"+idArray[i]+"_wuser",
+                        "repeating_weapon_"+idArray[i]+"_wusem",
+                        "repeating_weapon_"+idArray[i]+"_wusec",
+                        "repeating_weapon_"+idArray[i]+"_whand1",
+                        "repeating_weapon_"+idArray[i]+"_whand2"], 
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+2);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+            getSectionIDs("repeating_armour", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_armour_"+idArray[i]+"_atype",
+                        "repeating_armour_"+idArray[i]+"_aequip",
+                        "repeating_armour_"+idArray[i]+"_aproact",
+                        "repeating_armour_"+idArray[i]+"_anotes",
+                        "repeating_armour_"+idArray[i]+"_awgt",
+                        "repeating_armour_"+idArray[i]+"_apro",
+                        "repeating_armour_"+idArray[i]+"_aag",
+                        "repeating_armour_"+idArray[i]+"_aagact",
+                        "repeating_armour_"+idArray[i]+"_asth"], 
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+2);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+            getSectionIDs("repeating_shield", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_shield_"+idArray[i]+"_stype",
+                        "repeating_shield_"+idArray[i]+"_sequip",
+                        "repeating_shield_"+idArray[i]+"_srank",
+                        "repeating_shield_"+idArray[i]+"_sdf",
+                        "repeating_shield_"+idArray[i]+"_sdef",
+                        "repeating_shield_"+idArray[i]+"_snotes",
+                        "repeating_shield_"+idArray[i]+"_swgt",
+                        "repeating_shield_"+idArray[i]+"_sdfpr",
+                        "repeating_shield_"+idArray[i]+"_smd",
+                        "repeating_shield_"+idArray[i]+"_smdact"],
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+2);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+            getSectionIDs("repeating_possession", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_possession_"+idArray[i]+"_pname",
+                        "repeating_possession_"+idArray[i]+"_pwgt"],
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+2);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+            getSectionIDs("repeating_spell", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_spell_"+idArray[i]+"_sprank",
+                        "repeating_spell_"+idArray[i]+"_spmain",
+                        "repeating_spell_"+idArray[i]+"_spdesc",
+                        "repeating_spell_"+idArray[i]+"_spname",
+                        "repeating_spell_"+idArray[i]+"_sprg",
+                        "repeating_spell_"+idArray[i]+"_spdur",
+                        "repeating_spell_"+idArray[i]+"_spexm",
+                        "repeating_spell_"+idArray[i]+"_sptype",
+                        "repeating_spell_"+idArray[i]+"_spbase",
+                        "repeating_spell_"+idArray[i]+"_spresp",
+                        "repeating_spell_"+idArray[i]+"_spresa",
+                        "repeating_spell_"+idArray[i]+"_sprit"],
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+3);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+            getSectionIDs("repeating_skill", function(idArray) {
+                for (var i = 0; i < idArray.length; i++) {
+                    getAttrs(
+                        ["repeating_skill_"+idArray[i]+"_sktype",
+                        "repeating_skill_"+idArray[i]+"_sknotes",
+                        "repeating_skill_"+idArray[i]+"_skrank"],
+                        function(obj) {
+                            var attrs = {};
+                            for (var attr in obj) {
+                                var newAttr = attr.slice(0, attr.lastIndexOf("_")+1) + attr.slice(attr.lastIndexOf("_")+3);
+                                attrs[newAttr] = obj[attr];
+                            }
+                            setAttrs(attrs);
+                        }
+                    );
+                }
+            });
+        }
+        setAttrs({version: 1.1});
     });
 });
 
@@ -847,7 +905,7 @@ on("change:repeating_spell:sprit", function() {
             <div class="sheet-stat"><span class="sheet-pictos">U</span><span name="attr_stat-height"></span></div>
             <div class="sheet-stat"><span class="sheet-pictos">a</span><span name="attr_stat-weight"></span></div>
             <div class="sheet-stat"><span class="sheet-pictos">\</span><span name="attr_stat-age"></span></div>
-            <div class="sheet-stat"><span class="sheet-pictos">k</span><button class="sheet-btn" type="roll" value="&{template:default} {{name=Beauty Roll}} {{D100=[[1d100]]}} {{Physical Beauty=[[@{pb}]]}}}"><span name="attr_stat-pb"></span></button></div>
+            <div class="sheet-stat"><span class="sheet-pictos">k</span><button class="sheet-btn" type="roll" value="&{template:default} {{name=Beauty Roll}}} {{Physical Beauty=[[@{pb}]]}} {{D100=[[1d100]]}}"><span name="attr_stat-pb"></span></button></div>
         </div>
         <div class="sheet-header">History</div>
         <div class="sheet-hsummary">
@@ -947,22 +1005,22 @@ on("change:repeating_spell:sprit", function() {
                 <div class="sheet-prichars">
                     <ul>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Strength Roll}} {{D100=[[1d100]]}} {{Physical Strength=[[@{ps}]]}} {{Mults = [[@{ps}*3]] | [[@{ps}/5]] }}">Physical Strength (PS):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Strength Roll}} {{Physical Strength=[[@{ps}]]}} {{D100=[[1d100]]}}">Physical Strength (PS):</button>
                             <input type="number" name="attr_ps" value="0" min="0"></li>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Dexterity Roll}} {{D100=[[1d100]]}} {{Manual Dexterity=[[@{mdcurr}]]}}">Manual Dexterity (MD):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Dexterity Roll}} {{Manual Dexterity=[[@{mdcurr}]]}} {{D100=[[1d100]]}}">Manual Dexterity (MD):</button>
                             <input type="number" name="attr_mdcurr" value="0" readonly> / <input type="number" name="attr_md" value="0" min="0"></li>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Agility Roll}} {{D100=[[1d100]]}} {{Agility=[[@{agcurr}]]}}">Agility (AG):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Agility Roll}} {{Agility=[[@{agcurr}]]}} {{D100=[[1d100]]}}">Agility (AG):</button>
                             <input type="number" name="attr_agcurr" readonly value="0"> / <input type="number" name="attr_ag" value="0" min="0"></li>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Magic Aptitude Roll}} {{D100=[[1d100]]}} {{Magical Aptitude=[[@{ma}]]}}">Magical Aptitude (MA):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Magic Aptitude Roll}} {{Magical Aptitude=[[@{ma}]]}} {{D100=[[1d100]]}}">Magical Aptitude (MA):</button>
                             <input type="number" name="attr_ma" value="0" min="0"></li>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Will Power Roll}} {{D100=[[1d100]]}} {{Will Power=[[@{wp}]]}}">Will Power (WP):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Will Power Roll}} {{Will Power=[[@{wp}]]}} {{D100=[[1d100]]}}">Will Power (WP):</button>
                             <input type="number" name="attr_wp" value="0" min="0"></li>
                         <li>
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Perception Roll}} {{D100=[[1d100]]}} {{Perception=[[@{pc}]]}}">Perception (PC):</button>
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=Perception Roll}} {{Perception=[[@{pc}]]}} {{D100=[[1d100]]}}">Perception (PC):</button>
                             <input type="number" name="attr_pc" value="0" min="0"></li>
                         <li>
                             <span>Initiative base:</span>
@@ -1009,7 +1067,7 @@ on("change:repeating_spell:sprit", function() {
         <!-- Weapons -->
         <div class="sheet-weapons">
             <div class="sheet-header">Weapons</div>
-            <div class="sheet-wheaders">
+            <div class="sheet-headers">
                 <span>Name</span>
                 <span>Use</span>
                 <span>RG</span>
@@ -1018,22 +1076,22 @@ on("change:repeating_spell:sprit", function() {
                 <span>DM</span>
                 <span>CL</span>
                 <span>RNK</span>
-                <span> </span>
+                <span> </span><!-- For icons  -->
             </div>
             <div class="sheet-repeating-weapon sheet-unarmed-combat">
                 <input class="sheet-options-flag" type="checkbox" name="attr_wuc-options-flag" checked>
                 <span class="sheet-flag-unchecked">W</span><span class="sheet-flag-checked">3</span>
-                <div class="sheet-wsummary">
-                    <button class="sheet-btn" type="roll" value="&{template:default} {{name=Unarmed Combat}} {{D100=[[1d100]]}} {{SC=[[@{wuc-wsc}]]}} {{Damage D10 +  @{wuc-wdm}=[[1d10+@{wuc-wdm}]]}}">
+                <div class="sheet-summary">
+                    <button class="sheet-btn" type="roll" value="&{template:default} {{name=Unarmed Combat}} {{SC=[[@{wuc-sc}]]}} {{D100=[[1d100]]}} {{Damage D10 +  @{wuc-dm}=[[1d10+@{wuc-dm}]]}}">
                     <span>Unarmed combat</span></button>
                     <span>MC</span>
                     <span>0</span>
-                    <span name="attr_wuc-wsum-iv">0</span>
-                    <span name="attr_wuc-wsum-sc">0</span>
-                    <span name="attr_wuc-wsum-dm">0</span>
+                    <span name="attr_wuc-sum-iv">0</span>
+                    <span name="attr_wuc-sum-sc">0</span>
+                    <span name="attr_wuc-sum-dm">0</span>
                     <span>C</span>
-                    <span name="attr_wuc-wsum-rank">0</span>
-                    <span> </span>
+                    <span name="attr_wuc-sum-rank">0</span>
+                    <span> </span><!-- For icons  -->
                 </div>
                 <div class="sheet-weapon">
                     <input class="sheet-expand-flag" type="checkbox" name="attr_wuc-expand-flag" checked>
@@ -1046,10 +1104,10 @@ on("change:repeating_spell:sprit", function() {
                                 <input type="text" value="Unarmed combat" readonly></li>
                             <li>
                                 <span>Rank:</span>
-                                <input type="number" name="attr_wuc-wrank"></li>
+                                <input type="number" name="attr_wuc-rank"></li>
                         </ul>
                         <span>Notes:</span>
-                        <textarea name="attr_wuc-wnotes" placeholder="Weapon notes"></textarea>
+                        <textarea name="attr_wuc-notes" placeholder="Weapon notes"></textarea>
                     </div>
                     <div class="sheet-weaponstats">
                         <div class="sheet-2colsec">
@@ -1057,18 +1115,18 @@ on("change:repeating_spell:sprit", function() {
                                 <ul>
                                     <li>
                                         <span>Initiative (IV):</span>
-                                        <input type="number" name="attr_wuc-wiv" value="0" readonly>
+                                        <input type="number" name="attr_wuc-iv" value="0" readonly>
                                     </li>
                                     <li>
                                         <span>Success chance (SC):</span>
-                                        <input type="number" name="attr_wuc-wsc" value="0" readonly>
+                                        <input type="number" name="attr_wuc-sc" value="0" readonly>
                                     </li>
                                     <li>
                                         <span>Base %:</span>
-                                        <input type="number" name="attr_wuc-wbase" value="0"readonly></li>
+                                        <input type="number" name="attr_wuc-base" value="0" readonly></li>
                                     <li>
                                         <span>Damage (DM):</span>
-                                        <input type="number" name="attr_wuc-wdm" value="0" readonly></li>
+                                        <input type="number" name="attr_wuc-dm" value="0" readonly></li>
                                     <li>
                                         <span>Range (RG):</span>
                                         <input type="number" value="0" readonly></li>
@@ -1082,7 +1140,7 @@ on("change:repeating_spell:sprit", function() {
                                             <option>C - Crushing</option>
                                         </select></li>
                                     <li>
-                                        <div class="sheet-wuse">
+                                        <div class="sheet-use">
                                             <span>Combat Use:</span>
                                             <ul>
                                                 <li>
@@ -1094,7 +1152,7 @@ on("change:repeating_spell:sprit", function() {
                                             </ul>
                                         </div></li>
                                     <li>
-                                        <div class="sheet-whand">
+                                        <div class="sheet-hand">
                                             <span>Handed:</span>
                                                 <input type="checkbox" value="1" checked readonly><span>1</span>
                                                 <input type="checkbox" value="2" readonly><span>2</span>
@@ -1109,17 +1167,17 @@ on("change:repeating_spell:sprit", function() {
                 <div class="sheet-repeating-weapon">
                     <input class="sheet-options-flag" type="checkbox" name="attr_options-flag" checked>
                     <span class="sheet-flag-unchecked">W</span><span class="sheet-flag-checked">3</span>
-                    <div class="sheet-wsummary">
-                        <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{wname}}} {{D100=[[1d100]]}} {{SC=[[@{wsc}]]}} {{Damage D10 + @{wdm}=[[1d10+@{wdm}]]}}">
-                        <span name="attr_wsum-name"></span></button>
-                        <span name="attr_wsum-use"></span>
-                        <span name="attr_wsum-range"></span>
-                        <span name="attr_wsum-iv"></span>
-                        <span name="attr_wsum-sc"></span>
-                        <span name="attr_wsum-dm"></span>
-                        <span name="attr_wsum-cl"></span>
-                        <span name="attr_wsum-rank"></span>
-                        <span> </span>
+                    <div class="sheet-summary">
+                        <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{name}}} {{SC=[[@{sc}]]}} {{D100=[[1d100]]}} {{Damage D10 + @{dm}=[[1d10+@{dm}]]}}">
+                        <span name="attr_sum-name"></span></button>
+                        <span name="attr_sum-use"></span>
+                        <span name="attr_sum-range"></span>
+                        <span name="attr_sum-iv"></span>
+                        <span name="attr_sum-sc"></span>
+                        <span name="attr_sum-dm"></span>
+                        <span name="attr_sum-cl"></span>
+                        <span name="attr_sum-rank"></span>
+                        <span> </span><!-- For icons  -->
                     </div>
                     <div class="sheet-weapon">
                     <input class="sheet-expand-flag" type="checkbox" name="attr_expand-flag" checked>
@@ -1129,22 +1187,22 @@ on("change:repeating_spell:sprit", function() {
                             <div class="sheet-2colsec">
                                 <div class="sheet-colm">
                                             <span>Weapon:</span>
-                                            <input type="text" name="attr_wname" placeholder="Shortsword">
+                                            <input type="text" name="attr_name" placeholder="Shortsword">
                                 </div>
                                 <div class="sheet-colm">
                                     <ul>
                                         <li>
                                             <span>Rank:</span>
-                                            <input type="number" name="attr_wrank" min="0"> /
-                                            <input type="number" name="attr_wrankmax" min="0"></li>
+                                            <input type="number" name="attr_rank" min="0"> /
+                                            <input type="number" name="attr_rankmax" min="0"></li>
                                         <li>
                                             <span>Number carried:</span>
-                                            <input type="number" name="attr_wnum" value="0" min="0"></li>
+                                            <input type="number" name="attr_num" value="0" min="0"></li>
                                     </ul>
                                 </div>
                             </div>
                             <span>Notes:</span>
-                            <textarea name="attr_wnotes" placeholder="Weapon notes"></textarea>
+                            <textarea name="attr_notes" placeholder="Weapon notes"></textarea>
                         </div>
                         <div class="sheet-weaponstats">
                             <div class="sheet-2colsec">
@@ -1152,60 +1210,60 @@ on("change:repeating_spell:sprit", function() {
                                     <ul>
                                         <li>
                                             <span>Initiative (IV):</span>
-                                            <input type="number" name="attr_wiv" value="0" readonly>
+                                            <input type="number" name="attr_iv" value="0" readonly>
                                         </li>
                                         <li>
                                             <span>Success chance (SC):</span>
-                                            <input type="number" name="attr_wsc" value="0" readonly>
+                                            <input type="number" name="attr_sc" value="0" readonly>
                                         </li>
                                         <li>
                                             <span>Weight (lbs):</span>
-                                            <input type="number" name="attr_wwgt" value="0" min="0" step="any"></li>
-                                            <input type="hidden" name="attr_wwgtact" value="0">
+                                            <input type="number" name="attr_wgt" value="0" min="0" step="any"></li>
+                                            <input type="hidden" name="attr_wgtact" value="0">
                                         <li>
                                             <span>Base %:</span>
-                                            <input type="number" name="attr_wbase" value="0" min="0"></li>
+                                            <input type="number" name="attr_base" value="0" min="0"></li>
                                         <li>
                                             <span>Damage (DM):</span>
-                                            <input type="number" name="attr_wdm" value="0" min="0"></li>
+                                            <input type="number" name="attr_dm" value="0" min="0"></li>
                                         <li>
                                             <span>Range (RG):</span>
-                                            <input type="number" name="attr_wrg" value="0" min="0"></li>
+                                            <input type="number" name="attr_rg" value="0" min="0"></li>
                                     </ul>
                                 </div>
                                 <div class="sheet-colm">
                                     <ul>
                                         <li>
                                             <span>PS required:</span>
-                                            <input type="number" name="attr_wps" value="0" min="0"></li>
+                                            <input type="number" name="attr_ps" value="0" min="0"></li>
                                         <li>
                                             <span>MD required:</span>
-                                            <input type="number" name="attr_wmd" value="0" min="0"></li>
+                                            <input type="number" name="attr_md" value="0" min="0"></li>
                                         <li>
                                             <span>Class (CL):</span>
-                                            <select name="attr_wcl">
+                                            <select name="attr_cl">
                                                 <option value="-">-</option>
                                                 <option value="A">A - Thrusting</option>
                                                 <option value="B">B - Slashing</option>
                                                 <option value="C">C - Crushing</option>
                                             </select></li>
                                         <li>
-                                            <div class="sheet-wuse">
+                                            <div class="sheet-use">
                                                 <span>Combat Use:</span>
                                                 <ul>
                                                     <li>
-                                                        <input type="checkbox" name="attr_wuser" value="R"><span>R - Ranged</span></li>
+                                                        <input type="checkbox" name="attr_user" value="R"><span>R - Ranged</span></li>
                                                     <li>
-                                                        <input type="checkbox" name="attr_wusem" value="M"><span>M - Melee</span></li>
+                                                        <input type="checkbox" name="attr_usem" value="M"><span>M - Melee</span></li>
                                                     <li>
-                                                        <input type="checkbox" name="attr_wusec" value="C"><span>C - Close</span></li>
+                                                        <input type="checkbox" name="attr_usec" value="C"><span>C - Close</span></li>
                                                 </ul>
                                             </div></li>
                                         <li>
-                                            <div class="sheet-whand">
+                                            <div class="sheet-hand">
                                                 <span>Handed:</span>
-                                                <input type="checkbox" value="1" checked name="attr_whand1"><span>1</span>
-                                                <input type="checkbox" value="2" name="attr_whand2"><span>2</span>
+                                                <input type="checkbox" value="1" checked name="attr_hand1"><span>1</span>
+                                                <input type="checkbox" value="2" name="attr_hand2"><span>2</span>
                                             </div></li>
                                     </ul>
                                 </div>
@@ -1218,62 +1276,62 @@ on("change:repeating_spell:sprit", function() {
         <!-- Armour -->
         <div class="sheet-armours">
             <div class="sheet-header">Armours</div>
-            <div class="sheet-aheaders">
+            <div class="sheet-headers">
                 <span>Type</span>
                 <span>Pro</span>
                 <span>AG</span>
                 <span>Sth</span>
                 <span>Equip</span>
-                <span> </span>
+                <span> </span><!-- For icons  -->
             </div>
             <fieldset class="repeating_armour">
                 <div class="sheet-repeating-armour">
                     <input class="sheet-options-flag" type="checkbox" name="attr_options-flag" checked>
                     <span class="sheet-flag-unchecked">W</span><span class="sheet-flag-checked">3</span>
-                    <div class="sheet-asummary">
-                        <span name="attr_asum-type"></span>
-                        <span name="attr_asum-pro"></span>
-                        <span name="attr_asum-ag"></span>
-                        <span name="attr_asum-sth"></span>
-                        <span name="attr_asum-equip"></span>
-                        <span> </span>
+                    <div class="sheet-summary">
+                        <span name="attr_sum-type"></span>
+                        <span name="attr_sum-pro"></span>
+                        <span name="attr_sum-ag"></span>
+                        <span name="attr_sum-sth"></span>
+                        <span name="attr_sum-equip"></span>
+                        <span> </span><!-- For icons  -->
                     </div>
                     <div class="sheet-armour">
                         <ul>
                             <li>
                                 <span>Type:</span>
-                                <input type="text" name="attr_atype" placeholder="Cloth">
+                                <input type="text" name="attr_type" placeholder="Cloth">
                             </li>
                             <li>
                                 <span>Equipped?</span>
-                                <input type="checkbox" name="attr_aequip">
-                                <input type="hidden" name="attr_aproact" value="0">
+                                <input type="checkbox" name="attr_equip">
+                                <input type="hidden" name="attr_proact" value="0">
                             </li>
                             <li>
-                                <textarea name="attr_anotes" placeholder="Armour notes"></textarea>
+                                <textarea name="attr_notes" placeholder="Armour notes"></textarea>
                             </li>
                             <li>
                                 <span>Weight:</span>
-                                <input type="number" name="attr_awgt" value="0" min="0">
+                                <input type="number" name="attr_wgt" value="0" min="0">
                             </li>
                             <li>
                                 <span>Protection:</span>
-                                <input type="number" name="attr_apro" value="0" min="0">  
+                                <input type="number" name="attr_pro" value="0" min="0">  
                             </li>
                             <li>
                                 <span>Agility Loss:</span>
-                                <input type="number" name="attr_aag" value="0" max="0">
-                                <input type="hidden" name="attr_aagact" value="0">
+                                <input type="number" name="attr_ag" value="0" max="0">
+                                <input type="hidden" name="attr_agact" value="0">
                             </li>
                             <li>
                                 <span>Stealth Adjustment:</span>
-                                <input type="number" name="attr_asth" value="0">
+                                <input type="number" name="attr_sth" value="0">
                             </li>
                         </ul>
                     </div>
                 </div>
             </fieldset>
-            <div class="sheet-atotal">
+            <div class="sheet-total">
                 <span>PROTECTION</span>
                 <input type="number" name="attr_pro" readonly value="0">
                 <input type="hidden" name="attr_aagtot" value="0">
@@ -1282,66 +1340,66 @@ on("change:repeating_spell:sprit", function() {
         <!-- Shields -->
         <div class="sheet-shields">
             <div class="sheet-header">Shields</div>
-            <div class="sheet-sheaders">
+            <div class="sheet-headers">
                 <span>Type</span>
                 <span>Rank</span>
                 <span>DF</span>
                 <span>MD</span>
                 <span>Equip</span>
-                <span> </span>
+                <span> </span><!-- For icons  -->
             </div>
             <fieldset class="repeating_shield">
                 <div class="sheet-repeating-shield">
                     <input class="sheet-options-flag" type="checkbox" name="attr_options-flag" checked>
                     <span class="sheet-flag-unchecked">W</span><span class="sheet-flag-checked">3</span>
-                    <div class="sheet-ssummary">
-                        <span name="attr_ssum-type"></span>
-                        <span name="attr_ssum-rank"></span>
-                        <span name="attr_ssum-df"></span>
-                        <span name="attr_ssum-md"></span>
-                        <span name="attr_ssum-equip"></span>
-                        <span> </span>
+                    <div class="sheet-summary">
+                        <span name="attr_sum-type"></span>
+                        <span name="attr_sum-rank"></span>
+                        <span name="attr_sum-df"></span>
+                        <span name="attr_sum-md"></span>
+                        <span name="attr_sum-equip"></span>
+                        <span> </span><!-- For icons  -->
                     </div>
                     <div class="sheet-shield">
                         <ul>
                             <li>
                                 <span>Type:</span>
-                                <input type="text" name="attr_stype">
+                                <input type="text" name="attr_type">
                             </li>
                             <li>
                                 <span>Equipped?</span>
-                                <input type="checkbox" name="attr_sequip">
+                                <input type="checkbox" name="attr_equip">
                             </li>
                             <li>
                                 <span>Rank:</span>
-                                <input type="number" name="attr_srank" value="0" min="0">
+                                <input type="number" name="attr_rank" value="0" min="0">
                             </li>
                             <li>
                                 <span>Shield defence (DF):</span>
-                                <input type="hidden" name="attr_sdf" value="0">
-                                <input type="number" name="attr_sdef" value="0" readonly>
+                                <input type="hidden" name="attr_df" value="0">
+                                <input type="number" name="attr_def" value="0" readonly>
                             </li>
                             <li>
-                                <textarea name="attr_snotes" placeholder="Shield notes"></textarea>
+                                <textarea name="attr_notes" placeholder="Shield notes"></textarea>
                             </li>
                             <li>
                                 <span>Weight:</span>
-                                <input type="number" name="attr_swgt" value="0" min="0">
+                                <input type="number" name="attr_wgt" value="0" min="0">
                             </li>
                             <li>
                                 <span>Defence per rank:</span>
-                                <input type="number" name="attr_sdfpr" value="0" min="0">
+                                <input type="number" name="attr_dfpr" value="0" min="0">
                             </li>
                             <li>
                                 <span>Manual Dexterity loss:</span>
-                                <input type="number" name="attr_smd" value="0" max="0">
-                                <input type="hidden" name="attr_smdact" value="0">
+                                <input type="number" name="attr_md" value="0" max="0">
+                                <input type="hidden" name="attr_mdact" value="0">
                             </li>
                         </ul>
                     </div>
                 </div>
             </fieldset>
-            <div class="sheet-stotal">
+            <div class="sheet-total">
                 <span>SHIELD DEFENCE</span>
                 <input type="number" name="attr_sdftot" readonly value="0">
                 <input type="hidden" name="attr_smdtot" value="0">
@@ -1349,33 +1407,33 @@ on("change:repeating_spell:sprit", function() {
         </div>
         <div class="sheet-possessions">
             <div class="sheet-header">Possessions</div>
-            <div class="sheet-pheaders">
+            <div class="sheet-headers">
                 <span>Name</span>
                 <span>Weight (lbs)</span>
             </div>
-            <div class="sheet-psummary">
+            <div class="sheet-summary">
                 <span>Weapons</span>
                 <span name="attr_wwgttot"></span>
             </div>
-            <div class="sheet-psummary">
+            <div class="sheet-summary">
                 <span>Armours</span>
                 <span name="attr_awgttot"></span>
             </div>
-            <div class="sheet-psummary">
+            <div class="sheet-summary">
                 <span>Shields</span>
                 <span name="attr_swgttot"></span>
             </div>
-            <div class="sheet-psummary">
+            <div class="sheet-summary">
                 <span>Money</span>
                 <span name="attr_monwgt"></span>
             </div>
             <fieldset class="repeating_possession">
                 <div class="sheet-possession">
-                    <input type="text" name="attr_pname">
-                    <input type="number" name="attr_pwgt" value="0" step="any" min="0">
+                    <input type="text" name="attr_name">
+                    <input type="number" name="attr_wgt" value="0" step="any" min="0">
                 </div>
             </fieldset>
-            <div class="sheet-psummary">
+            <div class="sheet-summary">
                 <span>TOTAL</span>
                 <input type="hidden" name="attr_pwgttot" value="0">
                 <span name="attr_wgttot"></span>
@@ -1432,14 +1490,14 @@ on("change:repeating_spell:sprit", function() {
                     <span>DR</span>
                     <span>RS</span>
                     <span>RT</span>
-                    <span> </span> <!-- for the icon -->
+                    <span> </span><!-- For icons  -->
                 </div>
                 <fieldset class="repeating_spell">
                     <div class="sheet-repeating-spell">
                         <input class="sheet-options-flag" type="checkbox" name="attr_options-flag" checked>
                         <span class="sheet-flag-unchecked">W</span><span class="sheet-flag-checked">3</span>
                         <div class="sheet-summary">
-                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{spname}}} {{D100=[[1d100]]}} {{SC=[[@{spmain}]]}}">
+                            <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{name}}} {{SC=[[@{main}]]}} {{D100=[[1d100]]}}">
                             <span name="attr_sum-name"></span></button>
                             <span name="attr_sum-type"></span>
                             <span name="attr_sum-rank"></span>
@@ -1448,22 +1506,22 @@ on("change:repeating_spell:sprit", function() {
                             <span name="attr_sum-dur"></span>
                             <span name="attr_sum-res"></span>
                             <span name="attr_sum-rit"></span>
-                            <span> </span> <!-- for the icon -->
+                            <span> </span><!-- For icons  -->
                         </div>
                         <div class="sheet-spell">
-                            <input class="sheet-expand-flag" type="checkbox" name="attr_wuc-expand-flag" checked>
+                            <input class="sheet-expand-flag" type="checkbox" name="attr_expand-flag" checked>
                             <span class="sheet-shrink">J</span>
                             <span class="sheet-expand">.</span>
                             <div class="sheet-spelldets">
                                 <ul>
                                     <li>
                                         <span>Rank (RK):</span>
-                                        <input type="number" name="attr_sprank" value="0" min="0">
+                                        <input type="number" name="attr_rank" value="0" min="0">
                                     </li>
-                                    <li><span>Main % (SC):</span><input type="number" name="attr_spmain" value="0"></li>
+                                    <li><span>Main % (SC):</span><input type="number" name="attr_main" value="0"></li>
                                     <li>
                                         <span>Effects:</span>
-                                        <textarea name="attr_spdesc" placeholder="Sees the caster as true friend"></textarea>
+                                        <textarea name="attr_desc" placeholder="Sees the caster as true friend"></textarea>
                                     </li>
                                 </ul>
                             </div>
@@ -1473,39 +1531,39 @@ on("change:repeating_spell:sprit", function() {
                                         <ul>
                                             <li>
                                                 <span>Name:</span>
-                                                <input type="text" name="attr_spname" placeholder="Spell of Charming">
+                                                <input type="text" name="attr_name" placeholder="Spell of Charming">
                                             </li>
                                             <li>
                                                 <span>Range (RG):</Span>
-                                                <input type="text" name="attr_sprg" placeholder="15ft">
+                                                <input type="text" name="attr_rg" placeholder="15ft">
                                             </li>
                                             <li>
                                                 <span>Duration (DR):</span>
-                                                <input type="text" name="attr_spdur" placeholder="1 hr">
+                                                <input type="text" name="attr_dur" placeholder="1 hr">
                                             </li>
-                                            <li><span>Experience Multiple (EXM):</span><input type="number" name="attr_spexm" value="0" min="0"></li>
+                                            <li><span>Experience Multiple (EXM):</span><input type="number" name="attr_exm" value="0" min="0"></li>
                                         </ul>
                                     </div>
                                     <div class="sheet-colm">
                                         <ul>
                                             <li>
                                                 <span>Knowledge type (KT):</span>
-                                                <select name="attr_sptype">
+                                                <select name="attr_type">
                                                     <option value="G">General Knowledge</option>
                                                     <option value="S">Special Knowledge</option>
                                                 </select>
                                             </li>
-                                            <li><span>Base %:</span><input type="number" name="attr_spbase" value="0" min="0"></li>
+                                            <li><span>Base %:</span><input type="number" name="attr_base" value="0" min="0"></li>
                                             <li>
-                                                <div class="sheet-spres">
+                                                <div class="sheet-res">
                                                     <span>Resistance (RS):</span>
                                                     <ul>
-                                                        <li><input type="checkbox" value="P" name="attr_spresp">Passive</li>
-                                                        <li><input type="checkbox" value="A" name="attr_spresa">Active</li>
+                                                        <li><input type="checkbox" value="P" name="attr_resp">Passive</li>
+                                                        <li><input type="checkbox" value="A" name="attr_resa">Active</li>
                                                     </ul>
                                                 </div>
                                             </li>
-                                            <li><span>Ritual (RT):</span><input type="checkbox" name="attr_sprit"></li>
+                                            <li><span>Ritual (RT):</span><input type="checkbox" name="attr_rit"></li>
                                             </ul>    
                                     </div>
                                 </div>
@@ -1517,7 +1575,7 @@ on("change:repeating_spell:sprit", function() {
         </div>
         <div class="sheet-skills">
             <div class="sheet-header">Skills</div>
-            <div class="sheet-skheaders">
+            <div class="sheet-headers">
                 <span>Skill</span>
                 <span>Notes</span>
                 <span>Rank</span>
@@ -1525,8 +1583,8 @@ on("change:repeating_spell:sprit", function() {
             <fieldset class="repeating_skill">
                 <div class="sheet-skdata">
                     <div class="sheet-sktype">
-                        <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{sktype}}} {{D100=[[1d100]]}}"></button>
-                        <select name="attr_sktype">
+                        <button class="sheet-btn" type="roll" value="&{template:default} {{name=@{type}}} {{D100=[[1d100]]}}"></button>
+                        <select name="attr_type">
                             <option value="adventuring">Adventuring</option>
                             <option value="language">Language</option>
                             <optgroup label="Skill groups">
@@ -1547,8 +1605,8 @@ on("change:repeating_spell:sprit", function() {
                             </optgroup>
                         </select>
                     </div>
-                    <input type="text" name="attr_sknotes">
-                    <input type="number" value="0" name="attr_skrank" min="0">
+                    <input type="text" name="attr_notes">
+                    <input type="number" value="0" name="attr_rank" min="0">
                 </div>
             </fieldset>
         </div>
@@ -1574,5 +1632,8 @@ on("change:repeating_spell:sprit", function() {
             </ul>
         </div>
     </div>    
+</div>
+<div class="sheet-hidden">
+    Version <input type="hidden" name="attr_version">
 </div>
 </div>

--- a/DragonQuest/readme.txt
+++ b/DragonQuest/readme.txt
@@ -3,3 +3,12 @@ DragonQuest is an old d100 RPG system from around 1982
 This character sheet is designed to allow for the calculation of some of the success chance statistics from the basic stats in the manuals, and easy dice rolling for weapons & spells.
 
 Skills & spells have much more complicated calculations for their SC and future development on these would greatly improve the sheet.
+
+
+v1.1 - 2016-04-07
+Simplified attributes - removed unnecessary prefixes for attributes in repeating sections
+Fixed display issues in Firefox
+Changed summaries to update when options tab is closed, as new items didn't run an 'on change' command when defaults were used
+Changed order of fields in roll templates to have fixed data at the top and rolls at the bottom
+Tidied up the css to remove some of the repeated information
+Re-ordered the script workers to follow the order of the html elements


### PR DESCRIPTION
v1.1 - 2016-04-07
Simplified attributes - removed unnecessary prefixes for attributes in repeating sections
Fixed display issues in Firefox
Changed summaries to update when options tab is closed, as new items didn't run an 'on change' command when defaults were used
Changed order of fields in roll templates to have fixed data at the top and rolls at the bottom
Tidied up the css to remove some of the repeated information
Re-ordered the script workers to follow the order of the html elements