### PR TITLE
Added Options for NPC management and a couple of missing skills and spells

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
@@ -247,6 +247,39 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
     display: none;
 }
 
+input.sheet-reduzierte-talentansicht:checked ~ .sheet-tab,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Koerper,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Gesellschaft,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Natur,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Wissen,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Handwerk,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Gaben,
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Sprachen {
+	display:none;
+}
+
+input.sheet-reduzierte-talentansicht:checked ~ div.sheet-section-Talente-reduziert {
+    max-height: 999999px;
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s linear 0s;
+    overflow: hidden;
+    
+    border: 1px solid #222;
+    margin: 7px 0 0 5px;
+    padding: 5px
+}
+
+input.sheet-gegner:checked ~ .sheet-kein-gegner,
+input.sheet-gegner:not(:checked) ~ .sheet-gegner {
+    display: none;
+}
+
+input.sheet-show-nicht-humanoid:not(:checked) ~ .sheet-nicht-humanoid,
+input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
+    display: none;
+}
+
 .sheet-show-optional:not(:checked )+ input.sheet-tab57,
 .sheet-show-optional:not(:checked )~ span.sheet-tab57 {
     display: none;
@@ -335,18 +368,7 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
 
 
 .sheet-kampf-passiv:checked + div.sheet-sf-row ,
-.sheet-sf-riposte:checked + div.sheet-sf-row ,
-.sheet-sf-zu-fall-bringen:checked + div.sheet-sf-row ,
-.sheet-sf-vorstoss:checked + div.sheet-sf-row ,
-.sheet-sf-todesstoss:checked + div.sheet-sf-row ,
-.sheet-sf-sturmangriff:checked + div.sheet-sf-row ,
-.sheet-sf-schildspalter:checked + div.sheet-sf-row ,
-.sheet-sf-rundumschlag:checked + div.sheet-sf-row ,
-.sheet-sf-hammerschlag:checked + div.sheet-sf-row ,
-.sheet-sf-entwaffnen:checked + div.sheet-sf-row ,
-.sheet-sf-wuchtschlag:checked + div.sheet-sf-row ,
-.sheet-sf-praeziser-stich:checked + div.sheet-sf-row,
-.sheet-sf-finte:checked + div.sheet-sf-row {
+.sheet-sf-aktiviert:checked + div.sheet-sf-row {
     display: inline-block;  
     white-space: nowrap;
 }
@@ -373,55 +395,26 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
 }
 
 
-.sheet-zauber-wasseratem:checked + div.sheet-zauber,
-.sheet-zauber-visibili:checked + div.sheet-zauber,
-.sheet-zauber-transversalis:checked + div.sheet-zauber,
-.sheet-zauber-spurlos:checked + div.sheet-zauber,
-.sheet-zauber-spinnenlauf:checked + div.sheet-zauber,
-.sheet-zauber-somnigravis:checked + div.sheet-zauber,
-.sheet-zauber-silentium:checked + div.sheet-zauber,
-.sheet-zauber-satuarias-herrlichkeit:checked + div.sheet-zauber,
-.sheet-zauber-sanftmut:checked + div.sheet-zauber,
-.sheet-zauber-salander:checked + div.sheet-zauber,
-.sheet-zauber-respondami:checked + div.sheet-zauber,
-.sheet-zauber-radau:checked + div.sheet-zauber,
-.sheet-zauber-psychostabilis:checked + div.sheet-zauber,
-.sheet-zauber-penetrizzel:checked + div.sheet-zauber,
-.sheet-zauber-paralysis:checked + div.sheet-zauber,
-.sheet-zauber-odem-arcanum:checked + div.sheet-zauber,
-.sheet-zauber-oculus-illusionis:checked + div.sheet-zauber,
-.sheet-zauber-nebelwand:checked + div.sheet-zauber,
-.sheet-zauber-motoricus:checked + div.sheet-zauber,
-.sheet-zauber-manus-miracula:checked + div.sheet-zauber,
-.sheet-zauber-manifesto:checked + div.sheet-zauber,
-.sheet-zauber-kroetensprung:checked + div.sheet-zauber,
-.sheet-zauber-katzenaugen:checked + div.sheet-zauber,
-.sheet-zauber-invocatio-minima:checked + div.sheet-zauber,
-.sheet-zauber-ignifaxius:checked + div.sheet-zauber,
-.sheet-zauber-horriphobus:checked + div.sheet-zauber,
-.sheet-zauber-hexenkrallen:checked + div.sheet-zauber,
-.sheet-zauber-hexengalle:checked + div.sheet-zauber,
-.sheet-zauber-harmlose-gestalt:checked + div.sheet-zauber,
-.sheet-zauber-grosse-gier:checked + div.sheet-zauber,
-.sheet-zauber-gardianum:checked + div.sheet-zauber,
-.sheet-zauber-fulminictus:checked + div.sheet-zauber,
-.sheet-zauber-flim-flam:checked + div.sheet-zauber,
-.sheet-zauber-falkenauge:checked + div.sheet-zauber,
-.sheet-zauber-duplicatus:checked + div.sheet-zauber,
-.sheet-zauber-disruptivo:checked + div.sheet-zauber,
-.sheet-zauber-corpofesso:checked + div.sheet-zauber,
-.sheet-zauber-blitz:checked + div.sheet-zauber,
-.sheet-zauber-blick:checked + div.sheet-zauber,
-.sheet-zauber-bannbaladin:checked + div.sheet-zauber,
-.sheet-zauber-balsam:checked + div.sheet-zauber,
-.sheet-zauber-axxeleratus:checked + div.sheet-zauber,
-.sheet-zauber-armatrutz:checked + div.sheet-zauber,
-.sheet-zauber-analys:checked + div.sheet-zauber,
-.sheet-zauber-adlerauge:checked + div.sheet-zauber
+.sheet-zauber-aktiviert:checked + div.sheet-zauber
  {
     display: inline-block;
     white-space: nowrap;
 }
+
+.sheet-grundwert-name
+{
+	text-align:left;
+	width:10em;
+}
+
+.sheet-grundwert-name,
+.sheet-grundwert-wert
+{
+    display: inline-block;
+    white-space: nowrap;
+}
+	
+
 
 .sheet-zauber-bannderdunkelheit:checked + div.sheet-zauber,
 .sheet-zauber-bannderfurcht:checked + div.sheet-zauber,
@@ -707,6 +700,7 @@ input.sheet-tab13:checked + span.sheet-tab13,
 input.sheet-tab14:checked + span.sheet-tab14,
 input.sheet-tab2:checked + span.sheet-tab2,
 input.sheet-tab3:checked + span.sheet-tab3,
+input.sheet-tab30:checked + span.sheet-tab30,
 input.sheet-tab31:checked + span.sheet-tab31,
 input.sheet-tab32:checked + span.sheet-tab32,
 input.sheet-tab33:checked + span.sheet-tab33,

--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -4,6 +4,7 @@
     <h4>Created by Patrick Gebhardt</h4>
     <br>
 
+  	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" title="Allgemein" checked="checked"/>
     <span class="sheet-tab sheet-tab1">Allgemein</span>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Status"/>
@@ -18,10 +19,10 @@
     <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab" style="display:none;" />
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab6" value="6" title="Götterwirken"/>
     <span class="sheet-tab sheet-tab6">Götterwirken</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab7" value="7" title="Inventar"/>
-    <span class="sheet-tab sheet-tab7">Inventar</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab8" value="8" title="Notizen"/>
-    <span class="sheet-tab sheet-tab8">Notizen</span>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab7 sheet-kein-gegner" value="7" title="Inventar"/>
+    <span class="sheet-tab sheet-tab7 sheet-kein-gegner">Inventar</span>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab8 sheet-kein-gegner" value="8" title="Notizen"/>
+    <span class="sheet-tab sheet-tab8 sheet-kein-gegner">Notizen</span>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9" title="Konfiguration"/>
     <span class="sheet-tab sheet-tab9">Konfiguration</span>
     <br/>
@@ -36,125 +37,199 @@
         <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab14" value="14" title="Sonderfertigkeiten"/>
             <span class="sheet-tab sheet-tab14">Sonderfertigkeit.</span>
         <br>        
+        
         <div class="sheet-section sheet-section-Grundwerte" align="center"> 
+        	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
+        	<div class="sheet-kein-gegner">
+	            <table>
+	            <tr>
+	                <td>Name</td>
+	                <td colspan="5"><input type="text" name="attr_Charaktername"></td>
+	            </tr>
+	            <tr>
+	                <td>Familie</td>
+	                <td><input type="text" name="attr_Familie"></td>
+	                <td>Geburtsort</td>
+	                <td colspan="3"><input type="text" name="attr_Geburtsort"></td>
+	            </tr>
+	            <tr>
+	                <td>Geburtsdatum</td>
+	                <td><input type="text" name="attr_Geburtsdatum"></td>
+	                <td>Alter</td>
+	                <td><input type="text" name="attr_Alter"></td>
+	                <td>Geschlecht</td>
+	                <td><input type="text" name="attr_Geschlecht"></td>
+	            </tr>
+	            <tr>
+	                <td>Spezies</td>
+	                <td>
+	                    <input style="display:none;" name="attr_spezies_mensch" type="number" disabled="true" value="1-ceil((@{Spezies}%3)/100)"/>
+	                    <input style="display:none;" name="attr_spezies_elf" type="number" disabled="true" value="1-ceil((@{Spezies}%5)/100)"/>
+	                    <input style="display:none;" name="attr_spezies_halbelf" type="number" disabled="true" value="1-ceil((@{Spezies}%7)/100)"/>
+	                    <input style="display:none;" name="attr_spezies_zwerg" type="number" disabled="true" value="1-ceil((@{Spezies}%11)/100)"/>
+	                    <select name="attr_Spezies">
+	                        <option value="3">Mensch</option>
+	                        <option value="5">Elf</option>
+	                        <option value="7">Halbelf</option>
+	                        <option value="11">Zwerg</option>
+	                    </select>
+	                </td>
+	                <td>Größe</td>
+	                <td><input type="text" name="attr_Grösse"></td>
+	                <td>Gewicht</td>
+	                <td><input type="text" name="attr_Gewicht"></td>
+	            </tr>
+	            <tr>
+	                <td>Haarfarbe</td>
+	                <td><input type="text" name="attr_Haarfarbe"></td>
+	                <td>Augenfarbe</td>
+	                <td><input type="text" name="attr_Augenfarbe"></td>
+	                <td>Erfahrungsgrad</td>
+	                <td>
+	                    <select name="attr_Erfahrungsgrad">
+	                        <option value="Unerfahren">Unerfahren</option>
+	                        <option value="Durchschnittlich">Durchschnittlich</option>
+	                        <option value="Erfahren">Erfahren</option>
+	                        <option value="Kompetent">Kompetent</option>
+	                        <option value="Meisterlich">Meisterlich</option>
+	                        <option value="Brillant">Brillant</option>
+	                        <option value="Legendär">Legendär</option>
+	                    </select>
+	                </td>
+	            </tr>
+	            <tr>
+	                <td>Kultur</td>
+	                <td>
+	                    <select name="attr_Kultur">
+	                        <option value="Ambosszwerge">Ambosszwerge</option>
+	                        <option value="Andergaster">Andergaster</option>
+	                        <option value="Aranier">Aranier</option>
+	                        <option value="Auelfen">Auelfen</option>
+	                        <option value="Bornländer">Bornländer</option>
+	                        <option value="Brillantzwerge">Brillantzwerge</option>
+	                        <option value="Brobim">Brobim</option>
+	                        <option value="Erzzwerge">Erzzwerge</option>
+	                        <option value="Firnelfen">Firnelfen</option>
+	                        <option value="Fjarninger">Fjarninger</option>
+	                        <option value="Horasier">Horasier</option>
+	                        <option value="Hügelzwerge">Hügelzwerge</option>
+	                        <option value="Maraskaner">Maraskaner</option>
+	                        <option value="Mhanadistani">Mhanadistani</option>
+	                        <option value="Mittelreicher">Mittelreicher</option>
+	                        <option value="Mohas">Mohas</option>
+	                        <option value="Nivesen">Nivesen</option>
+	                        <option value="Norbarden">Norbarden</option>
+	                        <option value="Nordaventurier">Nordaventurier</option>
+	                        <option value="Nostrier">Nostrier</option>
+	                        <option value="Novadis">Novadis</option>
+	                        <option value="Steppenelfen ">Steppenelfen</option>
+	                        <option value="Südaventurier">Südaventurier</option>
+	                        <option value="Svellttaler">Svellttaler</option>
+	                        <option value="Thorwaler">Thorwaler</option>
+	                        <option value="Trollzacker">Trollzacker</option>
+	                        <option value="Waldelfen">Waldelfen</option>
+	                        <option value="Zyklopäer">Zyklopäer</option>
+	                    </select>
+	                </td>
+	                <td>Profession</td>
+	                <td><input type="text" name="attr_Profession"></td>
+	                <td>AP Gesamt</td>
+	                <td><input type="number" name="attr_APgesamt" style="width: 100px"></td>
+	            </tr>
+	            <tr>
+	                <td>Titel</td>
+	                <td><input type="text" name="attr_Titel"></td>
+	                <td>Sozialstatus</td>
+	                <td><input type="text" name="attr_Sozialstatus"></td>
+	                <td>AP verfügbar</td>
+	                <td><input type="number" name="attr_APverfuegbar" value="@{APgesamt}-@{APausgegeben}" disabled="true" style="width: 100px"></td>
+	            </tr>
+	            <tr>
+	                <td>Charakteristika</td>
+	                <td colspan="3"><input type="text" name="attr_Charakteristika"></td>
+	                <td>AP ausgegeben</td>
+	                <td><input type="number" name="attr_APausgegeben" style="width: 100px"></td>
+	            </tr>
+	            <tr>
+	                <td>Sonstiges</td>
+	                <td colspan="5"><input type="text" name="attr_Sonstiges"></td>
+	            </tr>
+	        </table>
+        </div>
+       	<div class="sheet-gegner">
             <table>
-            <tr>
-                <td>Name</td>
-                <td colspan="5"><input type="text" name="attr_Charaktername"></td>
-            </tr>
-            <tr>
-                <td>Familie</td>
-                <td><input type="text" name="attr_Familie"></td>
-                <td>Geburtsort</td>
-                <td colspan="3"><input type="text" name="attr_Geburtsort"></td>
-            </tr>
-            <tr>
-                <td>Geburtsdatum</td>
-                <td><input type="text" name="attr_Geburtsdatum"></td>
-                <td>Alter</td>
-                <td><input type="text" name="attr_Alter"></td>
-                <td>Geschlecht</td>
-                <td><input type="text" name="attr_Geschlecht"></td>
-            </tr>
-            <tr>
-                <td>Spezies</td>
-                <td>
-                    <input style="display:none;" name="attr_spezies_mensch" type="number" disabled="true" value="1-ceil((@{Spezies}%3)/100)"/>
-                    <input style="display:none;" name="attr_spezies_elf" type="number" disabled="true" value="1-ceil((@{Spezies}%5)/100)"/>
-                    <input style="display:none;" name="attr_spezies_halbelf" type="number" disabled="true" value="1-ceil((@{Spezies}%7)/100)"/>
-                    <input style="display:none;" name="attr_spezies_zwerg" type="number" disabled="true" value="1-ceil((@{Spezies}%11)/100)"/>
-                    <select name="attr_Spezies">
-                        <option value="3">Mensch</option>
-                        <option value="5">Elf</option>
-                        <option value="7">Halbelf</option>
-                        <option value="11">Zwerg</option>
-                    </select>
-                </td>
-                <td>Größe</td>
-                <td><input type="text" name="attr_Grösse"></td>
-                <td>Gewicht</td>
-                <td><input type="text" name="attr_Gewicht"></td>
-            </tr>
-            <tr>
-                <td>Haarfarbe</td>
-                <td><input type="text" name="attr_Haarfarbe"></td>
-                <td>Augenfarbe</td>
-                <td><input type="text" name="attr_Augenfarbe"></td>
-                <td>Erfahrungsgrad</td>
-                <td>
-                    <select name="attr_Erfahrungsgrad">
-                        <option value="Unerfahren">Unerfahren</option>
-                        <option value="Durchschnittlich">Durchschnittlich</option>
-                        <option value="Erfahren">Erfahren</option>
-                        <option value="Kompetent">Kompetent</option>
-                        <option value="Meisterlich">Meisterlich</option>
-                        <option value="Brillant">Brillant</option>
-                        <option value="Legendär">Legendär</option>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <td>Kultur</td>
-                <td>
-                    <select name="attr_Kultur">
-                        <option value="Ambosszwerge">Ambosszwerge</option>
-                        <option value="Andergaster">Andergaster</option>
-                        <option value="Aranier">Aranier</option>
-                        <option value="Auelfen">Auelfen</option>
-                        <option value="Bornländer">Bornländer</option>
-                        <option value="Brillantzwerge">Brillantzwerge</option>
-                        <option value="Brobim">Brobim</option>
-                        <option value="Erzzwerge">Erzzwerge</option>
-                        <option value="Firnelfen">Firnelfen</option>
-                        <option value="Fjarninger">Fjarninger</option>
-                        <option value="Horasier">Horasier</option>
-                        <option value="Hügelzwerge">Hügelzwerge</option>
-                        <option value="Maraskaner">Maraskaner</option>
-                        <option value="Mhanadistani">Mhanadistani</option>
-                        <option value="Mittelreicher">Mittelreicher</option>
-                        <option value="Mohas">Mohas</option>
-                        <option value="Nivesen">Nivesen</option>
-                        <option value="Norbarden">Norbarden</option>
-                        <option value="Nordaventurier">Nordaventurier</option>
-                        <option value="Nostrier">Nostrier</option>
-                        <option value="Novadis">Novadis</option>
-                        <option value="Steppenelfen ">Steppenelfen</option>
-                        <option value="Südaventurier">Südaventurier</option>
-                        <option value="Svellttaler">Svellttaler</option>
-                        <option value="Thorwaler">Thorwaler</option>
-                        <option value="Trollzacker">Trollzacker</option>
-                        <option value="Waldelfen">Waldelfen</option>
-                        <option value="Zyklopäer">Zyklopäer</option>
-                    </select>
-                </td>
-                <td>Profession</td>
-                <td><input type="text" name="attr_Profession"></td>
-                <td>AP Gesamt</td>
-                <td><input type="number" name="attr_APgesamt" style="width: 100px"></td>
-            </tr>
-            <tr>
-                <td>Titel</td>
-                <td><input type="text" name="attr_Titel"></td>
-                <td>Sozialstatus</td>
-                <td><input type="text" name="attr_Sozialstatus"></td>
-                <td>AP verfügbar</td>
-                <td><input type="number" name="attr_APverfuegbar" value="@{APgesamt}-@{APausgegeben}" disabled="true" style="width: 100px"></td>
-            </tr>
-            <tr>
-                <td>Charakteristika</td>
-                <td colspan="3"><input type="text" name="attr_Charakteristika"></td>
-                <td>AP ausgegeben</td>
-                <td><input type="number" name="attr_APausgegeben" style="width: 100px"></td>
-            </tr>
-            <tr>
-                <td>Sonstiges</td>
-                <td colspan="5"><input type="text" name="attr_Sonstiges"></td>
-            </tr>
-        </table>
-        <br>
+	            <tr>
+	                <td>Typus</td>
+	                <td>
+	                    <input style="display:none;" name="attr_typus_beseelter" type="number" disabled="true" value="1-ceil((@{Typus}%3)/100)"/>
+	                    <input style="display:none;" name="attr_typus_chimaere" type="number" disabled="true" value="1-ceil((@{Typus}%5)/100)"/>
+	                    <input style="display:none;" name="attr_typus_daimonid" type="number" disabled="true" value="1-ceil((@{Typus}%7)/100)"/>
+	                    <input style="display:none;" name="attr_typus_daemon" type="number" disabled="true" value="1-ceil((@{Typus}%11)/100)"/>
+	                    <input style="display:none;" name="attr_typus_drache" type="number" disabled="true" value="1-ceil((@{Typus}%13)/100)"/>
+	                    <input style="display:none;" name="attr_typus_elementar" type="number" disabled="true" value="1-ceil((@{Typus}%17)/100)"/>
+	                    <input style="display:none;" name="attr_typus_fee" type="number" disabled="true" value="1-ceil((@{Typus}%19)/100)"/>
+	                    <input style="display:none;" name="attr_typus_geist" type="number" disabled="true" value="1-ceil((@{Typus}%23)/100)"/>
+	                    <input style="display:none;" name="attr_typus_golem" type="number" disabled="true" value="1-ceil((@{Typus}%29)/100)"/>
+	                    <input style="display:none;" name="attr_typus_hirnloser" type="number" disabled="true" value="1-ceil((@{Typus}%31)/100)"/>
+	                    <input style="display:none;" name="attr_typus_kulturschaffender" type="number" disabled="true" value="1-ceil((@{Typus}%37)/100)"/>
+	                    <input style="display:none;" name="attr_typus_pflanze" type="number" disabled="true" value="1-ceil((@{Typus}%41)/100)"/>
+	                    <input style="display:none;" name="attr_typus_pilz" type="number" disabled="true" value="1-ceil((@{Typus}%43)/100)"/>
+	                    <input style="display:none;" name="attr_typus_tier" type="number" disabled="true" value="1-ceil((@{Typus}%47)/100)"/>
+	                    <input style="display:none;" name="attr_typus_untoter" type="number" disabled="true" value="1-ceil((@{Typus}%53)/100)"/>
+	                    <input style="display:none;" name="attr_typus_vampir" type="number" disabled="true" value="1-ceil((@{Typus}%59)/100)"/>
+	                    <input style="display:none;" name="attr_typus_lebewesen" type="number" disabled="true" value="@{typus_kulturschaffender}+@{typus_tier}+@{typus_pflanze}+@{typus_pilz}+@{typus_uebernatuerliches_lebewesen}"/>
+	                    <input style="display:none;" name="attr_typus_uebernatuerliches_lebewesen" type="number" disabled="true" value="@{typus_fee}+@{typus_chimaere}+@{typus_drache}+@{typus_daimonid}"/>
+	                    <input style="display:none;" name="attr_typus_nicht_lebender" type="number" disabled="true" value="@{typus_untoter_gattung}+@{typus_daemon}+@{typus_elementar}+@{typus_golem}"/>
+	                    <input style="display:none;" name="attr_typus_untoter_gattung" type="number" disabled="true" value="@{typus_untoter}+@{typus_geist}+@{typus_hirnloser}+@{typus_vampir}+@{typus_beseelter}"/>
+  	                    <select name="attr_Typus">
+	                        <option value="0">---</option>
+	                        <option value="3">Beseelter</option>
+	                        <option value="5">Chimäre</option>
+	                        <option value="7">Daimonid</option>
+	                        <option value="11">Dämon</option>
+	                        <option value="13">Drache</option>
+	                        <option value="17">Elementar</option>
+	                        <option value="19">Fee</option>
+	                        <option value="23">Geist</option>
+	                        <option value="29">Golem</option>
+	                        <option value="31">Hirnloser</option>
+	                        <option value="37">Kulturschaffender</option>
+	                        <option value="41">Pflanze</option>
+	                        <option value="43">Pilz</option>
+	                        <option value="47">Tier</option>
+	                        <option value="53">Untoter</option>
+	                        <option value="59">Vampir</option>
+	                    </select>
+	                </td>
+	                <td>Größe</td>
+	                <td><input type="text" name="attr_Grösse"></td>
+	                <td>Gewicht</td>
+	                <td><input type="text" name="attr_Gewicht"></td>
+	           </tr>
+	           <tr>
+	                <td>Nicht-Humanoid</td>
+	                <td><input type="checkbox" name="attr_nicht_humanoid" value="1"></td>
+	                <td>Größenkategorie</td>
+	                <td>
+	                    <select name="attr_Groessenkategorie" style="width: 8em;">
+		                    <option value="-2">Winzig</option>
+		                    <option value="-1">Klein</option>
+		                    <option value="0" selected="true">Mittel</option>
+		                    <option value="1">Groß</option>
+		                    <option value="2">Riesig</option>
+	                    </select>
+                    </td>
+	                <td></td>
+	                <td></td>
+	            </tr>
+	        </table>
+       	</div>
+        <br />
+       	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
+       	<div class="sheet-kein-gegner">
         <table>
             <tr>
-                <td>
+                <td>	
                     <table>
                         <tr align=center>
                             <td></td>
@@ -167,7 +242,7 @@
                         <tr>
                             <td>Mut</td>
                             <td><input type="number" name="attr_MU_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_MU_Wert" value="(@{MU_Grundwert}+@{MU_Mod}+@{MU_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_MU_Wert" value="((@{MU_Grundwert}+@{MU_Mod}+@{MU_Zukauf}))*(1-@{gegner_sheet})+@{MU_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_MU_Mod" value="0"></td>
                             <td><input type="number" name="attr_MU_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_MU_Max" value="round(@{MU_Grundwert}*1.5)"></td>
@@ -176,7 +251,7 @@
                         <tr>
                             <td>Klugheit</td>
                             <td><input type="number" name="attr_KL_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KL_Wert" value="(@{KL_Grundwert}+@{KL_Mod}+@{KL_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_KL_Wert" value="((@{KL_Grundwert}+@{KL_Mod}+@{KL_Zukauf}))*(1-@{gegner_sheet})+@{KL_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_KL_Mod" value="0"></td>
                             <td><input type="number" name="attr_KL_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_KL_Max" value="round(@{KL_Grundwert}*1.5)"></td>
@@ -185,7 +260,7 @@
                         <tr>
                             <td>Intuition</td>
                             <td><input type="number" name="attr_IN_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_IN_Wert" value="(@{IN_Grundwert}+@{IN_Mod}+@{IN_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_IN_Wert" value="((@{IN_Grundwert}+@{IN_Mod}+@{IN_Zukauf}))*(1-@{gegner_sheet})+@{IN_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_IN_Mod" value="0"></td>
                             <td><input type="number" name="attr_IN_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_IN_Max" value="round(@{IN_Grundwert}*1.5)"></td>
@@ -194,7 +269,7 @@
                         <tr>
                             <td>Charisma</td>
                             <td><input type="number" name="attr_CH_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_CH_Wert" value="(@{CH_Grundwert}+@{CH_Mod}+@{CH_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_CH_Wert" value="((@{CH_Grundwert}+@{CH_Mod}+@{CH_Zukauf}))*(1-@{gegner_sheet})+@{CH_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_CH_Mod" value="0"></td>
                             <td><input type="number" name="attr_CH_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_CH_Max" value="round(@{CH_Grundwert}*1.5)"></td>
@@ -203,7 +278,7 @@
                         <tr>
                             <td>Fingerfertigkeit</td>
                             <td><input type="number" name="attr_FF_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_FF_Wert" value="(@{FF_Grundwert}+@{FF_Mod}+@{FF_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_FF_Wert" value="((@{FF_Grundwert}+@{FF_Mod}+@{FF_Zukauf}))*(1-@{gegner_sheet})+@{FF_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_FF_Mod" value="0"></td>
                             <td><input type="number" name="attr_FF_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_FF_Max" value="round(@{FF_Grundwert}*1.5)"></td>
@@ -212,7 +287,7 @@
                         <tr>
                             <td>Gewandheit</td>
                             <td><input type="number" name="attr_GE_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_GE_Wert" value="(@{GE_Grundwert}+@{GE_Mod}+@{GE_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_GE_Wert" value="((@{GE_Grundwert}+@{GE_Mod}+@{GE_Zukauf}))*(1-@{gegner_sheet})+@{GE_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_GE_Mod" value="0"></td>
                             <td><input type="number" name="attr_GE_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_GE_Max" value="round(@{GE_Grundwert}*1.5)"></td>
@@ -221,7 +296,7 @@
                         <tr>
                             <td>Konstitution</td>
                             <td><input type="number" name="attr_KO_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KO_Wert" value="(@{KO_Grundwert}+@{KO_Mod}+@{KO_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_KO_Wert" value="((@{KO_Grundwert}+@{KO_Mod}+@{KO_Zukauf}))*(1-@{gegner_sheet})+@{KO_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_KO_Mod" value="0"></td>
                             <td><input type="number" name="attr_KO_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_KO_Max" value="round(@{KO_Grundwert}*1.5)"></td>
@@ -230,7 +305,7 @@
                         <tr>
                             <td>Körperkraft</td>
                             <td><input type="number" name="attr_KK_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KK_Wert" value="(@{KK_Grundwert}+@{KK_Mod}+@{KK_Zukauf})"></td>
+                            <td><input type="number" disabled=true name="attr_KK_Wert" value="((@{KK_Grundwert}+@{KK_Mod}+@{KK_Zukauf}))*(1-@{gegner_sheet})+@{KK_Wert_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="number" name="attr_KK_Mod" value="0"></td>
                             <td><input type="number" name="attr_KK_Zukauf" value="0"></td>
                             <td><input type="number" disabled=true name="attr_KK_Max" value="round(@{KK_Grundwert}*1.5)"></td>
@@ -329,6 +404,108 @@
                 </td>
             </tr>
         </table>
+        </div>
+       	<div class="sheet-gegner">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td>Mut</td>
+                            <td><input type="number" name="attr_MU_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Mut}} {{Probe=[[@{MU_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Klugheit</td>
+                            <td><input type="number" name="attr_KL_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Klugheit}} {{Probe=[[@{KL_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Intuition</td>
+                            <td><input type="number" name="attr_IN_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Intuition}} {{Probe=[[@{IN_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Charisma</td>
+                            <td><input type="number" name="attr_CH_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Charisma}} {{Probe=[[@{CH_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Fingerfertigkeit</td>
+                            <td><input type="number" name="attr_FF_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Fingerfertigkeit}} {{Probe=[[@{FF_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Gewandheit</td>
+                            <td><input type="number" name="attr_GE_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Gewandheit}} {{Probe=[[@{GE_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>                
+                        </tr>
+                        <tr>
+                            <td>Konstitution</td>
+                            <td><input type="number" name="attr_KO_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Konstitution}} {{Probe=[[@{KO_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                        <tr>
+                            <td>Körperkraft</td>
+                            <td><input type="number" name="attr_KK_Wert_Fix" value="8"></td>
+                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Körperkraft}} {{Probe=[[@{KK_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class='sheet-col'>
+                	<div>
+                		<div class="grundwert-name">Lebensenergie</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_LE_Wert" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Astralenenergie</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_AE_Wert" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Karmaenergie</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_KE_Wert" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Schicksalspunkte</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_Schicksal_Wert" value="3"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Seelenkraft</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_SK_Grundwert" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Zähigkeit</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_ZK_Grundwert" value="0"></div>
+                	</div>
+                </div>
+                <div class='sheet-col'>
+	                <input type="checkbox" class="sheet-show-nicht-humanoid" name="attr_nicht_humanoid" style="display:none;" value="1" />
+                	<div class="sheet-nicht-humanoid">
+                		<div class="grundwert-name">Verteidigung</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_Verteidigung_Wert" value="0"></div>
+                	</div>
+                	<div class="sheet-humanoid">
+                		<div class="grundwert-name">Ausweichen</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_Ausweichen_Wert" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Initiative</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_INI_Wert_Fix" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Rüstungsschutz</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_RS_Fix" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Geschwindigkeit</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_GS_Wert_Fix" value="0"></div>
+                	</div>
+                	<div>
+                		<div class="grundwert-name">Aktionen</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_Aktionen" value="1"></div>
+                	</div>
+                </div>
+            </div>
+       	</div>
         </div>
         <div class="sheet-section sheet-section-Vorteile" align=center> 
         <h3>Vorteile</h3>
@@ -2026,6 +2203,7 @@
 
     
     <div class="sheet-section sheet-section-Talente" align=center>
+        <input type="checkbox" name="attr_reduzierte_talentansicht" style="display:none;" class="sheet-reduzierte-talentansicht" value="1"/>
         <input type="radio" name="attr_talent_tab" class="sheet-tab sheet-tab31" value="31" title="Koerper" checked="checked"/>
             <span class="sheet-tab sheet-tab31">Körper</span>
         <input type="radio" name="attr_talent_tab" class="sheet-tab sheet-tab32" value="32" title="Gesellschaft"/>
@@ -2061,6 +2239,334 @@
             <th>BE</th>
                 <th><input type="number" name=attr_BE_Talente disabled=true value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></th>
         </table>
+
+        <div class="sheet-section sheet-section-Talente-reduziert" align=center> 
+            <table>
+                <tr align=center>
+                    <th>Talent</th>
+                    <th>Eigenschaften</th>
+                    <th>BE</th>
+                    <th>Fw</th>
+                    <th>Mod</th>
+                    <th><span class="sheet-tooltip-ef">Info<span>Weitere Mod. &amp; Regeln<br />+: Erleichterung<br />-: Erschwernis<br />AG: Neues Anwendungsgebiet<br />EM: Neue Einsatzmöglichkeit<br />QS: Erhöhung der QS<br />BG: Berufsgeheimnis</span></span></th>
+                    <th>Proben</th>
+                </tr>
+                <tr>
+                    <td>Klettern</td>
+                    <td><select name="attr_Klettern_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Klettern_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}" selected="selected">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Klettern_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}" selected="selected">KK</option>
+                            </select></td>
+                    <td>Ja</td>
+                    <td><input type="number" name="attr_Klettern_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Klettern_Mod" disabled="true" value="@{Zustand_Mod_max_inkl_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                Werkzeuge (-)<br/>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_fettleibig" value="1" />
+                                <div>Fettleibig (-)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Klettern}} {{subtags=Körperlich}} {{Talent=[[ @{Klettern_FW} - {1d20cs1cf20 - ([[@{Klettern_Eigenschaft1}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Klettern_Eigenschaft2}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Klettern_Eigenschaft3}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Klettern_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Klettern}} {{subtags=Körperlich}} {{Talent=[[ @{Klettern_FW} + 2 - {1d20cs1cf20 - ([[@{Klettern_Eigenschaft1}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Klettern_Eigenschaft2}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Klettern_Eigenschaft3}]] + [[@{Klettern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Klettern_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Klettern}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Klettern_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Klettern_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Klettern_Eigenschaft3}]]}} {{FP=[[round(@{Klettern_FW}/2)]]}} {{Modifikator=[[ceil(((@{Klettern_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Körperbeherrschung</td>
+                    <td><select name="attr_Koerperbeherrschung_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}" selected="selected">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Koerperbeherrschung_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}" selected="selected">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Koerperbeherrschung_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}" selected="selected">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Ja</td>
+                    <td><input type="number" name="attr_Koerperbeherrschung_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Koerperbeherrschung_Mod" disabled="true" value="@{Zustand_Mod_max_inkl_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_schlangenmensch" value="1" />
+                                <div>Schlangenmensch (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_fettleibig" value="1" />
+                                <div>Fettleibig (-)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Körperbeherrschung}} {{subtags=Körperlich}} {{Talent=[[ @{Koerperbeherrschung_FW} - {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft1}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft2}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft3}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Koerperbeherrschung_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Körperbeherrschung}} {{subtags=Körperlich}} {{Talent=[[ @{Koerperbeherrschung_FW} + 2 - {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft1}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft2}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Koerperbeherrschung_Eigenschaft3}]] + [[@{Koerperbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Koerperbeherrschung_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Körperbeherrschung}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Koerperbeherrschung_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Koerperbeherrschung_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Koerperbeherrschung_Eigenschaft3}]]}} {{FP=[[round(@{Koerperbeherrschung_FW}/2)]]}} {{Modifikator=[[ceil(((@{Koerperbeherrschung_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Kraftakt</td>
+                    <td><select name="attr_Kraftakt_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}" selected="selected">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Kraftakt_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}" selected="selected">KK</option>
+                            </select>
+                        <select name="attr_Kraftakt_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}" selected="selected">KK</option>
+                            </select></td>
+                    <td>Ja</td>
+                    <td><input type="number" name="attr_Kraftakt_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Kraftakt_Mod" disabled="true" value="@{Zustand_Mod_max_inkl_BE}"></td>
+                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span>Werkzeuge (-)</span></span></td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Kraftakt}} {{subtags=Körperlich}} {{Talent=[[ @{Kraftakt_FW} - {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft1}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft2}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft3}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Kraftakt_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Kraftakt}} {{subtags=Körperlich}} {{Talent=[[ @{Kraftakt_FW} + 2 - {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft1}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft2}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Kraftakt_Eigenschaft3}]] + [[@{Kraftakt_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Kraftakt_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Kraftakt}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Kraftakt_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Kraftakt_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Kraftakt_Eigenschaft3}]]}} {{FP=[[round(@{Kraftakt_FW}/2)]]}} {{Modifikator=[[ceil(((@{Kraftakt_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Schwimmen</td>
+                    <td><select name="attr_Schwimmen_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}" selected="selected">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Schwimmen_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}" selected="selected">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Schwimmen_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}" selected="selected">KK</option>
+                            </select></td>
+                    <td>Ja</td>
+                    <td><input type="number" name="attr_Schwimmen_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Schwimmen_Mod" disabled="true" value="@{Zustand_Mod_max_inkl_BE}"></td>
+                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Schwimmen}} {{subtags=Körperlich}} {{Talent=[[ @{Schwimmen_FW} - {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft1}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft2}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft3}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Schwimmen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Schwimmen}} {{subtags=Körperlich}} {{Talent=[[ @{Schwimmen_FW} + 2 - {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft1}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft2}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Schwimmen_Eigenschaft3}]] + [[@{Schwimmen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Schwimmen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Schwimmen}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Schwimmen_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Schwimmen_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Schwimmen_Eigenschaft3}]]}} {{FP=[[round(@{Schwimmen_FW}/2)]]}} {{Modifikator=[[ceil(((@{Schwimmen_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Selbstbeherrschung</td>
+                    <td><select name="attr_Selbstbeherrschung_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Selbstbeherrschung_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Selbstbeherrschung_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}" selected="selected">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Nein</td>
+                    <td><input type="number" name="attr_Selbstbeherrschung_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Selbstbeherrschung_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_schmerzen_unterdruecken" value="1" />
+                                <div>Schmerzen unterdrücken (EM)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Selbstbeherrschung}} {{subtags=Körperlich}} {{Talent=[[ @{Selbstbeherrschung_FW} - {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft1}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft2}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft3}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Selbstbeherrschung_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Selbstbeherrschung}} {{subtags=Körperlich}} {{Talent=[[ @{Selbstbeherrschung_FW} + 2 - {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft1}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft2}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Selbstbeherrschung_Eigenschaft3}]] + [[@{Selbstbeherrschung_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Selbstbeherrschung_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Selbstbeherrschung}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Selbstbeherrschung_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Selbstbeherrschung_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Selbstbeherrschung_Eigenschaft3}]]}} {{FP=[[round(@{Selbstbeherrschung_FW}/2)]]}} {{Modifikator=[[ceil(((@{Selbstbeherrschung_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Sinnesschärfe</td>
+                    <td><select name="attr_Sinnesschaerfe_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}" selected="selected">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Sinnesschaerfe_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}" selected="selected">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Sinnesschaerfe_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}" selected="selected">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Evtl.</td>
+                    <td><input type="number" name="attr_Sinnesschaerfe_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Sinnesschaerfe_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_lippenlesen" value="1" />
+                                <div>Lippenlesen (AG)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_fuchssinn" value="1" />
+                                <div>Fuchssinn (AG)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_gehoer" value="1" />
+                                <div>Herausragender Sinn: Gehör (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_geruch_geschmack" value="1" />
+                                <div>Herausragender Sinn: Geruch &amp; Geschmack (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_sicht" value="1" />
+                                <div>Herausragender Sinn: Sicht (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_tastsinn" value="1" />
+                                <div>Herausragender Sinn: Tastsinn (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_zwergennase" value="1" />
+                                <div>Zwergennase (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_eingeschraenkter_sinn" value="1" />
+                                <div>Eingeschränkter Sinn (-)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Sinnesschärfe}} {{subtags=Körperlich}} {{Talent=[[ @{Sinnesschaerfe_FW} - {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft1}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft2}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft3}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sinnesschaerfe_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Sinnesschärfe}} {{subtags=Körperlich}} {{Talent=[[ @{Sinnesschaerfe_FW} + 2 - {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft1}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft2}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sinnesschaerfe_Eigenschaft3}]] + [[@{Sinnesschaerfe_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sinnesschaerfe_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Sinnesschärfe}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Sinnesschaerfe_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Sinnesschaerfe_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Sinnesschaerfe_Eigenschaft3}]]}} {{FP=[[round(@{Sinnesschaerfe_FW}/2)]]}} {{Modifikator=[[ceil(((@{Sinnesschaerfe_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Verbergen</td>
+                    <td><select name="attr_Verbergen_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Verbergen_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}" selected="selected">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Verbergen_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}" selected="selected">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Ja</td>
+                    <td><input type="number" name="attr_Verbergen_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Verbergen_Mod" disabled="true" value="@{Zustand_Mod_max_inkl_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_fettleibig" value="1" />
+                                <div>Fettleibig (-)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Verbergen}} {{subtags=Körperlich}} {{Talent=[[ @{Verbergen_FW} - {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft1}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft2}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft3}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Verbergen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Verbergen}} {{subtags=Körperlich}} {{Talent=[[ @{Verbergen_FW} + 2 - {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft1}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft2}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Verbergen_Eigenschaft3}]] + [[@{Verbergen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Verbergen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Verbergen}} {{subtags=Körperlich}} {{Eigenschaft1=[[@{Verbergen_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Verbergen_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Verbergen_Eigenschaft3}]]}} {{FP=[[round(@{Verbergen_FW}/2)]]}} {{Modifikator=[[ceil(((@{Verbergen_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Einschüchtern</td>
+                    <td><select name="attr_Einschuechtern_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Einschuechtern_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}" selected="selected">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Einschuechtern_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}" selected="selected">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Nein</td>
+                    <td><input type="number" name="attr_Einschuechtern_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Einschuechtern_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
+                    <td>
+                        <span class="sheet-tooltip-ef">
+                            <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                            <span>
+                                Sozialer Stand (+)<br/>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_basiliskentoeter" value="1" />
+                                <div>Basiliskentöter (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_drachentoeter" value="1" />
+                                <div>Drachentöter (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_sprachfehler" value="1" />
+                                <div>Sprachfehler (-)</div>
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Einschüchtern}} {{subtags=Gesellschaft}} {{Talent=[[ @{Einschuechtern_FW} - {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft1}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft2}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft3}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Einschuechtern_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Einschüchtern}} {{subtags=Gesellschaft}} {{Talent=[[ @{Einschuechtern_FW} + 2 - {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft1}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft2}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Einschuechtern_Eigenschaft3}]] + [[@{Einschuechtern_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Einschuechtern_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Einschüchtern}} {{subtags=Gesellschaft}} {{Eigenschaft1=[[@{Einschuechtern_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Einschuechtern_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Einschuechtern_Eigenschaft3}]]}} {{FP=[[round(@{Einschuechtern_FW}/2)]]}} {{Modifikator=[[ceil(((@{Einschuechtern_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Willenskraft</td>
+                    <td><select name="attr_Willenskraft_Eigenschaft1" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}" selected="selected">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Willenskraft_Eigenschaft2" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}" selected="selected">IN</option><option value="@{CH_Wert}">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select>
+                        <select name="attr_Willenskraft_Eigenschaft3" style="width: 4.25em;">
+                            <option value="0">---</option><option value="@{MU_Wert}">MU</option><option value="@{KL_Wert}">KL</option>
+                            <option value="@{IN_Wert}">IN</option><option value="@{CH_Wert}" selected="selected">CH</option><option value="@{FF_Wert}">FF</option>
+                            <option value="@{GE_Wert}">GE</option><option value="@{KO_Wert}">KO</option><option value="@{KK_Wert}">KK</option>
+                            </select></td>
+                    <td>Nein</td>
+                    <td><input type="number" name="attr_Willenskraft_FW" value="0" min="0"></td>
+                    <td><input type="number" name="attr_Willenskraft_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
+                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Willenskraft}} {{subtags=Gesellschaft}} {{Talent=[[ @{Willenskraft_FW} - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft1}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft2}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft3}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Willenskraft_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
+                        <button type="roll" value="&{template:DSA-Talente} {{name=Willenskraft}} {{subtags=Gesellschaft}} {{Talent=[[ @{Willenskraft_FW} + 2 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft1}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft2}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft3}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Willenskraft_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
+                        <button type="roll" value="&{template:Routineprobe} {{name=Willenskraft}} {{subtags=Gesellschaft}} {{Eigenschaft1=[[@{Willenskraft_Eigenschaft1}]]}} {{Eigenschaft2=[[@{Willenskraft_Eigenschaft2}]]}} {{Eigenschaft3=[[@{Willenskraft_Eigenschaft3}]]}} {{FP=[[round(@{Willenskraft_FW}/2)]]}} {{Modifikator=[[ceil(((@{Willenskraft_FW}-10)*-1)/3)]]}}">R</button>
+                    </td>
+                </tr>
+            </table>
+        </div>
+
         
         <div class="sheet-section sheet-section-Koerper" align=center> 
             <table>
@@ -2415,8 +2921,14 @@
                                 <div>Lippenlesen (AG)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_fuchssinn" value="1" />
                                 <div>Fuchssinn (AG)</div>
-                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn" value="1" />
-                                <div>Herausragender Sinn (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_gehoer" value="1" />
+                                <div>Herausragender Sinn: Gehör (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_geruch_geschmack" value="1" />
+                                <div>Herausragender Sinn: Geruch &amp; Geschmack (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_sicht" value="1" />
+                                <div>Herausragender Sinn: Sicht (+)</div>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_herausragender_sinn_tastsinn" value="1" />
+                                <div>Herausragender Sinn: Tastsinn (+)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_zwergennase" value="1" />
                                 <div>Zwergennase (+)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_eingeschraenkter_sinn" value="1" />
@@ -4660,190 +5172,255 @@
         </div>
         
         <div class="sheet-section sheet section-fight" align="center">
+            <input type="checkbox" class="sheet-gegner" name="attr_gegner_sheet" style="display:none;" value="1" />
             <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab41" value="41" title="fightvalues1" checked="checked"/>
                 <span class="sheet-tab sheet-tab41">Ausrüstung</span>
             <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab42" value="42" title="fightvalues2"/>
                 <span class="sheet-tab sheet-tab42">Nahkampf</span>
             <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab43" value="43" title="fightvalues3"/>
                 <span class="sheet-tab sheet-tab43">Fernkampf</span>
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab44" value="44" title="fightvalues4"/>
-                <span class="sheet-tab sheet-tab44">Kampftechniken</span>
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab44 sheet-kein-gegner" value="44" title="fightvalues4"/>
+                <span class="sheet-tab sheet-tab44 sheet-kein-gegner">Kampftechniken</span>
             <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab45" value="45" title="fightvalues5"/>
                 <span class="sheet-tab sheet-tab45">Sonderfertigk.</span>
                     
         <div class="sheet-section sheet section-fightvalues1">
         
         <h3>Nahkampfwaffen</h3>
-            <table>
-                <tr>
-                    <th>Waffe</th>
-                    <th>EH/ZH</th>
-                    <th>Kampftechnik</th>
-                    <th>Leiteig.</th>
-                    <th colspan="2">Schadensb.</th>
-                    <th colspan="2">Trefferpunkte</th>
-                    <th colspan="2">AT/PA Mod</th>
-                    <th>Reichweite</th>
-                    <th>Gewicht</th>
-                    <th>Länge</th>
-              </tr>
-              <tr align="center">
-                    <td><input type="text" name="attr_NKWname1" style="width: 11em;"></td>
-                    <td><select name="attr_NKW1_EHZH" style="width: 4em;" >
-                            <option value="0">EH</option>
-                            <option value="1">ZH</option>
-                        </select>
-                    </td>
-                    <td><select name="attr_NKWtyp1" style="width: 10em;" >
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
-                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
-                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
-                            <option value="@{KtW_Lanzen}">Lanzen</option>
-                            <option value="@{KtW_Raufen}">Raufen</option>
-                            <option value="@{KtW_Schwerter}">Schwerter</option>
-                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
-                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
-                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
-                        </select></td>
-                    <td><select style="width: 4em;" name="attr_NKW1_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchadensberechnungWertNKW1" value="0"></td>
-                    <td><input type="number" disabled="true" name="attr_NKW1_SB" value="(((@{NKW1_Leiteigenschaft} - @{SchadensberechnungWertNKW1}) + abs(@{NKW1_Leiteigenschaft} - @{SchadensberechnungWertNKW1})) / 2)"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_1" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_2" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW1" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW1" value="0"></td>
-                    <td><select name="attr_ReichweiteNKWaffe1" style="width: 5em;">
-                            <option value="1">kurz</option>
-                            <option value="2">mittel</option>
-                            <option value="3">lang</option>                            
-                        </select></td>
-                    <td><input type="number" name="attr_Gewicht_NKW1" value="0"></td>
-                    <td><input type="number" name="attr_Laenge_NKW1" value="0">
-              </tr>
-              <tr align="center">
-                    <td><input type="text" name="attr_NKWname2" style="width: 11em;"></td>
-                    <td><select name="attr_NKW2_EHZH" style="width: 4em;" >
-                            <option value="0">EH</option>
-                            <option value="1">ZH</option>
-                        </select>
-                    </td>                   
-                    <td><select name="attr_NKWtyp2" style="width: 10em;" >
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
-                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
-                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
-                            <option value="@{KtW_Lanzen}">Lanzen</option>
-                            <option value="@{KtW_Raufen}">Raufen</option>
-                            <option value="@{KtW_Schwerter}">Schwerter</option>
-                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
-                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
-                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
-                        </select></td>
-                    <td><select style="width: 4em;" name="attr_NKW2_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchadensberechnungWertNKW2" value="0"></td>
-                    <td><input type="number" disabled="true" name="attr_NKW2_SB" value="(((@{NKW2_Leiteigenschaft} - @{SchadensberechnungWertNKW2}) + abs(@{NKW2_Leiteigenschaft} - @{SchadensberechnungWertNKW2})) / 2)"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_1" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_2" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW2" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW2" value="0"></td>
-                    <td><select name="attr_ReichweiteNKWaffe2" style="width: 5em;">
-                            <option value="1">kurz</option>
-                            <option value="2">mittel</option>
-                            <option value="3">lang</option>                            
-                        </select></td>
-                    <td><input type="number" name="attr_Gewicht_NKW2" value="0"></td>
-                    <td><input type="number" name="attr_Laenge_NKW2" value="0">
-              </tr>
-              <tr align="center">
-                    <td><input type="text" name="attr_NKWname3" style="width: 11em;"></td>
-                    <td><select name="attr_NKW3_EHZH" style="width: 4em;" >
-                            <option value="0">EH</option>
-                            <option value="1">ZH</option>
-                        </select>
-                    </td>                   
-                    <td><select name="attr_NKWtyp3" style="width: 10em;" >
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
-                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
-                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
-                            <option value="@{KtW_Lanzen}">Lanzen</option>
-                            <option value="@{KtW_Raufen}">Raufen</option>
-                            <option value="@{KtW_Schwerter}">Schwerter</option>
-                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
-                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
-                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
-                        </select></td>
-                    <td><select style="width: 4em;" name="attr_NKW3_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchadensberechnungWertNKW3" value="0"></td>
-                    <td><input type="number" disabled="true" name="attr_NKW3_SB" value="(((@{NKW3_Leiteigenschaft} - @{SchadensberechnungWertNKW3}) + abs(@{NKW3_Leiteigenschaft} - @{SchadensberechnungWertNKW3})) / 2)"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_1" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_2" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW3" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW3" value="0"></td>
-                    <td><select name="attr_ReichweiteNKWaffe3" style="width: 5em;">
-                            <option value="1">kurz</option>
-                            <option value="2">mittel</option>
-                            <option value="3">lang</option>                            
-                        </select></td>
-                    <td><input type="number" name="attr_Gewicht_NKW3" value="0"></td>
-                    <td><input type="number" name="attr_Laenge_NKW3" value="0">
-              </tr>
-              <tr align="center">
-                    <td><input type="text" name="attr_NKWname4" style="width: 11em;"></td>
-                    <td><select name="attr_NKW4_EHZH" style="width: 4em;" >
-                            <option value="0">EH</option>
-                            <option value="1">ZH</option>
-                        </select>
-                    </td>                   
-                    <td><select name="attr_NKWtyp4" style="width: 10em;">
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
-                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
-                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
-                            <option value="@{KtW_Lanzen}">Lanzen</option>
-                            <option value="@{KtW_Raufen}">Raufen</option>
-                            <option value="@{KtW_Schwerter}">Schwerter</option>
-                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
-                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
-                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
-                        </select></td>
-                    <td><select style="width: 4em;" name="attr_NKW4_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchadensberechnungWertNKW4" value="0"></td>
-                    <td><input type="number" disabled="true" name="attr_NKW4_SB" value="(((@{NKW4_Leiteigenschaft} - @{SchadensberechnungWertNKW4}) + abs(@{NKW4_Leiteigenschaft} - @{SchadensberechnungWertNKW4})) / 2)"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_1" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_2" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW4" value="0"></td>
-                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW4" value="0"></td>
-                    <td><select name="attr_ReichweiteNKWaffe4" style="width: 5em;">
-                            <option value="1">kurz</option>
-                            <option value="2">mittel</option>
-                            <option value="3">lang</option>                            
-                        </select></td>
-                    <td><input type="number" name="attr_Gewicht_NKW4" value="0"></td>
-                    <td><input type="number" name="attr_Laenge_NKW4" value="0">
-              </tr>
-        </table>
+        	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
+        	<div class="sheet-kein-gegner">
+	            <table>
+	                <tr>
+	                    <th>Waffe</th>
+	                    <th>EH/ZH</th>
+	                    <th>Kampftechnik</th>
+	                    <th>Leiteig.</th>
+	                    <th colspan="2">Schadensb.</th>
+	                    <th colspan="2">Trefferpunkte</th>
+	                    <th colspan="2">AT/PA Mod</th>
+	                    <th>Reichweite</th>
+	                    <th>Gewicht</th>
+	                    <th>Länge</th>
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname1" style="width: 11em;"></td>
+	                    <td><select name="attr_NKW1_EHZH" style="width: 4em;" >
+	                            <option value="0">EH</option>
+	                            <option value="1">ZH</option>
+	                        </select>
+	                    </td>
+	                    <td><select name="attr_NKWtyp1" style="width: 10em;" >
+	                            <option value="0">---</option>
+	                            <option value="@{KtW_Dolche}">Dolche</option>
+	                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
+	                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
+	                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
+	                            <option value="@{KtW_Lanzen}">Lanzen</option>
+	                            <option value="@{KtW_Raufen}">Raufen</option>
+	                            <option value="@{KtW_Schwerter}">Schwerter</option>
+	                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
+	                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+	                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
+	                        </select></td>
+	                    <td><select style="width: 4em;" name="attr_NKW1_Leiteigenschaft">
+	                            <option value="0">--</option>
+	                            <option value="@{KK_Wert}">KK</option>
+	                            <option value="@{GE_Wert}">GE</option>
+	                        </select></td>
+	                    <td><input type="number" name="attr_SchadensberechnungWertNKW1" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_NKW1_SB" value="(((@{NKW1_Leiteigenschaft} - @{SchadensberechnungWertNKW1}) + abs(@{NKW1_Leiteigenschaft} - @{SchadensberechnungWertNKW1})) / 2)"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW1" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe1" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	                    <td><input type="number" name="attr_Gewicht_NKW1" value="0"></td>
+	                    <td><input type="number" name="attr_Laenge_NKW1" value="0">
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname2" style="width: 11em;"></td>
+	                    <td><select name="attr_NKW2_EHZH" style="width: 4em;" >
+	                            <option value="0">EH</option>
+	                            <option value="1">ZH</option>
+	                        </select>
+	                    </td>                   
+	                    <td><select name="attr_NKWtyp2" style="width: 10em;" >
+	                            <option value="0">---</option>
+	                            <option value="@{KtW_Dolche}">Dolche</option>
+	                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
+	                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
+	                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
+	                            <option value="@{KtW_Lanzen}">Lanzen</option>
+	                            <option value="@{KtW_Raufen}">Raufen</option>
+	                            <option value="@{KtW_Schwerter}">Schwerter</option>
+	                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
+	                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+	                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
+	                        </select></td>
+	                    <td><select style="width: 4em;" name="attr_NKW2_Leiteigenschaft">
+	                            <option value="0">--</option>
+	                            <option value="@{KK_Wert}">KK</option>
+	                            <option value="@{GE_Wert}">GE</option>
+	                        </select></td>
+	                    <td><input type="number" name="attr_SchadensberechnungWertNKW2" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_NKW2_SB" value="(((@{NKW2_Leiteigenschaft} - @{SchadensberechnungWertNKW2}) + abs(@{NKW2_Leiteigenschaft} - @{SchadensberechnungWertNKW2})) / 2)"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW2" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe2" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	                    <td><input type="number" name="attr_Gewicht_NKW2" value="0"></td>
+	                    <td><input type="number" name="attr_Laenge_NKW2" value="0">
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname3" style="width: 11em;"></td>
+	                    <td><select name="attr_NKW3_EHZH" style="width: 4em;" >
+	                            <option value="0">EH</option>
+	                            <option value="1">ZH</option>
+	                        </select>
+	                    </td>                   
+	                    <td><select name="attr_NKWtyp3" style="width: 10em;" >
+	                            <option value="0">---</option>
+	                            <option value="@{KtW_Dolche}">Dolche</option>
+	                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
+	                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
+	                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
+	                            <option value="@{KtW_Lanzen}">Lanzen</option>
+	                            <option value="@{KtW_Raufen}">Raufen</option>
+	                            <option value="@{KtW_Schwerter}">Schwerter</option>
+	                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
+	                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+	                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
+	                        </select></td>
+	                    <td><select style="width: 4em;" name="attr_NKW3_Leiteigenschaft">
+	                            <option value="0">--</option>
+	                            <option value="@{KK_Wert}">KK</option>
+	                            <option value="@{GE_Wert}">GE</option>
+	                        </select></td>
+	                    <td><input type="number" name="attr_SchadensberechnungWertNKW3" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_NKW3_SB" value="(((@{NKW3_Leiteigenschaft} - @{SchadensberechnungWertNKW3}) + abs(@{NKW3_Leiteigenschaft} - @{SchadensberechnungWertNKW3})) / 2)"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW3" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW3" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe3" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	                    <td><input type="number" name="attr_Gewicht_NKW3" value="0"></td>
+	                    <td><input type="number" name="attr_Laenge_NKW3" value="0">
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname4" style="width: 11em;"></td>
+	                    <td><select name="attr_NKW4_EHZH" style="width: 4em;" >
+	                            <option value="0">EH</option>
+	                            <option value="1">ZH</option>
+	                        </select>
+	                    </td>                   
+	                    <td><select name="attr_NKWtyp4" style="width: 10em;">
+	                            <option value="0">---</option>
+	                            <option value="@{KtW_Dolche}">Dolche</option>
+	                            <option value="@{KtW_Fechtwaffen}">Fechtwaffen</option>
+	                            <option value="@{KtW_Hiebwaffen}">Hiebwaffen</option>
+	                            <option value="@{KtW_Kettenwaffen}">Kettenwaffen</option>
+	                            <option value="@{KtW_Lanzen}">Lanzen</option>
+	                            <option value="@{KtW_Raufen}">Raufen</option>
+	                            <option value="@{KtW_Schwerter}">Schwerter</option>
+	                            <option value="@{KtW_Stangenwaffen}">Stangenwaffen</option>
+	                            <option value="@{KtW_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+	                            <option value="@{KtW_Zweihandschwerter}">Zweihandschwerter</option>
+	                        </select></td>
+	                    <td><select style="width: 4em;" name="attr_NKW4_Leiteigenschaft">
+	                            <option value="0">--</option>
+	                            <option value="@{KK_Wert}">KK</option>
+	                            <option value="@{GE_Wert}">GE</option>
+	                        </select></td>
+	                    <td><input type="number" name="attr_SchadensberechnungWertNKW4" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_NKW4_SB" value="(((@{NKW4_Leiteigenschaft} - @{SchadensberechnungWertNKW4}) + abs(@{NKW4_Leiteigenschaft} - @{SchadensberechnungWertNKW4})) / 2)"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_ATMod_NKW4" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PAMod_NKW4" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe4" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	                    <td><input type="number" name="attr_Gewicht_NKW4" value="0"></td>
+	                    <td><input type="number" name="attr_Laenge_NKW4" value="0">
+	              </tr>
+	        </table>
+        </div>
+
+		<div class="sheet-gegner">
+	            <table>
+	                <tr>
+	                    <th>Angriff</th>
+	                    <th colspan="2">Trefferpunkte</th>
+	                    <th colspan="2">AT/PA</th>
+	                    <th>Reichweite</th>
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname1" style="width: 11em;"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden1_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_AT_NKW1_Fix" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PA_NKW1_Fix" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe1" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname2" style="width: 11em;"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden2_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_AT_NKW2_Fix" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PA_NKW2_Fix" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe2" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname3" style="width: 11em;"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden3_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_AT_NKW3_Fix" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PA_NKW3_Fix" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe3" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	              </tr>
+	              <tr align="center">
+	                    <td><input type="text" name="attr_NKWname4" style="width: 11em;"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_1" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_NKWschaden4_2" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_AT_NKW4_Fix" value="0"></td>
+	                    <td><input style="width: 3em;" type="number" name="attr_PA_NKW4_Fix" value="0"></td>
+	                    <td><select name="attr_ReichweiteNKWaffe4" style="width: 5em;">
+	                            <option value="1">kurz</option>
+	                            <option value="2">mittel</option>
+	                            <option value="3">lang</option>                            
+	                        </select></td>
+	              </tr>
+	        </table>
+		</div>
+	        <div class="sheet-kein-gegner">
+
             <br>
             <h3>Schild/Parierwaffe</h3>
             <table>
@@ -4942,136 +5519,190 @@
                     <td><input type="number" name="attr_SchildGewicht4" value="0"></td>
                 </tr>
             </table>
+            </div>
             <br>
-            <h3>Fernkampfwaffen</h3>
-            <table>
-                <tr>
-                    <th>Waffe</th>
-                    <th>Kampftechnik</th>
-                    <th>Ladezeit</th>
-                    <th colspan="2">Trefferpunkte</th>
-                    <th>Reichweite</th>
-                    <th>Munition</th>
-                    <th>Gewicht</th>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
-                    <td><select name="attr_FKWtyp1" style="width: 10em;">
-                            <option value="0">--</option>
-                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-                            <option value="@{KtW_Boegen}">Bögen</option>
-                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-                        </select></td>
-                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
-                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
-                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
-                    <td><input type="text" name="attr_FKWReichweite1"></td>
-                    <td><input type="number" name="attr_FKWMunition1"></td>
-                    <td><input type="number" name="attr_FKWGewicht1" value="0"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
-                    <td><select name="attr_FKWtyp2" style="width: 10em;">
-                            <option value="0">--</option>
-                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-                            <option value="@{KtW_Boegen}">Bögen</option>
-                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-                        </select></td>
-                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
-                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
-                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
-                    <td><input type="text" name="attr_FKWReichweite2"></td>
-                    <td><input type="number" name="attr_FKWMunition2"></td>
-                    <td><input type="number" name="attr_FKWGewicht2" value="0"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
-                    <td><select name="attr_FKWtyp3" style="width: 10em;">
-                            <option value="0">--</option>
-                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-                            <option value="@{KtW_Boegen}">Bögen</option>
-                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-                        </select></td>
-                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
-                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
-                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
-                    <td><input type="text" name="attr_FKWReichweite3"></td>
-                    <td><input type="number" name="attr_FKWMunition3"></td>
-                    <td><input type="number" name="attr_FKWGewicht3" value="0"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
-                    <td><select name="attr_FKWtyp4" style="width: 10em;">
-                            <option value="0">--</option>
-                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-                            <option value="@{KtW_Boegen}">Bögen</option>
-                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-                        </select></td>
-                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
-                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
-                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
-                    <td><input type="text" name="attr_FKWReichweite4"></td>
-                    <td><input type="number" name="attr_FKWMunition4"></td>
-                    <td><input type="number" name="attr_FKWGewicht4" value="0"></td>
-                </tr>
-            </table> 
+	        <h3>Fernkampfwaffen</h3>
+            <input type="checkbox" class="sheet-gegner" name="attr_gegner_sheet" style="display:none;" value="1" />
+            <div class="sheet-kein-gegner">
+	            <table>
+	                <tr>
+	                    <th>Waffe</th>
+	                    <th>Kampftechnik</th>
+	                    <th>Ladezeit</th>
+	                    <th colspan="2">Trefferpunkte</th>
+	                    <th>Reichweite</th>
+	                    <th>Munition</th>
+	                    <th>Gewicht</th>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
+	                    <td><select name="attr_FKWtyp1" style="width: 10em;">
+	                            <option value="0">--</option>
+	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+	                            <option value="@{KtW_Boegen}">Bögen</option>
+	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+	                        </select></td>
+	                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition1"></td>
+	                    <td><input type="number" name="attr_FKWGewicht1" value="0"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
+	                    <td><select name="attr_FKWtyp2" style="width: 10em;">
+	                            <option value="0">--</option>
+	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+	                            <option value="@{KtW_Boegen}">Bögen</option>
+	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+	                        </select></td>
+	                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite2"></td>
+	                    <td><input type="number" name="attr_FKWMunition2" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWGewicht2" value="0"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
+	                    <td><select name="attr_FKWtyp3" style="width: 10em;">
+	                            <option value="0">--</option>
+	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+	                            <option value="@{KtW_Boegen}">Bögen</option>
+	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+	                        </select></td>
+	                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition3"></td>
+	                    <td><input type="number" name="attr_FKWGewicht3" value="0"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
+	                    <td><select name="attr_FKWtyp4" style="width: 10em;">
+	                            <option value="0">--</option>
+	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+	                            <option value="@{KtW_Boegen}">Bögen</option>
+	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+	                        </select></td>
+	                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition4"></td>
+	                    <td><input type="number" name="attr_FKWGewicht4" value="0"></td>
+	                </tr>
+	            </table>
+	        </div> 
+            <div class="sheet-gegner">
+	            <table>
+	                <tr>
+	                    <th>Waffe</th>
+	                    <th>FK</th>
+	                    <th>Ladezeit</th>
+	                    <th colspan="2">Trefferpunkte</th>
+	                    <th>Reichweite</th>
+	                    <th>Munition</th>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_FKW1_Fix" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition1"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_FKW2_Fix" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition2"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_FKW3_Fix" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition3"></td>
+	                </tr>
+	                <tr align=center>
+	                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_FKW4_Fix" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
+	                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
+	                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
+	                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
+	                    <td><input type="number" name="attr_FKWMunition4"></td>
+	                </tr>
+	            </table>
+	        </div> 
             <br />
-            <h3>Rüstung</h3>
-            <table>
-                <tr align="center">
-                    <th>Rüstung</th>
-                    <th>RS</th>
-                    <th>BE</th>
-                    <th>Zus. Abzüge</th>
-                    <th>Gewicht</th>
-                    <th>Reise, Schlacht,...</th>
-                    <th>Aktiv</th>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_RuestungsName1" style="width: 15em;"></td>
-                    <td><input type="number" name="attr_RS1" value="0"></td>
-                    <td><input type="number" name="attr_BE1" value="0"></td>
-                    <td><input type="checkbox" name="attr_RuestungsAbzuege1" value="-1"></td>
-                    <td><input type="number" name="attr_RuestungsGewicht1" value="0"></td>
-                    <td><input type="text" name="attr_RuestungsNotiz1"></td>
-                    <td><input type="checkbox" name="attr_RuestungAktiv1" value="1"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_RuestungsName2" style="width: 15em;"></td>
-                    <td><input type="number" name="attr_RS2" value="0"></td>
-                    <td><input type="number" name="attr_BE2" value="0"></td>
-                    <td><input type="checkbox" name="attr_RuestungsAbzuege2" value="-1"></td>
-                    <td><input type="number" name="attr_RuestungsGewicht2" value="0"></td>
-                    <td><input type="text" name="attr_RuestungsNotiz2"></td>
-                    <td><input type="checkbox" name="attr_RuestungAktiv2" value="1"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_RuestungsName3" style="width: 15em;"></td>
-                    <td><input type="number" name="attr_RS3" value="0"></td>
-                    <td><input type="number" name="attr_BE3" value="0"></td>
-                    <td><input type="checkbox" name="attr_RuestungsAbzuege3" value="-1"></td>
-                    <td><input type="number" name="attr_RuestungsGewicht3" value="0"></td>
-                    <td><input type="text" name="attr_RuestungsNotiz3"></td>
-                    <td><input type="checkbox" name="attr_RuestungAktiv3" value="1"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_RuestungsName4" style="width: 15em;"></td>
-                    <td><input type="number" name="attr_RS4" value="0"></td>
-                    <td><input type="number" name="attr_BE4" value="0"></td>
-                    <td><input type="checkbox" name="attr_RuestungsAbzuege4" value="-1"></td>
-                    <td><input type="number" name="attr_RuestungsGewicht4" value="0"></td>
-                    <td><input type="text" name="attr_RuestungsNotiz4"></td>
-                    <td><input type="checkbox" name="attr_RuestungAktiv4" value="1"></td>
-                </tr>
-                <tr align="center">
-                    <td />
-                    <td><input type="number" disabled="true" name="attr_Ges_RS" value="@{RuestungAktiv1} * @{RS1} + @{RuestungAktiv2} * @{RS2} + @{RuestungAktiv3} * @{RS3} + @{RuestungAktiv4} * @{RS4}"></td>
-                    <td><input type="number" disabled="true" name="attr_Ges_BE" value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></td>
-                    <td><input type="number" disabled="true" name="attr_RuestungsAbzuege" value="@{RuestungAktiv1} * @{RuestungsAbzuege1} + @{RuestungAktiv2} * @{RuestungsAbzuege2} + @{RuestungAktiv3} * @{RuestungsAbzuege3} + @{RuestungAktiv4} * @{RuestungsAbzuege4}"></td>
-                    <td><input type="number" disabled="true" name="attr_Ges_Gewicht" value="@{RuestungAktiv1} * @{RuestungsGewicht1} + @{RuestungAktiv2} * @{RuestungsGewicht2} + @{RuestungAktiv3} * @{RuestungsGewicht3} + @{RuestungAktiv4} * @{RuestungsGewicht4}"></td>
-                    <td />
-                </tr>
-            </table>
+            <div class="sheet-kein-gegner">
+	            <h3>Rüstung</h3>
+	            <table>
+	                <tr align="center">
+	                    <th>Rüstung</th>
+	                    <th>RS</th>
+	                    <th>BE</th>
+	                    <th>Zus. Abzüge</th>
+	                    <th>Gewicht</th>
+	                    <th>Reise, Schlacht,...</th>
+	                    <th>Aktiv</th>
+	                </tr>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_RuestungsName1" style="width: 15em;"></td>
+	                    <td><input type="number" name="attr_RS1" value="0"></td>
+	                    <td><input type="number" name="attr_BE1" value="0"></td>
+	                    <td><input type="checkbox" name="attr_RuestungsAbzuege1" value="-1"></td>
+	                    <td><input type="number" name="attr_RuestungsGewicht1" value="0"></td>
+	                    <td><input type="text" name="attr_RuestungsNotiz1"></td>
+	                    <td><input type="checkbox" name="attr_RuestungAktiv1" value="1"></td>
+	                </tr>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_RuestungsName2" style="width: 15em;"></td>
+	                    <td><input type="number" name="attr_RS2" value="0"></td>
+	                    <td><input type="number" name="attr_BE2" value="0"></td>
+	                    <td><input type="checkbox" name="attr_RuestungsAbzuege2" value="-1"></td>
+	                    <td><input type="number" name="attr_RuestungsGewicht2" value="0"></td>
+	                    <td><input type="text" name="attr_RuestungsNotiz2"></td>
+	                    <td><input type="checkbox" name="attr_RuestungAktiv2" value="1"></td>
+	                </tr>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_RuestungsName3" style="width: 15em;"></td>
+	                    <td><input type="number" name="attr_RS3" value="0"></td>
+	                    <td><input type="number" name="attr_BE3" value="0"></td>
+	                    <td><input type="checkbox" name="attr_RuestungsAbzuege3" value="-1"></td>
+	                    <td><input type="number" name="attr_RuestungsGewicht3" value="0"></td>
+	                    <td><input type="text" name="attr_RuestungsNotiz3"></td>
+	                    <td><input type="checkbox" name="attr_RuestungAktiv3" value="1"></td>
+	                </tr>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_RuestungsName4" style="width: 15em;"></td>
+	                    <td><input type="number" name="attr_RS4" value="0"></td>
+	                    <td><input type="number" name="attr_BE4" value="0"></td>
+	                    <td><input type="checkbox" name="attr_RuestungsAbzuege4" value="-1"></td>
+	                    <td><input type="number" name="attr_RuestungsGewicht4" value="0"></td>
+	                    <td><input type="text" name="attr_RuestungsNotiz4"></td>
+	                    <td><input type="checkbox" name="attr_RuestungAktiv4" value="1"></td>
+	                </tr>
+	                <tr align="center">
+	                    <td />
+	                    <td><input type="number" disabled="true" name="attr_Ges_RS" value="@{RuestungAktiv1} * @{RS1} + @{RuestungAktiv2} * @{RS2} + @{RuestungAktiv3} * @{RS3} + @{RuestungAktiv4} * @{RS4}"></td>
+	                    <td><input type="number" disabled="true" name="attr_Ges_BE" value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></td>
+	                    <td><input type="number" disabled="true" name="attr_RuestungsAbzuege" value="@{RuestungAktiv1} * @{RuestungsAbzuege1} + @{RuestungAktiv2} * @{RuestungsAbzuege2} + @{RuestungAktiv3} * @{RuestungsAbzuege3} + @{RuestungAktiv4} * @{RuestungsAbzuege4}"></td>
+	                    <td><input type="number" disabled="true" name="attr_Ges_Gewicht" value="@{RuestungAktiv1} * @{RuestungsGewicht1} + @{RuestungAktiv2} * @{RuestungsGewicht2} + @{RuestungAktiv3} * @{RuestungsGewicht3} + @{RuestungAktiv4} * @{RuestungsGewicht4}"></td>
+	                    <td />
+	                </tr>
+	            </table>
+            </div>
         
         </div>
         <div class="sheet-section sheet section-fightvalues2">
@@ -5079,17 +5710,17 @@
         <table>
             <tr>
                 <th>
-                    INI <input type="number" name="attr_INI_Aktiv" value="@{INI_Wert}" disabled="true">
+                    INI <input type="number" name="attr_INI_Aktiv" value="((@{INI_Wert}) * (1 - @{gegner_sheet})) + (@{INI_Wert_Fix}*(0+@{gegner_sheet}))" disabled="true">
                     <button type=roll value="[[(1d6+@{INI_Aktiv})&{tracker}]] @{Charaktername}´s Initiative" />
                 </th>
                 <th>
-                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="@{Ges_RS}" disabled="true" />
+                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="(@{Ges_RS})*(1-@{gegner_sheet})+(@{RS_Fix})*(0+@{gegner_sheet})" disabled="true" />
                 </th>
                 <th>
                     BE <input type="number" name="attr_BE_Kampf" style='width: 4em' value="@{Ges_BE}" disabled="true" />
                 </th>
                 <th>
-                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="@{GS_Wert}" disabled="true" />
+                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="(@{GS_Wert})*(1-@{gegner_sheet})+(@{GS_Wert_Fix})*(0+@{gegner_sheet})" disabled="true" />
                 </th>
                 <th>
                     LE <input type="number" name="attr_LE_Wert" style='width: 4em' value="@{LE_Wert}" />
@@ -5127,7 +5758,7 @@
                         <tr>
                             <td>Trefferpunkte:</td>
                             <td><input type="number" disabled="true" name="attr_TP_W_Aktiv" style='width: 3em' value="@{NKW_Aktiv1} * @{NKWschaden1_1} + @{NKW_Aktiv2} * @{NKWschaden2_1} + @{NKW_Aktiv3} * @{NKWschaden3_1} + @{NKW_Aktiv4} * @{NKWschaden4_1} + @{Manoever_Hammerschlag} + @{Manoever_Todesstoss}"/>W+</td>
-                            <td><input type="number" disabled="true" name="attr_TP_Bonus_Aktiv" style='width: 3em' value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB} + @{EHalsZH_NKW1}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB} + @{EHalsZH_NKW2}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB} + @{EHalsZH_NKW3}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB} + @{EHalsZH_NKW4}) + @{Basismanoever_TP_Mod} + @{Manoever_Sturmangriff} * (2 + round((@{GS_Kampf}) / 2)) +  @{Passiv_TP_Mod}"/></td>
+                            <td><input type="number" disabled="true" name="attr_TP_Bonus_Aktiv" style='width: 3em' value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB} + @{EHalsZH_NKW1}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB} + @{EHalsZH_NKW2}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB} + @{EHalsZH_NKW3}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB} + @{EHalsZH_NKW4}) + @{Basismanoever_TP_Mod} + @{Spezialmanoever_TP_Mod} +  @{Passiv_TP_Mod} + @{Situationen_TP_Mod}"/></td>
                             <td>
                                 <button type="roll" value="&{template:DSA-Nahkampf-TP}  {{name=Nahkampf-TP}} {{subtags=Nahkampf}} {{damage=[[[[(@{TP_W_Aktiv})]]d6 + @{TP_Bonus_Aktiv}]]}}" />
                                 <button type="roll" value="&{template:DSA-Nahkampf-TP}  {{name=Nahkampf-TP}} {{subtags=Nahkampf}} {{damage=[[([[(@{TP_W_Aktiv})]]d6 + @{TP_Bonus_Aktiv})*2]]}}">x2</button>
@@ -5149,7 +5780,8 @@
                         <div style="display:inline-block; width:3em"><b>Wert</b></div>
                         <div style="display:inline-block; width:10em"><b>Proben</b></div>
                     </div>
-                    <div>
+                    <input class="sheet-show-nicht-humanoid" type="checkbox" value="1" name="attr_nicht_humanoid" style="display:none"/>
+                    <div class="sheet-humanoid">
                         <div style="display:inline-block; width:9em;">Waffenparade:</div>
                         <input type="number" name="attr_PA_Aktiv" style='width: 3em' value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4}) + ((@{Schild_Aktiv1} * @{SchildPAMod1}) + (@{Schild_Aktiv2} * @{SchildPAMod2}) + (@{Schild_Aktiv3} * @{SchildPAMod3}) + (@{Schild_Aktiv4} * @{SchildPAMod4})) - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod}  + @{Passiv_PA_Mod} + @{Zustand_Mod_max_abzl_BE}" disabled="true" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})]]}} {{mod=[[d0]]}}" />
@@ -5158,14 +5790,14 @@
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
-                    <div>
+                    <div class="sheet-humanoid">
                         <div style="display:inline-block; width:12em;">Waffenparadepatzer:</div>
                         <input type="checkbox" class="sheet-verteidigungPatzerTabelle" name="attr_verteidigungPatzerTabelle" style="display:none;" value="1" />
                         <button class="optional" type="roll" value="&{template:DSA-Nahkampf-AT-Patzer} {{name=PA-Patzer}} {{wurf=[[2d6]]}}"/>
                         <button class="default" type="roll" value="@{Charaktername} erleidet [[1d6+2]] SP durch einen Patzer" ></button>
                     </div>
                     <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" style="display:none;"/>
-                    <div class="sheet-kampf-optional">
+                    <div class="sheet-humanoid sheet-kampf-optional">
                         <div style="display:inline-block; width:9em;">Schildparade:</div>
                         <input type="number" name="attr_Schild_PA_Aktiv" style='width: 3em' value="((@{Schild_Aktiv1} * (@{SchildPA1})) + (@{Schild_Aktiv2} * (@{SchildPA2})) + (@{Schild_Aktiv3} * (@{SchildPA3})) + (@{Schild_Aktiv4} * (@{SchildPA4}))) - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod} + @{Zustand_Mod_max_abzl_BE} + @{Passiv_Verteidigungshaltung_PA_Mod}" disabled="true" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})]]}} {{mod=[[d0]]}}" />
@@ -5175,13 +5807,13 @@
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
                     <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" style="display:none;"/>
-                    <div class="sheet-kampf-optional">
+                    <div class="sheet-humanoid sheet-kampf-optional">
                         <div style="display:inline-block; width:12em;">Schildparadepatzer:</div>
                         <input type="checkbox" class="sheet-verteidigungPatzerTabelle" name="attr_verteidigungPatzerTabelle" style="display:none;" value="1" />
                         <button class="optional" type="roll" value="&{template:DSA-Nahkampf-Schild-Patzer} {{name=Schild-Patzer}} {{wurf=[[2d6]]}}"/>
                         <button class="default" type="roll" value="@{Charaktername} erleidet [[1d6+2]] SP durch einen Patzer" ></button>
                     </div>
-                    <div>
+                    <div class="sheet-humanoid">
                         <div style="display:inline-block; width:9em;">Ausweichen:</div>
                         <input type="number"  name="attr_Ausweichen_Kampf" style='width: 3em' value="@{Ausweichen_Wert} - @{Ges_BE}  + @{Zustand_Mod_max_abzl_BE}" disabled="true">
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})]]}}" />
@@ -5189,6 +5821,13 @@
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbiertes Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Ausweichen_Kampf})/2)]]}} {{mod=0}}">1/2</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
+                    </div>
+                    <div class="sheet-nicht-humanoid">
+                        <div style="display:inline-block; width:9em;">Verteidigung:</div>
+                        <input type="number"  name="attr_Verteidigung_Kampf" style='width: 3em' value="@{Verteidigung_Wert} + @{Zustand_Mod_max_abzl_BE}" disabled="true">
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf})]]}}" />
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf}+?{Erleichterung(+) / Erschwernis(-)|0})]]}} {{mod=[[?{Erleichterung(+) / Erschwernis(-)|0}]]}}">+/-</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Verteidigung_Kampf})/2)]]}} {{mod=0}}">1/2</button>
                     </div>
                 </td>
             </tr>
@@ -5201,7 +5840,7 @@
                         <div style="display:inline-block; width:2.5em"><b>Mod</b></div>
                         <div style="display:inline-block; width:2.5em"><b>TP+</b></div>
                     </div>
-                    <input class="sheet-sf-finte" type="checkbox" name="attr_sf_finte" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_finte" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Finte:</div>
                         <select name="attr_Manoever_Finte" style="width: 3em;">
@@ -5212,7 +5851,7 @@
                         </select>
                         <input name="attr_Manoever_Finte_AT_Mod" style="width: 2.5em;" type="number" value="-@{Manoever_Finte}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-praeziser-stich" type="checkbox" name="attr_sf_praeziser_stich" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_praeziser_stich" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Präziser Stich:</div>
                         <select name="attr_Manoever_Praeziser_Stich" style="width: 3em;">
@@ -5224,7 +5863,7 @@
                         <input name="attr_Manoever_Praezisier_Stich_AT_Mod" style="width: 2.5em;" type="number" value="-@{Manoever_Praeziser_Stich}" disabled="true"/>
                         <input name="attr_Manoever_Praezisier_Stich_TP" style="width: 2.5em;" type="number" value="@{Manoever_Praeziser_Stich}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-wuchtschlag" type="checkbox" name="attr_sf_wuchtschlag" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_wuchtschlag" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Wuchtschlag:</div>
                         <select name="attr_Manoever_Wuchtschlag" style="width: 3em;">
@@ -5244,7 +5883,19 @@
                         <div style="display:inline-block; width:13em"><b>Spezialmanöver</b></div>
                         <div style="display:inline-block; width:3em"><b>Mod</b></div>
                     </div>
-                    <input class="sheet-sf-entwaffnen" type="checkbox" name="attr_sf_entwaffnen" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_angriff_auf_ungeschuetzte_stellen" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Angriff auf ungesch. Stellen:</div>
+                        <input type="checkbox" name="attr_Manoever_Angriff_auf_ungeschuetzte_Stellen" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Angriff_auf_ungeschuetzte_Stellen_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Angriff_auf_ungeschuetzte_Stellen}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_anspringen" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Anspringen:</div>
+                        <input type="checkbox" name="attr_Manoever_Anspringen" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Anspringen_AT_Mod" style="width: 3em;" type="number" value="-4*@{Manoever_Anspringen}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_entwaffnen" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Entwaffnen gg.:</div>
                         <select name="attr_Manoever_Entwaffnen" style="width: 6em;">
@@ -5254,19 +5905,31 @@
                         </select>
                         <input name="attr_Manoever_Entwaffnen_AT_Mod" style="width: 3em;" type="number" value="-@{Manoever_Entwaffnen}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-hammerschlag" type="checkbox" name="attr_sf_hammerschlag" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_flugangriff" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Flugangriff:</div>
+                        <input type="checkbox" name="attr_Manoever_Flugangriff" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Flugangriff_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Flugangriff}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_hammerschlag" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Hammerschlag:</div>
                         <input type="checkbox" name="attr_Manoever_Hammerschlag" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Hammerschlag_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Hammerschlag}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-riposte" type="checkbox" name="attr_sf_riposte" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_klammergriff" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Klammergriff:</div>
+                        <input type="checkbox" name="attr_Manoever_Klammergriff" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Klammergriff_AT_Mod" style="width: 3em;" type="number" value="-4*@{Manoever_Klammergriff}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_riposte" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Riposte:</div>
                         <input type="checkbox" name="attr_Manoever_Riposte" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Riposte_PA_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Riposte}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-rundumschlag" type="checkbox" name="attr_sf_rundumschlag" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_rundumschlag" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Rundumschlag gg.:</div>
                         <select name="attr_Manoever_Rundumschlag" style="width: 6em;">
@@ -5277,38 +5940,69 @@
                         </select>
                         <input name="attr_Manoever_Rundumschlag_AT_Mod" style="width: 3em;" type="number" value="-@{Manoever_Rundumschlag}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-schildspalter" type="checkbox" name="attr_sf_schildspalter" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_schildspalter" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Schildspalter:</div>
                         <input type="checkbox" name="attr_Manoever_Schildspalter" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Schildspalter_AT_Mod" style="width: 3em;" type="number" value="0" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-sturmangriff" type="checkbox" name="attr_sf_sturmangriff" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_schwanz_tentakelschwung" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Schwanz- o. Tentakelschwung:</div>
+                        <select name="attr_Manoever_Schwanz_Tentakelschwung" style="width: 6em;">
+                            <option value="0">-</option>
+                            <option value="1">1 Ziel</option>
+                            <option value="2">2 Ziele</option>
+                            <option value="3">3 Ziele</option>
+                            <option value="4">4 Ziele</option>
+                        </select>
+                        <input name="attr_Manoever_Schwanz_Tentakelschwung_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Schwanz_Tentakelschwung}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_sturmangriff" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Sturmangriff:</div>
                         <input type="checkbox" name="attr_Manoever_Sturmangriff" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Sturmangriff_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Sturmangriff}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-todesstoss" type="checkbox" name="attr_sf_todesstoss" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_todesstoss" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Todesstoß:</div>
                         <input type="checkbox" name="attr_Manoever_Todesstoss" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Todesstoss_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Todesstoss}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-vorstoss" type="checkbox" name="attr_sf_vorstoss" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_trampeln" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Trampeln:</div>
+                        <input type="checkbox" name="attr_Manoever_Trampeln" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Trampeln_PA_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Trampeln}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_ueberrennen" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Überrennen:</div>
+                        <input type="checkbox" name="attr_Manoever_Ueberrennen" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Ueberrennen_AT_Mod" style="width: 3em;" type="number" value="0" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_verbeissen" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Verbeißen:</div>
+                        <input type="checkbox" name="attr_Manoever_Verbeissen" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Verbeissen_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Verbeissen}" disabled="true"/>
+                    </div>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_vorstoss" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Vorstoß:</div>
                         <input type="checkbox" name="attr_Manoever_Vorstoss" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Vorstoss_AT_Mod" style="width: 3em;" type="number" value="2*@{Manoever_Vorstoss}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-zu-fall-bringen" type="checkbox" name="attr_sf_zu_fall_bringen" value="1" style="display:none;"/>
+                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_zu_fall_bringen" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Zu Fall bringen:</div>
                         <input type="checkbox" name="attr_Manoever_Zu_Fall_bringen" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Zu_Fall_bringen_AT_Mod" style="width: 3em;" type="number" value="-4*@{Manoever_Zu_Fall_bringen}" disabled="true"/>
                     </div>
-                    <input name="attr_Spezialmanoever_AT_Mod" style="display:none;" type="number" value="@{Manoever_Entwaffnen_AT_Mod} + @{Manoever_Hammerschlag_AT_Mod} + @{Manoever_Rundumschlag_AT_Mod} + @{Manoever_Sturmangriff_AT_Mod}+ @{Manoever_Todesstoss_AT_Mod}+ @{Manoever_Vorstoss_AT_Mod} + @{Manoever_Zu_Fall_bringen_AT_Mod}" disabled="true"/>
-                    <input name="attr_Spezialmanoever_PA_Mod" style="display:none;" type="number" value="@{Manoever_Riposte_PA_Mod}" disabled="true"/>
+                    <input name="attr_Spezialmanoever_AT_Mod" style="display:none;" type="number" value="@{Manoever_Angriff_auf_ungeschuetzte_Stellen_AT_Mod} + @{Manoever_Anspringen_AT_Mod} + @{Manoever_Entwaffnen_AT_Mod} + @{Manoever_Flugangriff_AT_Mod} + @{Manoever_Hammerschlag_AT_Mod} + @{Manoever_Klammergriff_AT_Mod} + @{Manoever_Rundumschlag_AT_Mod} + @{Manoever_Schwanz_Tentakelschwung_AT_Mod} + @{Manoever_Sturmangriff_AT_Mod}+ @{Manoever_Todesstoss_AT_Mod} + @{Manoever_Verbeissen_AT_Mod} + @{Manoever_Vorstoss_AT_Mod} + @{Manoever_Zu_Fall_bringen_AT_Mod}" disabled="true"/>
+                    <input name="attr_Spezialmanoever_PA_Mod" style="display:none;" type="number" value="@{Manoever_Riposte_PA_Mod} + @{Manoever_Trampeln_PA_Mod}" disabled="true"/>
+                    <input name="attr_Spezialmanoever_TP_Mod" style="display:none;" type="number" value="@{Manoever_Sturmangriff} * (2 + round((@{GS_Kampf}) / 2))" disabled="true" />
                 </td>
                 <td width="30%" valign="top">
                     <div>
@@ -5340,6 +6034,13 @@
                         <input name="attr_Passiv_Hass_auf_AT_Mod" type="number" value="0" disabled="true" style="width:3em;"/>
                         <input name="attr_Passiv_Hass_auf_PA_Mod" type="number" value="0" disabled="true" style="width:3em;"/>
                         <input name="attr_Passiv_Hass_auf_TP_Mod" type="number" value="@{passiv_hass_auf}" disabled="true" style="width:3em;"/>
+                    </div>
+                    <input class="sheet-kampf-passiv" type="checkbox" name="attr_sf_maechtiger_schlag" value="1" style="display:none;"/>
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:8em;">Mächtiger Schlag:</div>
+                        <input type="checkbox" name="attr_Passiv_Maechtiger_Schlag" value="1" style="width:2em;"/>
+                        <input type="number" value="0" style="width: 3em;" disabled="true" style="width:3em;"/>
+                        <input type="number" name="attr_Passiv_Verteidigungshaltung_PA_Mod" style="width: 3em;" value="0" disabled="true" style="width:3em;"/>
                     </div>
                     <input class="sheet-kampf-passiv" type="checkbox" name="attr_sf_verteidigungshaltung" value="1" style="display:none;"/>
                     <div class="sheet-sf-row">
@@ -5410,6 +6111,12 @@
                             <td><input name="attr_Eingeengt_Abzuege_Waffe_PA" type="number" value="-@{Eingeengt}*((@{NKW_Aktiv1}*(@{ReichweiteNKWaffe1}-1)*4)+(@{NKW_Aktiv2}*(@{ReichweiteNKWaffe2}-1)*4)+(@{NKW_Aktiv3}*(@{ReichweiteNKWaffe3}-1)*4)+(@{NKW_Aktiv4}*(@{ReichweiteNKWaffe4}-1)*4))" disabled="true"/></td>
                         </tr>
                         <tr>
+                            <td>Blutrausch:</td>
+                            <td><input name="attr_Blutrausch" type="checkbox" value="1"/></td>
+                            <td><input name="attr_Blutrausch_Abzuege_Waffe_AT" type="number" value="-@{Blutrausch}*4" disabled="true"/></td>
+                            <td><input name="attr_Blutrausch_Abzuege_Waffe_PA" type="number" value="0" disabled="true"/></td>
+                        </tr>
+                        <tr>
                             <td>Liegend:</td>
                             <td><input name="attr_Liegend" type="checkbox" value="1"/></td>
                             <td><input name="attr_Liegend_Abzuege_Waffe_AT" type="number" value="-@{Liegend}*4" disabled="true"/></td>
@@ -5430,15 +6137,13 @@
                         <tr>
                             <td>Kampf unter Wasser:</td>
                             <td><input name="attr_Kampf_unter_Wasser" type="checkbox" value="1"/></td>
-                            <td><input name="attr_Kampf_unter_Wasser_Waffe_AT" type="number" value="-@{Kampf_unter_Wasser}*6" disabled="true"/></td>
-                            <td><input name="attr_Kampf_unter_Wasser_Waffe_PA" type="number" value="-@{Kampf_unter_Wasser}*6" disabled="true"/></td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">Gesamt:</td>
-                            <td><input name="attr_Situationen_AT_Mod" type="number" value="@{GegnerRW_Abzuege_Waffe_AT}+@{GegnerKT_Abzuege_Waffe_AT}+@{Eingeengt_Abzuege_Waffe_AT}+@{Liegend_Abzuege_Waffe_AT}+@{Vorteilhafte_Position_Waffe_AT}+@{Kampf_im_Wasser_Waffe_AT}+@{Kampf_unter_Wasser_Waffe_AT}+@{Sicht_Mod_Abzuege_Waffe_AT}" disabled="true"/></td>
-                            <td><input name="attr_Situationen_PA_Mod" type="number" value="@{GegnerRW_Abzuege_Waffe_PA}+@{GegnerKT_Abzuege_Waffe_PA}+@{Eingeengt_Abzuege_Waffe_PA}+@{Liegend_Abzuege_Waffe_PA}+@{Vorteilhafte_Position_Waffe_PA}+@{Kampf_im_Wasser_Waffe_PA}+@{Kampf_unter_Wasser_Waffe_PA}+@{Sicht_Mod_Abzuege_Waffe_PA}" disabled="true"/></td>
+                            <td><input name="attr_Kampf_unter_Wasser_Waffe_AT" type="number" value="(-@{Kampf_unter_Wasser}*6)*(1-@{sf_unterwasserkampf})" disabled="true"/></td>
+                            <td><input name="attr_Kampf_unter_Wasser_Waffe_PA" type="number" value="(-@{Kampf_unter_Wasser}*6)*(1-@{sf_unterwasserkampf})" disabled="true"/></td>
                         </tr>
                     </table>
+                    <input name="attr_Situationen_AT_Mod" type="number" value="@{GegnerRW_Abzuege_Waffe_AT}+@{GegnerKT_Abzuege_Waffe_AT}+@{Eingeengt_Abzuege_Waffe_AT}+@{Blutrausch_Abzuege_Waffe_AT}+@{Liegend_Abzuege_Waffe_AT}+@{Vorteilhafte_Position_Waffe_AT}+@{Kampf_im_Wasser_Waffe_AT}+@{Kampf_unter_Wasser_Waffe_AT}+@{Sicht_Mod_Abzuege_Waffe_AT}" style="display:none;" disabled="true"/>
+                    <input name="attr_Situationen_PA_Mod" type="number" value="@{GegnerRW_Abzuege_Waffe_PA}+@{GegnerKT_Abzuege_Waffe_PA}+@{Eingeengt_Abzuege_Waffe_PA}+@{Blutrausch_Abzuege_Waffe_PA}+@{Liegend_Abzuege_Waffe_PA}+@{Vorteilhafte_Position_Waffe_PA}+@{Kampf_im_Wasser_Waffe_PA}+@{Kampf_unter_Wasser_Waffe_PA}+@{Sicht_Mod_Abzuege_Waffe_PA}" style="display:none;" disabled="true"/>
+                    <input name="attr_Situationen_TP_Mod" type="number" value="@{Blutrausch}*2" style="display:none;" disabled="true"/>
                 </td>
                 <td valign="top">
                     <table>
@@ -5451,34 +6156,36 @@
                       </tr>
                       <tr align="center">
                             <td><input type="text" name="attr_NKWname1" style="width: 11em;" ></td>
-                            <td><input type="number" name="attr_AT_NKW1" disabled=true value="@{NKWtyp1}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW1}"></td>
-                            <td><input type="number" name="attr_PA_NKW1" disabled=true value="round(@{NKWtyp1}/2)+@{PAMod_NKW1}+@{OptPA_GW}+floor((@{NKW1_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW1}"></td>
+                            <td><input type="number" name="attr_AT_NKW1" disabled=true value="(@{NKWtyp1}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW1})*(1-@{gegner_sheet})+@{AT_NKW1_Fix}*(0+@{gegner_sheet})"></td>
+                            <td><input type="number" name="attr_PA_NKW1" disabled=true value="(round(@{NKWtyp1}/2)+@{PAMod_NKW1}+@{OptPA_GW}+floor((@{NKW1_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW1})*(1-@{gegner_sheet})+@{PA_NKW1_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="checkbox" name="attr_NKW_Aktiv1" value="1" checked="true"></td>
                             <td><input type="checkbox" name="attr_EHalsZH_NKW1" value="1"></td>
                       </tr>
                       <tr align="center">
                             <td><input type="text" name="attr_NKWname2" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW2" disabled=true value="@{NKWtyp2}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW2}"></td>
-                            <td><input type="number" name="attr_PA_NKW2" disabled=true value="round(@{NKWtyp2}/2)+@{PAMod_NKW2}+@{OptPA_GW}+floor((@{NKW2_Leiteigenschaft}-8)/3)"></td>
+                            <td><input type="number" name="attr_AT_NKW2" disabled=true value="(@{NKWtyp2}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW2})*(1-@{gegner_sheet})+@{AT_NKW2_Fix}*(0+@{gegner_sheet})"></td>
+                            <td><input type="number" name="attr_PA_NKW2" disabled=true value="(round(@{NKWtyp2}/2)+@{PAMod_NKW2}+@{OptPA_GW}+floor((@{NKW2_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW2})*(1-@{gegner_sheet})+@{PA_NKW2_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="checkbox" name="attr_NKW_Aktiv2" value="1"></td>
                             <td><input type="checkbox" name="attr_EHalsZH_NKW2" value="1"></td>
                       </tr>
                       <tr align="center">
                             <td><input type="text" name="attr_NKWname3" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW3" disabled=true value="@{NKWtyp3}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW3}"></td>
-                            <td><input type="number" name="attr_PA_NKW3" disabled=true value="round(@{NKWtyp3}/2)+@{PAMod_NKW3}+@{OptPA_GW}+floor((@{NKW3_Leiteigenschaft}-8)/3)"></td>
+                            <td><input type="number" name="attr_AT_NKW3" disabled=true value="(@{NKWtyp3}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW3})*(1-@{gegner_sheet})+@{AT_NKW3_Fix}*(0+@{gegner_sheet})"></td>
+                            <td><input type="number" name="attr_PA_NKW3" disabled=true value="(round(@{NKWtyp3}/2)+@{PAMod_NKW3}+@{OptPA_GW}+floor((@{NKW3_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW3})*(1-@{gegner_sheet})+@{PA_NKW3_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="checkbox" name="attr_NKW_Aktiv3" value="1"></td>
                             <td><input type="checkbox" name="attr_EHalsZH_NKW3" value="1"></td>
                       </tr>
                       <tr align="center">
                             <td><input type="text" name="attr_NKWname4" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW4" disabled=true value="@{NKWtyp4}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW4}"></td>
-                            <td><input type="number" name="attr_PA_NKW4" disabled=true value="round(@{NKWtyp4}/2)+@{PAMod_NKW4}+@{OptPA_GW}+floor((@{NKW4_Leiteigenschaft}-8)/3)"></td>
+                            <td><input type="number" name="attr_AT_NKW4" disabled=true value="(@{NKWtyp4}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW4})*(1-@{gegner_sheet})+@{AT_NKW4_Fix}*(0+@{gegner_sheet})"></td>
+                            <td><input type="number" name="attr_PA_NKW4" disabled=true value="(round(@{NKWtyp4}/2)+@{PAMod_NKW4}+@{OptPA_GW}+floor((@{NKW4_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW4})*(1-@{gegner_sheet})+@{PA_NKW4_Fix}*(0+@{gegner_sheet})"></td>
                             <td><input type="checkbox" name="attr_NKW_Aktiv4" value="1"></td>
                             <td><input type="checkbox" name="attr_EHalsZH_NKW4" value="1"></td>
                       </tr>
                     </table>
                     <br />
+                    <input class="sheet-gegner" type="checkbox" value="1" name="attr_gegner_sheet" style="display:none;" />
+                    <div class="sheet-kein-gegner">
                     <table>
                         <tr>
                             <th>Schild/Parierwaffe</th>
@@ -5515,6 +6222,7 @@
                             <td><input type="checkbox" name="attr_Schild_Aktiv4" value="1"></td>
                         </tr>
                     </table>
+                    </div>
                 </td>
         </div>      
         
@@ -5522,17 +6230,17 @@
             <table>
             <tr>
                 <th>
-                    INI <input type="number" name="attr_INI_Aktiv" value="@{INI_Wert}" disabled="true">
+                    INI <input type="number" name="attr_INI_Aktiv" value="((@{INI_Wert}) * (1 - @{gegner_sheet})) + (@{INI_Wert_Fix}*(0+@{gegner_sheet}))" disabled="true">
                     <button type=roll value="[[(1d6+@{INI_Aktiv})&{tracker}]] @{Charaktername}´s Initiative" />
                 </th>
                 <th>
-                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="@{Ges_RS}" disabled="true" />
+                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="(@{Ges_RS})*(1-@{gegner_sheet})+(@{RS_Fix})*(0+@{gegner_sheet})" disabled="true" />
                 </th>
                 <th>
                     BE <input type="number" name="attr_BE_Kampf" style='width: 4em' value="@{Ges_BE}" disabled="true" />
                 </th>
                 <th>
-                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="@{GS_Wert}" disabled="true" />
+                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="(@{GS_Wert})*(1-@{gegner_sheet})+(@{GS_Wert_Fix})*(0+@{gegner_sheet})" disabled="true" />
                 </th>
                 <th>
                     LE <input type="number" name="attr_LE_Wert" style='width: 4em' value="@{LE_Wert}" />
@@ -5696,15 +6404,15 @@
                 <tr align=center>
                     <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
                     <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite1"></td>
-                    <td><input type="number" name="attr_FKWFK1" disabled=true value="@{FKWtyp1}+floor((@{FF_Wert}-8)/3)"></td>
+                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
+                    <td><input type="number" name="attr_FKWFK1" disabled=true value="(@{FKWtyp1}+floor((@{FF_Wert}-8)/3))*(1-@{gegner_sheet})+@{FKW1_Fix}*(0+@{gegner_sheet})"></td>
                     <td><input type="number" name="attr_FKWMunition1"></td>
-                    <td><input type="checkbox" name="attr_FKW_Aktiv1" value="1"></td>
+                    <td><input type="checkbox" name="attr_FKW_Aktiv1" value="1" checked="true"></td>
                 </tr>
                 <tr align=center>
                     <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
                     <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite2"></td>
+                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
                     <td><input type="number" name="attr_FKWFK2" disabled=true value="@{FKWtyp2}+floor((@{FF_Wert}-8)/3)"></td>
                     <td><input type="number" name="attr_FKWMunition2"></td>
                     <td><input type="checkbox" name="attr_FKW_Aktiv2" value="1"></td>
@@ -5712,7 +6420,7 @@
                 <tr align=center>
                     <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
                     <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite3"></td>
+                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
                     <td><input type="number" name="attr_FKWFK3" disabled=true value="@{FKWtyp3}+floor((@{FF_Wert}-8)/3)"></td>
                     <td><input type="number" name="attr_FKWMunition3"></td>
                     <td><input type="checkbox" name="attr_FKW_Aktiv3" value="1"></td>
@@ -5720,7 +6428,7 @@
                 <tr align=center>
                     <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
                     <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite4"></td>
+                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
                     <td><input type="number" name="attr_FKWFK4" disabled=true value="@{FKWtyp4}+floor((@{FF_Wert}-8)/3)"></td>
                     <td><input type="number" name="attr_FKWMunition4"></td>
                     <td><input type="checkbox" name="attr_FKW_Aktiv4" value="1"></td>
@@ -5901,222 +6609,284 @@
         
         <div class="sheet-section sheet section-fightvalues5">
             <h3>Kampfsonderfertigkeiten</h3>
-            <table>
-                <tr>
-                    <th>Name</th>
-                    <th>Aktiv</th>
-                    <th>Stufe</th>
-                <tr>
-                    <td>Aufmerksamkeit:</td>
-                    <td><input type="checkbox" name="attr_sf_aufmerksamkeit" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Belastungsgewöhnung:</td>
-                    <td><input type="checkbox" name="attr_sf_belastungsgewoehnung" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_belastungsgewoehnung_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Beidhändiger Kampf:</td>
-                    <td><input type="checkbox" name="attr_sf_bh_kampf" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_bh_kampf_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Berittener Kampf:</td>
-                    <td><input type="checkbox" name="attr_sf_berittener_kampf" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Berittener Schütze:</td>
-                    <td><input type="checkbox" name="attr_sf_berittener_schuetze" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Einhändiger Kampf:</td>
-                    <td><input type="checkbox" name="attr_sf_eh_kampf" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Entwaffnen:</td>
-                    <td><input type="checkbox" name="attr_sf_entwaffnen" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Feindgespür:</td>
-                    <td><input type="checkbox" name="attr_sf_feindgespuer" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Finte:</td>
-                    <td><input type="checkbox" name="attr_sf_finte" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_finte_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Haltegriff:</td>
-                    <td><input type="checkbox" name="attr_sf_haltegriff" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Hammerschlag:</td>
-                    <td><input type="checkbox" name="attr_sf_hammerschlag" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Kampfreflexe:</td>
-                    <td><input type="checkbox" name="attr_sf_kampfreflexe" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_kampfreflexe_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Klingenfänger:</td>
-                    <td><input type="checkbox" name="attr_sf_klingenfaenger" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Kreuzblock:</td>
-                    <td><input type="checkbox" name="attr_sf_kreuzblock" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Lanzenangriff:</td>
-                    <td><input type="checkbox" name="attr_sf_lanzenangriff" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Präziser Schuss/Wurf:</td>
-                    <td><input type="checkbox" name="attr_sf_praeziser_schuss" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_praeziser_schuss_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Präziser Stich:</td>
-                    <td><input type="checkbox" name="attr_sf_praeziser_stich" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_praeziser_stich_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Riposte:</td>
-                    <td><input type="checkbox" name="attr_sf_riposte" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Rundumschlag:</td>
-                    <td><input type="checkbox" name="attr_sf_rundumschlag" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_rundumschlag_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Schildspalter:</td>
-                    <td><input type="checkbox" name="attr_sf_schildspalter" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Schnellladen:</td>
-                    <td><input type="checkbox" name="attr_sf_schnellladen" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Schnellziehen:</td>
-                    <td><input type="checkbox" name="attr_sf_schnellziehen" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Sturmangriff:</td>
-                    <td><input type="checkbox" name="attr_sf_sturmangriff" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Todesstoß:</td>
-                    <td><input type="checkbox" name="attr_sf_todesstoss" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Verbessertes Ausweichen:</td>
-                    <td><input type="checkbox" name="attr_sf_verb_ausweichen" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_verb_ausweichen_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Verteidigungshaltung:</td>
-                    <td><input type="checkbox" name="attr_sf_verteidigungshaltung" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Vorstoß:</td>
-                    <td><input type="checkbox" name="attr_sf_vorstoss" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Wuchtschlag:</td>
-                    <td><input type="checkbox" name="attr_sf_wuchtschlag" value="1"/></td>
-                    <td>
-                        <select type="text" name="attr_sf_wuchtschlag_stufe" style='width: 3em;'>
-                            <option value="0">-</option>
-                            <option value="1">I</option>
-                            <option value="2">II</option>
-                            <option value="3">III</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Wurf:</td>
-                    <td><input type="checkbox" name="attr_sf_wurf" value="1"/></td>
-                    <td />
-                </tr>
-                <tr>
-                    <td>Zu Fall bringen:</td>
-                    <td><input type="checkbox" name="attr_sf_zu_fall_bringen" value="1"/></td>
-                    <td />
-                </tr>
-            </table>
+            <div class='sheet-2colrow'>
+                <div class='sheet-col'>
+		            <table>
+		                <tr>
+		                    <th>Name</th>
+		                    <th>Aktiv</th>
+		                    <th>Stufe</th>
+		                <tr>
+		                    <td>Aufmerksamkeit:</td>
+		                    <td><input type="checkbox" name="attr_sf_aufmerksamkeit" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Belastungsgewöhnung:</td>
+		                    <td><input type="checkbox" name="attr_sf_belastungsgewoehnung" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_belastungsgewoehnung_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Beidhändiger Kampf:</td>
+		                    <td><input type="checkbox" name="attr_sf_bh_kampf" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_bh_kampf_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Berittener Kampf:</td>
+		                    <td><input type="checkbox" name="attr_sf_berittener_kampf" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Berittener Schütze:</td>
+		                    <td><input type="checkbox" name="attr_sf_berittener_schuetze" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Einhändiger Kampf:</td>
+		                    <td><input type="checkbox" name="attr_sf_eh_kampf" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Entwaffnen:</td>
+		                    <td><input type="checkbox" name="attr_sf_entwaffnen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Feindgespür:</td>
+		                    <td><input type="checkbox" name="attr_sf_feindgespuer" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Finte:</td>
+		                    <td><input type="checkbox" name="attr_sf_finte" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_finte_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Haltegriff:</td>
+		                    <td><input type="checkbox" name="attr_sf_haltegriff" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Hammerschlag:</td>
+		                    <td><input type="checkbox" name="attr_sf_hammerschlag" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Kampfreflexe:</td>
+		                    <td><input type="checkbox" name="attr_sf_kampfreflexe" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_kampfreflexe_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Klingenfänger:</td>
+		                    <td><input type="checkbox" name="attr_sf_klingenfaenger" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Kreuzblock:</td>
+		                    <td><input type="checkbox" name="attr_sf_kreuzblock" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Lanzenangriff:</td>
+		                    <td><input type="checkbox" name="attr_sf_lanzenangriff" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Präziser Schuss/Wurf:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_schuss" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_praeziser_schuss_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Präziser Stich:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_stich" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_praeziser_stich_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Riposte:</td>
+		                    <td><input type="checkbox" name="attr_sf_riposte" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Rundumschlag:</td>
+		                    <td><input type="checkbox" name="attr_sf_rundumschlag" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_rundumschlag_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Schildspalter:</td>
+		                    <td><input type="checkbox" name="attr_sf_schildspalter" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Schnellladen:</td>
+		                    <td><input type="checkbox" name="attr_sf_schnellladen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Schnellziehen:</td>
+		                    <td><input type="checkbox" name="attr_sf_schnellziehen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Sturmangriff:</td>
+		                    <td><input type="checkbox" name="attr_sf_sturmangriff" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Todesstoß:</td>
+		                    <td><input type="checkbox" name="attr_sf_todesstoss" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Verbessertes Ausweichen:</td>
+		                    <td><input type="checkbox" name="attr_sf_verb_ausweichen" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_verb_ausweichen_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Verteidigungshaltung:</td>
+		                    <td><input type="checkbox" name="attr_sf_verteidigungshaltung" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Vorstoß:</td>
+		                    <td><input type="checkbox" name="attr_sf_vorstoss" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Wuchtschlag:</td>
+		                    <td><input type="checkbox" name="attr_sf_wuchtschlag" value="1"/></td>
+		                    <td>
+		                        <select type="text" name="attr_sf_wuchtschlag_stufe" style='width: 3em;'>
+		                            <option value="0">-</option>
+		                            <option value="1">I</option>
+		                            <option value="2">II</option>
+		                            <option value="3">III</option>
+		                        </select>
+		                    </td>
+		                </tr>
+		                <tr>
+		                    <td>Wurf:</td>
+		                    <td><input type="checkbox" name="attr_sf_wurf" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Zu Fall bringen:</td>
+		                    <td><input type="checkbox" name="attr_sf_zu_fall_bringen" value="1"/></td>
+		                    <td />
+		                </tr>
+		            </table>
+		    	</div>
+                <div class='sheet-col'>
+		            <table>
+		                <tr>
+		                    <th>Name</th>
+		                    <th>Aktiv</th>
+		                    <th>Stufe</th>
+		                <tr>
+		                    <td>Angriff auf ungeschützte Stellen:</td>
+		                    <td><input type="checkbox" name="attr_sf_angriff_auf_ungeschuetzte_stellen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Anspringen:</td>
+		                    <td><input type="checkbox" name="attr_sf_anspringen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Flugangriff:</td>
+		                    <td><input type="checkbox" name="attr_sf_flugangriff" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Klammergriff:</td>
+		                    <td><input type="checkbox" name="attr_sf_klammergriff" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Mächtiger Schlag:</td>
+		                    <td><input type="checkbox" name="attr_sf_maechtiger_schlag" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Schwanz- oder Tentakelschwung:</td>
+		                    <td><input type="checkbox" name="attr_sf_schwanz_tentakelschwung" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Trampeln:</td>
+		                    <td><input type="checkbox" name="attr_sf_trampeln" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Überrennen:</td>
+		                    <td><input type="checkbox" name="attr_sf_ueberrennen" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Unterwasserkampf:</td>
+		                    <td><input type="checkbox" name="attr_sf_unterwasserkampf" value="1"/></td>
+		                    <td />
+		                </tr>
+		                <tr>
+		                    <td>Verbeißen:</td>
+		                    <td><input type="checkbox" name="attr_sf_verbeissen" value="1"/></td>
+		                    <td />
+		                </tr>
+		            </table>
+		       	</div>
+            </div>
         </div>
     </div>
 
@@ -6441,7 +7211,7 @@
                 <div class="sheet-zauber-merkmal"><b>Merkmal</b></div>
                 <div style="display:inline-block; width:3em; font-weight:bold;">FW</div>
             </div>
-            <input class="sheet-zauber-adlerauge" type="checkbox" name="attr_zauber_adlerauge" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_adlerauge" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Adlerauge</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -6454,7 +7224,7 @@
                 <input type="number" name="attr_zfw_Adlerauge" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Adlerauge}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Adlerauge} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div><br />
-            <input class="sheet-zauber-analys" type="checkbox" name="attr_zauber_analys" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_analys" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Analys Arkanstruktur</div>
                 <div class="sheet-zauber-probe">KL/KL/IN</div>
@@ -6467,7 +7237,7 @@
                 <input type="number" name="attr_zfw_Analys" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Analys Arkanstruktur}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Analys} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div><br />
-            <input class="sheet-zauber-armatrutz" type="checkbox" name="attr_zauber_armatrutz" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_armatrutz" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Armatrutz</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -6480,7 +7250,7 @@
                 <input type="number" name="attr_zfw_Armatrutz" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Armatrutz}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Armatrutz} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div><br />
-            <input class="sheet-zauber-axxeleratus" type="checkbox" name="attr_zauber_axxeleratus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_axxeleratus" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Axxeleratus</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -6495,7 +7265,7 @@
                 <input type="number" name="attr_zfw_Axxeleratus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Axxeleratus}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Axxeleratus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-balsam" type="checkbox" name="attr_zauber_balsam_salabunde" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_balsam_salabunde" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Balsam</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -6508,7 +7278,7 @@
                 <input type="number" name="attr_zfw_Balsam" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Balsam}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Balsam} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-bannbaladin" type="checkbox" name="attr_zauber_bannbaladin" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_bannbaladin" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Bannbaladin</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6521,7 +7291,7 @@
                 <input type="number" name="attr_zfw_Bannbaladin" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Bannbaladin}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Bannbaladin} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-blick" type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Blick in die Gedanken</div>
                 <div class="sheet-zauber-probe">MU/KL/IN +SK</div>
@@ -6534,7 +7304,7 @@
                 <input type="number" name="attr_zfw_Blick" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Blick}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Blick} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-blitz" type="checkbox" name="attr_zauber_blitz_dich_find" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blitz_dich_find" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Blitz dich find</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6547,7 +7317,7 @@
                 <input type="number" name="attr_zfw_Blitz" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Blitz}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Blitz} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-corpofesso" type="checkbox" name="attr_zauber_corpofesso" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_corpofesso" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Corpofesso</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -6560,7 +7330,7 @@
                 <input type="number" name="attr_zfw_Corpofesso" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Corpofesso}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Corpofesso} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-disruptivo" type="checkbox" name="attr_zauber_disruptivo" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_disruptivo" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Disruptivo</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6573,7 +7343,20 @@
                 <input type="number" name="attr_zfw_Disruptivo" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Disruptivo}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Antimagie}} {{Zauber=[[ @{zfw_Disruptivo} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-duplicatus" type="checkbox" name="attr_zauber_duplicatus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_dunkelheit" value="1" style="display:none;"/>
+            <div class="sheet-zauber">
+                <div class="sheet-zauber-zauberspruch">Dunkelheit</div>
+                <div class="sheet-zauber-probe">MU/KL/CH</div>
+                <div class="sheet-zauber-zauberdauer">8 A</div>
+                <div class="sheet-zauber-kosten">16 + 8 / 5 Min</div>
+                <div class="sheet-zauber-reichweite">s</div>
+                <div class="sheet-zauber-wirkungsdauer">aufrechterhaltend</div>
+                <div class="sheet-zauber-zielkategorie">Z</div>
+                <div class="sheet-zauber-merkmal">Dämonisch</div>
+                <input type="number" name="attr_zfw_Dunkelheit" style="width:3em;" value="0"/>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Dunkelheit}} {{subtag=Zauber}}} {{subtag1=Sonstige}} {{subtag2=Dämonisch}} {{Zauber=[[ @{zfw_Dunkelheit} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+            </div>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_duplicatus" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Duplicatus</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -6586,7 +7369,7 @@
                 <input type="number" name="attr_zfw_Duplicatus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Duplicatus}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Duplicatus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-falkenauge" type="checkbox" name="attr_zauber_falkenauge" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_falkenauge" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Falkenauge</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
@@ -6601,7 +7384,7 @@
                 <input type="number" name="attr_zfw_Falkenauge" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Falkenauge}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Falkenauge} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-flim-flam" type="checkbox" name="attr_zauber_flim_flam" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_flim_flam" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Flim Flam</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6614,7 +7397,7 @@
                 <input type="number" name="attr_zfw_Flim_Flam" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Flim_Flam}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Flim_Flam} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-fulminictus" type="checkbox" name="attr_zauber_fulminictus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_fulminictus" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Fulminictus</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -6627,7 +7410,7 @@
                 <input type="number" name="attr_zfw_Fulminictus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Fulminictus}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Fulminictus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-gardianum" type="checkbox" name="attr_zauber_gardianum" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_gardianum" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Gardianum</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6640,7 +7423,7 @@
                 <input type="number" name="attr_zfw_Gardianum" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Gardianum}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Antimagie}} {{Zauber=[[ @{zfw_Gardianum} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-grosse-gier" type="checkbox" name="attr_zauber_grosse_gier" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_gier" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Große Gier</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6653,7 +7436,20 @@
                 <input type="number" name="attr_zfw_Grosse_Gier" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Grosse_Gier}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Grosse_Gier} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-harmlose-gestalt" type="checkbox" name="attr_zauber_harmlose_gestalt" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_verwirrung" value="1" style="display:none;"/>
+            <div class="sheet-zauber">
+                <div class="sheet-zauber-zauberspruch">Große Verwirrung</div>
+                <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
+                <div class="sheet-zauber-zauberdauer">4 A</div>
+                <div class="sheet-zauber-kosten">8</div>
+                <div class="sheet-zauber-reichweite">B</div>
+                <div class="sheet-zauber-wirkungsdauer">QS x 15 Min</div>
+                <div class="sheet-zauber-zielkategorie">LW</div>
+                <div class="sheet-zauber-merkmal">Dämonisch</div>
+                <input type="number" name="attr_zfw_Grosse_Verwirrung" style="width:3em;" value="0"/>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Grosse_Verwirrung}} {{subtag=Zauber}}} {{subtag1=Sonstige}} {{subtag2=Dämonisch}} {{Zauber=[[ @{zfw_Grosse_Verwirrung} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+            </div>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_harmlose_gestalt" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Harmlose Gestalt</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -6666,7 +7462,7 @@
                 <input type="number" name="attr_zfw_Harmlose_Gestalt" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Harmlose_Gestalt}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Harmlose_Gestalt} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-hexengalle" type="checkbox" name="attr_zauber_hexengalle" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexengalle" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Hexengalle</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6679,7 +7475,7 @@
                 <input type="number" name="attr_zfw_Hexengalle" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Hexengalle}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Hexengalle} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-hexenkrallen" type="checkbox" name="attr_zauber_hexenkrallen" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexenkrallen" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Hexenkrallen</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6692,7 +7488,7 @@
                 <input type="number" name="attr_zfw_Hexenkrallen" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Hexenkrallen}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Hexenkrallen} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-horriphobus" type="checkbox" name="attr_zauber_horriphobus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_horriphobus" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Horriphobus</div>
                 <div class="sheet-zauber-probe">MU/IN/CH + SK</div>
@@ -6705,7 +7501,7 @@
                 <input type="number" name="attr_zfw_Horriphobus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Horriphobus}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Horriphobus} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-ignifaxius" type="checkbox" name="attr_zauber_ignifaxius" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_ignifaxius" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Ignifaxius</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6718,7 +7514,7 @@
                 <input type="number" name="attr_zfw_Ignifaxius" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Ignifaxius}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Ignifaxius} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-invocatio-minima" type="checkbox" name="attr_zauber_invocatio_minima" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_invocatio_minima" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Invocatio Minima</div>
                 <div class="sheet-zauber-probe">MU/CH/KO</div>
@@ -6731,7 +7527,7 @@
                 <input type="number" name="attr_zfw_Invocatio_Minima" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Invocatio_Minima}} {{subtag=Zauber}}} {{subtag1=Gildenmagier, Hexen}} {{subtag2=Sphären}} {{Zauber=[[ @{zfw_Invocatio_Minima} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-katzenaugen" type="checkbox" name="attr_zauber_katzenaugen" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_katzenaugen" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Katzenaugen</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6744,7 +7540,7 @@
                 <input type="number" name="attr_zfw_Katzenaugen" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Katzenaugen}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Katzenaugen} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-kroetensprung" type="checkbox" name="attr_zauber_kroetensprung" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_kroetensprung" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Krötensprung</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6757,7 +7553,7 @@
                 <input type="number" name="attr_zfw_Kroetensprung" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Kroetensprung}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Kroetensprung} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-manifesto" type="checkbox" name="attr_zauber_manifesto" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manifesto" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Manifesto</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6770,7 +7566,7 @@
                 <input type="number" name="attr_zfw_Manifesto" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Manifesto}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Manifesto} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-manus-miracula" type="checkbox" name="attr_zauber_manus_miracula" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manus_miracula" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Manus Miracula</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -6783,7 +7579,7 @@
                 <input type="number" name="attr_zfw_Manus_Miracula" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Manus_Miracula}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Manus_Miracula} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-motoricus" type="checkbox" name="attr_zauber_motoricus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_motoricus" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Motoricus</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -6796,7 +7592,7 @@
                 <input type="number" name="attr_zfw_Motoricus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Motoricus}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Motoricus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-nebelwand" type="checkbox" name="attr_zauber_nebelwand" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_nebelwand" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Nebelwand</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -6811,7 +7607,7 @@
                 <input type="number" name="attr_zfw_Nebelwand" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Nebelwand}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Nebelwand} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-oculus-illusionis" type="checkbox" name="attr_zauber_oculus_illusionis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_oculus_illusionis" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Oculus Illusionis</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -6824,7 +7620,7 @@
                 <input type="number" name="attr_zfw_Oculus_Illusionis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Oculus_Illusionis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Oculus_Illusionis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-odem-arcanum" type="checkbox" name="attr_zauber_odem_arcanum" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_odem_arcanum" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Odem</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
@@ -6837,7 +7633,7 @@
                 <input type="number" name="attr_zfw_Odem" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Odem}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Odem} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-paralysis" type="checkbox" name="attr_zauber_paralysis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_paralysis" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Paralysis</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -6850,7 +7646,7 @@
                 <input type="number" name="attr_zfw_Paralysis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Paralysis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Paralysis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-penetrizzel" type="checkbox" name="attr_zauber_penetrizzel" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_penetrizzel" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Penetrizzel</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
@@ -6863,7 +7659,7 @@
                 <input type="number" name="attr_zfw_Penetrizzel" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Penetrizzel}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Penetrizzel} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-psychostabilis" type="checkbox" name="attr_zauber_psychostabilis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_psychostabilis" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Psychostabilis</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -6876,7 +7672,7 @@
                 <input type="number" name="attr_zfw_Psychostabilis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Psychostabilis}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Psychostabilis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-radau" type="checkbox" name="attr_zauber_radau" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_radau" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Radau</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -6889,7 +7685,7 @@
                 <input type="number" name="attr_zfw_Radau" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Radau}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Radau} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-respondami" type="checkbox" name="attr_zauber_respondami" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_respondami" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Respondami</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6902,7 +7698,7 @@
                 <input type="number" name="attr_zfw_Respondami" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Respondami}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Respondami} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-salander" type="checkbox" name="attr_zauber_salander" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_salander" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Salander</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -6915,7 +7711,7 @@
                 <input type="number" name="attr_zfw_Salander" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Salander}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Salander} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-sanftmut" type="checkbox" name="attr_zauber_sanftmut" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_sanftmut" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Sanftmut</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6928,7 +7724,7 @@
                 <input type="number" name="attr_zfw_Sanftmut" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Sanftmut}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Sanftmut} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-satuarias-herrlichkeit" type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Satuarias Herrlichkeit</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6941,7 +7737,7 @@
                 <input type="number" name="attr_zfw_Satuarias_Herrlichkeit" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Satuarias_Herrlichkeit}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Satuarias_Herrlichkeit} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-silentium" type="checkbox" name="attr_zauber_silentium" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_silentium" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Silentium</div>
                 <div class="sheet-zauber-probe">KL/FF/KO</div>
@@ -6954,7 +7750,7 @@
                 <input type="number" name="attr_zfw_Silentium" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Silentium}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Silentium} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-somnigravis" type="checkbox" name="attr_zauber_somnigravis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_somnigravis" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Somnigravis</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -6969,7 +7765,7 @@
                 <input type="number" name="attr_zfw_Somnigravis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Somnigravis}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Somnigravis} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-spinnenlauf" type="checkbox" name="attr_zauber_spinnenlauf" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spinnenlauf" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Spinnenlauf</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -6982,7 +7778,7 @@
                 <input type="number" name="attr_zfw_Spinnenlauf" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Spinnenlauf}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Spinnenlauf} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-spurlos" type="checkbox" name="attr_zauber_spurlos" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spurlos" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Spurlos</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -6995,7 +7791,7 @@
                 <input type="number" name="attr_zfw_Spurlos" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Spurlos}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Spurlos} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-transversalis" type="checkbox" name="attr_zauber_transversalis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_transversalis" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Transversalis</div>
                 <div class="sheet-zauber-probe">MU/CH/KO</div>
@@ -7008,7 +7804,7 @@
                 <input type="number" name="attr_zfw_Transversalis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Transversalis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Sphären}} {{Zauber=[[ @{zfw_Transversalis} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-visibili" type="checkbox" name="attr_zauber_visibili" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_visibili" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Visibili</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7021,7 +7817,7 @@
                 <input type="number" name="attr_zfw_Visibili" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Visibili}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Visibili} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-wasseratem" type="checkbox" name="attr_zauber_wasseratem" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_wasseratem" value="1" style="display:none;"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Wasseratem</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7043,61 +7839,66 @@
                         <tr>
                             <td valign="top">
                             <b>Allgemein</b><br/>
-                            <input type="checkbox" name="attr_zauber_analys" value="1"/>Analys <br/>
-                            <input type="checkbox" name="attr_zauber_armatrutz" value="1"/>Armatrutz <br/>
-                            <input type="checkbox" name="attr_zauber_balsam_salabunde" value="1"/>Balsam Salabunde <br/>
-                            <input type="checkbox" name="attr_zauber_bannbaladin" value="1"/>Bannbaladin <br/>
-                            <input type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1"/>Blick in die Gedanken <br/>
-                            <input type="checkbox" name="attr_zauber_blitz_dich_find" value="1"/>Blitz dich find <br/>
-                            <input type="checkbox" name="attr_zauber_disruptivo" value="1"/>Disruptivo <br/>
-                            <input type="checkbox" name="attr_zauber_flim_flam" value="1"/>Flim Flam <br/>
-                            <input type="checkbox" name="attr_zauber_manifesto" value="1"/>Manifesto <br/>
-                            <input type="checkbox" name="attr_zauber_manus_miracula" value="1"/>Manus Miracula <br/>
-                            <input type="checkbox" name="attr_zauber_motoricus" value="1"/>Motoricus <br/>
-                            <input type="checkbox" name="attr_zauber_odem_arcanum" value="1"/>Odem Arcanum <br/>
-                            <input type="checkbox" name="attr_zauber_psychostabilis" value="1"/>Psychostabilis <br/>
+                            <input type="checkbox" name="attr_zauber_analys" value="1"/> Analys<br/>
+                            <input type="checkbox" name="attr_zauber_armatrutz" value="1"/> Armatrutz<br/>
+                            <input type="checkbox" name="attr_zauber_balsam_salabunde" value="1"/> Balsam Salabunde<br/>
+                            <input type="checkbox" name="attr_zauber_bannbaladin" value="1"/> Bannbaladin<br/>
+                            <input type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1"/> Blick in die Gedanken<br/>
+                            <input type="checkbox" name="attr_zauber_blitz_dich_find" value="1"/> Blitz dich find<br/>
+                            <input type="checkbox" name="attr_zauber_disruptivo" value="1"/> Disruptivo<br/>
+                            <input type="checkbox" name="attr_zauber_flim_flam" value="1"/> Flim Flam<br/>
+                            <input type="checkbox" name="attr_zauber_manifesto" value="1"/> Manifesto<br/>
+                            <input type="checkbox" name="attr_zauber_manus_miracula" value="1"/> Manus Miracula<br/>
+                            <input type="checkbox" name="attr_zauber_motoricus" value="1"/> Motoricus<br/>
+                            <input type="checkbox" name="attr_zauber_odem_arcanum" value="1"/> Odem Arcanum<br/>
+                            <input type="checkbox" name="attr_zauber_psychostabilis" value="1"/> Psychostabilis<br/>
                             </td>
                             <td valign="top">
                             <b>Elfen</b><br/>
-                            <input type="checkbox" name="attr_zauber_adlerauge" value="1"/>Adlerauge <br/>
-                            <input type="checkbox" name="attr_zauber_axxeleratus" value="1"/>Axxeleratus <br/>
-                            <input type="checkbox" name="attr_zauber_falkenauge" value="1"/>Falkenauge <br/>
-                            <input type="checkbox" name="attr_zauber_fulminictus" value="1"/>Fulminictus <br/>
-                            <input type="checkbox" name="attr_zauber_nebelwand" value="1"/>Nebelwand <br/>
-                            <input type="checkbox" name="attr_zauber_silentium" value="1"/>Silentium <br/>
-                            <input type="checkbox" name="attr_zauber_somnigravis" value="1"/>Somnigravis <br/>
-                            <input type="checkbox" name="attr_zauber_spurlos" value="1"/>Spurlos <br/>
-                            <input type="checkbox" name="attr_zauber_visibili" value="1"/>Visibli <br/>
-                            <input type="checkbox" name="attr_zauber_wasseratem" value="1"/>Wasseratem <br/>                    
+                            <input type="checkbox" name="attr_zauber_adlerauge" value="1"/> Adlerauge<br/>
+                            <input type="checkbox" name="attr_zauber_axxeleratus" value="1"/> Axxeleratus<br/>
+                            <input type="checkbox" name="attr_zauber_falkenauge" value="1"/> Falkenauge<br/>
+                            <input type="checkbox" name="attr_zauber_fulminictus" value="1"/> Fulminictus<br/>
+                            <input type="checkbox" name="attr_zauber_nebelwand" value="1"/> Nebelwand<br/>
+                            <input type="checkbox" name="attr_zauber_silentium" value="1"/> Silentium<br/>
+                            <input type="checkbox" name="attr_zauber_somnigravis" value="1"/> Somnigravis<br/>
+                            <input type="checkbox" name="attr_zauber_spurlos" value="1"/> Spurlos<br/>
+                            <input type="checkbox" name="attr_zauber_visibili" value="1"/> Visibli<br/>
+                            <input type="checkbox" name="attr_zauber_wasseratem" value="1"/> Wasseratem<br/>                    
                             </td>
                             <td valign="top">
                             <b>Gildenmagier</b><br/>
-                            <input type="checkbox" name="attr_zauber_corpofesso" value="1"/>Corpofesso <br/>
-                            <input type="checkbox" name="attr_zauber_duplicatus" value="1"/>Duplicatus <br/>
-                            <input type="checkbox" name="attr_zauber_gardianum" value="1"/>Gardianum <br/>
-                            <input type="checkbox" name="attr_zauber_horriphobus" value="1"/>Horriphobus <br/>
-                            <input type="checkbox" name="attr_zauber_ignifaxius" value="1"/>Ignifaxius <br/>
-                            <input type="checkbox" name="attr_zauber_invocatio_minima" value="1"/>Invocatio Minima <br/>
-                            <input type="checkbox" name="attr_zauber_oculus_illusionis" value="1"/>Occulus Illusionis <br/>
-                            <input type="checkbox" name="attr_zauber_paralysis" value="1"/>Paralysis <br/>
-                            <input type="checkbox" name="attr_zauber_penetrizzel" value="1"/>Penetrizzel <br/>
-                            <input type="checkbox" name="attr_zauber_respondami" value="1"/>Respondami <br/>
-                            <input type="checkbox" name="attr_zauber_salander" value="1"/>Salander <br/>
-                            <input type="checkbox" name="attr_zauber_transversalis" value="1"/>Transversalis <br/>
+                            <input type="checkbox" name="attr_zauber_corpofesso" value="1"/> Corpofesso<br/>
+                            <input type="checkbox" name="attr_zauber_duplicatus" value="1"/> Duplicatus<br/>
+                            <input type="checkbox" name="attr_zauber_gardianum" value="1"/> Gardianum<br/>
+                            <input type="checkbox" name="attr_zauber_horriphobus" value="1"/> Horriphobus<br/>
+                            <input type="checkbox" name="attr_zauber_ignifaxius" value="1"/> Ignifaxius<br/>
+                            <input type="checkbox" name="attr_zauber_invocatio_minima" value="1"/> Invocatio Minima<br/>
+                            <input type="checkbox" name="attr_zauber_oculus_illusionis" value="1"/> Occulus Illusionis<br/>
+                            <input type="checkbox" name="attr_zauber_paralysis" value="1"/> Paralysis<br/>
+                            <input type="checkbox" name="attr_zauber_penetrizzel" value="1"/> Penetrizzel<br/>
+                            <input type="checkbox" name="attr_zauber_respondami" value="1"/> Respondami<br/>
+                            <input type="checkbox" name="attr_zauber_salander" value="1"/> Salander<br/>
+                            <input type="checkbox" name="attr_zauber_transversalis" value="1"/> Transversalis<br/>
                             </td>
                             <td valign="top">
                             <b>Hexen</b><br/>
-                            <input type="checkbox" name="attr_zauber_grosse_gier" value="1"/>Große Gier <br/>
-                            <input type="checkbox" name="attr_zauber_harmlose_gestalt" value="1"/>Harmlose Gestalt <br/>
-                            <input type="checkbox" name="attr_zauber_hexengalle" value="1"/>Hexengalle <br/>
-                            <input type="checkbox" name="attr_zauber_hexenkrallen" value="1"/>Hexenkrallen <br/>
-                            <input type="checkbox" name="attr_zauber_invocatio_minima" value="1"/>Invocatio Minima <br/>
-                            <input type="checkbox" name="attr_zauber_katzenaugen" value="1"/>Katzenaugen <br/>
-                            <input type="checkbox" name="attr_zauber_kroetensprung" value="1"/>Krötensprung <br/>
-                            <input type="checkbox" name="attr_zauber_radau" value="1"/>Radau <br/>
-                            <input type="checkbox" name="attr_zauber_sanftmut" value="1"/>Sanftmut <br/>
-                            <input type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1"/>Satuarias Herrlichkeit <br/>
-                            <input type="checkbox" name="attr_zauber_spinnenlauf" value="1"/>Spinnenlauf <br/>                  
+                            <input type="checkbox" name="attr_zauber_grosse_gier" value="1"/> Große Gier<br/>
+                            <input type="checkbox" name="attr_zauber_harmlose_gestalt" value="1"/> Harmlose Gestalt<br/>
+                            <input type="checkbox" name="attr_zauber_hexengalle" value="1"/> Hexengalle<br/>
+                            <input type="checkbox" name="attr_zauber_hexenkrallen" value="1"/> Hexenkrallen<br/>
+                            <input type="checkbox" name="attr_zauber_invocatio_minima" value="1"/> Invocatio Minima<br/>
+                            <input type="checkbox" name="attr_zauber_katzenaugen" value="1"/> Katzenaugen<br/>
+                            <input type="checkbox" name="attr_zauber_kroetensprung" value="1"/> Krötensprung<br/>
+                            <input type="checkbox" name="attr_zauber_radau" value="1"/> Radau<br/>
+                            <input type="checkbox" name="attr_zauber_sanftmut" value="1"/> Sanftmut<br/>
+                            <input type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1"/> Satuarias Herrlichkeit<br/>
+                            <input type="checkbox" name="attr_zauber_spinnenlauf" value="1"/> Spinnenlauf<br/>                  
+                            </td>
+                            <td valign="top">
+                            <b>Sonstige</b><br/>
+                            <input type="checkbox" name="attr_zauber_dunkelheit" value="1"/> Dunkelheit<br/>
+                            <input type="checkbox" name="attr_zauber_grosse_verwirrung" value="1"/> Große Verwirrung<br/>
                             </td>
                         </tr>
                     </table>
@@ -9309,7 +10110,9 @@
         <input type="radio" name="attr_config_tab" class="sheet-tab sheet-tab92" value="92" title="config2"/>
             <span class="sheet-tab sheet-tab92">Optionalregeln</span>
             
-        <div class="sheet-section sheet section-config1">
+        <div class="sheet-section sheet section-config1" style="align:left;">
+            <input type="checkbox" name="attr_gegner_sheet" value="1"/> Gegner-Sheet<br />
+            <input type="checkbox" name="attr_reduzierte_talentansicht" value="1"/> Reduzierte Talentansicht<br />
             <input type="checkbox" class="versteckeMagie" name="attr_MagieTab"/> Verstecke Magie<br />
             <input type="checkbox" class="versteckeLiturgien" name="attr_LiturgienTab"/> Verstecke Götterwirken<br />
             <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" /> Verstecke Schildparade<br />


### PR DESCRIPTION
- Anzeigeoption "Gegner-Sheet": Versteckt die Tabs Inventar, Notizen. Zeigt vereinfachte Ansicht der Grundwerte und Kampfausrüstung.
- Anzeigeoption "Reduzierte Talentansicht": Zeigt im Talente-Tab ausschließlich die für nicht-humanoide Gegner gängigen Talente.
- Flag "Nicht-Humanoider": Option nur verfügbar in Gegner-Sheets, ersetzt Ausweichen, Waffen- und Schildparade durch Verteidigung.
- Kampf-Sonderfertigkeiten aus Bestiarium ergänzt
- Zauber Dunkelheit und Große Verwirrung ergänzt