### PR TITLE
Minor improvements and new rule elements from recent adventure books

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
@@ -195,6 +195,7 @@ input.sheet-tab53:checked ~ div.sheet-section-rituale,
 input.sheet-tab54:checked ~ div.sheet-section-stabzauber,
 input.sheet-tab55:checked ~ div.sheet-section-flueche,
 input.sheet-tab56:checked ~ div.sheet-section-elfenlieder,
+input.sheet-tab57:checked ~ div.sheet-section-zauberzeichen,
 input.sheet-tab6:checked ~ div.sheet-section-Liturgien,
 input.sheet-tab61:checked ~ div.sheet-section-goetter-allgemein,
 input.sheet-tab62:checked ~ div.sheet-section-goetter-liturgie,
@@ -228,16 +229,26 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
     display: none;
 }
 
+.sheet-show_tradition_zibilja:checked + input.sheet-tab52,
+.sheet-show_tradition_zibilja:checked ~ span.sheet-tab52 {
+    display: none;
+}
+
 .sheet-show_tradition_hexe:not(:checked) + input.sheet-tab55,
 .sheet-show_tradition_hexe:not(:checked) ~ span.sheet-tab55,
-.sheet-show_tradition_hexe:not(:checked) + div.sheet-optional{
+.sheet-show_tradition_hexe:not(:checked) + div.sheet-optional {
     display: none;
 }
 
 .sheet-show_tradition_elf:not(:checked )+ input.sheet-tab56,
 .sheet-show_tradition_elf:not(:checked) ~ span.sheet-tab56 ,
 .sheet-show_tradition_elf:checked + div.sheet-zauber-wirkungsdauer,
-.sheet-show_tradition_elf:not(:checked) ~ div.sheet-zauber-wirkungsdauer-elf{
+.sheet-show_tradition_elf:not(:checked) ~ div.sheet-zauber-wirkungsdauer-elf {
+    display: none;
+}
+
+.sheet-show-optional:not(:checked )+ input.sheet-tab57,
+.sheet-show-optional:not(:checked )~ span.sheet-tab57 {
     display: none;
 }
 
@@ -245,6 +256,20 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
 .sheet-versteckeLiturgien:checked ~ span.sheet-tab6,
 .sheet-versteckeLiturgien:checked + div.sheet-section-Liturgien {
     display: none;
+}
+
+.sheet-show-optional:not(:checked) + div.sheet-optional {
+    display: none;
+}
+
+
+.sheet-liturgie-aktiviert:checked + div.sheet-zauber {
+    display: inline-block;  
+    white-space: nowrap;
+}
+
+.sheet-zauberzeichen-aktiviert:not(:checked) + div.sheet-zauberzeichen {
+    display: none;  
 }
 
 /*-------------------------------------------------Tooltips--------------------------------------*/
@@ -437,12 +462,7 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
 }
 
 
-.sheet-rituale-zauberklinge-geisterspeer:checked + div.sheet-rituale ,
-.sheet-rituale-invocatio-minor:checked + div.sheet-rituale ,
-.sheet-rituale-invocatio-maior:checked + div.sheet-rituale ,
-.sheet-rituale-elementarer-diener:checked + div.sheet-rituale ,
-.sheet-rituale-dschinnenruf:checked + div.sheet-rituale ,
-.sheet-rituale-arcanovi:checked + div.sheet-rituale {
+.sheet-rituale-aktiviert:checked + div.sheet-rituale {
     display: inline-block;
     white-space: nowrap;
 }
@@ -707,6 +727,7 @@ input.sheet-tab53:checked + span.sheet-tab53,
 input.sheet-tab54:checked + span.sheet-tab54,
 input.sheet-tab55:checked + span.sheet-tab55,
 input.sheet-tab56:checked + span.sheet-tab56,
+input.sheet-tab57:checked + span.sheet-tab57,
 input.sheet-tab6:checked + span.sheet-tab6,
 input.sheet-tab7:checked + span.sheet-tab7,
 input.sheet-tab8:checked + span.sheet-tab8 ,

--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -476,9 +476,24 @@
                     <td><input type="text" name="attr_vorteil_herausragende_kampftechnik_zusatz" /></td>
                 </tr>               
                 <tr>
-                    <td>Herausragender Sinn</td>
-                    <td><input type="checkbox" name="attr_vorteil_herausragender_sinn" value="1"/></td>
-                    <td><input type="text" name="attr_vorteil_herausragender_sinn_zusatz" /></td>
+                    <td>Herausragender Sinn: Gehör</td>
+                    <td><input type="checkbox" name="attr_vorteil_herausragender_sinn_gehoer" value="1"/></td>
+                    <td></td>
+                </tr>               
+                <tr>
+                    <td>Herausragender Sinn: Geruch &amp; Geschmack</td>
+                    <td><input type="checkbox" name="attr_vorteil_herausragender_sinn_geruch_geschmack" value="1"/></td>
+                    <td></td>
+                </tr>               
+                <tr>
+                    <td>Herausragender Sinn: Sicht</td>
+                    <td><input type="checkbox" name="attr_vorteil_herausragender_sinn_sicht" value="1"/></td>
+                    <td></td>
+                </tr>               
+                <tr>
+                    <td>Herausragender Sinn: Tastsinn</td>
+                    <td><input type="checkbox" name="attr_vorteil_herausragender_sinn_tastsinn" value="1"/></td>
+                    <td></td>
                 </tr>               
                 <tr>
                     <td>Hitzeresistenz</td>
@@ -1151,6 +1166,11 @@
                 		<div class="sheet-allgemeine-sf-name">Analytiker</div>
                 		<div class="sheet-allgemeine-sf-zusatz"></div>
                 	</div>
+                	<input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_bine_maschores" value="1" style="display:none;"/>
+                	<div class="sheet-allgemeine-sf">
+                		<div class="sheet-allgemeine-sf-name">Bine Maschores</div>
+                		<div class="sheet-allgemeine-sf-zusatz"></div>
+                	</div>
                 	<input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_dokumentenfaelscher" value="1" style="display:none;"/>
                 	<div class="sheet-allgemeine-sf">
                 		<div class="sheet-allgemeine-sf-name">Dokumentenfälscher</div>
@@ -1260,6 +1280,11 @@
                 	<input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_kulturlandkundig" value="1" style="display:none;"/>
                 	<div class="sheet-allgemeine-sf">
                 		<div class="sheet-allgemeine-sf-name">Kulturlandkundig</div>
+                		<div class="sheet-allgemeine-sf-zusatz"></div>
+                	</div>
+                	<input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_leg-ga-leg" value="1" style="display:none;"/>
+                	<div class="sheet-allgemeine-sf">
+                		<div class="sheet-allgemeine-sf-name">Leg-ga-Leg</div>
                 		<div class="sheet-allgemeine-sf-zusatz"></div>
                 	</div>
                 	<input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_lippenlesen" value="1" style="display:none;"/>
@@ -1460,6 +1485,10 @@
 			                    <td>Analytiker</td>
 			                </tr>
 			                <tr>
+			                    <td><input type="checkbox" name="attr_sf_bine_maschores" value="1"/></td>
+			                    <td>Bine Maschores</td>
+			                </tr>
+			                <tr>
 			                    <td><input type="checkbox" name="attr_sf_dokumentenfaelscher" value="1"/></td>
 			                    <td>Dokumentenfälscher</td>
 			                </tr>           
@@ -1543,6 +1572,10 @@
 			                    <td><input type="checkbox" name="attr_sf_kulturlandkundig" value="1"/></td>
 			                    <td>Kulturlandkundig</td>
 			                </tr>
+			                <tr>
+			                    <td><input type="checkbox" name="attr_sf_leg-ga-leg" value="1"/></td>
+			                    <td>Leg-ga-Leg</td>
+			                </tr>       
 			                <tr>
 			                    <td><input type="checkbox" name="attr_sf_lippenlesen" value="1"/></td>
 			                    <td>Lippenlesen</td>
@@ -3946,6 +3979,8 @@
                                 <div>Basiliskentöter (-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_drachentoeter" value="1" />
                                 <div>Drachentöter (-)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_bine_maschores" value="1" />
+                                <div>Bine Maschores (AG)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_hehlerei" value="1" />
                                 <div>Hehlerei (AG)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_rosstaeuscher" value="1" />
@@ -4269,6 +4304,8 @@
                                 <div>Meister der Improvisation (+)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_dokumentenfaelscher" value="1" />
                                 <div>Dokumente fälschen (AG)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_zauberzeichen_malen" value="1" />
+                                <div>Zauberzeichen malen (AG)</div>
                             </span>
                         </span>
                     </td>
@@ -5557,7 +5594,7 @@
                                     <option value="-1">Weit</option>
                                 </select>
                             </td>
-                            <td><input name="attr_Distanz_Mod_Abzuege_FK" type="number" value="@{Distanz_Mod}*2" disabled="true"/></td>
+                            <td><input name="attr_Distanz_Mod_Abzuege_FK" type="number" value="@{Distanz_Mod}*(2-(@{vorteil_entfernungssinn}))" disabled="true"/></td>
                             <td><input name="attr_Distanz_Mod_TP" type="number" value="@{Distanz_Mod}" disabled="true"/></td>
                         </tr>
                         <tr>
@@ -6086,6 +6123,7 @@
     <div class="sheet-section sheet-section-Magie" align="center">
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab51" value="51" title="Magie" checked="checked"/>
             <span class="sheet-tab sheet-tab51">Allgemein</span>
+        <input type="checkbox" class="sheet-show_tradition_zibilja" name="attr_show_tradition_zibilja" style="display:none;" />
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab52" value="52" title="Zauber"/>
             <span class="sheet-tab sheet-tab52">Zauber</span>
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab53" value="53" title="Rituale"/>
@@ -6099,6 +6137,9 @@
         <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab56" value="56" title="Elfenlieder"/>
             <span class="sheet-tab sheet-tab56">Elfenlieder</span>
+        <input type="checkbox" class="sheet-show-optional" name="attr_sf_zauberzeichen" style="display:none;" value="1" />
+        <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab57" value="57" title="Zauberzeichen"/>
+            <span class="sheet-tab sheet-tab57">Zauberzeichen</span>
         <table align=center>
             <th>MU</th>
                 <th><input type="number" name=attr_MU2 disabled=true value="@{MU_Wert}"></th>
@@ -6125,12 +6166,16 @@
             <input style="display:none;" name="attr_tradition_gildenmagier" type="number" disabled="true" value="1-ceil((@{Tradition}%3)/100)"/>
             <input style="display:none;" name="attr_tradition_hexe" type="number" disabled="true" value="1-ceil((@{Tradition}%5)/100)"/>
             <input style="display:none;" name="attr_tradition_elf" type="number" disabled="true" value="1-ceil((@{Tradition}%7)/100)"/>
+            <input style="display:none;" name="attr_tradition_goblin" type="number" disabled="true" value="1-ceil((@{Tradition}%11)/100)"/>
+            <input style="display:none;" name="attr_tradition_zibilja" type="number" disabled="true" value="1-ceil((@{Tradition}%13)/100)"/>
             <div align="left" style="display:inline-block">Tradition: </div>
                 <select name="attr_Tradition" style="width: 10em;">
                     <option value="0">---</option>
                     <option value="3">Gildenmagier</option>
                     <option value="5">Hexe</option>
                     <option value="7">Elf</option>
+                    <option value="11">Goblinzauberinnen</option>
+                    <option value="13">Zibilja</option>
                 </select>
             <div align="left" style="display:inline-block;">Leiteigenschaft: </div>
                 <select name="attr_Tradition" style="width: 4.25em;">
@@ -6138,6 +6183,8 @@
                     <option value="3">KL</option>
                     <option value="5">CH</option>
                     <option value="7">IN</option>
+                    <option value="11">IN</option>
+                    <option value="13">IN</option>
                 </select>
             <div class='sheet-2colrow'>
                 <div class='sheet-col'>
@@ -6246,6 +6293,7 @@
                             <td>Elementar</td>
                             <td><input type="checkbox" name="attr_zaubertrick_trocken" value="1"/></td>
                         </tr>
+                     </table>
                 </div>
                 <div class='sheet-col'>
                     <table>
@@ -6267,6 +6315,16 @@
                         <tr>
                             <td>Tradition: Elf</td>
                             <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_elf"/></td>
+                            <td/>
+                        </tr>
+                        <tr>
+                            <td>Tradition: Goblinzauberinnen</td>
+                            <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_goblinzauberinnen"/></td>
+                            <td/>
+                        </tr>
+                        <tr>
+                            <td>Tradition: Zibilja</td>
+                            <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_zibilja"/></td>
                             <td/>
                         </tr>
                         <tr>
@@ -6294,6 +6352,7 @@
                             <td><input type="checkbox" name="attr_sf_zauberzeichen" value="1"/></td>
                             <td/>
                         </tr>
+                      </table>
                 </div>
             </div>
         </div>
@@ -6353,13 +6412,17 @@
                     <div align="left" style="display:inline-block; width:10em;">Formel weglassen</div><input name="attr_Mod_Formel" type="checkbox" value="-2" /><br />
                     <div align="left" style="display:inline-block; width:10em;">Fremdtradition</div><input name="attr_Mod_Fremdtradition" type="checkbox" value="-2" /><br />
                     <div align="left" style="display:inline-block; width:10em;">Aufrechterhalten</div><input name="attr_Mod_Aufrechterhaltene_Zauber" type="number" value="0"/><br />
-                    <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_show_tradition_hexe" style="display:none;" />
+                    <input type="checkbox" class="sheet-show-optional" name="attr_nachteil_magische_einschraenkung" style="display:none;" value="1"/>
+                    <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einschränkung</div><input name="attr_Mod_Magische_Einschraenkung" type="checkbox" value="-1" /><br /></div>
+                    <input type="checkbox" class="sheet-show-optional" name="attr_vorteil_magische_einstimmung" style="display:none;" value="1"/>
+                    <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einstimmung</div><input name="attr_Mod_Magische_Einstimmung" type="checkbox" value="1" /><br /></div>
+                    <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_show_tradition_hexe" style="display:none;"/>
                     <div class="optional"><div align="left" style="display:inline-block; width:10em;">Gefühle</div><input name="attr_Mod_Gefuehle" type="number" value="0" /><br /></div>
                 </td>
                 <td valign="top" width="30%">
                     <div align="left" style="font-weight:bold;">Summe</div>
                     <div align="left" style="display:inline-block; width:10em;">Zaubermodifikationen</div><input name="attr_Zauber_Mod" type="number" disabled="true" value="@{Mod_Zauberdauer} + @{Mod_Reichweite} + @{Mod_Kosten}"/><br />
-                    <div align="left" style="display:inline-block; width:10em;">Speziell</div><input name="attr_Zauber_Mod_Speziell" type="number" disabled="true" value="@{Mod_Geste} + @{Mod_Formel} + @{Mod_Fremdtradition} - @{Mod_Aufrechterhaltene_Zauber} + @{Mod_Gefuehle}"/><br />
+                    <div align="left" style="display:inline-block; width:10em;">Speziell</div><input name="attr_Zauber_Mod_Speziell" type="number" disabled="true" value="@{Mod_Geste} + @{Mod_Formel} + @{Mod_Fremdtradition} - @{Mod_Aufrechterhaltene_Zauber} + @{Mod_Magische_Einschraenkung} + @{Mod_Magische_Einstimmung} + @{Mod_Gefuehle}"/><br />
                     <div align="left" style="display:inline-block; width:10em;">Zustände</div><input name="attr_Zauber_Mod_Zustaende" type="number" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"/><br />
                     <div align="left" style="display:inline-block; width:10em;">Gesamt</div><input name="attr_Zauber_Mod_Gesamt" type="number" disabled="true" value="@{Zauber_Mod} + @{Zauber_Mod_Speziell} + @{Zauber_Mod_Zustaende}"/><br />
                 </td>
@@ -7105,11 +7168,15 @@
                     <div align="left" style="display:inline-block; width:10em;">Passende Kleidung</div><input name="attr_Mod_Ritual_Kleidung" type="checkbox" value="1" /><br />
                     <div align="left" style="display:inline-block; width:10em;">Geeignete Gerätschaften</div><input name="attr_Mod_Ritual_Geraetschaften" type="checkbox" value="1" /><br />
                     <div align="left" style="display:inline-block; width:10em;">Fremdtradition</div><input name="attr_Mod_Ritual_Fremdtradition" type="checkbox" value="1" /><br />
+                    <input type="checkbox" class="sheet-show-optional" name="attr_nachteil_magische_einschraenkung" style="display:none;" value="1"/>
+                    <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einschränkung</div><input name="attr_Mod_Magische_Einschraenkung" type="checkbox" value="-1" /><br /></div>
+                    <input type="checkbox" class="sheet-show-optional" name="attr_vorteil_magische_einstimmung" style="display:none;" value="1"/>
+                    <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einstimmung</div><input name="attr_Mod_Magische_Einstimmung" type="checkbox" value="1" /><br /></div>
                 </td>
                 <td valign="top" width="25%">
                     <div align="left" style="font-weight:bold;">Summe</div>
                     <div align="left" style="display:inline-block; width:10em;">Ritualmodifikationen</div><input name="attr_Ritual_Mod" type="number" disabled="true" value="@{Mod_Ritualdauer} + @{Mod_Ritual_Reichweite} + @{Mod_Ritual_Kosten}"/><br />
-                    <div align="left" style="display:inline-block; width:10em;">Speziell</div><input name="attr_Ritual_Mod_Speziell" type="number" disabled="true" value="@{Mod_Ritual_Ritualplatz} + @{Mod_Ritual_Zeit} + @{Mod_Ritual_Kleidung} + @{Mod_Ritual_Geraetschaften} - @{Mod_Ritual_Fremdtradition}"/><br />
+                    <div align="left" style="display:inline-block; width:10em;">Speziell</div><input name="attr_Ritual_Mod_Speziell" type="number" disabled="true" value="@{Mod_Ritual_Ritualplatz} + @{Mod_Ritual_Zeit} + @{Mod_Ritual_Kleidung} + @{Mod_Ritual_Geraetschaften} - @{Mod_Ritual_Fremdtradition} + @{Mod_Magische_Einschraenkung} + @{Mod_Magische_Einstimmung}"/><br />
                     <div align="left" style="display:inline-block; width:10em;">Zustände</div><input name="attr_Ritual_Mod_Zustaende" type="number" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"/><br />
                     <div align="left" style="display:inline-block; width:10em;">Gesamt</div><input name="attr_Ritual_Mod_Gesamt" type="number" disabled="true" value="@{Ritual_Mod} + @{Ritual_Mod_Speziell} + @{Ritual_Mod_Zustaende}"/><br />
                 </td>
@@ -7128,7 +7195,7 @@
                 <div class="sheet-rituale-merkmal"><b>Merkmal</b></div>
                 <div style="display:inline-block; width:3em; font-weight:bold;">FW</div>
             </div>
-            <input class="sheet-rituale-arcanovi" type="checkbox" name="attr_ritual_arcanovi" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_arcanovi" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Arcanovi</div>
                 <div class="sheet-rituale-probe">KL/IN/FF</div>
@@ -7141,7 +7208,20 @@
                 <input type="number" name="attr_rfw_Arcanovi" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Arcanovi}} {{subtag=Ritual}}} {{subtag1=Allgemein}} {{subtag2=Objekt}} {{Zauber=[[ @{rfw_Arcanovi} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-rituale-dschinnenruf" type="checkbox" name="attr_ritual_dschinnenruf" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_aufmerksamer_waechter" value="1" style="display:none;"/>
+            <div class="sheet-rituale">
+                <div class="sheet-rituale-ritual">Aufmerksamer Wächter</div>
+                <div class="sheet-rituale-probe">IN/CH/FF</div>
+                <div class="sheet-rituale-zauberdauer">30 Min</div>
+                <div class="sheet-rituale-kosten">8</div>
+                <div class="sheet-rituale-reichweite">spez.</div>
+                <div class="sheet-rituale-wirkungsdauer">QS x 3 Std</div>
+                <div class="sheet-rituale-zielkategorie">pO</div>
+                <div class="sheet-rituale-merkmal">Objekt</div>
+                <input type="number" name="attr_rfw_Aufmerksamer_Waechter" style="width:3em;" value="0"/>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Aufmerksamer Wächter}} {{subtag=Ritual}}} {{subtag1=Goblinzauberinnen}} {{subtag2=Objekt}} {{Zauber=[[ @{rfw_Aufmerksamer_Waechter} - {1d20cs1cf20 - ([[@{IN_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+            </div>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_dschinnenruf" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Dschinnenruf</div>
                 <div class="sheet-rituale-probe">MU/CH/KO</div>
@@ -7154,7 +7234,7 @@
                 <input type="number" name="attr_rfw_Dschinnenruf" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Dschinnenruf}} {{subtag=Ritual}}} {{subtag1=Gildenmagier}} {{subtag2=Sphären}} {{Zauber=[[ @{rfw_Dschinnenruf} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div><br />
-            <input class="sheet-rituale-elementarer-diener" type="checkbox" name="attr_ritual_elementarer_diener" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_elementarer_diener" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Elementarer Diener</div>
                 <div class="sheet-rituale-probe">MU/CH/KO</div>
@@ -7167,7 +7247,7 @@
                 <input type="number" name="attr_rfw_Elementarer_Diener" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Elementarer Diener}} {{subtag=Ritual}}} {{subtag1=Gildenmagier}} {{subtag2=Sphären}} {{Zauber=[[ @{rfw_Elementarer_Diener} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-rituale-invocatio-maior" type="checkbox" name="attr_ritual_invocatio_maior" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_invocatio_maior" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Invocatio Maior</div>
                 <div class="sheet-rituale-probe">MU/CH/KO</div>
@@ -7180,7 +7260,7 @@
                 <input type="number" name="attr_rfw_Invocatio_Maior" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Invocatio Maior}} {{subtag=Ritual}}} {{subtag1=Gildenmagier, Hexen}} {{subtag2=Sphären}} {{Zauber=[[ @{rfw_Invocatio_Maior} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-rituale-invocatio-minor" type="checkbox" name="attr_ritual_invocatio_minor" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_invocatio_minor" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Invocatio Minor</div>
                 <div class="sheet-rituale-probe">MU/CH/KO</div>
@@ -7193,7 +7273,33 @@
                 <input type="number" name="attr_rfw_Invocatio_Minor" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Invocatio Minor}} {{subtag=Ritual}}} {{subtag1=Gildenmagier, Hexen}} {{subtag2=Sphären}} {{Zauber=[[ @{rfw_Invocatio_Minor} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-rituale-zauberklinge-geisterspeer" type="checkbox" name="attr_ritual_zauberklinge_geisterspeer" value="1" style="display:none;"/>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_orvai_kurims_kriegstrommel" value="1" style="display:none;"/>
+            <div class="sheet-rituale">
+                <div class="sheet-rituale-ritual">Orvai Kurims Kriegstrommel</div>
+                <div class="sheet-rituale-probe">IN/FF/KO</div>
+                <div class="sheet-rituale-zauberdauer">30 Min</div>
+                <div class="sheet-rituale-kosten">16</div>
+                <div class="sheet-rituale-reichweite">B</div>
+                <div class="sheet-rituale-wirkungsdauer">QS x 3 Tage</div>
+                <div class="sheet-rituale-zielkategorie">pO</div>
+                <div class="sheet-rituale-merkmal">Objekt</div>
+                <input type="number" name="attr_rfw_Orvai_Kurims_Kriegstrommel" style="width:3em;" value="0"/>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Orvai Kurims Kriegstrommel}} {{subtag=Ritual}}} {{subtag1=Goblinzauberinnen}} {{subtag2=Objekt}} {{Zauber=[[ @{rfw_Orvai_Kurims_Kriegstrommel} - {1d20cs1cf20 - ([[@{IN_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+            </div>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_ruf_des_bienenstocks" value="1" style="display:none;"/>
+            <div class="sheet-rituale">
+                <div class="sheet-rituale-ritual">Ruf des Bienenstocks</div>
+                <div class="sheet-rituale-probe">KL/IN/FF</div>
+                <div class="sheet-rituale-zauberdauer">30 Min</div>
+                <div class="sheet-rituale-kosten">16</div>
+                <div class="sheet-rituale-reichweite">FW x 50 M</div>
+                <div class="sheet-rituale-wirkungsdauer">sofort</div>
+                <div class="sheet-rituale-zielkategorie">pO</div>
+                <div class="sheet-rituale-merkmal">Objekt</div>
+                <input type="number" name="attr_rfw_Ruf_des_Bienenstocks" style="width:3em;" value="0"/>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Ruf des Bienenstocks}} {{subtag=Ritual}}} {{subtag1=Zibilja}} {{subtag2=Objekt}} {{Zauber=[[ @{rfw_Ruf_des_Bienenstocks} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Ritual_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+            </div>
+            <input class="sheet-rituale-aktiviert" type="checkbox" name="attr_ritual_zauberklinge_geisterspeer" value="1" style="display:none;"/>
             <div class="sheet-rituale">
                 <div class="sheet-rituale-ritual">Zauberklinge Geisterspeer</div>
                 <div class="sheet-rituale-probe">KL/IN/FF</div>
@@ -7215,20 +7321,29 @@
                         <tr>
                             <td valign="top">
                             <b>Allgemein</b><br/>
-                            Arcanovi <input type="checkbox" name="attr_ritual_arcanovi" value="1"/><br/>
-                            Zauberklinge Geisterspeer <input type="checkbox" name="attr_ritual_zauberklinge_geisterspeer" value="1"/><br/>
+                            <input type="checkbox" name="attr_ritual_arcanovi" value="1"/> Arcanovi <br/>
+                            <input type="checkbox" name="attr_ritual_zauberklinge_geisterspeer" value="1"/> Zauberklinge Geisterspeer <br/>
                             </td>
                             <td valign="top">
                             <b>Gildenmagier</b><br/>
-                            Dschinnenruf <input type="checkbox" name="attr_ritual_dschinnenruf" value="1"/><br/>
-                            Elementarer Diener <input type="checkbox" name="attr_ritual_elementarer_diener" value="1"/><br/>
-                            Invocatio Maior <input type="checkbox" name="attr_ritual_invocatio_maior" value="1"/><br/>
-                            Invocatio Minor <input type="checkbox" name="attr_ritual_invocatio_minor" value="1"/><br/>
+                            <input type="checkbox" name="attr_ritual_dschinnenruf" value="1"/> Dschinnenruf <br/>
+                            <input type="checkbox" name="attr_ritual_elementarer_diener" value="1"/> Elementarer Diener <br/>
+                            <input type="checkbox" name="attr_ritual_invocatio_maior" value="1"/> Invocatio Maior <br/>
+                            <input type="checkbox" name="attr_ritual_invocatio_minor" value="1"/> Invocatio Minor <br/>
+                            </td>
+                            <td valign="top">
+                            <b>Goblinzauberinnen</b><br/>
+                            <input type="checkbox" name="attr_ritual_aufmerksamer_waechter" value="1"/> Aufmerksamer Wächter <br/>
+                            <input type="checkbox" name="attr_ritual_orvai_kurims_kriegstrommel" value="1"/> Orvai Kurims Kriegstrommel <br/>
                             </td>
                             <td valign="top">
                             <b>Hexen</b><br/>
-                            Invocatio Maior <input type="checkbox" name="attr_ritual_invocatio_maior" value="1"/><br/>
-                            Invocatio Minor <input type="checkbox" name="attr_ritual_invocatio_minor" value="1"/><br/>
+                            <input type="checkbox" name="attr_ritual_invocatio_maior" value="1"/> Invocatio Maior <br/>
+                            <input type="checkbox" name="attr_ritual_invocatio_minor" value="1"/> Invocatio Minor <br/>
+                            </td>
+                            <td valign="top">
+                            <b>Zibilja</b><br/>
+                            <input type="checkbox" name="attr_ritual_ruf_des_bienenstocks" value="1"/> Ruf des Bienenstocks <br/>
                             </td>
                         </tr>
                     </table>
@@ -7305,40 +7420,40 @@
                 <div class="sheet-desc">
                     <table>
                         <tr>
-                            <th>Stabzauber</th>
                             <th>Aktiv</th>
+                            <th>Stabzauber</th>
                         </tr>
                         <tr>
-                            <td>Bindung des Stabes</td>
                             <td><input type="checkbox" name="attr_stabzauber_bindung" value="1"/></td>
+                            <td>Bindung des Stabes</td>
                         </tr>
                         <tr>
-                            <td>Doppeltes Maß</td>
                             <td><input type="checkbox" name="attr_stabzauber_doppeltes_mass" value="1"/></td>
+                            <td>Doppeltes Maß</td>
                         </tr>
                         <tr>
-                            <td>Ewige Flamme</td>
                             <td><input type="checkbox" name="attr_stabzauber_ewige_flamme" value="1"/></td>
+                            <td>Ewige Flamme</td>
                         </tr>
                         <tr>
-                            <td>Flammenschwert</td>
                             <td><input type="checkbox" name="attr_stabzauber_flammenschwert" value="1"/></td>
+                            <td>Flammenschwert</td>
                         </tr>
                         <tr>
-                            <td>Kraftfokus</td>
                             <td><input type="checkbox" name="attr_stabzauber_kraftfokus" value="1"/></td>
+                            <td>Kraftfokus</td>
                         </tr>
                         <tr>
-                            <td>Merkmalsfokus</td>
                             <td><input type="checkbox" name="attr_stabzauber_merkmalsfokus" value="1"/></td>
+                            <td>Merkmalsfokus</td>
                         </tr>
                         <tr>
-                            <td>Seil des Adepten</td>
                             <td><input type="checkbox" name="attr_stabzauber_seil_des_adepten" value="1"/></td>
+                            <td>Seil des Adepten</td>
                         </tr>
                         <tr>
-                            <td>Stab-Apport</td>
                             <td><input type="checkbox" name="attr_stabzauber_stab_apport" value="1"/></td>
+                            <td>Stab-Apport</td>
                         </tr>
                     </table>
                 </div>
@@ -7461,48 +7576,48 @@
                 <div class="sheet-desc">
                     <table>
                         <tr>
-                            <th>Flüche</th>
                             <th>Aktiv</th>
+                            <th>Flüche</th>
                         </tr>
                         <tr>
-                            <td>Beiß auf Granit!</td>
                             <td><input type="checkbox" name="attr_fluch_beiss_auf_granit" value="1"/></td>
+                            <td>Beiß auf Granit!</td>
                         </tr>
                         <tr>
-                            <td>Beute!</td>
                             <td><input type="checkbox" name="attr_fluch_beute" value="1"/></td>
+                            <td>Beute!</td>
                         </tr>
                         <tr>
-                            <td>Hagelschlag</td>
                             <td><input type="checkbox" name="attr_fluch_hagelschlag" value="1"/></td>
+                            <td>Hagelschlag</td>
                         </tr>
                         <tr>
-                            <td>Hexenschuss</td>
                             <td><input type="checkbox" name="attr_fluch_hexenschuss" value="1"/></td>
+                            <td>Hexenschuss</td>
                         </tr>
                         <tr>
-                            <td>Pech an den Hals wünschen</td>
                             <td><input type="checkbox" name="attr_fluch_pech" value="1"/></td>
+                            <td>Pech an den Hals wünschen</td>
                         </tr>
                         <tr>
-                            <td>Pestilenz</td>
                             <td><input type="checkbox" name="attr_fluch_pestilenz" value="1"/></td>
+                            <td>Pestilenz</td>
                         </tr>
                         <tr>
-                            <td>Schlaf rauben</td>
                             <td><input type="checkbox" name="attr_fluch_schlaf_rauben" value="1"/></td>
+                            <td>Schlaf rauben</td>
                         </tr>
                         <tr>
-                            <td>Unfruchtbarkeit</td>
                             <td><input type="checkbox" name="attr_fluch_unfruchtbarkeit" value="1"/></td>
+                            <td>Unfruchtbarkeit</td>
                         </tr>
                         <tr>
-                            <td>Warzen sprießen</td>
                             <td><input type="checkbox" name="attr_fluch_warzen_spriessen" value="1"/></td>
+                            <td>Warzen sprießen</td>
                         </tr>
                         <tr>
-                            <td>Zunge lähmen</td>
                             <td><input type="checkbox" name="attr_fluch_zunge_laehmen" value="1"/></td>
+                            <td>Zunge lähmen</td>
                         </tr>
                     </table>
                 </div>
@@ -7585,38 +7700,86 @@
                 <div class="sheet-desc">
                     <table>
                         <tr>
-                            <th>Elfenlieder</th>
                             <th>Aktiv</th>
+                            <th>Elfenlieder</th>
                         </tr>
                         <tr>
-                            <td>Erinnerungsmelodie</td>
                             <td><input type="checkbox" name="attr_elfenlied_erinnerungsmelodie" value="1"/></td>
+                            <td>Erinnerungsmelodie</td>
                         </tr>
                         <tr>
-                            <td>Friedenslied</td>
                             <td><input type="checkbox" name="attr_elfenlied_friedenslied" value="1"/></td>
+                            <td>Friedenslied</td>
                         </tr>
                         <tr>
-                            <td>Freundschaftslied</td>
                             <td><input type="checkbox" name="attr_elfenlied_freundschaftslied" value="1"/></td>
+                            <td>Freundschaftslied</td>
                         </tr>
                         <tr>
-                            <td>Melodie der Kunstfertigkeit</td>
                             <td><input type="checkbox" name="attr_elfenlied_melodie_der_kunstfertigkeit" value="1"/></td>
+                            <td>Melodie der Kunstfertigkeit</td>
                         </tr>
                         <tr>
-                            <td>Sorgenlied</td>
                             <td><input type="checkbox" name="attr_elfenlied_sorgenlied" value="1"/></td>
+                            <td>Sorgenlied</td>
                         </tr>
                         <tr>
-                            <td>Zaubermelodie</td>
                             <td><input type="checkbox" name="attr_elfenlied_zaubermelodie" value="1"/></td>
+                            <td>Zaubermelodie</td>
                         </tr>
                     </table>
                 </div>
             </div>        
         </div>
+        
+        <div class="sheet-section sheet-section-zauberzeichen" align="left">
+        
+            	<input class="sheet-zauberzeichen-aktiviert" type="checkbox" name="attr_zauberzeichen_bann_schutz_gg_elementargeister" value="1" style="display:none;"/>
+	            <div class="sheet-zauberzeichen">
+	                <div class="sheet-zauberzeichen-name">Bann-/Schutzkreis gegen Elementargeister</div>
+	                <div class="sheet-zauberzeichen-kosten">4 AsP</div>
+	            </div>     
+ 
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div class="sheet-desc">
+                    <table>
+                        <tr>
+                            <th>Erworben</th>
+                            <th>Zauberzeichen</th>
+                            <th>Kosten</th>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="attr_zauberzeichen_bann_schutz_gg_elementargeister" value="1"/></td>
+                            <td>Bann-/Schutzkreis gegen Elementargeister</td>
+                            <td>4</td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="attr_zauberzeichen_bann_schutz_gg_dschinne" value="1"/></td>
+                            <td>Bann-/Schutzkreis gegen Dschinne</td>
+                            <td>8</td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="attr_zauberzeichen_bann_schutz_gg_niedere_daemonen" value="1"/></td>
+                            <td>Bann-/Schutzkreis gegen niedere Dämonen</td>
+                            <td>4</td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="attr_zauberzeichen_bann_schutz_gg_gehoernte_daemonen" value="1"/></td>
+                            <td>Bann-/Schutzkreis gegen Gehörnte Dämonen</td>
+                            <td>8</td>
+                        </tr>
+                        <tr>
+                            <td><input type="checkbox" name="attr_zauberzeichen_verschluss" value="1"/></td>
+                            <td>Verschluss</td>
+                            <td>16</td>
+                        </tr>
+                    </table>        
+             </div>
+        </div>
+        
     </div>       
+    
+    
     
 
     <div class="sheet-section sheet-section-Liturgien" align="center">
@@ -7627,7 +7790,7 @@
         <input type="radio" name="attr_goetter_tab" class="sheet-tab sheet-tab63" value="63" title="goetter-zeremonien"/>
             <span class="sheet-tab sheet-tab63">Zeremonien</span>
         <input type="radio" name="attr_goetter_tab" class="sheet-tab sheet-tab64" value="64" title="goetter-sonderfertigkeiten"/>
-            <span class="sheet-tab sheet-tab64">Sonderfertigkeiten</span><br>
+            <span class="sheet-tab sheet-tab64">Sonderfertigk.</span><br>
         <table align=center>
             <th>MU</th>
                 <th><input type="number" name="attr_MU2" disabled=true value="@{MU_Wert}"></th>
@@ -7722,6 +7885,7 @@
                             <td>Weisheitssegen</td><td>B</td><td>12 Std</td><td>K</td><td>allgemein</td>
                             <td><input type="checkbox" name="attr_segnung_Weisheitssegen" value="1"/></td>
                         </tr>
+                       </table>
                     </div>
                 <div class='sheet-col'>
                     <table>
@@ -7750,6 +7914,7 @@
                             <td><input type="checkbox" name="attr_sf_Starke_Segnungen" value="1"/></td>
                             <td/>
                         </tr>
+                       </table>
                     </div>
             </div>
         </div>
@@ -7881,7 +8046,20 @@
                     <div class="sheet-zauber-zielkategorie">L</div>
                     <div class="sheet-zauber-merkmal">PRA</div>
                     <input type="number" name="attr_zfw_blendstrahl" style="width:3em;" value="0"/>
-                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Blendstral}} {{subtag=Liturgie}}} {{subtag1=Praios}}  {{Liturgie=[[ @{zfw_blendstrahl} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Blendstrahl}} {{subtag=Liturgie}}} {{subtag1=Praios}}  {{Liturgie=[[ @{zfw_blendstrahl} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                </div>
+                <input class="sheet-liturgie-aktiviert" type="checkbox" name="attr_liturgie_des_einen_bezaubernder_sphaerenklang" value="1" style="display:none;"/>
+                <div class="sheet-zauber">
+                    <div class="sheet-zauber-zauberspruch">D. Einen bez. Sphärenklang</div>
+                    <div class="sheet-zauber-probe">IN/CH/CH</div>
+                    <div class="sheet-zauber-zauberdauer">1 A</div>
+                    <div class="sheet-zauber-kosten">8</div>
+                    <div class="sheet-zauber-reichweite">8 S</div>
+                    <div class="sheet-zauber-wirkungsdauer">QS x 3 Min</div>
+                    <div class="sheet-zauber-zielkategorie">K</div>
+                    <div class="sheet-zauber-merkmal">NL</div>
+                    <input type="number" name="attr_zfw_des_einen_bezaubernder_sphaerenklang" style="width:3em;" value="0"/>
+                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Des Einen bezaubernder Sphärenklang}} {{subtag=Liturgie}}} {{subtag1=Namenloser}}  {{Liturgie=[[ zfw_des_einen_bezaubernder_sphaerenklang - {1d20cs1cf20 - ([[@{IN_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
                 </div>
                 <input class="sheet-zauber-ehrenhaftigkeit" type="checkbox" name="attr_liturgie_ehrenhaftigkeit" value="1" style="display:none;"/>
                 <div class="sheet-zauber">
@@ -8000,6 +8178,19 @@
                     <input type="number" name="attr_zfw_heilsegen" style="width:3em;" value="0"/>
                     <button type="roll" value="&{template:DSA-Liturgie} {{name=Heilsegen}} {{subtag=Liturgie}}} {{subtag1=Peraine}}  {{Liturgie=[[ @{zfw_heilsegen} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
                 </div>
+                <input class="sheet-liturgie-aktiviert" type="checkbox" name="attr_liturgie_herbeirufung_der_heerscharen_des_rattenkindes" value="1" style="display:none;"/>
+                <div class="sheet-zauber">
+                    <div class="sheet-zauber-zauberspruch">Herb. d. Herrsch. d. Rattenk.</div>
+                    <div class="sheet-zauber-probe">MU/IN/CH</div>
+                    <div class="sheet-zauber-zauberdauer">1 A</div>
+                    <div class="sheet-zauber-kosten">8</div>
+                    <div class="sheet-zauber-reichweite">32 S</div>
+                    <div class="sheet-zauber-wirkungsdauer">QS x 3 Tage</div>
+                    <div class="sheet-zauber-zielkategorie">T</div>
+                    <div class="sheet-zauber-merkmal">NL</div>
+                    <input type="number" name="attr_zfw_herbeirufung_der_heerscharen_des_rattenkindes" style="width:3em;" value="0"/>
+                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Herbeirufung der Heerscharen des Rattenkindes}} {{subtag=Liturgie}}} {{subtag1=Namenloser}}  {{Liturgie=[[ @{zfw_herbeirufung_der_heerscharen_des_rattenkindes} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                </div>
                 <input class="sheet-zauber-kleinerbannwideruntote" type="checkbox" name="attr_liturgie_kleinerbannwideruntote" value="1" style="display:none;"/>
                 <div class="sheet-zauber">
                     <div class="sheet-zauber-zauberspruch">Kleiner Bann wider Untote</div>
@@ -8103,6 +8294,32 @@
                     <div class="sheet-zauber-merkmal">PHE</div>
                     <input type="number" name="attr_zfw_mondsilberzunge" style="width:3em;" value="0"/>
                     <button type="roll" value="&{template:DSA-Liturgie} {{name=Mondsilberzunge}} {{subtag=Liturgie}}} {{subtag1=Phex}}  {{Liturgie=[[ @{zfw_mondsilberzunge} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                </div>
+                <input class="sheet-liturgie-aktiviert" type="checkbox" name="attr_liturgie_namenlose_zweifel" value="1" style="display:none;"/>
+                <div class="sheet-zauber">
+                    <div class="sheet-zauber-zauberspruch">Namenlose Zweifel</div>
+                    <div class="sheet-zauber-probe">MU/IN/CH</div>
+                    <div class="sheet-zauber-zauberdauer">4 A</div>
+                    <div class="sheet-zauber-kosten">16</div>
+                    <div class="sheet-zauber-reichweite">16 S</div>
+                    <div class="sheet-zauber-wirkungsdauer">QS x 3 Tage</div>
+                    <div class="sheet-zauber-zielkategorie">K</div>
+                    <div class="sheet-zauber-merkmal">NL</div>
+                    <input type="number" name="attr_zfw_namenlose_zweifel" style="width:3em;" value="0"/>
+                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Namenlose Zweifel}} {{subtag=Liturgie}}} {{subtag1=Namenloser}}  {{Liturgie=[[ @{zfw_namenlose_zweifel} - {1d20cs1cf20 - ([[@{MU_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                </div>
+                <input class="sheet-liturgie-aktiviert" type="checkbox" name="attr_liturgie_namenloses_vergessen" value="1" style="display:none;"/>
+                <div class="sheet-zauber">
+                    <div class="sheet-zauber-zauberspruch">Namenloses Vergessen</div>
+                    <div class="sheet-zauber-probe">KL/IN/CH</div>
+                    <div class="sheet-zauber-zauberdauer">2 A</div>
+                    <div class="sheet-zauber-kosten">8</div>
+                    <div class="sheet-zauber-reichweite">B</div>
+                    <div class="sheet-zauber-wirkungsdauer">QS x 3 Tage</div>
+                    <div class="sheet-zauber-zielkategorie">K</div>
+                    <div class="sheet-zauber-merkmal">NL</div>
+                    <input type="number" name="attr_zfw_namenloses_vergessen" style="width:3em;" value="0"/>
+                    <button type="roll" value="&{template:DSA-Liturgie} {{name=Namenloses Vergessen}} {{subtag=Liturgie}}} {{subtag1=Namenloser}}  {{Liturgie=[[ @{zfw_namenloses_vergessen} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Liturgie_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
                 </div>
                 <input class="sheet-zauber-objektsegen" type="checkbox" name="attr_liturgie_objektsegen" value="1" style="display:none;"/>
                 <div class="sheet-zauber">
@@ -8294,46 +8511,50 @@
                     <table style="width:100%">
                         <tr>
                             <td valign="top">
-                                Bann der Dunkelheit <input type="checkbox" name="attr_liturgie_bannderdunkelheit" value="1"/><br/>
-                                Bann der Furcht <input type="checkbox" name="attr_liturgie_bannderfurcht" value="1"/><br/>
-                                Bann des Lichts  <input type="checkbox" name="attr_liturgie_banndeslichts" value="1"/><br/>
-                                Blendstrahl <input type="checkbox" name="attr_liturgie_blendstrahl" value="1"/><br/>
-                                Ehrenhaftigkeit <input type="checkbox" name="attr_liturgie_ehrenhaftigkeit" value="1"/><br/>
-                                Entzifferung <input type="checkbox" name="attr_liturgie_entzifferung" value="1"/><br/>
-                                Ermutigung <input type="checkbox" name="attr_liturgie_ermutigung" value="1"/><br/>
-                                Fall ins nichts <input type="checkbox" name="attr_liturgie_fallinsnichts" value="1"/><br/>
-                                Friedvolle Aura <input type="checkbox" name="attr_liturgie_friedvolleaura" value="1"/><br/>
+                                <input type="checkbox" name="attr_liturgie_bannderdunkelheit" value="1"/> Bann der Dunkelheit<br/>
+                                <input type="checkbox" name="attr_liturgie_bannderfurcht" value="1"/> Bann der Furcht<br/>
+                                <input type="checkbox" name="attr_liturgie_banndeslichts" value="1"/> Bann des Lichts<br/>
+                                <input type="checkbox" name="attr_liturgie_blendstrahl" value="1"/> Blendstrahl<br/>
+                                <input type="checkbox" name="attr_liturgie_des_einen_bezaubernder_sphaerenklang" value="1"/> Des Einen bez. Sphärenklang<br/>
+                                <input type="checkbox" name="attr_liturgie_ehrenhaftigkeit" value="1"/> Ehrenhaftigkeit<br/>
+                                <input type="checkbox" name="attr_liturgie_entzifferung" value="1"/> Entzifferung<br/>
+                                <input type="checkbox" name="attr_liturgie_ermutigung" value="1"/> Ermutigung<br/>
+                                <input type="checkbox" name="attr_liturgie_fallinsnichts" value="1"/> Fall ins nichts<br/>
+                                <input type="checkbox" name="attr_liturgie_friedvolleaura" value="1"/> Friedvolle Aura<br/>
                             </td>
                             <td valign="top">
-                                Giftbann <input type="checkbox" name="attr_liturgie_giftbann" value="1"/><br/>
-                                Gött. Fingerzeig <input type="checkbox" name="attr_liturgie_goettlicherfingerzeig" value="1"/><br/>
-                                Gött. Zeichen <input type="checkbox" name="attr_liturgie_goettlicheszeichen" value="1"/><br/>
-                                Heilsegen <input type="checkbox" name="attr_liturgie_heilsegen" value="1"/><br/>
-                                Kl. Bann wider Untote <input type="checkbox" name="attr_liturgie_kleinerbannwideruntote" value="1"/><br/>
-                                Kl. Bannstrahl <input type="checkbox" name="attr_liturgie_kleinerbannstrahl" value="1"/><br/>
-                                Krankheitsbann <input type="checkbox" name="attr_liturgie_krankheitsbann" value="1"/><br/>
-                                Lautlos <input type="checkbox" name="attr_liturgie_lautlos" value="1"/><br/>                    
+                                <input type="checkbox" name="attr_liturgie_giftbann" value="1"/> Giftbann<br/>
+                                <input type="checkbox" name="attr_liturgie_goettlicherfingerzeig" value="1"/> Gött. Fingerzeig<br/>
+                                <input type="checkbox" name="attr_liturgie_goettlicheszeichen" value="1"/> Gött. Zeichen<br/>
+                                <input type="checkbox" name="attr_liturgie_heilsegen" value="1"/> Heilsegen<br/>
+                                <input type="checkbox" name="attr_liturgie_herbeirufung_der_heerscharen_des_rattenkindes" value="1"/> Herb. d. Herrsch. d. Rattenkindes<br/>
+                                <input type="checkbox" name="attr_liturgie_kleinerbannwideruntote" value="1"/> Kl. Bann wider Untote<br/>
+                                <input type="checkbox" name="attr_liturgie_kleinerbannstrahl" value="1"/> Kl. Bannstrahl<br/>
+                                <input type="checkbox" name="attr_liturgie_krankheitsbann" value="1"/> Krankheitsbann<br/>
+                                <input type="checkbox" name="attr_liturgie_lautlos" value="1"/> Lautlos<br/>                    
+                                <input type="checkbox" name="attr_liturgie_magieschutz" value="1"/> Magieschutz<br/>
                             </td>
                             <td valign="top">
-                                Magieschutz <input type="checkbox" name="attr_liturgie_magieschutz" value="1"/><br/>
-                                Magiesicht <input type="checkbox" name="attr_liturgie_magiesicht" value="1"/><br/>
-                                Mondsicht <input type="checkbox" name="attr_liturgie_mondsicht" value="1"/><br/>
-                                Mondsilberzunge <input type="checkbox" name="attr_liturgie_mondsilberzunge" value="1"/><br/>
-                                Objektsegen <input type="checkbox" name="attr_liturgie_objektsegen" value="1"/><br/>
-                                Ort der Ruhe <input type="checkbox" name="attr_liturgie_ortderruhe" value="1"/><br/>
-                                Pflanzenwuchs <input type="checkbox" name="attr_liturgie_pflanzenwuchs" value="1"/><br/>
-                                Rabenruf <input type="checkbox" name="attr_liturgie_rabenruf" value="1"/><br/>
+                                <input type="checkbox" name="attr_liturgie_magiesicht" value="1"/> Magiesicht<br/>
+                                <input type="checkbox" name="attr_liturgie_mondsicht" value="1"/> Mondsicht<br/>
+                                <input type="checkbox" name="attr_liturgie_mondsilberzunge" value="1"/> Mondsilberzunge<br/>
+                                <input type="checkbox" name="attr_liturgie_namenlose_zweifel" value="1"/> Namenlose Zweifel<br/>
+                                <input type="checkbox" name="attr_liturgie_namenloses_vergessen" value="1"/> Namenloses Vergessen<br/>
+                                <input type="checkbox" name="attr_liturgie_objektsegen" value="1"/> Objektsegen<br/>
+                                <input type="checkbox" name="attr_liturgie_ortderruhe" value="1"/> Ort der Ruhe<br/>
+                                <input type="checkbox" name="attr_liturgie_pflanzenwuchs" value="1"/> Pflanzenwuchs<br/>
+                                <input type="checkbox" name="attr_liturgie_rabenruf" value="1"/> Rabenruf<br/>
                             </td>
                             <td valign="top">
-                                Schlaf <input type="checkbox" name="attr_liturgie_schlaf" value="1"/><br/>
-                                Schlangenstab <input type="checkbox" name="attr_liturgie_schlangenstab" value="1"/><br/>
-                                Schlangenzunge <input type="checkbox" name="attr_liturgie_schlangenzunge" value="1"/><br/>
-                                Schmerzresistenz <input type="checkbox" name="attr_liturgie_schmerzresistenz" value="1"/><br/>
-                                Schutz der Wehrlosen <input type="checkbox" name="attr_liturgie_schutzderwehrlosen" value="1"/><br/>
-                                Sternenglanz <input type="checkbox" name="attr_liturgie_sternenglanz" value="1"/><br/>
-                                Wahrheit <input type="checkbox" name="attr_liturgie_wahrheit" value="1"/><br/>
-                                Wieselflink <input type="checkbox" name="attr_liturgie_wieselflink" value="1"/><br/>
-                                Wunder. Verständigung <input type="checkbox" name="attr_liturgie_wundersameverstaendigung" value="1"/><br/>             
+                                <input type="checkbox" name="attr_liturgie_schlaf" value="1"/> Schlaf<br/>
+                                <input type="checkbox" name="attr_liturgie_schlangenstab" value="1"/> Schlangenstab<br/>
+                                <input type="checkbox" name="attr_liturgie_schlangenzunge" value="1"/> Schlangenzunge<br/>
+                                <input type="checkbox" name="attr_liturgie_schmerzresistenz" value="1"/> Schmerzresistenz<br/>
+                                <input type="checkbox" name="attr_liturgie_schutzderwehrlosen" value="1"/> Schutz der Wehrlosen<br/>
+                                <input type="checkbox" name="attr_liturgie_sternenglanz" value="1"/> Sternenglanz<br/>
+                                <input type="checkbox" name="attr_liturgie_wahrheit" value="1"/> Wahrheit<br/>
+                                <input type="checkbox" name="attr_liturgie_wieselflink" value="1"/> Wieselflink<br/>
+                                <input type="checkbox" name="attr_liturgie_wundersameverstaendigung" value="1"/> Wunder. Verständigung<br/>             
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
Verbesserungen in Umsetzung bestehender Regeln:
- Entfernungssinn in Fernkampf-Tab berücksichtigt
- Herausragender Sinn explizit auf Einzelsinne gesplittet
- Mag. Einstimmung und Mag. Einschränkung als spezielle Modifikatoren in Zauber- und Rituale-Tab berücksichtigt
- Zauberzeichen (Schutz- und Bannkreise) hinzugefügt

Neue Regelelemente aus Abenteuern hinzugefügt:
- Tradition Goblinzauberinnen inkl. neuer Rituale
- Tradition Zibilja inkl. neuem Ritual
- 4 Liturgien des Namenlosen
- Zauberzeichen Verschluss
- Sonderfertigkeiten Leg-ga-leg und Bine Maschores