### PR TITLE
[DSA5] Integrated sheet workers, UI improvements, minor feature additions and bugfixes

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.css
@@ -102,16 +102,20 @@ hr {
 .sheet-sect-show:not(:checked)~.sheet-sect {
     display:none;
 }
+
 .sheet-table {
     display:table;
     width:100%;
 }
+
 .sheet-small-label {
     font-size: 85%!important;
 }
+
 .sheet-center {
     text-align:center;
 }
+
 .sheet-table-data {
     display:table-cell;
     vertical-align:middle;
@@ -218,9 +222,61 @@ input.sheet-tab92:checked ~ div.sheet-section-config2 {
 }
 
 
-.sheet-versteckeMagie:checked + input.sheet-tab5,
-.sheet-versteckeMagie:checked ~ span.sheet-tab5,
-.sheet-versteckeMagie:checked + div.sheet-section-Magie {
+input.sheet-tab1:checked + span.sheet-tab1,
+input.sheet-tab11:checked + span.sheet-tab11,
+input.sheet-tab12:checked + span.sheet-tab12,
+input.sheet-tab13:checked + span.sheet-tab13,
+input.sheet-tab14:checked + span.sheet-tab14,
+input.sheet-tab2:checked + span.sheet-tab2,
+input.sheet-tab3:checked + span.sheet-tab3,
+input.sheet-tab30:checked + span.sheet-tab30,
+input.sheet-tab31:checked + span.sheet-tab31,
+input.sheet-tab32:checked + span.sheet-tab32,
+input.sheet-tab33:checked + span.sheet-tab33,
+input.sheet-tab34:checked + span.sheet-tab34,
+input.sheet-tab35:checked + span.sheet-tab35,
+input.sheet-tab36:checked + span.sheet-tab36,
+input.sheet-tab37:checked + span.sheet-tab37,
+input.sheet-tab4:checked + span.sheet-tab4,
+input.sheet-tab41:checked + span.sheet-tab41,
+input.sheet-tab42:checked + span.sheet-tab42,
+input.sheet-tab43:checked + span.sheet-tab43,
+input.sheet-tab44:checked + span.sheet-tab44,
+input.sheet-tab45:checked + span.sheet-tab45,
+input.sheet-tab5:checked + span.sheet-tab5,
+input.sheet-tab51:checked + span.sheet-tab51,
+input.sheet-tab52:checked + span.sheet-tab52,
+input.sheet-tab53:checked + span.sheet-tab53,
+input.sheet-tab54:checked + span.sheet-tab54,
+input.sheet-tab55:checked + span.sheet-tab55,
+input.sheet-tab56:checked + span.sheet-tab56,
+input.sheet-tab57:checked + span.sheet-tab57,
+input.sheet-tab6:checked + span.sheet-tab6,
+input.sheet-tab61:checked + span.sheet-tab61,
+input.sheet-tab62:checked + span.sheet-tab62,
+input.sheet-tab63:checked + span.sheet-tab63,
+input.sheet-tab64:checked + span.sheet-tab64,
+input.sheet-tab7:checked + span.sheet-tab7,
+input.sheet-tab8:checked + span.sheet-tab8 ,
+input.sheet-tab9:checked + span.sheet-tab9 ,
+input.sheet-tab91:checked + span.sheet-tab91,
+input.sheet-tab92:checked + span.sheet-tab92 {
+    background: gray;    
+    color: white;
+}
+
+input.sheet-hidden {
+	display: none;
+}
+
+/*-------------------------------------------Anzeigeoptionen-----------------------------------*/
+
+
+.sheet-verstecke-magie:checked ~ .sheet-magie,
+.sheet-verstecke-goetterwirken:checked ~ .sheet-goetterwirken,
+.sheet-verstecke-inventar:checked ~ .sheet-inventar,
+.sheet-verstecke-notizen:checked ~ .sheet-notizen
+{
     display: none;
 }
 
@@ -285,16 +341,21 @@ input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
     display: none;
 }
 
-.sheet-versteckeLiturgien:checked + input.sheet-tab6,
-.sheet-versteckeLiturgien:checked ~ span.sheet-tab6,
-.sheet-versteckeLiturgien:checked + div.sheet-section-Liturgien {
-    display: none;
-}
-
 .sheet-show-optional:not(:checked) + div.sheet-optional {
     display: none;
 }
 
+.sheet-zeige-fernkampf:not(:checked) ~ .sheet-fernkampf {
+	display: none;
+}
+
+.sheet-zeige-schilde:not(:checked) ~ .sheet-schilde {
+	display: none;
+}
+
+.sheet-zeige-parierwaffen:not(:checked) ~ .sheet-parierwaffen {
+	display: none;
+}
 
 .sheet-liturgie-aktiviert:checked + div.sheet-zauber {
     display: inline-block;  
@@ -303,6 +364,18 @@ input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
 
 .sheet-zauberzeichen-aktiviert:not(:checked) + div.sheet-zauberzeichen {
     display: none;  
+}
+
+.sheet-nahkampfPatzerTabelle:not(:checked) + button.sheet-optional,
+.sheet-fernkampfPatzerTabelle:not(:checked) + button.sheet-optional,
+.sheet-verteidigungPatzerTabelle:not(:checked) + button.sheet-optional {
+    display:none;
+}
+
+.sheet-nahkampfPatzerTabelle:checked ~ button.sheet-default,
+.sheet-fernkampfPatzerTabelle:checked ~ button.sheet-default ,
+.sheet-verteidigungPatzerTabelle:checked ~ button.sheet-default   {
+    display:none;   
 }
 
 /*-------------------------------------------------Tooltips--------------------------------------*/
@@ -349,29 +422,58 @@ input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
     display: block;
 }
 
-.sheet-versteckeSchildparade:checked + div.sheet-kampf-optional {
-    display: none;
+/*--------------------------------------Stylings - Grundwerte--------------------------------------*/
+
+.sheet-eigenschaft
+{
+	text-align:left;
 }
 
-.sheet-nahkampfPatzerTabelle:not(:checked) + button.sheet-optional,
-.sheet-fernkampfPatzerTabelle:not(:checked) + button.sheet-optional,
-.sheet-verteidigungPatzerTabelle:not(:checked) + button.sheet-optional {
-    display:none;
-}
-
-.sheet-nahkampfPatzerTabelle:checked ~ button.sheet-default,
-.sheet-fernkampfPatzerTabelle:checked ~ button.sheet-default ,
-.sheet-verteidigungPatzerTabelle:checked ~ button.sheet-default   {
-    display:none;   
-}
-
-
-
-.sheet-kampf-passiv:checked + div.sheet-sf-row ,
-.sheet-sf-aktiviert:checked + div.sheet-sf-row {
-    display: inline-block;  
+.sheet-eigenschaft-name
+{
+	width:8em;
+    display: inline-block;
     white-space: nowrap;
 }
+
+.sheet-eigenschaft-wert,
+.sheet-eigenschaft-basiswert,
+.sheet-eigenschaft-mod,
+.sheet-eigenschaft-zukauf,
+.sheet-eigenschaft-max,
+.sheet-eigenschaft-fix,
+.sheet-eigenschaft-proben
+{
+	width:3.5em;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.sheet-grundwert
+{
+	text-align:left;
+}
+
+.sheet-grundwert-name
+{
+	width:8em;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.sheet-grundwert-wert,
+.sheet-grundwert-basiswert,
+.sheet-grundwert-mod,
+.sheet-grundwert-zukauf,
+.sheet-grundwert-max,
+.sheet-grundwert-fix
+{
+	width:3.5em;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+/*--------------------------------------Stylings - Talente--------------------------------------*/
 
 .sheet-berufsgeheimnis,
 .sheet-allgemeine-sf {
@@ -394,27 +496,100 @@ input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
     white-space: nowrap;
 }
 
+/*--------------------------------------Stylings - Kampf--------------------------------------*/
+
+.sheet-kampf-passiv:checked + div.sheet-sf-row ,
+.sheet-sf-aktiviert:checked + div.sheet-sf-row {
+    display: inline-block;  
+    white-space: nowrap;
+}
+
+select.sheet-max-stufe {
+	display: none;
+}
+
+.sheet-stufe-aktiviert:checked + select.sheet-max-stufe {
+	display: inline-block;
+}
+
+
+.sheet-waffenauswahl,
+.sheet-schildauswahl,
+.sheet-parierwaffenauswahl,
+.sheet-fernwaffenauswahl
+{
+    text-align: left;
+    white-space: nowrap;
+    display: inline-block;
+}
+
+.sheet-waffenauswahl-name,
+.sheet-schildauswahl-name,
+.sheet-parierwaffenauswahl-name,
+.sheet-fernwaffenauswahl-name
+{
+	width:11em;
+}
+.sheet-waffenauswahl-at,
+.sheet-waffenauswahl-pa,
+.sheet-schildauswahl-at,
+.sheet-schildauswahl-pa,
+.sheet-parierwaffenauswahl-at,
+.sheet-parierwaffenauswahl-pa,
+.sheet-fernwaffenauswahl-fk
+{
+	width:3em;
+}
+
+.sheet-waffenauswahl-als-zh,
+.sheet-schildauswahl-struktur
+{
+	width:4em;
+}
+
+.sheet-waffenauswahl-aktiv,
+.sheet-schildauswahl-aktiv,
+.sheet-parierwaffenauswahl-aktiv,
+.sheet-fernwaffenauswahl-aktiv 
+{
+	width:2em;
+	text-align: right;
+}
+
+
+.sheet-waffenauswahl-name,
+.sheet-waffenauswahl-at,
+.sheet-waffenauswahl-pa,
+.sheet-waffenauswahl-aktiv,
+.sheet-waffenauswahl-als-zh,
+.sheet-schildauswahl-name,
+.sheet-schildauswahl-at,
+.sheet-schildauswahl-pa,
+.sheet-schildauswahl-aktiv,
+.sheet-schildauswahl-stuktur,
+.sheet-parierwaffenauswahl-name,
+.sheet-parierwaffenauswahl-at,
+.sheet-parierwaffenauswahl-pa,
+.sheet-parierwaffenauswahl-aktiv,
+.sheet-fernwaffenauswahl-name,
+.sheet-fernwaffenauswahl-aktiv,
+.sheet-fernwaffenauswahl-fk
+{
+    display: inline-block;
+}
+
+/*--------------------------------------Stylings - Magie--------------------------------------*/
+
+.sheet-zauber-aktiviert
+{
+	display: none;
+}
 
 .sheet-zauber-aktiviert:checked + div.sheet-zauber
  {
     display: inline-block;
     white-space: nowrap;
 }
-
-.sheet-grundwert-name
-{
-	text-align:left;
-	width:10em;
-}
-
-.sheet-grundwert-name,
-.sheet-grundwert-wert
-{
-    display: inline-block;
-    white-space: nowrap;
-}
-	
-
 
 .sheet-zauber-bannderdunkelheit:checked + div.sheet-zauber,
 .sheet-zauber-bannderfurcht:checked + div.sheet-zauber,
@@ -691,45 +866,6 @@ input.sheet-show-nicht-humanoid:checked ~ .sheet-humanoid {
 
 .sheet-elfenlieder-fw {
     width:3em; 
-}
-
-input.sheet-tab1:checked + span.sheet-tab1,
-input.sheet-tab11:checked + span.sheet-tab11,
-input.sheet-tab12:checked + span.sheet-tab12,
-input.sheet-tab13:checked + span.sheet-tab13,
-input.sheet-tab14:checked + span.sheet-tab14,
-input.sheet-tab2:checked + span.sheet-tab2,
-input.sheet-tab3:checked + span.sheet-tab3,
-input.sheet-tab30:checked + span.sheet-tab30,
-input.sheet-tab31:checked + span.sheet-tab31,
-input.sheet-tab32:checked + span.sheet-tab32,
-input.sheet-tab33:checked + span.sheet-tab33,
-input.sheet-tab34:checked + span.sheet-tab34,
-input.sheet-tab35:checked + span.sheet-tab35,
-input.sheet-tab36:checked + span.sheet-tab36,
-input.sheet-tab37:checked + span.sheet-tab37,
-input.sheet-tab4:checked + span.sheet-tab4,
-input.sheet-tab41:checked + span.sheet-tab41,
-input.sheet-tab42:checked + span.sheet-tab42,
-input.sheet-tab43:checked + span.sheet-tab43,
-input.sheet-tab44:checked + span.sheet-tab44,
-input.sheet-tab45:checked + span.sheet-tab45,
-input.sheet-tab5:checked + span.sheet-tab5,
-input.sheet-tab51:checked + span.sheet-tab51,
-input.sheet-tab52:checked + span.sheet-tab52,
-input.sheet-tab53:checked + span.sheet-tab53,
-input.sheet-tab54:checked + span.sheet-tab54,
-input.sheet-tab55:checked + span.sheet-tab55,
-input.sheet-tab56:checked + span.sheet-tab56,
-input.sheet-tab57:checked + span.sheet-tab57,
-input.sheet-tab6:checked + span.sheet-tab6,
-input.sheet-tab7:checked + span.sheet-tab7,
-input.sheet-tab8:checked + span.sheet-tab8 ,
-input.sheet-tab9:checked + span.sheet-tab9 ,
-input.sheet-tab91:checked + span.sheet-tab91,
-input.sheet-tab92:checked + span.sheet-tab92 {
-    background: gray;    
-    color: white;
 }
 
 /*--------------------------------------------Roll Templates-------------------------------------*/

--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -4,7 +4,7 @@
     <h4>Created by Patrick Gebhardt, enhanced by Sönke Holsten</h4>
     <br>
 
-	<input type="text" name="attr_version" class=hidden" value="new-version" />
+	<input type="text" name="attr_version" class="hidden" value="new-version" />
 
 	<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" checked="checked"/>
     <span class="sheet-tab sheet-tab1">Allgemein</span>

--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -1,7 +1,7 @@
 <div align="center">
     <img align="center" width="400" src="http://i.imgur.com/mVMQ7fW.png" />
-    <h4>DSA5 Character Sheet German Ver. 0.5</h4>
-    <h4>Created by Patrick Gebhardt</h4>
+    <h4>DSA5 Character Sheet German Ver. 0.9</h4>
+    <h4>Created by Patrick Gebhardt, enhanced by Sönke Holsten</h4>
     <br>
 
 	<input type="text" name="attr_version" class=hidden" value="new-version" />
@@ -10275,8 +10275,8 @@
     </div>
     
     
-    <br><b>DSA5 Character Sheet German Ver. 0.5</b>
-    <br><b>Created by Patrick Gebhardt</b>
+    <br><b>DSA5 Character Sheet German Ver. 0.9</b>
+    <br><b>Created by Patrick Gebhardt, enhanced by Sönke Holsten</b>
     <br><b>DAS SCHWARZE AUGE, AVENTURIEN, DERE, MYRANOR, THARUN, UTHURIA und RIESLAND sind eingetragene Marken der Significant Fantasy Medienrechte GbR. Ohne vorherige schriftliche Genehmigung der Ulisses Medien und Spiel Distribution GmbH ist eine Verwendung der genannten Markenzeichen nicht gestattet.</b>
 
 

--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -4,42 +4,45 @@
     <h4>Created by Patrick Gebhardt</h4>
     <br>
 
-  	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" title="Allgemein" checked="checked"/>
+	<input type="text" name="attr_version" class=hidden" value="new-version" />
+
+	<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" checked="checked"/>
     <span class="sheet-tab sheet-tab1">Allgemein</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Status"/>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" />
     <span class="sheet-tab sheet-tab2">Status</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Talente"/>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" />
     <span class="sheet-tab sheet-tab3">Talente</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="4" title="Kampf"/>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="4" />
     <span class="sheet-tab sheet-tab4">Kampf</span>
-    <input type="checkbox" class="sheet-versteckeMagie" name="attr_MagieTab" style="display:none;" />
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab5" value="5" title="Magie"/>
-    <span class="sheet-tab sheet-tab5">Magie</span>
-    <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab" style="display:none;" />
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab6" value="6" title="Götterwirken"/>
-    <span class="sheet-tab sheet-tab6">Götterwirken</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab7 sheet-kein-gegner" value="7" title="Inventar"/>
-    <span class="sheet-tab sheet-tab7 sheet-kein-gegner">Inventar</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab8 sheet-kein-gegner" value="8" title="Notizen"/>
-    <span class="sheet-tab sheet-tab8 sheet-kein-gegner">Notizen</span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9" title="Konfiguration"/>
+    <input type="checkbox" class="hidden sheet-verstecke-magie" name="attr_verstecke_magie" />
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab5 sheet-magie" value="5" />
+    <span class="sheet-tab sheet-tab5 sheet-magie">Magie</span>
+    <input type="checkbox" class="hidden sheet-verstecke-goetterwirken" name="attr_verstecke_goetterwirken" />
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab6 sheet-goetterwirken" value="6" />
+    <span class="sheet-tab sheet-tab6 sheet-goetterwirken">Götterwirken</span>
+    <input type="checkbox" class="hidden sheet-verstecke-inventar" name="attr_verstecke_inventar" />
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab7 sheet-inventar" value="7" />
+    <span class="sheet-tab sheet-tab7 sheet-inventar">Inventar</span>
+    <input type="checkbox" class="hidden sheet-verstecke-notizen" name="attr_verstecke_notizen" />
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab8 sheet-notizen" value="8" />
+    <span class="sheet-tab sheet-tab8 sheet-notizen">Notizen</span>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab9" value="9" />
     <span class="sheet-tab sheet-tab9">Konfiguration</span>
     <br/>
        
     <div class="sheet-section sheet-section-Allgemein" align="center">
-        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab11" value="11" title="Grundwerte" checked="checked"/>
+        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab11" value="11" checked="checked"/>
             <span class="sheet-tab sheet-tab11">Grundwerte</span>
-        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab12" value="12" title="Vorteile"/>
+        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab12" value="12" />
             <span class="sheet-tab sheet-tab12">Vorteile</span>
-        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab13" value="13" title="Nachteile"/>
+        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab13" value="13" />
             <span class="sheet-tab sheet-tab13">Nachteile</span>
-        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab14" value="14" title="Sonderfertigkeiten"/>
+        <input type="radio" name="attr_allgemein_tab" class="sheet-tab sheet-tab14" value="14" />
             <span class="sheet-tab sheet-tab14">Sonderfertigkeit.</span>
         <br>        
         
         <div class="sheet-section sheet-section-Grundwerte" align="center"> 
-        	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
+        	<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
         	<div class="sheet-kein-gegner">
 	            <table>
 	            <tr>
@@ -63,15 +66,11 @@
 	            <tr>
 	                <td>Spezies</td>
 	                <td>
-	                    <input style="display:none;" name="attr_spezies_mensch" type="number" disabled="true" value="1-ceil((@{Spezies}%3)/100)"/>
-	                    <input style="display:none;" name="attr_spezies_elf" type="number" disabled="true" value="1-ceil((@{Spezies}%5)/100)"/>
-	                    <input style="display:none;" name="attr_spezies_halbelf" type="number" disabled="true" value="1-ceil((@{Spezies}%7)/100)"/>
-	                    <input style="display:none;" name="attr_spezies_zwerg" type="number" disabled="true" value="1-ceil((@{Spezies}%11)/100)"/>
 	                    <select name="attr_Spezies">
-	                        <option value="3">Mensch</option>
-	                        <option value="5">Elf</option>
-	                        <option value="7">Halbelf</option>
-	                        <option value="11">Zwerg</option>
+	                        <option value="Mensch">Mensch</option>
+	                        <option value="Elf">Elf</option>
+	                        <option value="Halbelf">Halbelf</option>
+	                        <option value="Zwerg">Zwerg</option>
 	                    </select>
 	                </td>
 	                <td>Größe</td>
@@ -93,7 +92,7 @@
 	                        <option value="Kompetent">Kompetent</option>
 	                        <option value="Meisterlich">Meisterlich</option>
 	                        <option value="Brillant">Brillant</option>
-	                        <option value="Legendär">Legendär</option>
+	                        <option value="Legendaer">Legendär</option>
 	                    </select>
 	                </td>
 	            </tr>
@@ -161,26 +160,26 @@
 	            <tr>
 	                <td>Typus</td>
 	                <td>
-	                    <input style="display:none;" name="attr_typus_beseelter" type="number" disabled="true" value="1-ceil((@{Typus}%3)/100)"/>
-	                    <input style="display:none;" name="attr_typus_chimaere" type="number" disabled="true" value="1-ceil((@{Typus}%5)/100)"/>
-	                    <input style="display:none;" name="attr_typus_daimonid" type="number" disabled="true" value="1-ceil((@{Typus}%7)/100)"/>
-	                    <input style="display:none;" name="attr_typus_daemon" type="number" disabled="true" value="1-ceil((@{Typus}%11)/100)"/>
-	                    <input style="display:none;" name="attr_typus_drache" type="number" disabled="true" value="1-ceil((@{Typus}%13)/100)"/>
-	                    <input style="display:none;" name="attr_typus_elementar" type="number" disabled="true" value="1-ceil((@{Typus}%17)/100)"/>
-	                    <input style="display:none;" name="attr_typus_fee" type="number" disabled="true" value="1-ceil((@{Typus}%19)/100)"/>
-	                    <input style="display:none;" name="attr_typus_geist" type="number" disabled="true" value="1-ceil((@{Typus}%23)/100)"/>
-	                    <input style="display:none;" name="attr_typus_golem" type="number" disabled="true" value="1-ceil((@{Typus}%29)/100)"/>
-	                    <input style="display:none;" name="attr_typus_hirnloser" type="number" disabled="true" value="1-ceil((@{Typus}%31)/100)"/>
-	                    <input style="display:none;" name="attr_typus_kulturschaffender" type="number" disabled="true" value="1-ceil((@{Typus}%37)/100)"/>
-	                    <input style="display:none;" name="attr_typus_pflanze" type="number" disabled="true" value="1-ceil((@{Typus}%41)/100)"/>
-	                    <input style="display:none;" name="attr_typus_pilz" type="number" disabled="true" value="1-ceil((@{Typus}%43)/100)"/>
-	                    <input style="display:none;" name="attr_typus_tier" type="number" disabled="true" value="1-ceil((@{Typus}%47)/100)"/>
-	                    <input style="display:none;" name="attr_typus_untoter" type="number" disabled="true" value="1-ceil((@{Typus}%53)/100)"/>
-	                    <input style="display:none;" name="attr_typus_vampir" type="number" disabled="true" value="1-ceil((@{Typus}%59)/100)"/>
-	                    <input style="display:none;" name="attr_typus_lebewesen" type="number" disabled="true" value="@{typus_kulturschaffender}+@{typus_tier}+@{typus_pflanze}+@{typus_pilz}+@{typus_uebernatuerliches_lebewesen}"/>
-	                    <input style="display:none;" name="attr_typus_uebernatuerliches_lebewesen" type="number" disabled="true" value="@{typus_fee}+@{typus_chimaere}+@{typus_drache}+@{typus_daimonid}"/>
-	                    <input style="display:none;" name="attr_typus_nicht_lebender" type="number" disabled="true" value="@{typus_untoter_gattung}+@{typus_daemon}+@{typus_elementar}+@{typus_golem}"/>
-	                    <input style="display:none;" name="attr_typus_untoter_gattung" type="number" disabled="true" value="@{typus_untoter}+@{typus_geist}+@{typus_hirnloser}+@{typus_vampir}+@{typus_beseelter}"/>
+	                    <input class="hidden" name="attr_typus_beseelter" type="number" disabled="true" value="1-ceil((@{Typus}%3)/100)"/>
+	                    <input class="hidden" name="attr_typus_chimaere" type="number" disabled="true" value="1-ceil((@{Typus}%5)/100)"/>
+	                    <input class="hidden" name="attr_typus_daimonid" type="number" disabled="true" value="1-ceil((@{Typus}%7)/100)"/>
+	                    <input class="hidden" name="attr_typus_daemon" type="number" disabled="true" value="1-ceil((@{Typus}%11)/100)"/>
+	                    <input class="hidden" name="attr_typus_drache" type="number" disabled="true" value="1-ceil((@{Typus}%13)/100)"/>
+	                    <input class="hidden" name="attr_typus_elementar" type="number" disabled="true" value="1-ceil((@{Typus}%17)/100)"/>
+	                    <input class="hidden" name="attr_typus_fee" type="number" disabled="true" value="1-ceil((@{Typus}%19)/100)"/>
+	                    <input class="hidden" name="attr_typus_geist" type="number" disabled="true" value="1-ceil((@{Typus}%23)/100)"/>
+	                    <input class="hidden" name="attr_typus_golem" type="number" disabled="true" value="1-ceil((@{Typus}%29)/100)"/>
+	                    <input class="hidden" name="attr_typus_hirnloser" type="number" disabled="true" value="1-ceil((@{Typus}%31)/100)"/>
+	                    <input class="hidden" name="attr_typus_kulturschaffender" type="number" disabled="true" value="1-ceil((@{Typus}%37)/100)"/>
+	                    <input class="hidden" name="attr_typus_pflanze" type="number" disabled="true" value="1-ceil((@{Typus}%41)/100)"/>
+	                    <input class="hidden" name="attr_typus_pilz" type="number" disabled="true" value="1-ceil((@{Typus}%43)/100)"/>
+	                    <input class="hidden" name="attr_typus_tier" type="number" disabled="true" value="1-ceil((@{Typus}%47)/100)"/>
+	                    <input class="hidden" name="attr_typus_untoter" type="number" disabled="true" value="1-ceil((@{Typus}%53)/100)"/>
+	                    <input class="hidden" name="attr_typus_vampir" type="number" disabled="true" value="1-ceil((@{Typus}%59)/100)"/>
+	                    <input class="hidden" name="attr_typus_lebewesen" type="number" disabled="true" value="@{typus_kulturschaffender}+@{typus_tier}+@{typus_pflanze}+@{typus_pilz}+@{typus_uebernatuerliches_lebewesen}"/>
+	                    <input class="hidden" name="attr_typus_uebernatuerliches_lebewesen" type="number" disabled="true" value="@{typus_fee}+@{typus_chimaere}+@{typus_drache}+@{typus_daimonid}"/>
+	                    <input class="hidden" name="attr_typus_nicht_lebender" type="number" disabled="true" value="@{typus_untoter_gattung}+@{typus_daemon}+@{typus_elementar}+@{typus_golem}"/>
+	                    <input class="hidden" name="attr_typus_untoter_gattung" type="number" disabled="true" value="@{typus_untoter}+@{typus_geist}+@{typus_hirnloser}+@{typus_vampir}+@{typus_beseelter}"/>
   	                    <select name="attr_Typus">
 	                        <option value="0">---</option>
 	                        <option value="3">Beseelter</option>
@@ -225,288 +224,201 @@
 	        </table>
        	</div>
         <br />
-       	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
-       	<div class="sheet-kein-gegner">
         <table>
             <tr>
                 <td>	
-                    <table>
-                        <tr align=center>
-                            <td></td>
-                            <td>GW</td>
-                            <td>Wert</td>
-                            <td>Mod</td>
-                            <td>Zukauf</td>
-                            <td>Max</td>
-                        </tr>
-                        <tr>
-                            <td>Mut</td>
-                            <td><input type="number" name="attr_MU_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_MU_Wert" value="((@{MU_Grundwert}+@{MU_Mod}+@{MU_Zukauf}))*(1-@{gegner_sheet})+@{MU_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_MU_Mod" value="0"></td>
-                            <td><input type="number" name="attr_MU_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_MU_Max" value="round(@{MU_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Mut}} {{Probe=[[@{MU_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Klugheit</td>
-                            <td><input type="number" name="attr_KL_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KL_Wert" value="((@{KL_Grundwert}+@{KL_Mod}+@{KL_Zukauf}))*(1-@{gegner_sheet})+@{KL_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_KL_Mod" value="0"></td>
-                            <td><input type="number" name="attr_KL_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_KL_Max" value="round(@{KL_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Klugheit}} {{Probe=[[@{KL_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Intuition</td>
-                            <td><input type="number" name="attr_IN_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_IN_Wert" value="((@{IN_Grundwert}+@{IN_Mod}+@{IN_Zukauf}))*(1-@{gegner_sheet})+@{IN_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_IN_Mod" value="0"></td>
-                            <td><input type="number" name="attr_IN_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_IN_Max" value="round(@{IN_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Intuition}} {{Probe=[[@{IN_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Charisma</td>
-                            <td><input type="number" name="attr_CH_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_CH_Wert" value="((@{CH_Grundwert}+@{CH_Mod}+@{CH_Zukauf}))*(1-@{gegner_sheet})+@{CH_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_CH_Mod" value="0"></td>
-                            <td><input type="number" name="attr_CH_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_CH_Max" value="round(@{CH_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Charisma}} {{Probe=[[@{CH_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Fingerfertigkeit</td>
-                            <td><input type="number" name="attr_FF_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_FF_Wert" value="((@{FF_Grundwert}+@{FF_Mod}+@{FF_Zukauf}))*(1-@{gegner_sheet})+@{FF_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_FF_Mod" value="0"></td>
-                            <td><input type="number" name="attr_FF_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_FF_Max" value="round(@{FF_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Fingerfertigkeit}} {{Probe=[[@{FF_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Gewandheit</td>
-                            <td><input type="number" name="attr_GE_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_GE_Wert" value="((@{GE_Grundwert}+@{GE_Mod}+@{GE_Zukauf}))*(1-@{gegner_sheet})+@{GE_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_GE_Mod" value="0"></td>
-                            <td><input type="number" name="attr_GE_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_GE_Max" value="round(@{GE_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Gewandheit}} {{Probe=[[@{GE_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>                
-                        </tr>
-                        <tr>
-                            <td>Konstitution</td>
-                            <td><input type="number" name="attr_KO_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KO_Wert" value="((@{KO_Grundwert}+@{KO_Mod}+@{KO_Zukauf}))*(1-@{gegner_sheet})+@{KO_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_KO_Mod" value="0"></td>
-                            <td><input type="number" name="attr_KO_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_KO_Max" value="round(@{KO_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Konstitution}} {{Probe=[[@{KO_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Körperkraft</td>
-                            <td><input type="number" name="attr_KK_Grundwert" value="8"></td>
-                            <td><input type="number" disabled=true name="attr_KK_Wert" value="((@{KK_Grundwert}+@{KK_Mod}+@{KK_Zukauf}))*(1-@{gegner_sheet})+@{KK_Wert_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_KK_Mod" value="0"></td>
-                            <td><input type="number" name="attr_KK_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_KK_Max" value="round(@{KK_Grundwert}*1.5)"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Körperkraft}} {{Probe=[[@{KK_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                    </table>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name"></div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner">Start</div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner">Zukauf</div>
+                		<div class="eigenschaft-max sheet-kein-gegner">Max</div>
+                		<div class="eigenschaft-wert sheet-kein-gegner">Wert</div>
+                		<div class="eigenschaft-max sheet-gegner">Wert</div>
+                		<div class="eigenschaft-proben"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Mut</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_MU_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_MU_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_MU_Max" value="round(@{MU_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_MU_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Mut}} {{Probe=[[@{MU_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}" /></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Klugheit</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_KL_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_KL_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_KL_Max" value="round(@{KL_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_KL_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Klugheit}} {{Probe=[[@{KL_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}" /></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Intuition</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_IN_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_IN_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_IN_Max" value="round(@{IN_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_IN_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Intuition}} {{Probe=[[@{IN_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Charisma</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_CH_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_CH_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_CH_Max" value="round(@{CH_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_CH_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Charisma}} {{Probe=[[@{CH_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Fingerfertigkeit</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_FF_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_FF_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_FF_Max" value="round(@{FF_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_FF_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Fingerfertigkeit}} {{Probe=[[@{FF_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Gewandheit</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_GE_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_GE_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_GE_Max" value="round(@{GE_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_GE_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Gewandheit}} {{Probe=[[@{GE_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Konstitution</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_KO_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_KO_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_KO_Max" value="round(@{KO_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_KO_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Konstitution}} {{Probe=[[@{KO_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
+                	<div class="eigenschaft">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="eigenschaft-name">Körperkraft</div>
+                		<div class="eigenschaft-basiswert sheet-kein-gegner"><input type="number" name="attr_KK_Grundwert" value="8"></div>
+                		<div class="eigenschaft-zukauf sheet-kein-gegner"><input type="number" name="attr_KK_Zukauf" value="0"></div>
+                		<div class="eigenschaft-max sheet-kein-gegner"><input type="number" disabled=true name="attr_KK_Max" value="round(@{KK_Grundwert}*0.5)"></div>
+                		<div class="eigenschaft-wert"><input type="number" name="attr_KK_Wert" value="8"></div>
+                		<div class="eigenschaft-proben"><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Körperkraft}} {{Probe=[[@{KK_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></div>
+                	</div>
                 </td>
                 <td width="20px"></td>        
                 <td>    
-                    <table>
-                        <tr align=center>
-                            <td></th>
-                            <td>GW</td>
-                            <td>Wert</td>
-                            <td>Mod</td>
-                            <td>Zukauf</td>
-                            <td>Max</td>
-                        </tr>
-                        <tr>
-                            <td>Lebensenergie</td>
-                            <td><input type="number" name="attr_LE_Grundwert" disabled="true" value="(@{spezies_mensch})*5+(@{spezies_elf})*2+(@{spezies_halbelf})*5+(@{spezies_zwerg})*8+2*@{KO_Wert}+@{vorteil_hohe_lebenskraft_stufe}-@{nachteil_niedrige_lebenskraft_stufe}"></td>
-                            <td><input type="number" name="attr_LE_Wert" value="0"></td>
-                            <td><input type="number" name="attr_LE_Mod" value="0"></td>
-                            <td><input type="number" name="attr_LE_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_LE_Max" value="@{LE_Grundwert}+@{LE_Zukauf}+@{LE_Mod}"></td>
-                        </tr>
-                        <tr class="sheet-ae">
-                            <td>Astralenenergie</td>
-                            <td><input type="number" name="attr_AE_Grundwert" disabled="true" value="@{vorteil_zauberer}*(@{vorteil_zauberer}*20+@{AE_Leiteigenschaft}+@{vorteil_hohe_astralkraft_stufe}+@{nachteil_niedrige_astralkraft_stufe})"></td>
-                            <td><input type="number" name="attr_AE_Wert" value="0"></td>
-                            <td><input type="number" name="attr_AE_Mod" value="0"></td>
-                            <td><input type="number" name="attr_AE_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_AE_Max" value="@{AE_Grundwert}+@{AE_Zukauf}+@{AE_Mod}"></td>
-                            <td>
-                                <input type="number" disabled="true" style="display:none;" name="attr_AE_Leiteigenschaft" value="(@{tradition_gildenmagier}) * @{KL_Wert} + (@{tradition_hexe}) * @{CH_Wert} + (@{tradition_elf}) * @{IN_Wert}"/>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Karmaenergie</td>
-                            <td><input type="number" name="attr_KE_Grundwert" disabled="true" value="@{vorteil_geweihter}*20+@{KE_Leiteigenschaft}+@{vorteil_hohe_karmalkraft_stufe}-@{nachteil_niedrige_karmalkraft_stufe}"></td>
-                            <td><input type="number" name="attr_KE_Wert" value="0"></td>
-                            <td><input type="number" name="attr_KE_Mod" value="0"></td>
-                            <td><input type="number" name="attr_KE_Zukauf" value="0"></td>
-                            <td><input type="number" disabled=true name="attr_KE_Max" value="@{KE_Grundwert}+@{KE_Zukauf}+@{KE_Mod}"></td>
-                            <td>
-                                <select name="attr_KE_Leiteigenschaft" style="width: 4.25em;">
-                                    <option value="0">---</option>
-                                    <option value="@{MU_Wert}">MU</option>
-                                    <option value="@{KL_Wert}">KL</option>
-                                    <option value="@{IN_Wert}">IN</option>
-                                    <option value="@{CH_Wert}">CH</option>
-                                    <option value="@{FF_Wert}">FF</option>
-                                    <option value="@{GE_Wert}">GE</option>
-                                    <option value="@{KO_Wert}">KO</option>
-                                    <option value="@{KK_Wert}">KK</option>
-                                </select>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Schicksalspunkte</td>
-                            <td><input type="number" name="attr_SchicksalGW" value="3+@{Schicksal_Mod}+@{vorteil_glueck_stufe}-@{nachteil_pech_stufe}" disabled="true"></td>
-                            <td><input type="number" name="attr_Schicksal_Wert" value="3"></td>
-                            <td><input type="number" name="attr_Schicksal_Mod" value="0"></td>
-                        </tr>
-                        <tr>
-                            <td>Seelenkraft</td>
-                            <td><input type="number" disabled="true" name="attr_SK_Grundwert" value="-5*(@{spezies_mensch})-4*(@{spezies_elf})-4*(@{spezies_halbelf})-4*(@{spezies_zwerg})+round((@{MU_Wert}+@{KL_Wert}+@{IN_Wert})/6)+@{vorteil_hohe_seelenkraft}-@{nachteil_niedrige_seelenkraft}+@{SK_Mod}"></td>
-                            <td></td>
-                            <td><input type="number" name="attr_SK_Mod" value="0"></td>
-                        </tr>
-                        <tr>
-                            <td>Zähigkeit</td>
-                            <td><input type="number" disabled="true" name="attr_ZK_Grundwert" value="-5*(@{spezies_mensch})-6*(@{spezies_elf})-6*(@{spezies_halbelf})-4*(@{spezies_zwerg})+round((@{KO_Wert}+@{KO_Wert}+@{KK_Wert})/6)+@{vorteil_hohe_zaehigkeit}-@{nachteil_niedrige_zaehigkeit}+@{ZK_Mod}"></td>
-                            <td></td>
-                            <td><input type="number" name="attr_ZK_Mod" value="0"></td>
-                        </tr>
-                        <tr>
-                            <td>Ausweichen</td>
-                            <td><input type="number" disabled="true" name="attr_Ausweichen_Grundwert" value="round((@{GE_Wert}/2)+(@{optPA_GW}/2))+@{sf_verb_ausweichen_stufe}"></td>
-                            <td><input type="number" disabled="true" name="attr_Ausweichen_Wert" value="@{Ausweichen_Grundwert}-@{Ges_BE}+@{Ausweichen_Mod}"></td>
-                            <td><input type="number" name="attr_Ausweichen_Mod" value="0"></td>
-                        </tr>
-                        <tr>
-                            <td>Initiative</td>
-                            <td><input type="number" disabled="true" name="attr_INI_Grundwert" value="round((@{MU_Wert}+@{GE_Wert})/2)+@{sf_kampfreflexe_stufe}"></td>
-                            <td><input type="number" disabled="true" name="attr_INI_Wert" value="@{INI_Grundwert}-@{Ges_BE}+@{RuestungsAbzuege}+@{INI_Mod}"></td>
-                            <td><input type="number" name="attr_INI_Mod" value="0"></td>
-                        </tr>
-                        <tr>
-                            <td>Geschwindigkeit</td>
-                            <td><input type="number" disabled="true" name="attr_GS_Grundwert" value="8*(@{spezies_mensch})+8*(@{spezies_elf})+8*(@{spezies_halbelf})+6*(@{spezies_zwerg})+@{vorteil_flink}-@{nachteil_behaebig}"></td>
-                            <td><input type="number" disabled="true" name="attr_GS_Wert" value="@{GS_Grundwert}-@{Ges_BE}+@{RuestungsAbzuege}+@{GS_Mod}"></td>
-                            <td><input type="number" name="attr_GS_Mod" value="0"></td>
-                        </tr>
-                    </table>
-                </td>
-            </tr>
-        </table>
-        </div>
-       	<div class="sheet-gegner">
-            <div class='sheet-3colrow'>
-                <div class='sheet-col'>
-                    <table>
-                        <tr>
-                            <td>Mut</td>
-                            <td><input type="number" name="attr_MU_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Mut}} {{Probe=[[@{MU_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Klugheit</td>
-                            <td><input type="number" name="attr_KL_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Klugheit}} {{Probe=[[@{KL_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Intuition</td>
-                            <td><input type="number" name="attr_IN_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Intuition}} {{Probe=[[@{IN_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Charisma</td>
-                            <td><input type="number" name="attr_CH_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Charisma}} {{Probe=[[@{CH_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Fingerfertigkeit</td>
-                            <td><input type="number" name="attr_FF_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Fingerfertigkeit}} {{Probe=[[@{FF_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Gewandheit</td>
-                            <td><input type="number" name="attr_GE_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Gewandheit}} {{Probe=[[@{GE_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>                
-                        </tr>
-                        <tr>
-                            <td>Konstitution</td>
-                            <td><input type="number" name="attr_KO_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Konstitution}} {{Probe=[[@{KO_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                        <tr>
-                            <td>Körperkraft</td>
-                            <td><input type="number" name="attr_KK_Wert_Fix" value="8"></td>
-                            <td><button type="roll" value="&{template:DSA-Eigenschaft} {{name=Körperkraft}} {{Probe=[[@{KK_Wert}+?{Erleichterung(+) / Erschwernis(-)|0}-1d20cs1cf20]]}}"></td>
-                        </tr>
-                    </table>
-                </div>
-                <div class='sheet-col'>
-                	<div>
+	                <input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                	<div class="grundwert">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="grundwert-name"></div>
+                		<div class="grundwert-basiswert sheet-kein-gegner">Grund</div>
+                		<div class="grundwert-wert">Aktuell</div>
+                		<div class="grundwert-zukauf sheet-kein-gegner">Zukauf</div>
+                		<div class="grundwert-max sheet-kein-gegner">Max</div>
+                	</div>
+                	<div class="grundwert">
+                		<input type="number" name="attr_LE_Spezies" value="5" style="display:none;" /> 
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Lebensenergie</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"><input type="number" name="attr_LE_Grundwert" disabled="true" value="@{LE_Spezies}+2*(@{KO_Wert})+@{vorteil_hohe_lebenskraft_stufe}-@{nachteil_niedrige_lebenskraft_stufe}+@{LE_Zukauf}"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_LE_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"><input type="number" name="attr_LE_Zukauf" value="0"></div>
+                		<div class="grundwert-max sheet-kein-gegner"><input type="number" disabled=true name="attr_LE_Zukauf_Max" value="@{KO_Wert}"></div>
                 	</div>
-                	<div>
+    				<input type="checkbox" class="sheet-verstecke-magie" name="attr_verstecke_magie" style="display:none;" />
+                	<div class="grundwert sheet-magie">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Astralenenergie</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"><input type="number" name="attr_AE_Grundwert" disabled="true" value="@{vorteil_zauberer}*(20+@{AE_Leiteigenschaft}+@{vorteil_hohe_astralkraft_stufe}+@{nachteil_niedrige_astralkraft_stufe}+@{AE_Zukauf})"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_AE_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"><input type="number" name="attr_AE_Zukauf" value="0"></div>
+                		<div class="grundwert-max sheet-kein-gegner"><input type="number" disabled=true name="attr_AE_Zukauf_Max" value="@{AE_Leiteigenschaft}"></div>
+                        <input style="display:none;" type="number" name="attr_AE_Leiteigenschaft" value="0"/>
                 	</div>
-                	<div>
+    				<input type="checkbox" class="sheet-verstecke-goetterwirken hidden" name="attr_verstecke_goetterwirken"  />
+                	<div class="grundwert sheet-goetterwirken">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Karmaenergie</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"><input type="number" name="attr_KE_Grundwert" disabled="true" value="@{vorteil_geweihter}*(20+@{KE_Leiteigenschaft}+@{vorteil_hohe_karmalkraft_stufe}-@{nachteil_niedrige_karmalkraft_stufe}+@{KE_Zukauf})"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_KE_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"><input type="number" name="attr_KE_Zukauf" value="0"></div>
+                		<div class="grundwert-max sheet-kein-gegner"><input type="number" disabled=true name="attr_KE_Zukauf_Max" value="@{KE_Leiteigenschaft}"></div>
+                        <input style="display:none;" type="number" name="attr_KE_Leiteigenschaft" value="0"/>
                 	</div>
-                	<div>
+                	<div class="grundwert">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Schicksalspunkte</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"><input type="number" name="attr_SchicksalGW" value="3+@{vorteil_glueck_stufe}-@{nachteil_pech_stufe}" disabled="true"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_Schicksal_Wert" value="3"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
                 	</div>
-                	<div>
+                	<div class="grundwert">
+                		<input class="hidden" type="number" name="attr_SK_Spezies" value="-5" /> 
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Seelenkraft</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_SK_Grundwert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
                 	</div>
-                	<div>
+                	<div class="grundwert">
+                		<input class="hidden" type="number" name="attr_ZK_Spezies" value="-5" /> 
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Zähigkeit</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"></div>
                 		<div class="grundwert-wert"><input type="number" name="attr_ZK_Grundwert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
                 	</div>
-                </div>
-                <div class='sheet-col'>
-	                <input type="checkbox" class="sheet-show-nicht-humanoid" name="attr_nicht_humanoid" style="display:none;" value="1" />
-                	<div class="sheet-nicht-humanoid">
+                	<div class="grundwert sheet-humanoid">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                		<div class="grundwert-name">Ausweichen</div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"></div>
+                		<div class="grundwert-wert "><input type="number" name="attr_Ausweichen_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
+                	</div>
+                	<div class="grundwert sheet-nicht-humanoid">
                 		<div class="grundwert-name">Verteidigung</div>
                 		<div class="grundwert-wert"><input type="number" name="attr_Verteidigung_Wert" value="0"></div>
                 	</div>
-                	<div class="sheet-humanoid">
-                		<div class="grundwert-name">Ausweichen</div>
-                		<div class="grundwert-wert"><input type="number" name="attr_Ausweichen_Wert" value="0"></div>
-                	</div>
-                	<div>
+                	<div class="grundwert">
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Initiative</div>
-                		<div class="grundwert-wert"><input type="number" name="attr_INI_Wert_Fix" value="0"></div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"></div>
+                		<div class="grundwert-wert"><input type="number" name="attr_INI_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
                 	</div>
-                	<div>
-                		<div class="grundwert-name">Rüstungsschutz</div>
-                		<div class="grundwert-wert"><input type="number" name="attr_RS_Fix" value="0"></div>
-                	</div>
-                	<div>
+                	<div class="grundwert">
+                		<input type="number" name="attr_GS_Spezies" value="8" style="display:none;"/> 
+       					<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
                 		<div class="grundwert-name">Geschwindigkeit</div>
-                		<div class="grundwert-wert"><input type="number" name="attr_GS_Wert_Fix" value="0"></div>
+                		<div class="grundwert-basiswert sheet-kein-gegner"></div>
+                		<div class="grundwert-wert"><input type="number" name="attr_GS_Wert" value="0"></div>
+                		<div class="grundwert-zukauf sheet-kein-gegner"></div>
+                		<div class="grundwert-max sheet-kein-gegner"></div>
                 	</div>
-                	<div>
+       				<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                	<div class="grundwert sheet-gegner">
                 		<div class="grundwert-name">Aktionen</div>
                 		<div class="grundwert-wert"><input type="number" name="attr_Aktionen" value="1"></div>
                 	</div>
-                </div>
-            </div>
+       				<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
+                	<div class="grundwert sheet-gegner">
+                		<div class="grundwert-name">Rüstungsschutz</div>
+                		<div class="grundwert-wert"><input type="number" name="attr_RS_Fix" value="0"></div>
+                	</div>
+                </td>
+            </tr>
+        </table>
        	</div>
-        </div>
         <div class="sheet-section sheet-section-Vorteile" align=center> 
         <h3>Vorteile</h3>
             <table style="align:left;">
@@ -2203,7 +2115,7 @@
 
     
     <div class="sheet-section sheet-section-Talente" align=center>
-        <input type="checkbox" name="attr_reduzierte_talentansicht" style="display:none;" class="sheet-reduzierte-talentansicht" value="1"/>
+        <input type="checkbox" name="attr_reduzierte_talentansicht" class="hidden sheet-reduzierte-talentansicht" />
         <input type="radio" name="attr_talent_tab" class="sheet-tab sheet-tab31" value="31" title="Koerper" checked="checked"/>
             <span class="sheet-tab sheet-tab31">Körper</span>
         <input type="radio" name="attr_talent_tab" class="sheet-tab sheet-tab32" value="32" title="Gesellschaft"/>
@@ -2218,7 +2130,7 @@
             <span class="sheet-tab sheet-tab36">Sprachen</span>
         <input type="radio" name="attr_talent_tab" class="sheet-tab sheet-tab37" value="37" title="Gaben"/>
             <span class="sheet-tab sheet-tab37">Gaben</span>
-        <br>
+        <br />
         <table align=center>
             <th>MU</th>
                 <th><input type="number" name=attr_MU2 disabled=true value="@{MU_Wert}"></th>
@@ -2237,7 +2149,7 @@
             <th>KK</th>
                 <th><input type="number" name=attr_KK2 disabled=true value="@{KK_Wert}"></th>
             <th>BE</th>
-                <th><input type="number" name=attr_BE_Talente disabled=true value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></th>
+                <th><input type="number" name=attr_BE_Talente disabled=true value="@{Ges_BE}"></th>
         </table>
 
         <div class="sheet-section sheet-section-Talente-reduziert" align=center> 
@@ -3115,6 +3027,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (+)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_basiliskentoeter" value="1" />
                                 <div>Basiliskentöter (+)</div>
@@ -3165,6 +3079,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (+)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_angenehmer_geruch" value="1" />
                                 <div>Angenehmer Geruch (+)</div>
@@ -3217,6 +3133,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (+)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_basiliskentoeter" value="1" />
                                 <div>Basiliskentöter (+)</div>
@@ -3259,6 +3177,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (+)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_basiliskentoeter" value="1" />
                                 <div>Basiliskentöter (+)</div>
@@ -3307,6 +3227,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (-)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_vorteil_basiliskentoeter" value="1" />
                                 <div>Basiliskentöter (-)</div>
@@ -3359,6 +3281,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                             </span>
                         </span>
                     </td>
@@ -3394,6 +3318,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Sozialer Stand (+)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_anfuehrer" value="1" />
                                 <div>Anführer (EM)</div>
@@ -3450,6 +3376,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Werkzeuge (-)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_nachteil_sprachfehler" value="1" />
                                 <div>Sprachfehler (-)</div>
@@ -3488,7 +3416,15 @@
                     <td><input type="number" name="attr_Willenskraft_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Willenskraft_Anmerkung"></td>
                     <td><input type="number" name="attr_Willenskraft_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Willenskraft}} {{subtags=Gesellschaft}} {{Talent=[[ @{Willenskraft_FW} - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft1}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft2}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft3}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Willenskraft_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Willenskraft}} {{subtags=Gesellschaft}} {{Talent=[[ @{Willenskraft_FW} + 2 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft1}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft2}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Willenskraft_Eigenschaft3}]] + [[@{Willenskraft_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Willenskraft_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -3921,6 +3857,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 Werkzeuge (-)<br/>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_falschspielen" value="1" />
                                 <div>Falschspielen (EM)</div>
@@ -3975,6 +3913,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_kartographie" value="1" />
                                 <div>Kartographie (AG)</div>
                             </span>
@@ -4008,7 +3948,15 @@
                     <td><input type="number" name="attr_Geschichtswissen_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Geschichtswissen_Anmerkung"></td>
                     <td><input type="number" name="attr_Geschichtswissen_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Geschichtswissen}} {{subtags=Wissen}} {{Talent=[[ @{Geschichtswissen_FW} - {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft1}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft2}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft3}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Geschichtswissen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Geschichtswissen}} {{subtags=Wissen}} {{Talent=[[ @{Geschichtswissen_FW} + 2 - {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft1}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft2}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Geschichtswissen_Eigenschaft3}]] + [[@{Geschichtswissen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Geschichtswissen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -4037,7 +3985,15 @@
                     <td><input type="number" name="attr_Goetter_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Goetter_Anmerkung"></td>
                     <td><input type="number" name="attr_Goetter_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Götter &amp; Kulte}} {{subtags=Wissen}} {{Talent=[[ @{Goetter_FW} - {1d20cs1cf20 - ([[@{Goetter_Eigenschaft1}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Goetter_Eigenschaft2}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Goetter_Eigenschaft3}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Goetter_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Götter &amp; Kulte}} {{subtags=Wissen}} {{Talent=[[ @{Goetter_FW} + 2 - {1d20cs1cf20 - ([[@{Goetter_Eigenschaft1}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Goetter_Eigenschaft2}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Goetter_Eigenschaft3}]] + [[@{Goetter_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Goetter_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -4066,7 +4022,15 @@
                     <td><input type="number" name="attr_Kriegskunst_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Kriegskunst_Anmerkung"></td>
                     <td><input type="number" name="attr_Kriegskunst_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Kriegskunst}} {{subtags=Wissen}} {{Talent=[[ @{Kriegskunst_FW} - {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft1}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft2}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft3}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Kriegskunst_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Kriegskunst}} {{subtags=Wissen}} {{Talent=[[ @{Kriegskunst_FW} + 2 - {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft1}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft2}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Kriegskunst_Eigenschaft3}]] + [[@{Kriegskunst_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Kriegskunst_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -4099,6 +4063,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_analytiker" value="1" />
                                 <div>Analytiker (EM)</div>
                             </span>
@@ -4135,6 +4101,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_berufsgeheimnis_uhrwerk" value="1" />
                                 <div>Uhrwerk (BG)</div>
                             </span>
@@ -4172,6 +4140,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_zahlenmystik" value="1" />
                                 <div>Zahlenmystik (AG)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_berufsgeheimnis_algebra" value="1" />
@@ -4213,6 +4183,8 @@
                         <span class="sheet-tooltip-ef">
                             <img align="center" src="http://i.imgur.com/fK8iLhI.png" />
                             <span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
                                 <input class="sheet-tooltip-optional" type="checkbox" name="attr_sf_gildenrecht" value="1" />
                                 <div>Gildenrecht (AG)</div>
                             </span>
@@ -4246,7 +4218,15 @@
                     <td><input type="number" name="attr_Sagen_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Sagen_Anmerkung"></td>
                     <td><input type="number" name="attr_Sagen_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sagen &amp; Legenden}} {{subtags=Wissen}} {{Talent=[[ @{Sagen_FW} - {1d20cs1cf20 - ([[@{Sagen_Eigenschaft1}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sagen_Eigenschaft2}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sagen_Eigenschaft3}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sagen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sagen &amp; Legenden}} {{subtags=Wissen}} {{Talent=[[ @{Sagen_FW} + 2 - {1d20cs1cf20 - ([[@{Sagen_Eigenschaft1}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sagen_Eigenschaft2}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sagen_Eigenschaft3}]] + [[@{Sagen_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sagen_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -4275,7 +4255,15 @@
                     <td><input type="number" name="attr_Sphaerenkunde_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Sphaerenkunde_Anmerkung"></td>
                     <td><input type="number" name="attr_Sphaerenkunde_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sphärenkunde}} {{subtags=Wissen}} {{Talent=[[ @{Sphaerenkunde_FW} - {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft1}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft2}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft3}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sphaerenkunde_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sphärenkunde}} {{subtags=Wissen}} {{Talent=[[ @{Sphaerenkunde_FW} + 2 - {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft1}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft2}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sphaerenkunde_Eigenschaft3}]] + [[@{Sphaerenkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sphaerenkunde_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -4304,7 +4292,15 @@
                     <td><input type="number" name="attr_Sternkunde_FW" value="0" min="0"></td>
                     <td><input type="text" name="attr_Sternkunde_Anmerkung"></td>
                     <td><input type="number" name="attr_Sternkunde_Mod" disabled="true" value="@{Zustand_Mod_max_ohne_BE}"></td>
-                    <td><span class="sheet-tooltip-ef"><img align="center" src="http://i.imgur.com/fK8iLhI.png" /><span></span></span></td>
+                    <td>
+                    	<span class="sheet-tooltip-ef">
+                    		<img align="center" src="http://i.imgur.com/fK8iLhI.png" />
+                    		<span>
+                                <input class="sheet-tooltip-optional" type="checkbox" name="attr_optionalregel_kulturkunde" value="1" />
+                                <div>Kulturkunde (+/-)</div>
+                    		</span>
+                    	</span>
+                    </td>
                     <td>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sternkunde}} {{subtags=Wissen}} {{Talent=[[ @{Sternkunde_FW} - {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft1}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft2}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft3}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sternkunde_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}"></button>
                         <button type="roll" value="&{template:DSA-Talente} {{name=Sternkunde}} {{subtags=Wissen}} {{Talent=[[ @{Sternkunde_FW} + 2 - {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft1}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1 - {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft2}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1- {1d20cs1cf20 - ([[@{Sternkunde_Eigenschaft3}]] + [[@{Sternkunde_Mod}]] + ?{Erleichterung(+) / Erschwernis(-)|0}) , 0d1}kh1]]}} {{Modifikator=[[@{Sternkunde_Mod} + ?{Erleichterung(+) / Erschwernis(-)|0}]]}}">FS</button>
@@ -5172,22 +5168,27 @@
         </div>
         
         <div class="sheet-section sheet section-fight" align="center">
-            <input type="checkbox" class="sheet-gegner" name="attr_gegner_sheet" style="display:none;" value="1" />
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab41" value="41" title="fightvalues1" checked="checked"/>
+            <input type="checkbox" class="hidden sheet-gegner" name="attr_gegner_sheet" value="1" />
+            <input type="checkbox" class="zeige-fernkampf" name="attr_zeige_fernkampf" style="display:none;" value="1" />
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab41" value="41" checked="checked"/>
                 <span class="sheet-tab sheet-tab41">Ausrüstung</span>
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab42" value="42" title="fightvalues2"/>
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab42" value="42" />
                 <span class="sheet-tab sheet-tab42">Nahkampf</span>
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab43" value="43" title="fightvalues3"/>
-                <span class="sheet-tab sheet-tab43">Fernkampf</span>
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab44 sheet-kein-gegner" value="44" title="fightvalues4"/>
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab43 sheet-fernkampf" value="43" />
+                <span class="sheet-tab sheet-tab43 sheet-fernkampf">Fernkampf</span>
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab44 sheet-kein-gegner" value="44" />
                 <span class="sheet-tab sheet-tab44 sheet-kein-gegner">Kampftechniken</span>
-            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab45" value="45" title="fightvalues5"/>
+            <input type="radio" name="attr_fight_tab" class="sheet-tab sheet-tab45" value="45" />
                 <span class="sheet-tab sheet-tab45">Sonderfertigk.</span>
                     
         <div class="sheet-section sheet section-fightvalues1">
         
+        <input type="checkbox" class="hidden zeige-fernkampf" name="attr_zeige_fernkampf" value="1" />
+        <input type="checkbox" class="hidden zeige-schilde" name="attr_zeige_schilde" value="1" />
+        <input type="checkbox" class="hidden zeige-parierwaffen" name="attr_zeige_parierwaffen" value="1" />
+        <input type="checkbox" class="hidden sheet-show-nicht-humanoid" value="1" name="attr_nicht_humanoid"/>
         <h3>Nahkampfwaffen</h3>
-        	<input class="sheet-gegner" type="checkbox" name="attr_gegner_sheet" style="display:none;" value="1"/>
+        	<input class="hidden sheet-gegner" type="checkbox" name="attr_gegner_sheet" value="1"/>
         	<div class="sheet-kein-gegner">
 	            <table>
 	                <tr>
@@ -5419,287 +5420,383 @@
 	              </tr>
 	        </table>
 		</div>
-	        <div class="sheet-kein-gegner">
 
-            <br>
-            <h3>Schild/Parierwaffe</h3>
-            <table>
-                <tr>
-                    <th>Schild/Parierwaffe</th>
-                    <th>Kampftechnik</th>
-                    <th>Strukturp.</th>
-                    <th>Leiteig.</th>
-                    <th colspan="2">Schadensb.</th>
-                    <th colspan="2">Trefferpunkte</th>
-                    <th colspan="2">AT/PA Mod.</th>
-                    <th>Gewicht</th>
-                </tr>
-                 <tr align="center">
-                    <td><input type="text" name="attr_SchildName1" style="width: 12em;"></td>
-                    <td><select name="attr_Schild1_KT" style="width: 6em;">
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Schilde}">Schilde</option>
-                        </select></td>                  
-                    <td><input type="number" name="attr_SchildStrukturpunkte1"></td>
-                    <td><select style="width: 4em;" name="attr_Schild1_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchildSchadensberechnung1" value="0"></td>
-                    <td><input type="number" disabled="true" name="attr_Schild1_SB" value="(((@{Schild1_Leiteigenschaft} - @{SchildSchadensberechnung1}) + abs(@{Schild1_Leiteigenschaft} - @{SchildSchadensberechnung1})) / 2)"></td>
-                    <td><input type="number" name="attr_SchildTP1_1" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildTP1_2" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildATMod1" value="0"></td>
-                    <td><input type="number" name="attr_SchildPAMod1" value="0"></td>
-                    <td><input type="number" name="attr_SchildGewicht1" value="0"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_SchildName2" style="width: 12em;"></td>
-                    <td><select name="attr_Schild2_KT" style="width: 6em;">
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Schilde}">Schilde</option>
-                        </select></td>                  
-                    <td><input type="number" name="attr_SchildStrukturpunkte2"></td>
-                    <td><select style="width: 4em;" name="attr_Schild2_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchildSchadensberechnung2"></td>
-                    <td><input type="number" disabled="true" name="attr_Schild2_SB" value="(((@{Schild2_Leiteigenschaft} - @{SchildSchadensberechnung2}) + abs(@{Schild2_Leiteigenschaft} - @{SchildSchadensberechnung2})) / 2)"></td>
-                    <td><input type="number" name="attr_SchildTP2_1" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildTP2_2" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildATMod2" value="0"></td>
-                    <td><input type="number" name="attr_SchildPAMod2" value="0"></td>
-                    <td><input type="number" name="attr_SchildGewicht2" value="0"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_SchildName3" style="width: 12em;"></td>
-                    <td><select name="attr_Schild3_KT" style="width: 6em;">
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Schilde}">Schilde</option>
-                        </select></td>                  
-                    <td><input type="number" name="attr_SchildStrukturpunkte3"></td>
-                    <td><select style="width: 4em;" name="attr_Schild3_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchildSchadensberechnung3"></td>
-                    <td><input type="number" disabled="true" name="attr_Schild3_SB" value="(((@{Schild3_Leiteigenschaft} - @{SchildSchadensberechnung3}) + abs(@{Schild3_Leiteigenschaft} - @{SchildSchadensberechnung3})) / 2)"></td>
-                    <td><input type="number" name="attr_SchildTP3_1" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildTP3_2" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildATMod3" value="0"></td>
-                    <td><input type="number" name="attr_SchildPAMod3" value="0"></td>
-                    <td><input type="number" name="attr_SchildGewicht3" value="0"></td>
-                </tr>
-                <tr align="center">
-                    <td><input type="text" name="attr_SchildName4" style="width: 12em;"></td>
-                    <td><select name="attr_Schild4_KT" style="width: 6em;">
-                            <option value="0">---</option>
-                            <option value="@{KtW_Dolche}">Dolche</option>
-                            <option value="@{KtW_Schilde}">Schilde</option>
-                        </select></td>                  
-                    <td><input type="number" name="attr_SchildStrukturpunkte4"></td>
-                    <td><select style="width: 4em;" name="attr_Schild4_Leiteigenschaft">
-                            <option value="0">--</option>
-                            <option value="@{KK_Wert}">KK</option>
-                            <option value="@{GE_Wert}">GE</option>
-                        </select></td>
-                    <td><input type="number" name="attr_SchildSchadensberechnung4"></td>
-                    <td><input type="number" disabled="true" name="attr_Schild4_SB" value="(((@{Schild4_Leiteigenschaft} - @{SchildSchadensberechnung4}) + abs(@{Schild4_Leiteigenschaft} - @{SchildSchadensberechnung4})) / 2)"></td>                  
-                    <td><input type="number" name="attr_SchildTP4_1" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildTP4_2" value="0" style="width: 3em;"></td>
-                    <td><input type="number" name="attr_SchildATMod4" value="0"></td>
-                    <td><input type="number" name="attr_SchildPAMod4" value="0"></td>
-                    <td><input type="number" name="attr_SchildGewicht4" value="0"></td>
-                </tr>
-            </table>
-            </div>
-            <br>
-	        <h3>Fernkampfwaffen</h3>
-            <input type="checkbox" class="sheet-gegner" name="attr_gegner_sheet" style="display:none;" value="1" />
-            <div class="sheet-kein-gegner">
+        <div class="sheet-schilde sheet-humanoid">
+	        <br />
+	        <h3>Schilde</h3>
 	            <table>
 	                <tr>
-	                    <th>Waffe</th>
-	                    <th>Kampftechnik</th>
-	                    <th>Ladezeit</th>
+	                    <th>Schild</th>
+	                    <th>Strukturp.</th>
+	                    <th colspan="2">Schadensb.</th>
 	                    <th colspan="2">Trefferpunkte</th>
-	                    <th>Reichweite</th>
-	                    <th>Munition</th>
+	                    <th colspan="2">AT/PA Mod.</th>
+	                    <th>Größe</th>
 	                    <th>Gewicht</th>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
-	                    <td><select name="attr_FKWtyp1" style="width: 10em;">
-	                            <option value="0">--</option>
-	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-	                            <option value="@{KtW_Boegen}">Bögen</option>
-	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-	                        </select></td>
-	                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition1"></td>
-	                    <td><input type="number" name="attr_FKWGewicht1" value="0"></td>
+	                 <tr align="center">
+	                    <td><input type="text" name="attr_SchildName1" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_SchildStrukturpunkte1"></td>
+	                    <td><input type="number" name="attr_SchildSchadensberechnung1" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_Schild1_SB" value="(((@{KK_Wert} - @{SchildSchadensberechnung1}) + abs(@{KK_Wert} - @{SchildSchadensberechnung1})) / 2)"></td>
+	                    <td><input type="number" name="attr_SchildTP1_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildTP1_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildATMod1" value="0"></td>
+	                    <td><input type="number" name="attr_SchildPAMod1" value="0"></td>
+	                    <td>
+	                    	<select name="attr_Schild_Groesse1" style="width: 5em;">
+		                    	<option value="--">--</option>
+		                    	<option value="1">klein</option>
+								<option value="2">mittel</option>
+								<option value="3">groß</option>                            
+		                    </select>
+		                </td>
+	                    <td><input type="number" name="attr_SchildGewicht1" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
-	                    <td><select name="attr_FKWtyp2" style="width: 10em;">
-	                            <option value="0">--</option>
-	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-	                            <option value="@{KtW_Boegen}">Bögen</option>
-	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-	                        </select></td>
-	                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite2"></td>
-	                    <td><input type="number" name="attr_FKWMunition2" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWGewicht2" value="0"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_SchildName2" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_SchildStrukturpunkte2"></td>
+	                    <td><input type="number" name="attr_SchildSchadensberechnung2"></td>
+	                    <td><input type="number" disabled="true" name="attr_Schild2_SB" value="(((@{KK_Wert} - @{SchildSchadensberechnung2}) + abs(@{KK_Wert} - @{SchildSchadensberechnung2})) / 2)"></td>
+	                    <td><input type="number" name="attr_SchildTP2_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildTP2_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildATMod2" value="0"></td>
+	                    <td><input type="number" name="attr_SchildPAMod2" value="0"></td>
+	                    <td>
+	                    	<select name="attr_Schild_Groesse2" style="width: 5em;">
+		                    	<option value="--">--</option>
+		                    	<option value="1">klein</option>
+								<option value="2">mittel</option>
+								<option value="3">groß</option>                            
+		                    </select>
+		                </td>
+	                    <td><input type="number" name="attr_SchildGewicht2" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
-	                    <td><select name="attr_FKWtyp3" style="width: 10em;">
-	                            <option value="0">--</option>
-	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-	                            <option value="@{KtW_Boegen}">Bögen</option>
-	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-	                        </select></td>
-	                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition3"></td>
-	                    <td><input type="number" name="attr_FKWGewicht3" value="0"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_SchildName3" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_SchildStrukturpunkte3"></td>
+	                    <td><input type="number" name="attr_SchildSchadensberechnung3"></td>
+	                    <td><input type="number" disabled="true" name="attr_Schild3_SB" value="(((@{KK_Wert} - @{SchildSchadensberechnung3}) + abs(@{KK_Wert} - @{SchildSchadensberechnung3})) / 2)"></td>
+	                    <td><input type="number" name="attr_SchildTP3_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildTP3_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildATMod3" value="0"></td>
+	                    <td><input type="number" name="attr_SchildPAMod3" value="0"></td>
+	                    <td>
+	                    	<select name="attr_Schild_Groesse3" style="width: 5em;">
+		                    	<option value="--">--</option>
+		                    	<option value="1">klein</option>
+								<option value="2">mittel</option>
+								<option value="3">groß</option>                            
+		                    </select>
+		                </td>
+	                    <td><input type="number" name="attr_SchildGewicht3" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
-	                    <td><select name="attr_FKWtyp4" style="width: 10em;">
-	                            <option value="0">--</option>
-	                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
-	                            <option value="@{KtW_Boegen}">Bögen</option>
-	                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
-	                        </select></td>
-	                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition4"></td>
-	                    <td><input type="number" name="attr_FKWGewicht4" value="0"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_SchildName4" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_SchildStrukturpunkte4"></td>
+	                    <td><input type="number" name="attr_SchildSchadensberechnung4"></td>
+	                    <td><input type="number" disabled="true" name="attr_Schild4_SB" value="(((@{KK_Wert} - @{SchildSchadensberechnung4}) + abs(@{KK_Wert} - @{SchildSchadensberechnung4})) / 2)"></td>                  
+	                    <td><input type="number" name="attr_SchildTP4_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildTP4_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_SchildATMod4" value="0"></td>
+	                    <td><input type="number" name="attr_SchildPAMod4" value="0"></td>
+	                    <td>
+	                    	<select name="attr_Schild_Groesse4" style="width: 5em;">
+		                    	<option value="--">--</option>
+		                    	<option value="1">klein</option>
+								<option value="2">mittel</option>
+								<option value="3">groß</option>                            
+		                    </select>
+		                </td>
+	                    <td><input type="number" name="attr_SchildGewicht4" value="0"></td>
 	                </tr>
 	            </table>
-	        </div> 
-            <div class="sheet-gegner">
+	        </div>
+
+
+            <div class="sheet-parierwaffen sheet-humanoid">
+	            <br>
+	            <h3>Parierwaffen</h3>
 	            <table>
 	                <tr>
-	                    <th>Waffe</th>
-	                    <th>FK</th>
-	                    <th>Ladezeit</th>
+	                    <th>Parierwaffe</th>
+	                    <th>Kampftechnik</th>
+	                    <th colspan="2">Schadensb.</th>
 	                    <th colspan="2">Trefferpunkte</th>
-	                    <th>Reichweite</th>
-	                    <th>Munition</th>
+	                    <th colspan="2">AT/PA Mod.</th>
+	                    <th>Gewicht</th>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
-	                    <td><input type="number" name="attr_FKW1_Fix" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition1"></td>
+	                 <tr align="center">
+	                    <td><input type="text" name="attr_ParierwaffeName1" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeSchadensberechnung1" value="0"></td>
+	                    <td><input type="number" disabled="true" name="attr_Parierwaffe1_SB" value="(((@{GE_Wert} - @{ParierwaffeSchadensberechnung1}) + abs(@{GE_Wert} - @{ParierwaffeSchadensberechnung1})) / 2)"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP1_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP1_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeATMod1" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffePAMod1" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffeGewicht1" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
-	                    <td><input type="number" name="attr_FKW2_Fix" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition2"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_ParierwaffeName2" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeSchadensberechnung2"></td>
+	                    <td><input type="number" disabled="true" name="attr_Parierwaffe2_SB" value="(((@{GE_Wert} - @{ParierwaffeSchadensberechnung2}) + abs(@{GE_Wert} - @{ParierwaffeSchadensberechnung2})) / 2)"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP2_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP2_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeATMod2" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffePAMod2" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffeGewicht2" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
-	                    <td><input type="number" name="attr_FKW3_Fix" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition3"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_ParierwaffeName3" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeSchadensberechnung3"></td>
+	                    <td><input type="number" disabled="true" name="attr_Parierwaffe3_SB" value="(((@{GE_Wert} - @{ParierwaffeSchadensberechnung3}) + abs(@{GE_Wert} - @{ParierwaffeSchadensberechnung3})) / 2)"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP3_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP3_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeATMod3" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffePAMod3" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffeGewicht3" value="0"></td>
 	                </tr>
-	                <tr align=center>
-	                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
-	                    <td><input type="number" name="attr_FKW4_Fix" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
-	                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
-	                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
-	                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
-	                    <td><input type="number" name="attr_FKWMunition4"></td>
+	                <tr align="center">
+	                    <td><input type="text" name="attr_ParierwaffeName4" style="width: 12em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeSchadensberechnung4"></td>
+	                    <td><input type="number" disabled="true" name="attr_Parierwaffe4_SB" value="(((@{GE_Wert} - @{ParierwaffeSchadensberechnung4}) + abs(@{GE_Wert} - @{ParierwaffeSchadensberechnung4})) / 2)"></td>                  
+	                    <td><input type="number" name="attr_ParierwaffeTP4_1" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeTP4_2" value="0" style="width: 3em;"></td>
+	                    <td><input type="number" name="attr_ParierwaffeATMod4" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffePAMod4" value="0"></td>
+	                    <td><input type="number" name="attr_ParierwaffeGewicht4" value="0"></td>
 	                </tr>
 	            </table>
-	        </div> 
-            <br />
+	        </div>
+            
+            <div class="sheet-fernkampf">
+	            <br>
+		        <h3>Fernkampfwaffen</h3>
+	            <input type="checkbox" class="hidden sheet-gegner" name="attr_gegner_sheet" value="1" />
+	            <div class="sheet-kein-gegner">
+		            <table>
+		                <tr>
+		                    <th>Waffe</th>
+		                    <th>Kampftechnik</th>
+		                    <th>Ladezeit</th>
+		                    <th colspan="2">Trefferpunkte</th>
+		                    <th>Reichweite</th>
+		                    <th>Munition</th>
+		                    <th>Gewicht</th>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
+		                    <td><select name="attr_FKWtyp1" style="width: 10em;">
+		                            <option value="0">--</option>
+		                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+		                            <option value="@{KtW_Boegen}">Bögen</option>
+		                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+		                        </select></td>
+		                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition1"></td>
+		                    <td><input type="number" name="attr_FKWGewicht1" value="0"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
+		                    <td><select name="attr_FKWtyp2" style="width: 10em;">
+		                            <option value="0">--</option>
+		                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+		                            <option value="@{KtW_Boegen}">Bögen</option>
+		                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+		                        </select></td>
+		                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition2"></td>
+		                    <td><input type="number" name="attr_FKWGewicht2" value="0"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
+		                    <td><select name="attr_FKWtyp3" style="width: 10em;">
+		                            <option value="0">--</option>
+		                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+		                            <option value="@{KtW_Boegen}">Bögen</option>
+		                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+		                        </select></td>
+		                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition3"></td>
+		                    <td><input type="number" name="attr_FKWGewicht3" value="0"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
+		                    <td><select name="attr_FKWtyp4" style="width: 10em;">
+		                            <option value="0">--</option>
+		                            <option value="@{KtW_Armbrueste}">Armbrüste</option>
+		                            <option value="@{KtW_Boegen}">Bögen</option>
+		                            <option value="@{KtW_Wurfwaffen}">Wurfwaffen</option>
+		                        </select></td>
+		                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition4"></td>
+		                    <td><input type="number" name="attr_FKWGewicht4" value="0"></td>
+		                </tr>
+		            </table>
+		        </div> 
+	            <div class="sheet-gegner">
+		            <table>
+		                <tr>
+		                    <th>Waffe</th>
+		                    <th>FK</th>
+		                    <th>Ladezeit</th>
+		                    <th colspan="2">Trefferpunkte</th>
+		                    <th>Reichweite</th>
+		                    <th>Munition</th>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
+		                    <td><input type="number" name="attr_FKW1_Fix" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden1_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden1_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition1"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
+		                    <td><input type="number" name="attr_FKW2_Fix" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden2_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden2_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition2"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
+		                    <td><input type="number" name="attr_FKW3_Fix" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden3_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden3_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition3"></td>
+		                </tr>
+		                <tr align=center>
+		                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
+		                    <td><input type="number" name="attr_FKW4_Fix" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
+		                    <td><input type="number" name="attr_FKWSchaden4_1" style="width: 3em;" value="0"></td>
+		                    <td><input type="number" name="attr_FKWSchaden4_2" style="width: 3em;" value="0"></td>
+		                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
+		                    <td><input type="number" name="attr_FKWMunition4"></td>
+		                </tr>
+		            </table>
+		        </div>
+	        </div>
+	        
             <div class="sheet-kein-gegner">
+            	<br />
 	            <h3>Rüstung</h3>
+	            <input type="number" name="attr_Ges_RS" value="0" class="hidden" />
+	            <input type="number" name="attr_Ges_BE" value="0" class="hidden" />
+	            <input type="number" name="attr_RuestungsAbzuege" value=0" class="hidden" />
+	            <input type="number" name="attr_Ges_Gewicht" value="0" class="hidden" />
 	            <table>
 	                <tr align="center">
 	                    <th>Rüstung</th>
+	                    <th>Art</th>
 	                    <th>RS</th>
 	                    <th>BE</th>
-	                    <th>Zus. Abzüge</th>
+	                    <th>Zus. Abz.</th>
 	                    <th>Gewicht</th>
 	                    <th>Reise, Schlacht,...</th>
 	                    <th>Aktiv</th>
 	                </tr>
 	                <tr align="center">
-	                    <td><input type="text" name="attr_RuestungsName1" style="width: 15em;"></td>
+	                    <td><input type="text" name="attr_RuestungsName1" style="width: 10em;"></td>
+	                    <td>
+	                    	<select name="attr_RS_Art1" style="width: 10em;">
+	                            <option value="-1">--</option>
+	                            <option value="0">Normale Kleidung</option>
+	                            <option value="1">Schwere Kleidung</option>
+	                            <option value="2">Stoffrüstung</option>
+	                            <option value="3">Lederrüstung</option>
+	                            <option value="4">Kettenrüstung</option>
+	                            <option value="5">Schuppenrüstung</option>
+	                            <option value="6">Plattenrüstung</option>
+	                        </select>
+	                    </td>
 	                    <td><input type="number" name="attr_RS1" value="0"></td>
 	                    <td><input type="number" name="attr_BE1" value="0"></td>
 	                    <td><input type="checkbox" name="attr_RuestungsAbzuege1" value="-1"></td>
 	                    <td><input type="number" name="attr_RuestungsGewicht1" value="0"></td>
 	                    <td><input type="text" name="attr_RuestungsNotiz1"></td>
-	                    <td><input type="checkbox" name="attr_RuestungAktiv1" value="1"></td>
+	                    <td><input type="radio" name="attr_RuestungAktiv" value="1"></td>
 	                </tr>
 	                <tr align="center">
-	                    <td><input type="text" name="attr_RuestungsName2" style="width: 15em;"></td>
+	                    <td><input type="text" name="attr_RuestungsName2" style="width: 10em;"></td>
+	                    <td>
+	                    	<select name="attr_RS_Art2" style="width: 10em;">
+	                            <option value="-1">--</option>
+	                            <option value="0">Normale Kleidung</option>
+	                            <option value="1">Schwere Kleidung</option>
+	                            <option value="2">Stoffrüstung</option>
+	                            <option value="3">Lederrüstung</option>
+	                            <option value="4">Kettenrüstung</option>
+	                            <option value="5">Schuppenrüstung</option>
+	                            <option value="6">Plattenrüstung</option>
+	                        </select>
+	                    </td>
 	                    <td><input type="number" name="attr_RS2" value="0"></td>
 	                    <td><input type="number" name="attr_BE2" value="0"></td>
 	                    <td><input type="checkbox" name="attr_RuestungsAbzuege2" value="-1"></td>
 	                    <td><input type="number" name="attr_RuestungsGewicht2" value="0"></td>
 	                    <td><input type="text" name="attr_RuestungsNotiz2"></td>
-	                    <td><input type="checkbox" name="attr_RuestungAktiv2" value="1"></td>
+	                    <td><input type="radio" name="attr_RuestungAktiv" value="2"></td>
 	                </tr>
 	                <tr align="center">
-	                    <td><input type="text" name="attr_RuestungsName3" style="width: 15em;"></td>
+	                    <td><input type="text" name="attr_RuestungsName3" style="width: 10em;"></td>
+	                    <td>
+	                    	<select name="attr_RS_Art3" style="width: 10em;">
+	                            <option value="-1">--</option>
+	                            <option value="0">Normale Kleidung</option>
+	                            <option value="1">Schwere Kleidung</option>
+	                            <option value="2">Stoffrüstung</option>
+	                            <option value="3">Lederrüstung</option>
+	                            <option value="4">Kettenrüstung</option>
+	                            <option value="5">Schuppenrüstung</option>
+	                            <option value="6">Plattenrüstung</option>
+	                        </select>
+	                    </td>
 	                    <td><input type="number" name="attr_RS3" value="0"></td>
 	                    <td><input type="number" name="attr_BE3" value="0"></td>
 	                    <td><input type="checkbox" name="attr_RuestungsAbzuege3" value="-1"></td>
 	                    <td><input type="number" name="attr_RuestungsGewicht3" value="0"></td>
 	                    <td><input type="text" name="attr_RuestungsNotiz3"></td>
-	                    <td><input type="checkbox" name="attr_RuestungAktiv3" value="1"></td>
+	                    <td><input type="radio" name="attr_RuestungAktiv" value="3"></td>
 	                </tr>
 	                <tr align="center">
-	                    <td><input type="text" name="attr_RuestungsName4" style="width: 15em;"></td>
+	                    <td><input type="text" name="attr_RuestungsName4" style="width: 10em;"></td>
+	                    <td>
+	                    	<select name="attr_RS_Art4" style="width: 10em;">
+	                            <option value="-1">--</option>
+	                            <option value="0">Normale Kleidung</option>
+	                            <option value="1">Schwere Kleidung</option>
+	                            <option value="2">Stoffrüstung</option>
+	                            <option value="3">Lederrüstung</option>
+	                            <option value="4">Kettenrüstung</option>
+	                            <option value="5">Schuppenrüstung</option>
+	                            <option value="6">Plattenrüstung</option>
+	                        </select>
+	                    </td>
 	                    <td><input type="number" name="attr_RS4" value="0"></td>
 	                    <td><input type="number" name="attr_BE4" value="0"></td>
 	                    <td><input type="checkbox" name="attr_RuestungsAbzuege4" value="-1"></td>
 	                    <td><input type="number" name="attr_RuestungsGewicht4" value="0"></td>
 	                    <td><input type="text" name="attr_RuestungsNotiz4"></td>
-	                    <td><input type="checkbox" name="attr_RuestungAktiv4" value="1"></td>
-	                </tr>
-	                <tr align="center">
-	                    <td />
-	                    <td><input type="number" disabled="true" name="attr_Ges_RS" value="@{RuestungAktiv1} * @{RS1} + @{RuestungAktiv2} * @{RS2} + @{RuestungAktiv3} * @{RS3} + @{RuestungAktiv4} * @{RS4}"></td>
-	                    <td><input type="number" disabled="true" name="attr_Ges_BE" value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></td>
-	                    <td><input type="number" disabled="true" name="attr_RuestungsAbzuege" value="@{RuestungAktiv1} * @{RuestungsAbzuege1} + @{RuestungAktiv2} * @{RuestungsAbzuege2} + @{RuestungAktiv3} * @{RuestungsAbzuege3} + @{RuestungAktiv4} * @{RuestungsAbzuege4}"></td>
-	                    <td><input type="number" disabled="true" name="attr_Ges_Gewicht" value="@{RuestungAktiv1} * @{RuestungsGewicht1} + @{RuestungAktiv2} * @{RuestungsGewicht2} + @{RuestungAktiv3} * @{RuestungsGewicht3} + @{RuestungAktiv4} * @{RuestungsGewicht4}"></td>
-	                    <td />
+	                    <td><input type="radio" name="attr_RuestungAktiv" value="4"></td>
 	                </tr>
 	            </table>
             </div>
@@ -5710,17 +5807,17 @@
         <table>
             <tr>
                 <th>
-                    INI <input type="number" name="attr_INI_Aktiv" value="((@{INI_Wert}) * (1 - @{gegner_sheet})) + (@{INI_Wert_Fix}*(0+@{gegner_sheet}))" disabled="true">
+                    INI <input type="number" name="attr_INI_Aktiv" value="@{INI_Wert}" disabled="true">
                     <button type=roll value="[[(1d6+@{INI_Aktiv})&{tracker}]] @{Charaktername}´s Initiative" />
                 </th>
                 <th>
-                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="(@{Ges_RS})*(1-@{gegner_sheet})+(@{RS_Fix})*(0+@{gegner_sheet})" disabled="true" />
+                    RS <input type="number" name="attr_RS_Kampf" style='width: 4em' value="(@{Ges_RS})*(1-@{gegner_sheet}) + (@{RS_Fix}*(0+@{gegner_sheet}))" disabled="true" />
                 </th>
                 <th>
                     BE <input type="number" name="attr_BE_Kampf" style='width: 4em' value="@{Ges_BE}" disabled="true" />
                 </th>
                 <th>
-                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="(@{GS_Wert})*(1-@{gegner_sheet})+(@{GS_Wert_Fix})*(0+@{gegner_sheet})" disabled="true" />
+                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="@{GS_Wert}" disabled="true" />
                 </th>
                 <th>
                     LE <input type="number" name="attr_LE_Wert" style='width: 4em' value="@{LE_Wert}" />
@@ -5733,6 +5830,13 @@
         <table align="left" width="100%">
             <tr>
                 <td valign="top" width="40%">
+                	<input name="attr_NKW_Aktiv_Reichweite" type="number" value="0" class="hidden" />
+                	<input name="attr_AT_Aktiv_Waffe" type="number" value="0" class="hidden" />
+                	<input name="attr_PA_Aktiv_Waffe" type="number" value="0" class="hidden" />
+                	<input name="attr_TP_W_Aktiv_Waffe" type="number" value="0" class="hidden" />
+                	<input name="attr_TP_Bonus_Aktiv_Waffe" type="number" value="0" class="hidden" />
+                	<input name="attr_Leiteigenschaft_AT_Mod" type="number" value="0" class="hidden" />
+                	<input name="attr_SchildPAMod_Aktiv" type="number" value="0" class="hidden" />
                     <table align="top">
                         <tr>
                             <th>Angriff</th>
@@ -5741,7 +5845,9 @@
                         </tr>
                         <tr>
                             <td colspan="2">Attacke:</td>
-                            <td><input type="number" name="attr_AT_Aktiv" style='width: 3em' value="((@{AT_NKW1}) * @{NKW_Aktiv1}) + ((@{AT_NKW2}) * @{NKW_Aktiv2}) + ((@{AT_NKW3}) * @{NKW_Aktiv3}) + ((@{AT_NKW4}) * @{NKW_Aktiv4}) + @{Situationen_AT_Mod} + @{Basismanoever_AT_Mod} + @{Spezialmanoever_AT_Mod} + @{Passiv_AT_Mod} + @{Zustand_Mod_max_abzl_BE} - @{Ges_BE} " disabled="true" /></td>
+                            <td>
+                            	<input type="number" name="attr_AT_Aktiv" style='width: 3em' value="@{AT_Aktiv_Waffe} + @{Situationen_AT_Mod} + @{Basismanoever_AT_Mod} + @{Spezialmanoever_AT_Mod} + @{Passiv_AT_Mod} + @{Zustand_Mod_max_abzl_BE} - @{Ges_BE}" disabled="true" />
+                            </td>
                             <td>
                                 <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv})]]}}" />
                                 <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv}+?{Erleichterung(+) / Erschwernis(-)|0})]]}} {{mod=[[?{Erleichterung(+) / Erschwernis(-)|0}]]}}">+/-</button>
@@ -5757,8 +5863,8 @@
                         </tr>
                         <tr>
                             <td>Trefferpunkte:</td>
-                            <td><input type="number" disabled="true" name="attr_TP_W_Aktiv" style='width: 3em' value="@{NKW_Aktiv1} * @{NKWschaden1_1} + @{NKW_Aktiv2} * @{NKWschaden2_1} + @{NKW_Aktiv3} * @{NKWschaden3_1} + @{NKW_Aktiv4} * @{NKWschaden4_1} + @{Manoever_Hammerschlag} + @{Manoever_Todesstoss}"/>W+</td>
-                            <td><input type="number" disabled="true" name="attr_TP_Bonus_Aktiv" style='width: 3em' value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB} + @{EHalsZH_NKW1}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB} + @{EHalsZH_NKW2}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB} + @{EHalsZH_NKW3}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB} + @{EHalsZH_NKW4}) + @{Basismanoever_TP_Mod} + @{Spezialmanoever_TP_Mod} +  @{Passiv_TP_Mod} + @{Situationen_TP_Mod}"/></td>
+                            <td><input type="number" disabled="true" name="attr_TP_W_Aktiv" style='width: 3em' value="@{TP_W_Aktiv_Waffe} + @{Manoever_Hammerschlag} + @{Manoever_Todesstoss}"/>W+</td>
+                            <td><input type="number" disabled="true" name="attr_TP_Bonus_Aktiv" style='width: 3em' value="@{TP_Bonus_Aktiv_Waffe} + @{Basismanoever_TP_Mod} + @{Spezialmanoever_TP_Mod} +  @{Passiv_TP_Mod} + @{Situationen_TP_Mod}"/></td>
                             <td>
                                 <button type="roll" value="&{template:DSA-Nahkampf-TP}  {{name=Nahkampf-TP}} {{subtags=Nahkampf}} {{damage=[[[[(@{TP_W_Aktiv})]]d6 + @{TP_Bonus_Aktiv}]]}}" />
                                 <button type="roll" value="&{template:DSA-Nahkampf-TP}  {{name=Nahkampf-TP}} {{subtags=Nahkampf}} {{damage=[[([[(@{TP_W_Aktiv})]]d6 + @{TP_Bonus_Aktiv})*2]]}}">x2</button>
@@ -5781,9 +5887,12 @@
                         <div style="display:inline-block; width:10em"><b>Proben</b></div>
                     </div>
                     <input class="sheet-show-nicht-humanoid" type="checkbox" value="1" name="attr_nicht_humanoid" style="display:none"/>
+                    <input type="checkbox" class="hidden sheet-zeige-schilde" name="attr_schild_ausgeruestet" value="1" />
+                    <input class="hidden" type="number" value="0" name="attr_PA_Schild_Bonus" />
+                    <input class="hidden" type="number" value="0" name="attr_PA_Parierwaffe_Bonus" />
                     <div class="sheet-humanoid">
                         <div style="display:inline-block; width:9em;">Waffenparade:</div>
-                        <input type="number" name="attr_PA_Aktiv" style='width: 3em' value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4}) + ((@{Schild_Aktiv1} * @{SchildPAMod1}) + (@{Schild_Aktiv2} * @{SchildPAMod2}) + (@{Schild_Aktiv3} * @{SchildPAMod3}) + (@{Schild_Aktiv4} * @{SchildPAMod4})) - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod}  + @{Passiv_PA_Mod} + @{Zustand_Mod_max_abzl_BE}" disabled="true" />
+                        <input type="number" name="attr_PA_Aktiv" style='width: 3em' value="@{PA_Aktiv_Waffe} + @{PA_Schild_Bonus} + @{PA_Parierwaffe_Bonus} - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod}  + @{Passiv_PA_Mod} + @{Zustand_Mod_max_abzl_BE}" disabled="true" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})]]}} {{mod=[[d0]]}}" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv}+?{Erleichterung(+) / Erschwernis(-)|0})]]}} {{mod=[[?{Erleichterung(+) / Erschwernis(-)|0}]]}}">+/-</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
@@ -5796,18 +5905,17 @@
                         <button class="optional" type="roll" value="&{template:DSA-Nahkampf-AT-Patzer} {{name=PA-Patzer}} {{wurf=[[2d6]]}}"/>
                         <button class="default" type="roll" value="@{Charaktername} erleidet [[1d6+2]] SP durch einen Patzer" ></button>
                     </div>
-                    <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" style="display:none;"/>
-                    <div class="sheet-humanoid sheet-kampf-optional">
+                    <div class="sheet-humanoid sheet-schilde">
                         <div style="display:inline-block; width:9em;">Schildparade:</div>
-                        <input type="number" name="attr_Schild_PA_Aktiv" style='width: 3em' value="((@{Schild_Aktiv1} * (@{SchildPA1})) + (@{Schild_Aktiv2} * (@{SchildPA2})) + (@{Schild_Aktiv3} * (@{SchildPA3})) + (@{Schild_Aktiv4} * (@{SchildPA4}))) - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod} + @{Zustand_Mod_max_abzl_BE} + @{Passiv_Verteidigungshaltung_PA_Mod}" disabled="true" />
+                        <input class="hidden" type="number" name="attr_Schild_PA_Aktiv_Ausgeruestet" />
+                        <input type="number" name="attr_Schild_PA_Aktiv" style='width: 3em' value="@{Schild_PA_Aktiv_Ausgeruestet} - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod} + @{Zustand_Mod_max_abzl_BE} + @{Passiv_Verteidigungshaltung_PA_Mod}" disabled="true" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})]]}} {{mod=[[d0]]}}" />
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv}+?{Erleichterung(+) / Erschwernis(-)|0})]]}} {{mod=[[?{Erleichterung(+) / Erschwernis(-)|0}]]}}">+/-</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Schild_PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
                         <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
-                    <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" style="display:none;"/>
-                    <div class="sheet-humanoid sheet-kampf-optional">
+                    <div class="sheet-humanoid sheet-schilde">
                         <div style="display:inline-block; width:12em;">Schildparadepatzer:</div>
                         <input type="checkbox" class="sheet-verteidigungPatzerTabelle" name="attr_verteidigungPatzerTabelle" style="display:none;" value="1" />
                         <button class="optional" type="roll" value="&{template:DSA-Nahkampf-Schild-Patzer} {{name=Schild-Patzer}} {{wurf=[[2d6]]}}"/>
@@ -5840,10 +5948,22 @@
                         <div style="display:inline-block; width:2.5em"><b>Mod</b></div>
                         <div style="display:inline-block; width:2.5em"><b>TP+</b></div>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_finte" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_finte" value="1"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Finte:</div>
-                        <select name="attr_Manoever_Finte" style="width: 3em;">
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_finte_1" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Finte" style="width: 3em;">
+                                    <option value="0">-</option>
+                                    <option value="1">I</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_finte_2" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Finte" style="width: 3em;">
+                                    <option value="0">-</option>
+                                    <option value="1">I</option>
+                                    <option value="2">II</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_finte_3" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Finte" style="width: 3em;">
                                     <option value="0">-</option>
                                     <option value="1">I</option>
                                     <option value="2">II</option>
@@ -5851,10 +5971,22 @@
                         </select>
                         <input name="attr_Manoever_Finte_AT_Mod" style="width: 2.5em;" type="number" value="-@{Manoever_Finte}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_praeziser_stich" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_praeziser_stich" value="1"/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Präziser Stich:</div>
-                        <select name="attr_Manoever_Praeziser_Stich" style="width: 3em;">
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_praeziser_stich_1" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Praeziser_Stich" style="width: 3em;">
+                            <option value="0">-</option>
+                            <option value="2">I</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_praeziser_stich_2" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Praeziser_Stich" style="width: 3em;">
+                            <option value="0">-</option>
+                            <option value="2">I</option>
+                            <option value="4">II</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_praeziser_stich_3" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Praeziser_Stich" style="width: 3em;">
                             <option value="0">-</option>
                             <option value="2">I</option>
                             <option value="4">II</option>
@@ -5863,10 +5995,22 @@
                         <input name="attr_Manoever_Praezisier_Stich_AT_Mod" style="width: 2.5em;" type="number" value="-@{Manoever_Praeziser_Stich}" disabled="true"/>
                         <input name="attr_Manoever_Praezisier_Stich_TP" style="width: 2.5em;" type="number" value="@{Manoever_Praeziser_Stich}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_wuchtschlag" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_wuchtschlag" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Wuchtschlag:</div>
-                        <select name="attr_Manoever_Wuchtschlag" style="width: 3em;">
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_wuchtschlag_1" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Wuchtschlag" style="width: 3em;">
+                            <option value="0">-</option>
+                            <option value="2">I</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_wuchtschlag_2" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Wuchtschlag" style="width: 3em;">
+                            <option value="0">-</option>
+                            <option value="2">I</option>
+                            <option value="4">II</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_wuchtschlag_3" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Wuchtschlag" style="width: 3em;">
                             <option value="0">-</option>
                             <option value="2">I</option>
                             <option value="4">II</option>
@@ -5883,19 +6027,19 @@
                         <div style="display:inline-block; width:13em"><b>Spezialmanöver</b></div>
                         <div style="display:inline-block; width:3em"><b>Mod</b></div>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_angriff_auf_ungeschuetzte_stellen" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_angriff_auf_ungeschuetzte_stellen" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Angriff auf ungesch. Stellen:</div>
                         <input type="checkbox" name="attr_Manoever_Angriff_auf_ungeschuetzte_Stellen" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Angriff_auf_ungeschuetzte_Stellen_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Angriff_auf_ungeschuetzte_Stellen}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_anspringen" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_anspringen" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Anspringen:</div>
                         <input type="checkbox" name="attr_Manoever_Anspringen" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Anspringen_AT_Mod" style="width: 3em;" type="number" value="-4*@{Manoever_Anspringen}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_entwaffnen" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_entwaffnen" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Entwaffnen gg.:</div>
                         <select name="attr_Manoever_Entwaffnen" style="width: 6em;">
@@ -5905,34 +6049,47 @@
                         </select>
                         <input name="attr_Manoever_Entwaffnen_AT_Mod" style="width: 3em;" type="number" value="-@{Manoever_Entwaffnen}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_flugangriff" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_flugangriff" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Flugangriff:</div>
                         <input type="checkbox" name="attr_Manoever_Flugangriff" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Flugangriff_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Flugangriff}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_hammerschlag" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_hammerschlag" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Hammerschlag:</div>
                         <input type="checkbox" name="attr_Manoever_Hammerschlag" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Hammerschlag_AT_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Hammerschlag}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_klammergriff" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_haltegriff" value="1" />
+                    <div class="sheet-sf-row">
+                        <div style="display:inline-block; width:10em;">Haltegriff:</div>
+                        <input type="checkbox" name="attr_Manoever_Haltegriff" value="1" style="width:3em;"/>
+                        <input name="attr_Manoever_Haltegriff_AT_Mod" style="width: 3em;" type="number" value="0" disabled="true"/>
+                    </div>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_klammergriff" value="1" "/>
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Klammergriff:</div>
                         <input type="checkbox" name="attr_Manoever_Klammergriff" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Klammergriff_AT_Mod" style="width: 3em;" type="number" value="-4*@{Manoever_Klammergriff}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_riposte" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_riposte" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:10em;">Riposte:</div>
                         <input type="checkbox" name="attr_Manoever_Riposte" value="1" style="width:3em;"/>
                         <input name="attr_Manoever_Riposte_PA_Mod" style="width: 3em;" type="number" value="-2*@{Manoever_Riposte}" disabled="true"/>
                     </div>
-                    <input class="sheet-sf-aktiviert" type="checkbox" name="attr_sf_rundumschlag" value="1" style="display:none;"/>
+                    <input class="hidden sheet-sf-aktiviert" type="checkbox" name="attr_sf_rundumschlag" value="1" />
                     <div class="sheet-sf-row">
                         <div style="display:inline-block; width:7em;">Rundumschlag gg.:</div>
-                        <select name="attr_Manoever_Rundumschlag" style="width: 6em;">
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_rundumschlag_1" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Rundumschlag" style="width: 6em;">
+                            <option value="0">-</option>
+                            <option value="2">1. Geg.</option>
+                            <option value="6">2. Geg.</option>
+                        </select>
+	                    <input class="hidden sheet-stufe-aktiviert" type="checkbox" name="attr_manoever_rundumschlag_2" value="1"/>
+                        <select class="sheet-max-stufe" name="attr_Manoever_Rundumschlag" style="width: 6em;">
                             <option value="0">-</option>
                             <option value="2">1. Geg.</option>
                             <option value="6">2. Geg.</option>
@@ -6002,7 +6159,7 @@
                     </div>
                     <input name="attr_Spezialmanoever_AT_Mod" style="display:none;" type="number" value="@{Manoever_Angriff_auf_ungeschuetzte_Stellen_AT_Mod} + @{Manoever_Anspringen_AT_Mod} + @{Manoever_Entwaffnen_AT_Mod} + @{Manoever_Flugangriff_AT_Mod} + @{Manoever_Hammerschlag_AT_Mod} + @{Manoever_Klammergriff_AT_Mod} + @{Manoever_Rundumschlag_AT_Mod} + @{Manoever_Schwanz_Tentakelschwung_AT_Mod} + @{Manoever_Sturmangriff_AT_Mod}+ @{Manoever_Todesstoss_AT_Mod} + @{Manoever_Verbeissen_AT_Mod} + @{Manoever_Vorstoss_AT_Mod} + @{Manoever_Zu_Fall_bringen_AT_Mod}" disabled="true"/>
                     <input name="attr_Spezialmanoever_PA_Mod" style="display:none;" type="number" value="@{Manoever_Riposte_PA_Mod} + @{Manoever_Trampeln_PA_Mod}" disabled="true"/>
-                    <input name="attr_Spezialmanoever_TP_Mod" style="display:none;" type="number" value="@{Manoever_Sturmangriff} * (2 + round((@{GS_Kampf}) / 2))" disabled="true" />
+                    <input name="attr_Spezialmanoever_TP_Mod" style="display:none;" type="number" value="(@{Manoever_Sturmangriff} * (2 + round((@{GS_Kampf}) / 2))) + (2 * @{Manoever_Flugangriff})" disabled="true" />
                 </td>
                 <td width="30%" valign="top">
                     <div>
@@ -6107,13 +6264,13 @@
                         <tr>
                             <td>Eingeengt:</td>
                             <td><input name="attr_Eingeengt" type="checkbox" value="1"/></td>
-                            <td><input name="attr_Eingeengt_Abzuege_Waffe_AT" type="number" value="-@{Eingeengt}*((@{NKW_Aktiv1}*(@{ReichweiteNKWaffe1}-1)*4)+(@{NKW_Aktiv2}*(@{ReichweiteNKWaffe2}-1)*4)+(@{NKW_Aktiv3}*(@{ReichweiteNKWaffe3}-1)*4)+(@{NKW_Aktiv4}*(@{ReichweiteNKWaffe4}-1)*4))" disabled="true"/></td>
-                            <td><input name="attr_Eingeengt_Abzuege_Waffe_PA" type="number" value="-@{Eingeengt}*((@{NKW_Aktiv1}*(@{ReichweiteNKWaffe1}-1)*4)+(@{NKW_Aktiv2}*(@{ReichweiteNKWaffe2}-1)*4)+(@{NKW_Aktiv3}*(@{ReichweiteNKWaffe3}-1)*4)+(@{NKW_Aktiv4}*(@{ReichweiteNKWaffe4}-1)*4))" disabled="true"/></td>
+                            <td><input name="attr_Eingeengt_Abzuege_Waffe_AT" type="number" value="(-@{Eingeengt}*(@{NKW_Aktiv_Reichweite}-1)*4)" disabled="true"/></td>
+                            <td><input name="attr_Eingeengt_Abzuege_Waffe_PA" type="number" value="(-@{Eingeengt}*(@{NKW_Aktiv_Reichweite}-1)*4)" disabled="true"/></td>
                         </tr>
                         <tr>
                             <td>Blutrausch:</td>
                             <td><input name="attr_Blutrausch" type="checkbox" value="1"/></td>
-                            <td><input name="attr_Blutrausch_Abzuege_Waffe_AT" type="number" value="-@{Blutrausch}*4" disabled="true"/></td>
+                            <td><input name="attr_Blutrausch_Abzuege_Waffe_AT" type="number" value="@{Blutrausch}*4" disabled="true"/></td>
                             <td><input name="attr_Blutrausch_Abzuege_Waffe_PA" type="number" value="0" disabled="true"/></td>
                         </tr>
                         <tr>
@@ -6145,92 +6302,142 @@
                     <input name="attr_Situationen_PA_Mod" type="number" value="@{GegnerRW_Abzuege_Waffe_PA}+@{GegnerKT_Abzuege_Waffe_PA}+@{Eingeengt_Abzuege_Waffe_PA}+@{Blutrausch_Abzuege_Waffe_PA}+@{Liegend_Abzuege_Waffe_PA}+@{Vorteilhafte_Position_Waffe_PA}+@{Kampf_im_Wasser_Waffe_PA}+@{Kampf_unter_Wasser_Waffe_PA}+@{Sicht_Mod_Abzuege_Waffe_PA}" style="display:none;" disabled="true"/>
                     <input name="attr_Situationen_TP_Mod" type="number" value="@{Blutrausch}*2" style="display:none;" disabled="true"/>
                 </td>
+                <td width="5%">
+                </td>
                 <td valign="top">
-                    <table>
-                      <tr>
-                            <th>Hauptwaffe</th>
-                            <th>AT</th>
-                            <th>PA</th>
-                            <th>Aktiv</th>
-                            <th>Als ZH</th>
-                      </tr>
-                      <tr align="center">
-                            <td><input type="text" name="attr_NKWname1" style="width: 11em;" ></td>
-                            <td><input type="number" name="attr_AT_NKW1" disabled=true value="(@{NKWtyp1}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW1})*(1-@{gegner_sheet})+@{AT_NKW1_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_PA_NKW1" disabled=true value="(round(@{NKWtyp1}/2)+@{PAMod_NKW1}+@{OptPA_GW}+floor((@{NKW1_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW1})*(1-@{gegner_sheet})+@{PA_NKW1_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="checkbox" name="attr_NKW_Aktiv1" value="1" checked="true"></td>
-                            <td><input type="checkbox" name="attr_EHalsZH_NKW1" value="1"></td>
-                      </tr>
-                      <tr align="center">
-                            <td><input type="text" name="attr_NKWname2" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW2" disabled=true value="(@{NKWtyp2}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW2})*(1-@{gegner_sheet})+@{AT_NKW2_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_PA_NKW2" disabled=true value="(round(@{NKWtyp2}/2)+@{PAMod_NKW2}+@{OptPA_GW}+floor((@{NKW2_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW2})*(1-@{gegner_sheet})+@{PA_NKW2_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="checkbox" name="attr_NKW_Aktiv2" value="1"></td>
-                            <td><input type="checkbox" name="attr_EHalsZH_NKW2" value="1"></td>
-                      </tr>
-                      <tr align="center">
-                            <td><input type="text" name="attr_NKWname3" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW3" disabled=true value="(@{NKWtyp3}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW3})*(1-@{gegner_sheet})+@{AT_NKW3_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_PA_NKW3" disabled=true value="(round(@{NKWtyp3}/2)+@{PAMod_NKW3}+@{OptPA_GW}+floor((@{NKW3_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW3})*(1-@{gegner_sheet})+@{PA_NKW3_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="checkbox" name="attr_NKW_Aktiv3" value="1"></td>
-                            <td><input type="checkbox" name="attr_EHalsZH_NKW3" value="1"></td>
-                      </tr>
-                      <tr align="center">
-                            <td><input type="text" name="attr_NKWname4" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_AT_NKW4" disabled=true value="(@{NKWtyp4}+floor((@{MU_Wert}-8)/3)+@{ATMod_NKW4})*(1-@{gegner_sheet})+@{AT_NKW4_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="number" name="attr_PA_NKW4" disabled=true value="(round(@{NKWtyp4}/2)+@{PAMod_NKW4}+@{OptPA_GW}+floor((@{NKW4_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW4})*(1-@{gegner_sheet})+@{PA_NKW4_Fix}*(0+@{gegner_sheet})"></td>
-                            <td><input type="checkbox" name="attr_NKW_Aktiv4" value="1"></td>
-                            <td><input type="checkbox" name="attr_EHalsZH_NKW4" value="1"></td>
-                      </tr>
-                    </table>
+                	<div class="waffenauswahl">
+                		<input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                		<div class="waffenauswahl-aktiv"></div>
+                		<div class="waffenauswahl-name"><b>Hauptwaffe</b></div>
+                		<div class="waffenauswahl-at"><b>AT</b></div>
+                		<div class="waffenauswahl-pa sheet-humanoid"><b>PA</b></div>
+                		<div class="waffenauswahl-als-zh sheet-humanoid"><b>Als ZH</b></div>
+                	</div>
+                	<br />
+                	<div class="waffenauswahl">
+                		<input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                		<div class="waffenauswahl-aktiv"><input type="radio" name="attr_NKW_Aktiv" value="1" checked="true"></div>
+                		<div class="waffenauswahl-name"><input type="text" name="attr_NKWname1" ></div>
+                		<div class="waffenauswahl-at"><input type="number" name="attr_AT_NKW1" disabled=true value="(@{NKWtyp1}+@{Leiteigenschaft_AT_Mod}+@{ATMod_NKW1})*(1-@{gegner_sheet})+(@{AT_NKW1_Fix})*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-pa sheet-humanoid"><input type="number" name="attr_PA_NKW1" disabled=true value="(round(@{NKWtyp1}/2)+@{PAMod_NKW1}+@{OptPA_GW}+floor((@{NKW1_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW1})*(1-@{gegner_sheet})+@{PA_NKW1_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-als-zh sheet-humanoid"><input type="checkbox" name="attr_EHalsZH_NKW1" value="1"></div>
+                	</div>
+                	<br />
+                	<div class="waffenauswahl">
+                		<input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                		<div class="waffenauswahl-aktiv"><input type="radio" name="attr_NKW_Aktiv" value="2"></div>
+                		<div class="waffenauswahl-name"><input type="text" name="attr_NKWname2" ></div>
+                		<div class="waffenauswahl-at"><input type="number" name="attr_AT_NKW2" disabled=true value="(@{NKWtyp2}+@{Leiteigenschaft_AT_Mod}+@{ATMod_NKW2})*(1-@{gegner_sheet})+@{AT_NKW2_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-pa sheet-humanoid"><input type="number" name="attr_PA_NKW2" disabled=true value="(round(@{NKWtyp2}/2)+@{PAMod_NKW2}+@{OptPA_GW}+floor((@{NKW2_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW2})*(1-@{gegner_sheet})+@{PA_NKW2_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-als-zh sheet-humanoid"><input type="checkbox" name="attr_EHalsZH_NKW2" value="1"></div>
+                	</div>
+                	<br />
+                	<div class="waffenauswahl">
+                		<input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                		<div class="waffenauswahl-aktiv"><input type="radio" name="attr_NKW_Aktiv" value="3"></div>
+                		<div class="waffenauswahl-name"><input type="text" name="attr_NKWname3"></div>
+                		<div class="waffenauswahl-at"><input type="number" name="attr_AT_NKW3" disabled=true value="(@{NKWtyp3}+@{Leiteigenschaft_AT_Mod}+@{ATMod_NKW3})*(1-@{gegner_sheet})+@{AT_NKW3_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-pa sheet-humanoid"><input type="number" name="attr_PA_NKW3" disabled=true value="(round(@{NKWtyp3}/2)+@{PAMod_NKW3}+@{OptPA_GW}+floor((@{NKW3_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW3})*(1-@{gegner_sheet})+@{PA_NKW3_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-als-zh sheet-humanoid"><input type="checkbox" name="attr_EHalsZH_NKW3" value="1"></div>
+                	</div>
+                	<br />
+                	<div class="waffenauswahl">
+                		<input type="checkbox" class="hidden sheet-show-nicht-humanoid" name="attr_nicht_humanoid" value="1" />
+                		<div class="waffenauswahl-aktiv"><input type="radio" name="attr_NKW_Aktiv" value="4"></div>
+                		<div class="waffenauswahl-name"><input type="text" name="attr_NKWname4"></div>
+                		<div class="waffenauswahl-at"><input type="number" name="attr_AT_NKW4" disabled=true value="(@{NKWtyp4}+@{Leiteigenschaft_AT_Mod}+@{ATMod_NKW4})*(1-@{gegner_sheet})+@{AT_NKW4_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-pa sheet-humanoid"><input type="number" name="attr_PA_NKW4" disabled=true value="(round(@{NKWtyp4}/2)+@{PAMod_NKW4}+@{OptPA_GW}+floor((@{NKW4_Leiteigenschaft}-8)/3)-@{EHalsZH_NKW4})*(1-@{gegner_sheet})+@{PA_NKW4_Fix}*(0+@{gegner_sheet})"></div>
+                		<div class="waffenauswahl-als-zh sheet-humanoid"><input type="checkbox" name="attr_EHalsZH_NKW4" value="1"></div>
+                	</div>
                     <br />
-                    <input class="sheet-gegner" type="checkbox" value="1" name="attr_gegner_sheet" style="display:none;" />
-                    <div class="sheet-kein-gegner">
-                    <table>
-                        <tr>
-                            <th>Schild/Parierwaffe</th>
-                            <th>Strukturp.</th>
-                            <th colspan="2">AT/PA</th>
-                            <th>Aktiv</th>
-                        </tr>
-                         <tr align="center">
-                            <td><input type="text" name="attr_SchildName1" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_SchildStrukturpunkte1"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildAT1" value="@{Schild1_KT}+floor((@{MU_Wert}-8)/3)+@{SchildATMod1}"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildPA1" value="round(@{Schild1_KT}/2)+floor((@{Schild1_Leiteigenschaft}-8)/3)+@{OptPA_GW}+(@{SchildPAMod1}*2)"></td>
-                            <td><input type="checkbox" name="attr_Schild_Aktiv1" value="1"></td>
-                        </tr>
-                        <tr align="center">
-                            <td><input type="text" name="attr_SchildName2" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_SchildStrukturpunkte2"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildAT2" value="@{Schild2_KT}+floor((@{MU_Wert}-8)/3)+@{SchildATMod2}"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildPA2" value="round(@{Schild2_KT}/2)+floor((@{Schild2_Leiteigenschaft}-8)/3)+@{OptPA_GW}+(@{SchildPAMod2}*2)"></td>
-                            <td><input type="checkbox" name="attr_Schild_Aktiv2" value="1"></td>
-                        </tr>
-                        <tr align="center">
-                            <td><input type="text" name="attr_SchildName3" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_SchildStrukturpunkte3"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildAT3" value="@{Schild3_KT}+floor((@{MU_Wert}-8)/3)+@{SchildATMod3}"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildPA3" value="round(@{Schild3_KT}/2)+floor((@{Schild3_Leiteigenschaft}-8)/3)+@{OptPA_GW}+(@{SchildPAMod3}*2)"></td>
-                            <td><input type="checkbox" name="attr_Schild_Aktiv3" value="1"></td>
-                        </tr>
-                        <tr align="center">
-                            <td><input type="text" name="attr_SchildName4" style="width: 11em;"></td>
-                            <td><input type="number" name="attr_SchildStrukturpunkte4"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildAT4" value="@{Schild4_KT}+floor((@{MU_Wert}-8)/3)+@{SchildATMod4}"></td>
-                            <td><input type="number" disabled="true" name="attr_SchildPA4" value="round(@{Schild4_KT}/2)+floor((@{Schild4_Leiteigenschaft}-8)/3)+@{OptPA_GW}+(@{SchildPAMod4}*2)"></td>
-                            <td><input type="checkbox" name="attr_Schild_Aktiv4" value="1"></td>
-                        </tr>
-                    </table>
+                	<br />
+                    <input class="hidden sheet-zeige-schilde" type="checkbox" value="1" name="attr_zeige_schilde" />
+	                <input type="checkbox" class="hidden sheet-show-nicht-humanoid" value="1" name="attr_nicht_humanoid" />
+                    <div class="sheet-humanoid sheet-schilde">
+	                	<div class="schildauswahl">
+	                		<div class="schildauswahl-aktiv"></div>
+	                		<div class="schildauswahl-name"><b>Schild</b> (Aktiv: <input type="checkbox" value="1" name="attr_schild_ausgeruestet" />)</div>
+	                		<div class="schildauswahl-at"><b>AT</b></div>
+	                		<div class="schildauswahl-pa"><b>PA</b></div>
+	                		<div class="schildauswahl-stuktur"><b>Strukturp.</b></div>
+	                	</div>
+	                	<br />
+	                	<div class="schildauswahl">
+	                		<div class="schildauswahl-aktiv"><input type="radio" name="attr_Schild_Aktiv" value="1"></div>
+	                		<div class="schildauswahl-name"><input type="text" name="attr_SchildName1"></div>
+	                		<div class="schildauswahl-at"><input type="number" disabled="true" name="attr_SchildAT1" value="@{AT_Schilde}+@{SchildATMod1}"></div>
+	                		<div class="schildauswahl-pa"><input type="number" disabled="true" name="attr_SchildPA1" value="@{PA_Schilde}+@{OptPA_GW}+(@{SchildPAMod1}*2)"></div>
+	                		<div class="schildauswahl-stuktur"><input type="number" name="attr_SchildStrukturpunkte1"></div>
+	                	</div>
+	                	<br />
+	                	<div class="schildauswahl">
+	                		<div class="schildauswahl-aktiv"><input type="radio" name="attr_Schild_Aktiv" value="2"></div>
+	                		<div class="schildauswahl-name"><input type="text" name="attr_SchildName2"></div>
+	                		<div class="schildauswahl-at"><input type="number" disabled="true" name="attr_SchildAT2" value="@{AT_Schilde}+@{SchildATMod2}"></div>
+	                		<div class="schildauswahl-pa"><input type="number" disabled="true" name="attr_SchildPA2" value="@{PA_Schilde}+@{OptPA_GW}+(@{SchildPAMod2}*2)"></div>
+	                		<div class="schildauswahl-stuktur"><input type="number" name="attr_SchildStrukturpunkte2"></div>
+	                	</div>
+	                	<br />
+	                	<div class="schildauswahl">
+	                		<div class="schildauswahl-aktiv"><input type="radio" name="attr_Schild_Aktiv" value="3"></div>
+	                		<div class="schildauswahl-name"><input type="text" name="attr_SchildName3"></div>
+	                		<div class="schildauswahl-at"><input type="number" disabled="true" name="attr_SchildAT3" value="@{AT_Schilde}+@{SchildATMod3}"></div>
+	                		<div class="schildauswahl-pa"><input type="number" disabled="true" name="attr_SchildPA3" value="@{PA_Schilde}+@{OptPA_GW}+(@{SchildPAMod3}*2)"></div>
+	                		<div class="schildauswahl-stuktur"><input type="number" name="attr_SchildStrukturpunkte3"></div>
+	                	</div>
+	                	<br />
+	                	<div class="schildauswahl">
+	                		<div class="schildauswahl-aktiv"><input type="radio" name="attr_Schild_Aktiv" value="4"></div>
+	                		<div class="schildauswahl-name"><input type="text" name="attr_SchildName4"></div>
+	                		<div class="schildauswahl-at"><input type="number" disabled="true" name="attr_SchildAT4" value="@{AT_Schilde}+@{SchildATMod4}"></div>
+	                		<div class="schildauswahl-pa"><input type="number" disabled="true" name="attr_SchildPA4" value="@{PA_Schilde}+@{OptPA_GW}+(@{SchildPAMod4}*2)"></div>
+	                		<div class="schildauswahl-stuktur"><input type="number" name="attr_SchildStrukturpunkte4"></div>
+	                	</div>
+                    </div>
+	               	<br />
+                    <input class="hidden sheet-zeige-parierwaffen" type="checkbox" value="1" name="attr_zeige_parierwaffen" />
+                    <div class="sheet-humanoid sheet-parierwaffen">
+	                	<div class="parierwaffenauswahl">
+	                		<div class="parierwaffenauswahl-aktiv"></div>
+	                		<div class="parierwaffenauswahl-name"><b>Parierwaffe</b> (Aktiv: <input type="checkbox" value="1" name="attr_parierwaffe_ausgeruestet" />)</div>
+	                		<div class="parierwaffenauswahl-at"><b>AT</b></div>
+	                		<div class="parierwaffenauswahl-pa"><b>PA</b></div>
+	                	</div>
+	                	<div class="parierwaffenauswahl">
+	                		<div class="parierwaffenauswahl-aktiv"><input type="radio" name="attr_Parierwaffe_Aktiv" value="1"></div>
+	                		<div class="parierwaffenauswahl-name"><input type="text" name="attr_ParierwaffeName1" style="width: 11em;"></div>
+	                		<div class="parierwaffenauswahl-at"><input type="number" disabled="true" name="attr_ParierwaffeAT1" value="@{AT_Dolche}+@{ParierwaffeATMod1}"></div>
+	                		<div class="parierwaffenauswahl-pa"><input type="number" disabled="true" name="attr_ParierwaffePA1" value="@{PA_Dolche}+@{ParierwaffePAMod1}"></div>
+	                	</div>
+	                	<div class="parierwaffenauswahl">
+	                		<div class="parierwaffenauswahl-aktiv"><input type="radio" name="attr_Parierwaffe_Aktiv" value="2"></div>
+	                		<div class="parierwaffenauswahl-name"><input type="text" name="attr_ParierwaffeName2" style="width: 11em;"></div>
+	                		<div class="parierwaffenauswahl-at"><input type="number" disabled="true" name="attr_ParierwaffeAT2" value="@{AT_Dolche}+@{ParierwaffeATMod2}"></div>
+	                		<div class="parierwaffenauswahl-pa"><input type="number" disabled="true" name="attr_ParierwaffePA2" value="@{PA_Dolche}+@{ParierwaffePAMod2}"></div>
+	                	</div>
+	                	<div class="parierwaffenauswahl">
+	                		<div class="parierwaffenauswahl-aktiv"><input type="radio" name="attr_Parierwaffe_Aktiv" value="3"></div>
+	                		<div class="parierwaffenauswahl-name"><input type="text" name="attr_ParierwaffeName3" style="width: 11em;"></div>
+	                		<div class="parierwaffenauswahl-at"><input type="number" disabled="true" name="attr_ParierwaffeAT3" value="@{AT_Dolche}+@{ParierwaffeATMod3}"></div>
+	                		<div class="parierwaffenauswahl-pa"><input type="number" disabled="true" name="attr_ParierwaffePA3" value="@{PA_Dolche}+@{ParierwaffePAMod3}"></div>
+	                	</div>
+	                	<div class="parierwaffenauswahl">
+	                		<div class="parierwaffenauswahl-aktiv"><input type="radio" name="attr_Parierwaffe_Aktiv" value="4"></div>
+	                		<div class="parierwaffenauswahl-name"><input type="text" name="attr_ParierwaffeName4" style="width: 11em;"></div>
+	                		<div class="parierwaffenauswahl-at"><input type="number" disabled="true" name="attr_ParierwaffeAT4" value="@{AT_Dolche}+@{ParierwaffeATMod4}"></div>
+	                		<div class="parierwaffenauswahl-pa"><input type="number" disabled="true" name="attr_ParierwaffePA4" value="@{PA_Dolche}+@{ParierwaffePAMod4}"></div>
+	                	</div>
                     </div>
                 </td>
-        </div>      
+            </tr>
+        </table>
+        </div>
         
         <div class="sheet-section sheet section-fightvalues3">
             <table>
             <tr>
                 <th>
-                    INI <input type="number" name="attr_INI_Aktiv" value="((@{INI_Wert}) * (1 - @{gegner_sheet})) + (@{INI_Wert_Fix}*(0+@{gegner_sheet}))" disabled="true">
+                    INI <input type="number" name="attr_INI_Aktiv" value="@{INI_Wert}" disabled="true">
                     <button type=roll value="[[(1d6+@{INI_Aktiv})&{tracker}]] @{Charaktername}´s Initiative" />
                 </th>
                 <th>
@@ -6240,7 +6447,7 @@
                     BE <input type="number" name="attr_BE_Kampf" style='width: 4em' value="@{Ges_BE}" disabled="true" />
                 </th>
                 <th>
-                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="(@{GS_Wert})*(1-@{gegner_sheet})+(@{GS_Wert_Fix})*(0+@{gegner_sheet})" disabled="true" />
+                    GS <input type="number" name="attr_GS_Kampf" style='width: 4em' value="@{GS_Wert}" disabled="true" />
                 </th>
                 <th>
                     LE <input type="number" name="attr_LE_Wert" style='width: 4em' value="@{LE_Wert}" />
@@ -6254,6 +6461,9 @@
             <table width="100%">
                 <tr>
                     <td valign="top">
+		            <input type="number" name="attr_FKW_FK_Bonus_Leiteigenschaft" value="0" style="display:none"/>
+            		<input type="number" name="attr_FTP_W_Aktiv_Waffe" value="0" style="display:none"/>
+            		<input type="number" name="attr_FTP_Bonus_Aktiv_Waffe" value="0" style="display:none"/>
                     <table valign="top">
                         <tr>
                             <th colspan="2">Angriff</th>
@@ -6262,15 +6472,15 @@
                         </tr>
                         <tr>
                             <td colspan="2">Attacke:</td>
-                            <td><input type="number" name="attr_FK_Aktiv" style='width: 4em' value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4}) - @{Ges_BE} + @{Zustand_Mod_max_abzl_BE} + @{FK_Mod}" disabled="true" /></td>
+                            <td><input type="number" name="attr_FK_Aktiv" style='width: 4em' value="@{FK_Aktiv_Waffe} - @{Ges_BE} + @{Zustand_Mod_max_abzl_BE} + @{FK_Mod}" disabled="true" /></td>
                             <td>
                                 <button type="roll" value="&{template:DSA-Fernkampf-AT} {{name=Fernkampf-AT}} {{subtags=Fernkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{FK_Aktiv})]]}} {{mod=[[d0]]}}" />
                             </td>
                         </tr>
                         <tr>
                             <td>Trefferpunkte:</td>
-                            <td><input type="number" disabled="true" name="attr_FTP_W_Aktiv" style='width: 3em' value="@{FKW_Aktiv1} * @{FKWSchaden1_1} + @{FKW_Aktiv2} * @{FKWSchaden2_1} + @{FKW_Aktiv3} * @{FKWSchaden3_1} + @{FKW_Aktiv4} * @{FKWSchaden4_1}"/>W+</td>
-                            <td><input type="number" disabled="true" name="attr_FTP_Bonus_Aktiv" style='width: 4em' value="@{FKW_Aktiv1} * (@{FKWSchaden1_2}) + @{FKW_Aktiv2} * (@{FKWSchaden2_2}) + @{FKW_Aktiv3} * (@{FKWSchaden3_2}) + @{FKW_Aktiv4} * (@{FKWSchaden4_2}) + @{FK_TP_Mod}"/></td>
+                            <td><input type="number" disabled="true" name="attr_FTP_W_Aktiv" style='width: 3em' value="@{FTP_W_Aktiv_Waffe}"/>W+</td>
+                            <td><input type="number" disabled="true" name="attr_FTP_Bonus_Aktiv" style='width: 4em' value="@{FTP_Bonus_Aktiv_Waffe} + @{FK_TP_Mod}"/></td>
                             <td>
                                 <button type="roll" value="&{template:DSA-Fernkampf-TP}  {{name=Fernkampf-TP}} {{subtags=Fernkampf}} {{damage=[[[[(@{FTP_W_Aktiv})]]d6 + @{FTP_Bonus_Aktiv}]]}}" />
                                 <button type="roll" value="&{template:DSA-Fernkampf-TP}  {{name=Fernkampf-TP}} {{subtags=Fernkampf}} {{damage=[[([[(@{FTP_W_Aktiv})]]d6 + @{FTP_Bonus_Aktiv})*2]]}}">x2</button>
@@ -6284,7 +6494,44 @@
                                 <button class="default" type="roll" value="@{Charaktername} erleidet [[1d6+2]] SP durch einen Patzer" ></button>
                             </td>
                         </tr>
+                        <tr>
+                            <td>Reichweite:</td>
+                            <td colspan="3">
+                                <input type="text" name="attr_FKWReichweite" style="width:8em;"/>
+                            </td>
+                        </tr>
                     </table>
+	               	<br />
+	              	<div class="fernwaffenauswahl">
+	               		<div class="fernwaffenauswahl-aktiv"></div>
+	               		<div class="fernwaffenauswahl-name"><b>Fernwaffe</b></div>
+	               		<div class="fernwaffenauswahl-fk"><b>FK</b></div>
+	               	</div>
+	               	<br />
+	               	<div class="fernwaffenauswahl">
+	               		<div class="fernwaffenauswahl-aktiv"><input type="radio" name="attr_FKW_Aktiv" value="1" checked="true"></div>
+	               		<div class="fernwaffenauswahl-name"><input type="text" name="attr_FKWname1" style="width: 12em;"></div>
+	               		<div class="fernwaffenauswahl-fk"><input type="number" name="attr_FKWFK1" disabled=true value="(@{FKWtyp1}+@{FKW_FK_Bonus_Leiteigenschaft})*(1-@{gegner_sheet})+@{FKW1_Fix}*(0+@{gegner_sheet})"></div>
+	               	</div>
+	               	<br />
+	               	<div class="fernwaffenauswahl">
+	               		<div class="fernwaffenauswahl-aktiv"><input type="radio" name="attr_FKW_Aktiv" value="2"></div>
+	               		<div class="fernwaffenauswahl-name"><input type="text" name="attr_FKWname2" style="width: 12em;"></div>
+	               		<div class="fernwaffenauswahl-fk"><input type="number" name="attr_FKWFK2" disabled=true value="(@{FKWtyp2}+@{FKW_FK_Bonus_Leiteigenschaft})*(1-@{gegner_sheet})+@{FKW2_Fix}*(0+@{gegner_sheet})"></div>
+	               	</div>
+	               	<br />
+	               	<div class="fernwaffenauswahl">
+	               		<div class="fernwaffenauswahl-aktiv"><input type="radio" name="attr_FKW_Aktiv" value="3"></div>
+	               		<div class="fernwaffenauswahl-name"><input type="text" name="attr_FKWname3" style="width: 12em;"></div>
+	               		<div class="fernwaffenauswahl-fk"><input type="number" name="attr_FKWFK3" disabled=true value="(@{FKWtyp3}+@{FKW_FK_Bonus_Leiteigenschaft})*(1-@{gegner_sheet})+@{FKW3_Fix}*(0+@{gegner_sheet})"></div>
+	               	</div>
+	               	<br />
+	               	<div class="fernwaffenauswahl">
+	               		<div class="fernwaffenauswahl-aktiv"><input type="radio" name="attr_FKW_Aktiv" value="4"></div>
+	               		<div class="fernwaffenauswahl-name"><input type="text" name="attr_FKWname4" style="width: 12em;"></div>
+	               		<div class="fernwaffenauswahl-fk"><input type="number" name="attr_FKWFK4" disabled=true value="(@{FKWtyp4}+@{FKW_FK_Bonus_Leiteigenschaft})*(1-@{gegner_sheet})+@{FKW4_Fix}*(0+@{gegner_sheet})"></div>
+	               	</div>
+                    
                     </td>
                     <td valign="top">
                     <table>
@@ -6337,7 +6584,7 @@
                             <td>
                                 <select name="attr_Ziel_Bewegung_Mod" style="width: 8em;">
                                     <option value="1">still</option>
-                                    <option value="0">leicht</option>
+                                    <option value="0" selected="selected">leicht</option>
                                     <option value="-1">schnell</option>
                                     <option value="-2">hakenschlagend</option>
                                 </select>
@@ -6391,50 +6638,6 @@
                     </td>
                 </tr>
             </table>
-            <table align="left">
-                <tr>
-                    <h3>Waffenauswahl</h3>
-                    <th>Waffe</th>
-                    <th>Ladezeit</th>
-                    <th>Reichweite</th>
-                    <th>FK</th>
-                    <th>Munition</th>
-                    <th>Aktiv</th>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname1" style="width: 12em;"></td>
-                    <td><input type="text" name="attr_FKWLadezeit1" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite1" style="width: 8em;"></td>
-                    <td><input type="number" name="attr_FKWFK1" disabled=true value="(@{FKWtyp1}+floor((@{FF_Wert}-8)/3))*(1-@{gegner_sheet})+@{FKW1_Fix}*(0+@{gegner_sheet})"></td>
-                    <td><input type="number" name="attr_FKWMunition1"></td>
-                    <td><input type="checkbox" name="attr_FKW_Aktiv1" value="1" checked="true"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname2" style="width: 12em;"></td>
-                    <td><input type="text" name="attr_FKWLadezeit2" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite2" style="width: 8em;"></td>
-                    <td><input type="number" name="attr_FKWFK2" disabled=true value="@{FKWtyp2}+floor((@{FF_Wert}-8)/3)"></td>
-                    <td><input type="number" name="attr_FKWMunition2"></td>
-                    <td><input type="checkbox" name="attr_FKW_Aktiv2" value="1"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname3" style="width: 12em;"></td>
-                    <td><input type="text" name="attr_FKWLadezeit3" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite3" style="width: 8em;"></td>
-                    <td><input type="number" name="attr_FKWFK3" disabled=true value="@{FKWtyp3}+floor((@{FF_Wert}-8)/3)"></td>
-                    <td><input type="number" name="attr_FKWMunition3"></td>
-                    <td><input type="checkbox" name="attr_FKW_Aktiv3" value="1"></td>
-                </tr>
-                <tr align=center>
-                    <td><input type="text" name="attr_FKWname4" style="width: 12em;"></td>
-                    <td><input type="text" name="attr_FKWLadezeit4" style="width: 4em;"></td>
-                    <td><input type="text" name="attr_FKWReichweite4" style="width: 8em;"></td>
-                    <td><input type="number" name="attr_FKWFK4" disabled=true value="@{FKWtyp4}+floor((@{FF_Wert}-8)/3)"></td>
-                    <td><input type="number" name="attr_FKWMunition4"></td>
-                    <td><input type="checkbox" name="attr_FKW_Aktiv4" value="1"></td>
-                </tr>
-            </table> 
-        
         </div>      
         
         <div class="sheet-section sheet section-fightvalues4">
@@ -6477,7 +6680,7 @@
                         </select></td>
                     <td align="center">B</td>
                     <td align="center"><input type="number" name="attr_KtW_Dolche" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Dolche" value="@{KtW_Dolche}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Dolche" value="@{KtW_Dolche}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Dolche" value="round(@{KtW_Dolche}/2)+floor((@{Dolche}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6488,7 +6691,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Fechtwaffen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Fechtwaffen" value="@{KtW_Fechtwaffen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Fechtwaffen" value="@{KtW_Fechtwaffen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Fechtwaffen" value="round(@{KtW_Fechtwaffen}/2)+floor((@{Fechtwaffen}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6499,7 +6702,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Hiebwaffen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Hiebwaffen" value="@{KtW_Hiebwaffen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Hiebwaffen" value="@{KtW_Hiebwaffen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Hiebwaffen" value="round(@{KtW_Hiebwaffen}/2)+floor((@{Hiebwaffen}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6510,7 +6713,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Kettenwaffen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Kettenwaffen" value="@{KtW_Kettenwaffen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Kettenwaffen" value="@{KtW_Kettenwaffen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"></td>
                 </tr>
                 <tr>
@@ -6521,7 +6724,7 @@
                         </select></td>
                     <td align="center">B</td>
                     <td align="center"><input type="number" name="attr_KtW_Lanzen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Lanzen" value="@{KtW_Lanzen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Lanzen" value="@{KtW_Lanzen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"></td>
                 </tr>
                 <tr>
@@ -6533,7 +6736,7 @@
                         </select></td>
                     <td align="center">B</td>
                     <td align="center"><input type="number" name="attr_KtW_Raufen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Raufen" value="@{KtW_Raufen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Raufen" value="@{KtW_Raufen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Raufen" value="round(@{KtW_Raufen}/2)+floor((@{Raufen}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6544,7 +6747,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Schilde" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Schilde" value="@{KtW_Schilde}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Schilde" value="@{KtW_Schilde}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Schilde" value="round(@{KtW_Schilde}/2)+floor((@{Schilde}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6556,7 +6759,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Schwerter" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Schwerter" value="@{KtW_Schwerter}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Schwerter" value="@{KtW_Schwerter}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Schwerter" value="round(@{KtW_Schwerter}/2)+floor((@{Schwerter}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6568,7 +6771,7 @@
                         </select></td>
                     <td align="center">C</td>
                     <td align="center"><input type="number" name="attr_KtW_Stangenwaffen" value="6"></td>
-                    <td align="center"><input type="number" name="attr_AT_Stangenwaffen" value="@{KtW_Stangenwaffen}+floor((@{MU_Wert}-8)/3)" disabled=true></td>
+                    <td align="center"><input type="number" name="attr_AT_Stangenwaffen" value="@{KtW_Stangenwaffen}+@{Leiteigenschaft_AT_Mod}" disabled=true></td>
                     <td align="center"><input type="number" name="attr_PA_Stangenwaffen" value="round(@{KtW_Stangenwaffen}/2)+floor((@{Stangenwaffen}-8)/3)+@{OptPA_GW}" disabled=true></td>
                 </tr>
                 <tr>
@@ -6615,216 +6818,186 @@
 		                <tr>
 		                    <th>Name</th>
 		                    <th>Aktiv</th>
-		                    <th>Stufe</th>
 		                <tr>
 		                    <td>Aufmerksamkeit:</td>
 		                    <td><input type="checkbox" name="attr_sf_aufmerksamkeit" value="1"/></td>
 		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Belastungsgewöhnung:</td>
-		                    <td><input type="checkbox" name="attr_sf_belastungsgewoehnung" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_belastungsgewoehnung_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                        </select>
-		                    </td>
+		                    <td>Belastungsgewöhnung I:</td>
+		                    <td><input type="checkbox" name="attr_sf_belastungsgewoehnung_1" value="1"/></td>
 		                </tr>
 		                <tr>
-		                    <td>Beidhändiger Kampf:</td>
-		                    <td><input type="checkbox" name="attr_sf_bh_kampf" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_bh_kampf_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                        </select>
-		                    </td>
+		                    <td>Belastungsgewöhnung II:</td>
+		                    <td><input type="checkbox" name="attr_sf_belastungsgewoehnung_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Beidhändiger Kampf I:</td>
+		                    <td><input type="checkbox" name="attr_sf_bh_kampf_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Beidhändiger Kampf II:</td>
+		                    <td><input type="checkbox" name="attr_sf_bh_kampf_2" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Berittener Kampf:</td>
 		                    <td><input type="checkbox" name="attr_sf_berittener_kampf" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Berittener Schütze:</td>
 		                    <td><input type="checkbox" name="attr_sf_berittener_schuetze" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Einhändiger Kampf:</td>
 		                    <td><input type="checkbox" name="attr_sf_eh_kampf" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Entwaffnen:</td>
 		                    <td><input type="checkbox" name="attr_sf_entwaffnen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Feindgespür:</td>
 		                    <td><input type="checkbox" name="attr_sf_feindgespuer" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Finte:</td>
-		                    <td><input type="checkbox" name="attr_sf_finte" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_finte_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Finte I:</td>
+		                    <td><input type="checkbox" name="attr_sf_finte_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Finte II:</td>
+		                    <td><input type="checkbox" name="attr_sf_finte_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Finte III:</td>
+		                    <td><input type="checkbox" name="attr_sf_finte_3" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Haltegriff:</td>
 		                    <td><input type="checkbox" name="attr_sf_haltegriff" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Hammerschlag:</td>
 		                    <td><input type="checkbox" name="attr_sf_hammerschlag" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Kampfreflexe:</td>
-		                    <td><input type="checkbox" name="attr_sf_kampfreflexe" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_kampfreflexe_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Kampfreflexe I:</td>
+		                    <td><input type="checkbox" name="attr_sf_kampfreflexe_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Kampfreflexe II:</td>
+		                    <td><input type="checkbox" name="attr_sf_kampfreflexe_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Kampfreflexe III:</td>
+		                    <td><input type="checkbox" name="attr_sf_kampfreflexe_3" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Klingenfänger:</td>
 		                    <td><input type="checkbox" name="attr_sf_klingenfaenger" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Kreuzblock:</td>
 		                    <td><input type="checkbox" name="attr_sf_kreuzblock" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Lanzenangriff:</td>
 		                    <td><input type="checkbox" name="attr_sf_lanzenangriff" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Präziser Schuss/Wurf:</td>
-		                    <td><input type="checkbox" name="attr_sf_praeziser_schuss" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_praeziser_schuss_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Präziser Schuss/Wurf I:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_schuss_1" value="1"/></td>
 		                </tr>
 		                <tr>
-		                    <td>Präziser Stich:</td>
-		                    <td><input type="checkbox" name="attr_sf_praeziser_stich" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_praeziser_stich_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Präziser Schuss/Wurf II:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_schuss_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Präziser Schuss/Wurf III:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_schuss_3" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Präziser Stich I:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_stich_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Präziser Stich II:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_stich_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Präziser Stich III:</td>
+		                    <td><input type="checkbox" name="attr_sf_praeziser_stich_3" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Riposte:</td>
 		                    <td><input type="checkbox" name="attr_sf_riposte" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Rundumschlag:</td>
-		                    <td><input type="checkbox" name="attr_sf_rundumschlag" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_rundumschlag_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                        </select>
-		                    </td>
+		                    <td>Rundumschlag I:</td>
+		                    <td><input type="checkbox" name="attr_sf_rundumschlag_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Rundumschlag II:</td>
+		                    <td><input type="checkbox" name="attr_sf_rundumschlag_2" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Schildspalter:</td>
 		                    <td><input type="checkbox" name="attr_sf_schildspalter" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Schnellladen:</td>
 		                    <td><input type="checkbox" name="attr_sf_schnellladen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Schnellziehen:</td>
 		                    <td><input type="checkbox" name="attr_sf_schnellziehen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Sturmangriff:</td>
 		                    <td><input type="checkbox" name="attr_sf_sturmangriff" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Todesstoß:</td>
 		                    <td><input type="checkbox" name="attr_sf_todesstoss" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Verbessertes Ausweichen:</td>
-		                    <td><input type="checkbox" name="attr_sf_verb_ausweichen" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_verb_ausweichen_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Verbessertes Ausweichen I:</td>
+		                    <td><input type="checkbox" name="attr_sf_verb_ausweichen_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Verbessertes Ausweichen II:</td>
+		                    <td><input type="checkbox" name="attr_sf_verb_ausweichen_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Verbessertes Ausweichen III:</td>
+		                    <td><input type="checkbox" name="attr_sf_verb_ausweichen_3" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Verteidigungshaltung:</td>
 		                    <td><input type="checkbox" name="attr_sf_verteidigungshaltung" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Vorstoß:</td>
 		                    <td><input type="checkbox" name="attr_sf_vorstoss" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
-		                    <td>Wuchtschlag:</td>
-		                    <td><input type="checkbox" name="attr_sf_wuchtschlag" value="1"/></td>
-		                    <td>
-		                        <select type="text" name="attr_sf_wuchtschlag_stufe" style='width: 3em;'>
-		                            <option value="0">-</option>
-		                            <option value="1">I</option>
-		                            <option value="2">II</option>
-		                            <option value="3">III</option>
-		                        </select>
-		                    </td>
+		                    <td>Wuchtschlag I:</td>
+		                    <td><input type="checkbox" name="attr_sf_wuchtschlag_1" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Wuchtschlag II:</td>
+		                    <td><input type="checkbox" name="attr_sf_wuchtschlag_2" value="1"/></td>
+		                </tr>
+		                <tr>
+		                    <td>Wuchtschlag III:</td>
+		                    <td><input type="checkbox" name="attr_sf_wuchtschlag_3" value="1"/></td>
 		                </tr>
 		                <tr>
 		                    <td>Wurf:</td>
 		                    <td><input type="checkbox" name="attr_sf_wurf" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Zu Fall bringen:</td>
 		                    <td><input type="checkbox" name="attr_sf_zu_fall_bringen" value="1"/></td>
-		                    <td />
 		                </tr>
 		            </table>
 		    	</div>
@@ -6833,56 +7006,45 @@
 		                <tr>
 		                    <th>Name</th>
 		                    <th>Aktiv</th>
-		                    <th>Stufe</th>
 		                <tr>
 		                    <td>Angriff auf ungeschützte Stellen:</td>
 		                    <td><input type="checkbox" name="attr_sf_angriff_auf_ungeschuetzte_stellen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Anspringen:</td>
 		                    <td><input type="checkbox" name="attr_sf_anspringen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Flugangriff:</td>
 		                    <td><input type="checkbox" name="attr_sf_flugangriff" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Klammergriff:</td>
 		                    <td><input type="checkbox" name="attr_sf_klammergriff" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Mächtiger Schlag:</td>
 		                    <td><input type="checkbox" name="attr_sf_maechtiger_schlag" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Schwanz- oder Tentakelschwung:</td>
 		                    <td><input type="checkbox" name="attr_sf_schwanz_tentakelschwung" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Trampeln:</td>
 		                    <td><input type="checkbox" name="attr_sf_trampeln" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Überrennen:</td>
 		                    <td><input type="checkbox" name="attr_sf_ueberrennen" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Unterwasserkampf:</td>
 		                    <td><input type="checkbox" name="attr_sf_unterwasserkampf" value="1"/></td>
-		                    <td />
 		                </tr>
 		                <tr>
 		                    <td>Verbeißen:</td>
 		                    <td><input type="checkbox" name="attr_sf_verbeissen" value="1"/></td>
-		                    <td />
 		                </tr>
 		            </table>
 		       	</div>
@@ -6893,18 +7055,18 @@
     <div class="sheet-section sheet-section-Magie" align="center">
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab51" value="51" title="Magie" checked="checked"/>
             <span class="sheet-tab sheet-tab51">Allgemein</span>
-        <input type="checkbox" class="sheet-show_tradition_zibilja" name="attr_show_tradition_zibilja" style="display:none;" />
+        <input type="checkbox" class="sheet-show_tradition_zibilja" name="attr_tradition_zibilja" style="display:none;" value="1"/>
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab52" value="52" title="Zauber"/>
             <span class="sheet-tab sheet-tab52">Zauber</span>
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab53" value="53" title="Rituale"/>
             <span class="sheet-tab sheet-tab53">Rituale</span>
-        <input type="checkbox" class="sheet-show_tradition_gildenmagier" name="attr_show_tradition_gildenmagier" style="display:none;" />
+        <input type="checkbox" class="sheet-show_tradition_gildenmagier" name="attr_tradition_gildenmagier" style="display:none;" value="1" />
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab54" value="54" title="Stabzauber"/>
             <span class="sheet-tab sheet-tab54">Stabzauber</span>
-        <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_show_tradition_hexe" style="display:none;" />
+        <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_tradition_hexe" style="display:none;" value="1"/>
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab55" value="55" title="Flüche"/>
             <span class="sheet-tab sheet-tab55">Flüche</span>
-        <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
+        <input type="checkbox" class="sheet-show_tradition_elf" name="attr_tradition_elf" style="display:none;" value="1"/>
         <input type="radio" name="attr_magie_tab" class="sheet-tab sheet-tab56" value="56" title="Elfenlieder"/>
             <span class="sheet-tab sheet-tab56">Elfenlieder</span>
         <input type="checkbox" class="sheet-show-optional" name="attr_sf_zauberzeichen" style="display:none;" value="1" />
@@ -6933,29 +7095,27 @@
     
     
         <div class="sheet-section sheet-section-magie-allgemein" align="center">
-            <input style="display:none;" name="attr_tradition_gildenmagier" type="number" disabled="true" value="1-ceil((@{Tradition}%3)/100)"/>
-            <input style="display:none;" name="attr_tradition_hexe" type="number" disabled="true" value="1-ceil((@{Tradition}%5)/100)"/>
-            <input style="display:none;" name="attr_tradition_elf" type="number" disabled="true" value="1-ceil((@{Tradition}%7)/100)"/>
-            <input style="display:none;" name="attr_tradition_goblin" type="number" disabled="true" value="1-ceil((@{Tradition}%11)/100)"/>
-            <input style="display:none;" name="attr_tradition_zibilja" type="number" disabled="true" value="1-ceil((@{Tradition}%13)/100)"/>
+			<input style="display:none;" type="checkbox" name="attr_tradition_gildenmagier" value="1"/>
+            <input style="display:none;" type="checkbox" name="attr_tradition_hexe" value="1"/>
+            <input style="display:none;" type="checkbox" name="attr_tradition_elf" value="1"/>
+            <input style="display:none;" type="checkbox" name="attr_tradition_goblinzauberinnen" value="1"/>
+            <input style="display:none;" type="checkbox" name="attr_tradition_zibilja" value="1"/>
             <div align="left" style="display:inline-block">Tradition: </div>
-                <select name="attr_Tradition" style="width: 10em;">
-                    <option value="0">---</option>
-                    <option value="3">Gildenmagier</option>
-                    <option value="5">Hexe</option>
-                    <option value="7">Elf</option>
-                    <option value="11">Goblinzauberinnen</option>
-                    <option value="13">Zibilja</option>
-                </select>
+            <select name="attr_Tradition" style="width: 10em;">
+                <option value="---">---</option>
+                <option value="Gildenmagier">Gildenmagier</option>
+                <option value="Hexe">Hexe</option>
+                <option value="Elf">Elf</option>
+                <option value="Goblinzauberinnen">Goblinzauberinnen</option>
+                <option value="Zibilja">Zibilja</option>
+            </select>
             <div align="left" style="display:inline-block;">Leiteigenschaft: </div>
-                <select name="attr_Tradition" style="width: 4.25em;">
-                    <option value="0">---</option>
-                    <option value="3">KL</option>
-                    <option value="5">CH</option>
-                    <option value="7">IN</option>
-                    <option value="11">IN</option>
-                    <option value="13">IN</option>
-                </select>
+            <select name="attr_Tradition_Leiteigenschaft" style="width: 4.25em;">
+                <option value="--">--</option>
+                <option value="KL">KL</option>
+                <option value="CH">CH</option>
+                <option value="IN">IN</option>
+            </select>
             <div class='sheet-2colrow'>
                 <div class='sheet-col'>
                     <table>
@@ -7073,31 +7233,6 @@
                             <th>Zusatz</th>
                         </tr>
                         <tr>
-                            <td>Tradition: Gildenmagier</td>
-                            <td><input type="checkbox" class="show_tradition_gildenmagier" name="attr_show_tradition_gildenmagier"/></td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>Tradition: Hexe</td>
-                            <td><input type="checkbox" class="show_tradition_hexe" name="attr_show_tradition_hexe"/></td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>Tradition: Elf</td>
-                            <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_elf"/></td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>Tradition: Goblinzauberinnen</td>
-                            <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_goblinzauberinnen"/></td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>Tradition: Zibilja</td>
-                            <td><input type="checkbox" class="show_tradition_elf" name="attr_show_tradition_zibilja"/></td>
-                            <td/>
-                        </tr>
-                        <tr>
                             <td>Aura verbergen</td>
                             <td><input type="checkbox" name="attr_sf_aura_verbergen" value="1"/></td>
                             <td/>
@@ -7186,7 +7321,7 @@
                     <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einschränkung</div><input name="attr_Mod_Magische_Einschraenkung" type="checkbox" value="-1" /><br /></div>
                     <input type="checkbox" class="sheet-show-optional" name="attr_vorteil_magische_einstimmung" style="display:none;" value="1"/>
                     <div class="optional"><div align="left" style="display:inline-block; width:10em;">Magische Einstimmung</div><input name="attr_Mod_Magische_Einstimmung" type="checkbox" value="1" /><br /></div>
-                    <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_show_tradition_hexe" style="display:none;"/>
+                    <input type="checkbox" class="sheet-show_tradition_hexe" name="attr_tradition_hexe" style="display:none;" value="1"/>
                     <div class="optional"><div align="left" style="display:inline-block; width:10em;">Gefühle</div><input name="attr_Mod_Gefuehle" type="number" value="0" /><br /></div>
                 </td>
                 <td valign="top" width="30%">
@@ -7211,7 +7346,7 @@
                 <div class="sheet-zauber-merkmal"><b>Merkmal</b></div>
                 <div style="display:inline-block; width:3em; font-weight:bold;">FW</div>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_adlerauge" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_adlerauge" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Adlerauge</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -7223,8 +7358,8 @@
                 <div class="sheet-zauber-merkmal">Heilung</div>
                 <input type="number" name="attr_zfw_Adlerauge" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Adlerauge}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Adlerauge} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
-            </div><br />
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_analys" value="1" style="display:none;"/>
+            </div>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_analys" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Analys Arkanstruktur</div>
                 <div class="sheet-zauber-probe">KL/KL/IN</div>
@@ -7236,8 +7371,8 @@
                 <div class="sheet-zauber-merkmal">Hellsicht</div>
                 <input type="number" name="attr_zfw_Analys" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Analys Arkanstruktur}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Analys} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]), 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
-            </div><br />
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_armatrutz" value="1" style="display:none;"/>
+            </div>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_armatrutz" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Armatrutz</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -7249,15 +7384,15 @@
                 <div class="sheet-zauber-merkmal">Heilung</div>
                 <input type="number" name="attr_zfw_Armatrutz" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Armatrutz}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Armatrutz} - {1d20cs1cf20 - ([[@{KL_Wert}]] + ?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
-            </div><br />
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_axxeleratus" value="1" style="display:none;"/>
+            </div>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_axxeleratus" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Axxeleratus</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
                 <div class="sheet-zauber-zauberdauer">1 A</div>
                 <div class="sheet-zauber-kosten">8</div>
                 <div class="sheet-zauber-reichweite">B</div>
-                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
+                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_tradition_elf" style="display:none;"  value="1"/>
                 <div class="sheet-zauber-wirkungsdauer">QS x 5 KR</div>
                 <div class="sheet-zauber-wirkungsdauer-elf">QS x 10 KR</div>
                 <div class="sheet-zauber-zielkategorie">LW</div>
@@ -7265,7 +7400,7 @@
                 <input type="number" name="attr_zfw_Axxeleratus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Axxeleratus}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Axxeleratus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_balsam_salabunde" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_balsam_salabunde" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Balsam</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -7278,7 +7413,7 @@
                 <input type="number" name="attr_zfw_Balsam" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Balsam}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Balsam} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_bannbaladin" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_bannbaladin" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Bannbaladin</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7291,7 +7426,7 @@
                 <input type="number" name="attr_zfw_Bannbaladin" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Bannbaladin}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Bannbaladin} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blick_in_die_gedanken" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Blick in die Gedanken</div>
                 <div class="sheet-zauber-probe">MU/KL/IN +SK</div>
@@ -7302,9 +7437,9 @@
                 <div class="sheet-zauber-zielkategorie">K, üW</div>
                 <div class="sheet-zauber-merkmal">Hellsicht</div>
                 <input type="number" name="attr_zfw_Blick" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Blick}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Blick} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Blick in die Gedanken}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Blick} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blitz_dich_find" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_blitz_dich_find" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Blitz dich find</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7315,9 +7450,9 @@
                 <div class="sheet-zauber-zielkategorie">LW</div>
                 <div class="sheet-zauber-merkmal">Einfluss</div>
                 <input type="number" name="attr_zfw_Blitz" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Blitz}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Blitz} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Blitz dich find}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Blitz} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_corpofesso" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_corpofesso" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Corpofesso</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -7330,7 +7465,7 @@
                 <input type="number" name="attr_zfw_Corpofesso" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Corpofesso}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Corpofesso} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_disruptivo" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_disruptivo" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Disruptivo</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7343,7 +7478,7 @@
                 <input type="number" name="attr_zfw_Disruptivo" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Disruptivo}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Antimagie}} {{Zauber=[[ @{zfw_Disruptivo} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_dunkelheit" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_dunkelheit" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Dunkelheit</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7356,7 +7491,7 @@
                 <input type="number" name="attr_zfw_Dunkelheit" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Dunkelheit}} {{subtag=Zauber}}} {{subtag1=Sonstige}} {{subtag2=Dämonisch}} {{Zauber=[[ @{zfw_Dunkelheit} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_duplicatus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_duplicatus" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Duplicatus</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -7369,14 +7504,14 @@
                 <input type="number" name="attr_zfw_Duplicatus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Duplicatus}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Duplicatus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_falkenauge" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_falkenauge" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Falkenauge</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
                 <div class="sheet-zauber-zauberdauer">2 A</div>
                 <div class="sheet-zauber-kosten">4</div>
                 <div class="sheet-zauber-reichweite">B</div>
-                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
+                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_tradition_elf" style="display:none;" value="1" />
                 <div class="sheet-zauber-wirkungsdauer">max. QS x 2 KR</div>
                 <div class="sheet-zauber-wirkungsdauer-elf">max. QS x 4 KR</div>
                 <div class="sheet-zauber-zielkategorie">LW</div>
@@ -7384,7 +7519,7 @@
                 <input type="number" name="attr_zfw_Falkenauge" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Falkenauge}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Falkenauge} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_flim_flam" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_flim_flam" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Flim Flam</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7395,9 +7530,9 @@
                 <div class="sheet-zauber-zielkategorie">Z</div>
                 <div class="sheet-zauber-merkmal">Elementar</div>
                 <input type="number" name="attr_zfw_Flim_Flam" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Flim_Flam}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Flim_Flam} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Flim Flam}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Flim_Flam} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_fulminictus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_fulminictus" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Fulminictus</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -7410,7 +7545,7 @@
                 <input type="number" name="attr_zfw_Fulminictus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Fulminictus}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Fulminictus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_gardianum" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_gardianum" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Gardianum</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7423,7 +7558,7 @@
                 <input type="number" name="attr_zfw_Gardianum" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Gardianum}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Antimagie}} {{Zauber=[[ @{zfw_Gardianum} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_gier" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_gier" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Große Gier</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7434,9 +7569,9 @@
                 <div class="sheet-zauber-zielkategorie">LW</div>
                 <div class="sheet-zauber-merkmal">Einfluss</div>
                 <input type="number" name="attr_zfw_Grosse_Gier" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Grosse_Gier}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Grosse_Gier} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Große Gier}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Grosse_Gier} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_verwirrung" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_grosse_verwirrung" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Große Verwirrung</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7447,9 +7582,9 @@
                 <div class="sheet-zauber-zielkategorie">LW</div>
                 <div class="sheet-zauber-merkmal">Dämonisch</div>
                 <input type="number" name="attr_zfw_Grosse_Verwirrung" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Grosse_Verwirrung}} {{subtag=Zauber}}} {{subtag1=Sonstige}} {{subtag2=Dämonisch}} {{Zauber=[[ @{zfw_Grosse_Verwirrung} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Große Verwirrung}} {{subtag=Zauber}}} {{subtag1=Sonstige}} {{subtag2=Dämonisch}} {{Zauber=[[ @{zfw_Grosse_Verwirrung} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_harmlose_gestalt" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_harmlose_gestalt" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Harmlose Gestalt</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -7460,9 +7595,9 @@
                 <div class="sheet-zauber-zielkategorie">W</div>
                 <div class="sheet-zauber-merkmal">Illusion</div>
                 <input type="number" name="attr_zfw_Harmlose_Gestalt" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Harmlose_Gestalt}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Harmlose_Gestalt} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Harmlose Gestalt}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Harmlose_Gestalt} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexengalle" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexengalle" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Hexengalle</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7475,7 +7610,7 @@
                 <input type="number" name="attr_zfw_Hexengalle" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Hexengalle}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Hexengalle} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexenkrallen" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_hexenkrallen" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Hexenkrallen</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7488,7 +7623,7 @@
                 <input type="number" name="attr_zfw_Hexenkrallen" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Hexenkrallen}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Hexenkrallen} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_horriphobus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_horriphobus" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Horriphobus</div>
                 <div class="sheet-zauber-probe">MU/IN/CH + SK</div>
@@ -7501,7 +7636,7 @@
                 <input type="number" name="attr_zfw_Horriphobus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Horriphobus}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Horriphobus} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_ignifaxius" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_ignifaxius" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Ignifaxius</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7514,7 +7649,7 @@
                 <input type="number" name="attr_zfw_Ignifaxius" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Ignifaxius}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Ignifaxius} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_invocatio_minima" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_invocatio_minima" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Invocatio Minima</div>
                 <div class="sheet-zauber-probe">MU/CH/KO</div>
@@ -7525,9 +7660,9 @@
                 <div class="sheet-zauber-zielkategorie">O</div>
                 <div class="sheet-zauber-merkmal">Sphären</div>
                 <input type="number" name="attr_zfw_Invocatio_Minima" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Invocatio_Minima}} {{subtag=Zauber}}} {{subtag1=Gildenmagier, Hexen}} {{subtag2=Sphären}} {{Zauber=[[ @{zfw_Invocatio_Minima} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Invocatio Minima}} {{subtag=Zauber}}} {{subtag1=Gildenmagier, Hexen}} {{subtag2=Sphären}} {{Zauber=[[ @{zfw_Invocatio_Minima} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_katzenaugen" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_katzenaugen" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Katzenaugen</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7540,7 +7675,7 @@
                 <input type="number" name="attr_zfw_Katzenaugen" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Katzenaugen}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Katzenaugen} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_kroetensprung" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_kroetensprung" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Krötensprung</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7551,9 +7686,9 @@
                 <div class="sheet-zauber-zielkategorie">LW</div>
                 <div class="sheet-zauber-merkmal">Verwandlung</div>
                 <input type="number" name="attr_zfw_Kroetensprung" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Kroetensprung}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Kroetensprung} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Krötensprung}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Kroetensprung} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manifesto" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manifesto" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Manifesto</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
@@ -7566,7 +7701,7 @@
                 <input type="number" name="attr_zfw_Manifesto" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Manifesto}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Manifesto} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manus_miracula" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_manus_miracula" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Manus Miracula</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -7577,9 +7712,9 @@
                 <div class="sheet-zauber-zielkategorie">W</div>
                 <div class="sheet-zauber-merkmal">Telekinese</div>
                 <input type="number" name="attr_zfw_Manus_Miracula" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Manus_Miracula}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Manus_Miracula} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Manus Miracula}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Manus_Miracula} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_motoricus" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_motoricus" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Motoricus</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -7592,14 +7727,14 @@
                 <input type="number" name="attr_zfw_Motoricus" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Motoricus}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Motoricus} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_nebelwand" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_nebelwand" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Nebelwand</div>
                 <div class="sheet-zauber-probe">MU/KL/CH</div>
                 <div class="sheet-zauber-zauberdauer">2 A</div>
                 <div class="sheet-zauber-kosten">mind. 4</div>
                 <div class="sheet-zauber-reichweite">16 S</div>
-                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
+                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_tradition_elf" style="display:none;" value="1" />
                 <div class="sheet-zauber-wirkungsdauer">QS x 15 Min</div>
                 <div class="sheet-zauber-wirkungsdauer-elf">QS x 30 Min</div>
                 <div class="sheet-zauber-zielkategorie">Z</div>
@@ -7607,7 +7742,7 @@
                 <input type="number" name="attr_zfw_Nebelwand" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Nebelwand}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Elementar}} {{Zauber=[[ @{zfw_Nebelwand} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_oculus_illusionis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_oculus_illusionis" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Oculus Illusionis</div>
                 <div class="sheet-zauber-probe">KL/IN/CH</div>
@@ -7618,9 +7753,9 @@
                 <div class="sheet-zauber-zielkategorie">Z</div>
                 <div class="sheet-zauber-merkmal">Illusion</div>
                 <input type="number" name="attr_zfw_Oculus_Illusionis" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Oculus_Illusionis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Oculus_Illusionis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Oculus Illusionis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Illusion}} {{Zauber=[[ @{zfw_Oculus_Illusionis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_odem_arcanum" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_odem_arcanum" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Odem</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
@@ -7633,7 +7768,7 @@
                 <input type="number" name="attr_zfw_Odem" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Odem}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Odem} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_paralysis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_paralysis" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Paralysis</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -7646,7 +7781,7 @@
                 <input type="number" name="attr_zfw_Paralysis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Paralysis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Paralysis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_penetrizzel" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_penetrizzel" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Penetrizzel</div>
                 <div class="sheet-zauber-probe">MU/KL/IN</div>
@@ -7659,7 +7794,7 @@
                 <input type="number" name="attr_zfw_Penetrizzel" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Penetrizzel}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Hellsicht}} {{Zauber=[[ @{zfw_Penetrizzel} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_psychostabilis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_psychostabilis" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Psychostabilis</div>
                 <div class="sheet-zauber-probe">KL/IN/FF</div>
@@ -7672,7 +7807,7 @@
                 <input type="number" name="attr_zfw_Psychostabilis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Psychostabilis}} {{subtag=Zauber}}} {{subtag1=allgemein}} {{subtag2=Heilung}} {{Zauber=[[ @{zfw_Psychostabilis} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_radau" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_radau" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Radau</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -7685,7 +7820,7 @@
                 <input type="number" name="attr_zfw_Radau" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Radau}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Radau} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_respondami" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_respondami" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Respondami</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7698,7 +7833,7 @@
                 <input type="number" name="attr_zfw_Respondami" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Respondami}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Respondami} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_salander" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_salander" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Salander</div>
                 <div class="sheet-zauber-probe">KL/IN/KO +ZK</div>
@@ -7711,7 +7846,7 @@
                 <input type="number" name="attr_zfw_Salander" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Salander}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Salander} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_sanftmut" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_sanftmut" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Sanftmut</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
@@ -7724,7 +7859,7 @@
                 <input type="number" name="attr_zfw_Sanftmut" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Sanftmut}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Sanftmut} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_satuarias_herrlichkeit" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Satuarias Herrlichkeit</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7735,9 +7870,9 @@
                 <div class="sheet-zauber-zielkategorie">W</div>
                 <div class="sheet-zauber-merkmal">Verwandlung</div>
                 <input type="number" name="attr_zfw_Satuarias_Herrlichkeit" style="width:3em;" value="0"/>
-                <button type="roll" value="&{template:DSA-Zauber} {{name=Satuarias_Herrlichkeit}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Satuarias_Herrlichkeit} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
+                <button type="roll" value="&{template:DSA-Zauber} {{name=Satuarias Herrlichkeit}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Satuarias_Herrlichkeit} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_silentium" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_silentium" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Silentium</div>
                 <div class="sheet-zauber-probe">KL/FF/KO</div>
@@ -7750,14 +7885,14 @@
                 <input type="number" name="attr_zfw_Silentium" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Silentium}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Silentium} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_somnigravis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_somnigravis" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Somnigravis</div>
                 <div class="sheet-zauber-probe">MU/IN/CH +SK</div>
                 <div class="sheet-zauber-zauberdauer">8 A</div>
                 <div class="sheet-zauber-kosten">8</div>
                 <div class="sheet-zauber-reichweite">8 S</div>
-                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_show_tradition_elf" style="display:none;" />
+                <input type="checkbox" class="sheet-show_tradition_elf" name="attr_tradition_elf" style="display:none;" value="1" />
                 <div class="sheet-zauber-wirkungsdauer">QS x 3 Min</div>
                 <div class="sheet-zauber-wirkungsdauer-elf">QS x 6 Min</div>
                 <div class="sheet-zauber-zielkategorie">LW</div>
@@ -7765,7 +7900,7 @@
                 <input type="number" name="attr_zfw_Somnigravis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Somnigravis}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Einfluss}} {{Zauber=[[ @{zfw_Somnigravis} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spinnenlauf" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spinnenlauf" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Spinnenlauf</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7778,7 +7913,7 @@
                 <input type="number" name="attr_zfw_Spinnenlauf" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Spinnenlauf}} {{subtag=Zauber}}} {{subtag1=Hexen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Spinnenlauf} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spurlos" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_spurlos" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Spurlos</div>
                 <div class="sheet-zauber-probe">KL/FF/KK</div>
@@ -7791,7 +7926,7 @@
                 <input type="number" name="attr_zfw_Spurlos" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Spurlos}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Telekinese}} {{Zauber=[[ @{zfw_Spurlos} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{FF_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KK_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_transversalis" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_transversalis" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Transversalis</div>
                 <div class="sheet-zauber-probe">MU/CH/KO</div>
@@ -7804,7 +7939,7 @@
                 <input type="number" name="attr_zfw_Transversalis" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Transversalis}} {{subtag=Zauber}}} {{subtag1=Gildenmagier}} {{subtag2=Sphären}} {{Zauber=[[ @{zfw_Transversalis} - {1d20cs1cf20 - ([[@{MU_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{CH_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_visibili" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_visibili" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Visibili</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7817,7 +7952,7 @@
                 <input type="number" name="attr_zfw_Visibili" style="width:3em;" value="0"/>
                 <button type="roll" value="&{template:DSA-Zauber} {{name=Visibili}} {{subtag=Zauber}}} {{subtag1=Elfen}} {{subtag2=Verwandlung}} {{Zauber=[[ @{zfw_Visibili} - {1d20cs1cf20 - ([[@{KL_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1 - {1d20cs1cf20 - ([[@{IN_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1- {1d20cs1cf20 - ([[@{KO_Wert}]]+?{Erleichterung(+) / Erschwernis(-)|0}+[[@{Zauber_Mod_Gesamt}]]) , 0d1}kh1]]}}"></button>
             </div>
-            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_wasseratem" value="1" style="display:none;"/>
+            <input class="sheet-zauber-aktiviert" type="checkbox" name="attr_zauber_wasseratem" value="1"/>
             <div class="sheet-zauber">
                 <div class="sheet-zauber-zauberspruch">Wasseratem</div>
                 <div class="sheet-zauber-probe">KL/IN/KO</div>
@@ -7833,7 +7968,7 @@
             </div>
             <br/>
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-zauber" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table style="width:100%">
                         <tr>
@@ -8116,7 +8251,7 @@
             </div>
             <br/>
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-rituale" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table style="width:100%">
                         <tr>
@@ -8217,7 +8352,7 @@
             </div>          
             <br/>
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-staubzauber" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table>
                         <tr>
@@ -8373,7 +8508,7 @@
             </div>
             <br />
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-flueche" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table>
                         <tr>
@@ -8497,7 +8632,7 @@
             </div>
             <br />
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-elfenlieder" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table>
                         <tr>
@@ -8541,7 +8676,7 @@
 	                <div class="sheet-zauberzeichen-kosten">4 AsP</div>
 	            </div>     
  
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-zauberzeichen" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table>
                         <tr>
@@ -8612,25 +8747,32 @@
             <th>KaP<th>
                 <th><input type="number" name="attr_KE_Wert" value="0"></th>
             <th>BE</th>
-                <th><input type="number" name="attr_BE_Magic" disabled=true value="@{RuestungAktiv1} * @{BE1} + @{RuestungAktiv2} * @{BE2} + @{RuestungAktiv3} * @{BE3} + @{RuestungAktiv4} * @{BE4}"></th>
+                <th><input type="number" name="attr_BE_Magic" disabled=true value="@{Ges_BE}"></th>
         </table>
 
         <div class="sheet-section sheet-section-goetter-allgemein" align="center">
             <div align="left" style="display:inline-block">Tradition: </div>
                 <select type="number" name="attr_tradition_goetter" style="width: 10em;">
-                    <option value="0">---</option>
-                    <option value="1">Praios</option>
-                    <option value="2">Rondra</option>
-                    <option value="3">Boron</option>
-                    <option value="4">Hesinde</option>
-                    <option value="5">Phex</option>
-                    <option value="6">Peraine</option>
-                    <option value="0" disabled>Firun</option>
-                    <option value="0" disabled>Tsa</option>
-                    <option value="0" disabled>Travia</option>
-                    <option value="0" disabled>Ingerimm</option>
-                    <option value="0" disabled>Efferd</option>
-                    <option value="0" disabled>Rahja</option>
+                    <option value="---">---</option>
+                    <option value="Praios">Praios</option>
+                    <option value="Rondra">Rondra</option>
+                    <option value="Boron">Boron</option>
+                    <option value="Hesinde">Hesinde</option>
+                    <option value="Phex">Phex</option>
+                    <option value="Peraine">Peraine</option>
+                    <option value="Firun" disabled>Firun</option>
+                    <option value="Tsa" disabled>Tsa</option>
+                    <option value="Travia" disabled>Travia</option>
+                    <option value="Ingerimm" disabled>Ingerimm</option>
+                    <option value="Efferd" disabled>Efferd</option>
+                    <option value="Rahja" disabled>Rahja</option>
+                </select>
+            <div align="left" style="display:inline-block">Tradition: </div>
+                <select type="number" name="attr_tradition_goetter_leiteigenschaft" style="width: 10em;">
+                    <option value="--">--</option>
+                    <option value="MU">MU</option>
+                    <option value="KL">KL</option>
+                    <option value="IN">IN</option>
                 </select>
             <div class='sheet-2colrow'>
                 <div class='sheet-col'>
@@ -9307,7 +9449,7 @@
             </div>
             <br/>
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-liturgien" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table style="width:100%">
                         <tr>
@@ -9535,7 +9677,7 @@
             </div>
             <br/>
             <div align="left">
-                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_description-show" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
+                <div align="left" style="font-weight:bold; display:inline-block; width:9em;">Aktivierung</div><input type="checkbox" class="sheet-desc-show" name="attr_zeige-aktivierung-segen" value="1" style="opacity:0;width: 60px;height: 16px;margin:-48px;position: relative;left: 6px;cursor: pointer;z-index: 1;" /><span></span>
                 <div class="sheet-desc">
                     <table style="width:100%">
                         <tr>
@@ -10096,7 +10238,7 @@
         Ausrüstungsbelastung: <input type="number" disabled="true" name="attr_equipLast" style="width: 5em;" value="@{Gewicht_NKW1}+@{Gewicht_NKW2}+@{Gewicht_NKW3}+@{Gewicht_NKW4}+@{FKWGewicht1}+@{FKWGewicht2}+@{FKWGewicht3}+@{FKWGewicht4}+@{SchildGewicht1}+@{SchildGewicht2}+@{SchildGewicht3}+@{SchildGewicht4}+@{RuestungsGewicht1}+@{RuestungsGewicht2}+@{RuestungsGewicht3}+@{RuestungsGewicht4}">
 
         Aktuelle Last: <input type="number" disabled="true" name="attr_AktLast" style="width: 5em;" value="@{item001gewicht}+@{item002gewicht}+@{item003gewicht}+@{item004gewicht}+@{item005gewicht}+@{item006gewicht}+@{item007gewicht}+@{item008gewicht}+@{item009gewicht}+@{item010gewicht}+@{item011gewicht}+@{item012gewicht}+@{item013gewicht}+@{item014gewicht}+@{item015gewicht}+@{item016gewicht}+@{item017gewicht}+@{item018gewicht}+@{item019gewicht}+@{item020gewicht}+@{item021gewicht}+@{item022gewicht}+@{item023gewicht}+@{item024gewicht}+@{item025gewicht}+@{item026gewicht}+@{item027gewicht}+@{item028gewicht}+@{item029gewicht}+@{item030gewicht}+@{item031gewicht}+@{item032gewicht}+@{item033gewicht}+@{item034gewicht}+@{item035gewicht}+@{item036gewicht}+@{item037gewicht}+@{item038gewicht}+@{item039gewicht}+@{item040gewicht}+@{item041gewicht}+@{item042gewicht}+@{item043gewicht}+@{item044gewicht}+@{item045gewicht}+@{item046gewicht}+@{item047gewicht}+@{item048gewicht}+@{item049gewicht}+@{item050gewicht}+@{item051gewicht}+@{item052gewicht}+@{item053gewicht}+@{item054gewicht}+@{item055gewicht}+@{item056gewicht}+@{item057gewicht}+@{item058gewicht}+@{item059gewicht}+@{item060gewicht}+@{item061gewicht}+@{item062gewicht}+@{item063gewicht}+@{item064gewicht}+@{item065gewicht}+@{item066gewicht}+@{item067gewicht}+@{item068gewicht}+@{item069gewicht}+@{item070gewicht}+@{item071gewicht}+@{item072gewicht}+@{item073gewicht}+@{item074gewicht}+@{item075gewicht}+@{item076gewicht}+@{item077gewicht}+@{item078gewicht}+@{item079gewicht}+@{item080gewicht}+@{item081gewicht}+@{item082gewicht}+@{item083gewicht}+@{item084gewicht}+@{item085gewicht}+@{item086gewicht}+@{item087gewicht}+@{item088gewicht}+@{item089gewicht}+@{item090gewicht}+@{item091gewicht}+@{item092gewicht}+@{item093gewicht}+@{item094gewicht}+@{item095gewicht}+@{item096gewicht}+@{item097gewicht}+@{item098gewicht}+@{item099gewicht}+@{item100gewicht}+@{equipLast}">
-        Maximale Last: <input type="number" disabled="true" name="attr_MaxLast" style="width: 5em;" value="@{KK_Wert}*2">
+        Maximale Last: <input type="number" disabled="true" name="attr_MaxLast" style="width: 5em;" value="(@{KK_Wert})*2">
     </div>
 
     <div class="sheet-section sheet-section-notes" align=center>
@@ -10105,24 +10247,29 @@
     </div>
 
     <div class="sheet-section sheet-section-config" align=center>
-        <input type="radio" name="attr_config_tab" class="sheet-tab sheet-tab91" value="91" title="config1" checked="checked"/>
+        <input type="radio" name="attr_config_tab" class="sheet-tab sheet-tab91" value="91" checked="checked"/>
             <span class="sheet-tab sheet-tab91">Anzeige</span>
-        <input type="radio" name="attr_config_tab" class="sheet-tab sheet-tab92" value="92" title="config2"/>
+        <input type="radio" name="attr_config_tab" class="sheet-tab sheet-tab92" value="92" />
             <span class="sheet-tab sheet-tab92">Optionalregeln</span>
             
         <div class="sheet-section sheet section-config1" style="align:left;">
             <input type="checkbox" name="attr_gegner_sheet" value="1"/> Gegner-Sheet<br />
-            <input type="checkbox" name="attr_reduzierte_talentansicht" value="1"/> Reduzierte Talentansicht<br />
-            <input type="checkbox" class="versteckeMagie" name="attr_MagieTab"/> Verstecke Magie<br />
-            <input type="checkbox" class="versteckeLiturgien" name="attr_LiturgienTab"/> Verstecke Götterwirken<br />
-            <input type="checkbox" class="sheet-versteckeSchildparade" name="attr_SchildparadeProben" value="1" /> Verstecke Schildparade<br />
+            <input type="checkbox" name="attr_reduzierte_talentansicht"/> Reduzierte Talentansicht<br />
+            <input type="checkbox" name="attr_verstecke_inventar"/> Verstecke Inventar<br />
+            <input type="checkbox" name="attr_verstecke_notizen"/> Verstecke Notizen<br />
+            <input type="checkbox" name="attr_verstecke_magie"/> Verstecke Magie<br />
+            <input type="checkbox" name="attr_verstecke_goetterwirken"/> Verstecke Götterwirken<br />
+            <input type="checkbox" name="attr_zeige_schilde" value="1" /> Zeige Schilde<br />
+            <input type="checkbox" name="attr_zeige_parierwaffen" value="1" /> Zeige Parierwaffen<br />
+            <input type="checkbox" name="attr_zeige_fernkampf" value="1" /> Zeige Fernkampf<br />
         </div>
 
-        <div class="sheet-section sheet section-config2">
+        <div class="sheet-section sheet section-config2" style="align:left;">
             Opt. Paradebonus: <input type="radio" name="attr_OptPA_GW" value="0" checked="true"/>0 <input type="radio" name="attr_OptPA_GW" value="2" />+2 <input type="radio" name="attr_OptPA_GW" value="4" />+4 <br/>
-            Nahkampf-Patzertabelle <input type="checkbox" class="sheet-nahkampfPatzerTabelle" name="attr_nahkampfPatzerTabelle" value="1" /><br />
-            Fernkampf-Patzertabelle <input type="checkbox" class="sheet-fernkampfPatzerTabelle" name="attr_fernkampfPatzerTabelle" value="1" /><br />
-            Verteidigung-Patzertabelle <input type="checkbox" class="sheet-verteidigungPatzerTabelle" name="attr_verteidigungPatzerTabelle" value="1" /><br />
+            Nahkampf-Patzertabelle <input type="checkbox" name="attr_nahkampfPatzerTabelle" value="1" /><br />
+            Fernkampf-Patzertabelle <input type="checkbox" name="attr_fernkampfPatzerTabelle" value="1" /><br />
+            Verteidigung-Patzertabelle <input type="checkbox" name="attr_verteidigungPatzerTabelle" value="1" /><br />
+            Kulturkunde <input type="checkbox" name="attr_optionalregel_kulturkunde" value="1" /><br />
         </div>
 
     </div>
@@ -10531,3 +10678,963 @@
         {{/rollGreater() FP 0}}
     </table>
 </rolltemplate>
+
+<script type="text/worker">
+
+on("change:erfahrungsgrad", function() {
+   getAttrs(["Erfahrungsgrad", "APgesamt"], function(values) {
+		if (values.APgesamt == null || values.APgesamt == 0 || values.APgesamt == 900 || values.APgesamt == 1000 || values.APgesamt == 1100 || values.APgesamt == 1200 || values.APgesamt == 1400 || values.APgesamt == 1700 || values.APgesamt == 2100 ) {
+			if (values.Erfahrungsgrad == "Unerfahren") {
+				setAttrs({
+          			APgesamt: 900
+      			});
+			}
+			if (values.Erfahrungsgrad == "Durchschnittlich") {
+				setAttrs({
+          			APgesamt: 1000
+      			});
+			}
+			if (values.Erfahrungsgrad == "Erfahren") {
+				setAttrs({
+          			APgesamt: 1100
+      			});
+			}
+			if (values.Erfahrungsgrad == "Kompetent") {
+				setAttrs({
+          			APgesamt: 1200
+      			});
+			}
+			if (values.Erfahrungsgrad == "Meisterlich") {
+				setAttrs({
+          			APgesamt: 1400
+      			});
+			}
+			if (values.Erfahrungsgrad == "Brillant") {
+				setAttrs({
+          			APgesamt: 1700
+      			});
+			}
+			if (values.Erfahrungsgrad == "Legendaer") {
+				setAttrs({
+          			APgesamt: 2100
+      			});
+			}
+		}
+   });
+});
+
+on("change:spezies", function() {
+   getAttrs(["Spezies"], function(values) {
+		if (values.Spezies == "Mensch") {
+			setAttrs({
+       			LE_Spezies: 5,
+				SK_Spezies: -5,
+				ZK_Spezies: -5,
+				GS_Spezies: 8
+   			});
+		}
+		if (values.Spezies == "Elf") {
+			setAttrs({
+       			LE_Spezies: 2,
+				SK_Spezies: -4,
+				ZK_Spezies: -6,
+				GS_Spezies: 8
+   			});
+		}
+		if (values.Spezies == "Halbelf") {
+			setAttrs({
+       			LE_Spezies: 5,
+				SK_Spezies: -4,
+				ZK_Spezies: -6,
+				GS_Spezies: 8
+    		});
+		}
+		if (values.Spezies == "Zwerg") {
+			setAttrs({
+          		LE_Spezies: 8,
+				SK_Spezies: -4,
+				ZK_Spezies: -4,
+				GS_Spezies: 6
+      		});
+		}
+   });
+});
+
+on("change:mu_grundwert change:mu_zukauf", function() {
+   getAttrs(["MU_Grundwert", "MU_Zukauf"], function(values) {
+		setAttrs({
+			MU_Wert: parseInt(values.MU_Grundwert) + parseInt(values.MU_Zukauf)
+		});
+   });
+});
+
+on("change:kl_grundwert change:kl_zukauf", function() {
+   getAttrs(["KL_Grundwert", "KL_Zukauf"], function(values) {
+		setAttrs({
+			KL_Wert: parseInt(values.KL_Grundwert) + parseInt(values.KL_Zukauf)
+		});
+   });
+});
+
+on("change:in_grundwert change:in_zukauf", function() {
+   getAttrs(["IN_Grundwert", "IN_Zukauf"], function(values) {
+		setAttrs({
+			IN_Wert: parseInt(values.IN_Grundwert) + parseInt(values.IN_Zukauf)
+		});
+   });
+});
+
+on("change:ch_grundwert change:ch_zukauf", function() {
+   getAttrs(["CH_Grundwert", "CH_Zukauf"], function(values) {
+		setAttrs({
+			CH_Wert: parseInt(values.CH_Grundwert) + parseInt(values.CH_Zukauf)
+		});
+   });
+});
+
+on("change:ff_grundwert change:ff_zukauf", function() {
+   getAttrs(["FF_Grundwert", "FF_Zukauf"], function(values) {
+		setAttrs({
+			FF_Wert: parseInt(values.FF_Grundwert) + parseInt(values.FF_Zukauf)
+		});
+   });
+});
+
+on("change:ge_grundwert change:ge_zukauf", function() {
+   getAttrs(["GE_Grundwert", "GE_Zukauf"], function(values) {
+		setAttrs({
+			GE_Wert: parseInt(values.GE_Grundwert) + parseInt(values.GE_Zukauf)
+		});
+   });
+});
+
+on("change:ko_grundwert change:ko_zukauf", function() {
+   getAttrs(["KO_Grundwert", "KO_Zukauf"], function(values) {
+		setAttrs({
+			KO_Wert: parseInt(values.KO_Grundwert) + parseInt(values.KO_Zukauf)
+		});
+   });
+});
+
+on("change:kk_grundwert change:kk_zukauf", function() {
+   getAttrs(["KK_Grundwert", "KK_Zukauf"], function(values) {
+		setAttrs({
+			KK_Wert: parseInt(values.KK_Grundwert) + parseInt(values.KK_Zukauf)
+		});
+   });
+});
+
+on("change:mu_wert", function() {
+   getAttrs(["MU_Wert"], function(values) {
+		setAttrs({
+			Leiteigenschaft_AT_Mod: Math.floor((parseInt(values.MU_Wert)-8)/3)
+		});
+   });
+});
+
+
+
+
+on("change:tradition", function() {
+   getAttrs(["Tradition"], function(values) {
+		if (values.Tradition == "---") {
+			setAttrs({
+       			tradition_gildenmagier: 0,
+				tradition_hexe: 0,
+				tradition_elf: 0,
+				tradition_goblin: 0,
+				tradition_zibilja: 0,
+				Tradition_Leiteigenschaft: "--"
+   			});
+		}
+		if (values.Tradition == "Gildenmagier") {
+			setAttrs({
+       			tradition_gildenmagier: 1,
+				tradition_hexe: 0,
+				tradition_elf: 0,
+				tradition_goblin: 0,
+				tradition_zibilja: 0,
+				Tradition_Leiteigenschaft: "KL"
+   			});
+		}
+		if (values.Tradition == "Hexe") {
+			setAttrs({
+       			tradition_gildenmagier: 0,
+				tradition_hexe: 1,
+				tradition_elf: 0,
+				tradition_goblin: 0,
+				tradition_zibilja: 0,
+				Tradition_Leiteigenschaft: "CH"
+   			});
+		}
+		if (values.Tradition == "Elf") {
+			setAttrs({
+       			tradition_gildenmagier: 0,
+				tradition_hexe: 0,
+				tradition_elf: 1,
+				tradition_goblin: 0,
+				tradition_zibilja: 0,
+				Tradition_Leiteigenschaft: "IN"
+   			});
+		}
+		if (values.Tradition == "Goblinzauberinnen") {
+			setAttrs({
+       			tradition_gildenmagier: 0,
+				tradition_hexe: 0,
+				tradition_elf: 0,
+				tradition_goblin: 1,
+				tradition_zibilja: 0,
+				Tradition_Leiteigenschaft: "IN"
+   			});
+		}
+		if (values.Tradition == "Zibilja") {
+			setAttrs({
+       			tradition_gildenmagier: 0,
+				tradition_hexe: 0,
+				tradition_elf: 0,
+				tradition_goblin: 0,
+				tradition_zibilja: 1,
+				Tradition_Leiteigenschaft: "IN"
+   			});
+		}
+   });
+});
+
+on("change:tradition_leiteigenschaft", function() {
+   getAttrs(["Tradition_Leiteigenschaft", "KL_Wert", "IN_Wert", "CH_Wert"], function(values) {
+		if (values.Tradition_Leiteigenschaft == "--") {
+			setAttrs({
+				AE_Leiteigenschaft: 0
+   			});
+		}
+		if (values.Tradition_Leiteigenschaft == "KL") {
+			setAttrs({
+				AE_Leiteigenschaft: values.KL_Wert
+   			});
+		}
+		if (values.Tradition_Leiteigenschaft == "IN") {
+			setAttrs({
+				AE_Leiteigenschaft: values.IN_Wert
+   			});
+		}
+		if (values.Tradition_Leiteigenschaft == "CH") {
+			setAttrs({
+				AE_Leiteigenschaft: values.CH_Wert
+   			});
+		}
+   });
+});
+
+on("change:tradition_goetter", function() {
+   getAttrs(["tradition_goetter"], function(values) {
+		if (values.tradition_goetter == "---") {
+			setAttrs({
+				tradition_goetter_leiteigenschaft: "--"
+   			});
+		}
+		if (values.tradition_goetter == "Praios") {
+			setAttrs({
+       			tradition_goetter_leiteigenschaft: "KL" 
+   			});
+		}
+		if (values.tradition_goetter == "Rondra") {
+			setAttrs({
+       			tradition_goetter_leiteigenschaft: "MU"
+   			});
+		}
+		if (values.tradition_goetter == "Boron") {
+			setAttrs({
+				tradition_goetter_leiteigenschaft: "MU"
+   			});
+		}
+		if (values.tradition_goetter == "Hesinde") {
+			setAttrs({
+				tradition_goetter_leiteigenschaft: "KL"
+   			});
+		}
+		if (values.tradition_goetter == "Phex") {
+			setAttrs({
+				tradition_goetter_leiteigenschaft: "IN"
+   			});
+		}
+		if (values.tradition_goetter == "Peraine") {
+			setAttrs({
+				tradition_goetter_leiteigenschaft: "IN"
+   			});
+		}
+   });
+});
+
+on("change:tradition_goetter_leiteigenschaft", function() {
+   getAttrs(["tradition_goetter_leiteigenschaft", "KL_Wert", "IN_Wert", "MU_Wert"], function(values) {
+		if (values.tradition_goetter_leiteigenschaft == "--") {
+			setAttrs({
+				KE_Leiteigenschaft: 0
+   			});
+		}
+		if (values.tradition_goetter_leiteigenschaft == "KL") {
+			setAttrs({
+				KE_Leiteigenschaft: values.KL_Wert
+   			});
+		}
+		if (values.tradition_goetter_leiteigenschaft == "IN") {
+			setAttrs({
+				KE_Leiteigenschaft: values.IN_Wert
+   			});
+		}
+		if (values.tradition_goetter_leiteigenschaft == "MU") {
+			setAttrs({
+				KE_Leiteigenschaft: values.MU_Wert
+   			});
+		}
+   });
+});
+
+on("change:nkw_aktiv change:at_nkw1 change:at_nkw2 change:at_nkw3 change:at_nkw4 change:pa_nkw1 change:pa_nkw2 change:pa_nkw3 change:pa_nkw4 change:reichweitenkwaffe1 change:reichweitenkwaffe2 change:reichweitenkwaffe3 change:reichweitenkwaffe4 change:nkwschaden1_1 change:nkwschaden2_1 change:nkwschaden3_1 change:nkwschaden4_1 change:nkwschaden1_2 change:nkwschaden2_2 change:nkwschaden3_2 change:nkwschaden4_2 change:ehalszh_nkw1 change:ehalszh_nkw2 change:ehalszh_nkw3 change:ehalszh_nkw4", function() {
+   getAttrs(["NKW_Aktiv", "AT_NKW1", "AT_NKW2", "AT_NKW3", "AT_NKW4", "PA_NKW1", "PA_NKW2", "PA_NKW3", "PA_NKW4", "ReichweiteNKWaffe1", "ReichweiteNKWaffe2", "ReichweiteNKWaffe3", "ReichweiteNKWaffe4", "NKWschaden1_1", "NKWschaden2_1", "NKWschaden3_1", "NKWschaden4_1", "NKWschaden1_2", "NKWschaden2_2", "NKWschaden3_2", "NKWschaden4_2", "EHalsZH_NKW1", "EHalsZH_NKW2", "EHalsZH_NKW3", "EHalsZH_NKW4"], function(values) {
+		if (values.NKW_Aktiv == 1) {
+			setAttrs({
+				AT_Aktiv_Waffe: values.AT_NKW1,
+				PA_Aktiv_Waffe: values.PA_NKW1,
+				NKW_Aktiv_Reichweite: values.ReichweiteNKWaffe1,
+				TP_W_Aktiv_Waffe: values.NKWschaden1_1,
+				TP_Bonus_Aktiv_Waffe: parseInt(values.NKWschaden1_2) + parseInt(values.EHalsZH_NKW1)
+   			});
+		}
+		if (values.NKW_Aktiv == 2) {
+			setAttrs({
+				AT_Aktiv_Waffe: values.AT_NKW2,
+				PA_Aktiv_Waffe: values.PA_NKW2,
+				NKW_Aktiv_Reichweite: values.ReichweiteNKWaffe2,
+				TP_W_Aktiv_Waffe: values.NKWschaden2_1,
+				TP_Bonus_Aktiv_Waffe: parseInt(values.NKWschaden2_2) + parseInt(values.EHalsZH_NKW2)
+   			});
+		}
+		if (values.NKW_Aktiv == 3) {
+			setAttrs({
+				AT_Aktiv_Waffe: values.AT_NKW3,
+				PA_Aktiv_Waffe: values.PA_NKW3,
+				NKW_Aktiv_Reichweite: values.ReichweiteNKWaffe3,
+				TP_W_Aktiv_Waffe: values.NKWschaden3_1,
+				TP_Bonus_Aktiv_Waffe: parseInt(values.NKWschaden3_2) + parseInt(values.EHalsZH_NKW3)
+   			});
+		}
+		if (values.NKW_Aktiv == 4) {
+			setAttrs({
+				AT_Aktiv_Waffe: values.AT_NKW4,
+				PA_Aktiv_Waffe: values.PA_NKW4,
+				NKW_Aktiv_Reichweite: values.ReichweiteNKWaffe4,
+				TP_W_Aktiv_Waffe: values.NKWschaden4_1,
+				TP_Bonus_Aktiv_Waffe: parseInt(values.NKWschaden4_2) + parseInt(values.EHalsZH_NKW4)
+   			});
+		}
+   });
+});
+
+on("change:fkw_aktiv change:fkwfk1 change:fkwfk2 change:fkwfk3 change:fkwfk4 change:fkwschaden1_1 change:fkwschaden2_1 change:fkwschaden3_1 change:fkwschaden4_1 change:fkwschaden1_2 change:fkwschaden2_2 change:fkwschaden3_2 change:fkwschaden4_2 change:fkwreichweite1 change:fkwreichweite2 change:fkwreichweite3 change:fkwreichweite4", function() {
+   getAttrs(["FKW_Aktiv", "FKWFK1", "FKWFK2", "FKWFK3", "FKWFK4", "FKWSchaden1_1", "FKWSchaden2_1", "FKWSchaden3_1", "FKWSchaden4_1", "FKWSchaden1_2", "FKWSchaden2_2", "FKWSchaden3_2", "FKWSchaden4_2", "FKWReichweite1", "FKWReichweite2", "FKWReichweite3", "FKWReichweite4"], function(values) {
+		if (values.FKW_Aktiv == 1) {
+			setAttrs({
+				FK_Aktiv_Waffe: values.FKWFK1,
+				FTP_W_Aktiv_Waffe: values.FKWSchaden1_1,
+				FTP_Bonus_Aktiv_Waffe: values.FKWSchaden1_2,
+				FKWReichweite: values.FKWReichweite1
+   			});
+		}
+		if (values.FKW_Aktiv == 2) {
+			setAttrs({
+				FK_Aktiv_Waffe: values.FKWFK2,
+				FTP_W_Aktiv_Waffe: values.FKWSchaden2_1,
+				FTP_Bonus_Aktiv_Waffe: values.FKWSchaden2_2,
+				FKWReichweite: values.FKWReichweite2
+   			});
+		}
+		if (values.FKW_Aktiv == 3) {
+			setAttrs({
+				FK_Aktiv_Waffe: values.FKWFK3,
+				FTP_W_Aktiv_Waffe: values.FKWSchaden3_1,
+				FTP_Bonus_Aktiv_Waffe: values.FKWSchaden3_2,
+				FKWReichweite: values.FKWReichweite3
+   			});
+		}
+		if (values.FKW_Aktiv == 4) {
+			setAttrs({
+				FK_Aktiv_Waffe: values.FKWFK4,
+				FTP_W_Aktiv_Waffe: values.FKWSchaden4_1,
+				FTP_Bonus_Aktiv_Waffe: values.FKWSchaden4_2,
+				FKWReichweite: values.FKWReichweite4
+   			});
+		}
+   });
+});
+
+on("change:rs_art1 change:sf_belastungsgewoehnung_1 change:sf_belastungsgewoehnung_2", function() {
+   getAttrs(["RS_Art1", "sf_belastungsgewoehnung_1", "sf_belastungsgewoehnung_2"], function(values) {
+		var art = values.RS_Art1;
+		var gewoehnung = parseInt(values.sf_belastungsgewoehnung_1) + parseInt(values.sf_belastungsgewoehnung_2);
+		var modArt = getModifiedArt(art,gewoehnung);
+		var rs = getRS(art); 
+		var be = getBE(modArt);
+		var abzuege = getAbzuege(modArt);
+		setAttrs({
+			RS1: rs,
+			BE1: be,
+			RuestungsAbzuege1: abzuege
+		});
+   });
+});
+
+on("change:rs_art2 change:sf_belastungsgewoehnung_1 change:sf_belastungsgewoehnung_2", function() {
+   getAttrs(["RS_Art2", "sf_belastungsgewoehnung_1", "sf_belastungsgewoehnung_2"], function(values) {
+		var art = values.RS_Art2;
+		var gewoehnung = parseInt(values.sf_belastungsgewoehnung_1) + parseInt(values.sf_belastungsgewoehnung_2);
+		var modArt = getModifiedArt(art,gewoehnung);
+		var rs = getRS(art); 
+		var be = getBE(modArt);
+		var abzuege = getAbzuege(modArt);
+		setAttrs({
+			RS2: rs,
+			BE2: be,
+			RuestungsAbzuege2: abzuege
+		});
+   });
+});
+
+on("change:rs_art3 change:sf_belastungsgewoehnung_1 change:sf_belastungsgewoehnung_2", function() {
+   getAttrs(["RS_Art3", "sf_belastungsgewoehnung_1", "sf_belastungsgewoehnung_2"], function(values) {
+		var art = values.RS_Art3;
+		var gewoehnung = parseInt(values.sf_belastungsgewoehnung_1) + parseInt(values.sf_belastungsgewoehnung_2);
+		var modArt = getModifiedArt(art,gewoehnung);
+		var rs = getRS(art); 
+		var be = getBE(modArt);
+		var abzuege = getAbzuege(modArt);
+		setAttrs({
+			RS3: rs,
+			BE3: be,
+			RuestungsAbzuege3: abzuege
+		});
+   });
+});
+
+on("change:rs_art4 change:sf_belastungsgewoehnung_1 change:sf_belastungsgewoehnung_2", function() {
+   getAttrs(["RS_Art4", "sf_belastungsgewoehnung_1", "sf_belastungsgewoehnung_2"], function(values) {
+		var art = values.RS_Art4;
+		var gewoehnung = parseInt(values.sf_belastungsgewoehnung_1) + parseInt(values.sf_belastungsgewoehnung_2);
+		var modArt = getModifiedArt(art,gewoehnung);
+		var rs = getRS(art); 
+		var be = getBE(modArt);
+		var abzuege = getAbzuege(modArt);
+		setAttrs({
+			RS4: rs,
+			BE4: be,
+			RuestungsAbzuege4: abzuege
+		});
+   });
+});
+
+var getRS = function(art) {
+	if (art < 0) {
+		return 0;
+	} else {
+		return art;
+	}
+}
+
+var getBE = function(art) {
+	if (art == 0 || art == 1) {
+		return 0;
+	}
+	if (art == 2 || art == 3) {
+		return 1;
+	}
+	if (art == 4 || art == 5) {
+		return 2;
+	}
+	if (art == 6) {
+		return 3;
+	}
+	return 0;
+}
+
+var getAbzuege = function(art) {
+	if (art == 0 || art == 2 || art == 4 || art == 6) {
+		return 0;
+	}
+	if (art == 1 || art == 3 || art == 5) {
+		return -1;
+	}
+	return 0;
+}
+
+var getModifiedArt = function(art, gewoehnung) {
+	return parseInt(art) - (parseInt(gewoehnung) * 2);
+}
+
+on("change:RuestungAktiv change:RS1 change:RS2 hange:RS3 change:RS4 change:BE1 change:BE2 change:BE3 change:BE4 change:RuestungsAbzuege1 change:RuestungsAbzuege2 change:RuestungsAbzuege3 change:RuestungsAbzuege4 change:RuestungsGewicht1 change:RuestungsGewicht2 change:RuestungsGewicht3 change:RuestungsGewicht4", function() {
+   getAttrs(["RuestungAktiv", "RS1", "RS2", "RS3", "RS4", "BE1", "BE2", "BE3", "BE4", "RuestungsAbzuege1", "RuestungsAbzuege2", "RuestungsAbzuege3", "RuestungsAbzuege4", "RuestungsGewicht1", "RuestungsGewicht2", "RuestungsGewicht3", "RuestungsGewicht4"], function(values) {
+		var aktiv = values.RuestungAktiv;
+		if (aktiv == 1) {
+			setAttrs({
+				Ges_RS: values.RS1,
+				Ges_BE: values.BE1,
+				RuestungsAbzuege: values.RuestungsAbzuege1,
+				Ges_Gewicht: values.RuestungsGewicht1
+   			});
+		}
+		if (aktiv == 2) {
+			setAttrs({
+				Ges_RS: values.RS2,
+				Ges_BE: values.BE2,
+				RuestungsAbzuege: values.RuestungsAbzuege2,
+				Ges_Gewicht: values.RuestungsGewicht2
+   			});
+		}
+		if (aktiv == 3) {
+			setAttrs({
+				Ges_RS: values.RS3,
+				Ges_BE: values.BE3,
+				RuestungsAbzuege: values.RuestungsAbzuege3,
+				Ges_Gewicht: values.RuestungsGewicht3
+   			});
+		}
+		if (aktiv == 4) {
+			setAttrs({
+				Ges_RS: values.RS4,
+				Ges_BE: values.BE4,
+				RuestungsAbzuege: values.RuestungsAbzuege4,
+				Ges_Gewicht: values.RuestungsGewicht4
+   			});
+		}
+   });
+});
+
+
+on("change:schild_aktiv change:schildpamod1 change:schildpamod2 change:schildpamod3 change:schildpamod4 change:schild_ausgeruestet change:schildpa1 change:schildpa2 change:schildpa3 change:schildpa4", function() {
+   getAttrs(["Schild_Aktiv", "SchildPAMod1", "SchildPAMod2", "SchildPAMod3", "SchildPAMod4", "schild_ausgeruestet", "SchildPA1", "SchildPA2", "SchildPA3", "SchildPA4"], function(values) {
+		if (values.schild_ausgeruestet == 1) {
+			var aktiv = values.Schild_Aktiv;
+			if (aktiv == 1) {
+				setAttrs({
+					PA_Schild_Bonus: values.SchildPAMod1,
+					Schild_PA_Aktiv_Ausgeruestet: values.SchildPA1
+   				});
+			}
+			if (aktiv == 2) {
+				setAttrs({
+					PA_Schild_Bonus: values.SchildPAMod2,
+					Schild_PA_Aktiv_Ausgeruestet: values.SchildPA2
+   				});
+			}
+			if (aktiv == 3) {
+				setAttrs({
+					PA_Schild_Bonus: values.SchildPAMod3,
+					Schild_PA_Aktiv_Ausgeruestet: values.SchildPA3
+   				});
+			}
+			if (aktiv == 4) {
+				setAttrs({
+					PA_Schild_Bonus: values.SchildPAMod4,
+					Schild_PA_Aktiv_Ausgeruestet: values.SchildPA4
+   				});
+			}
+		} else {
+			setAttrs({
+				PA_Schild_Bonus: 0,
+				Schild_PA_Aktiv_Ausgeruestet: 0
+			});
+		}
+   });
+});
+
+on("change:parierwaffe_aktiv change:parierwaffepamod1 change:parierwaffepamod2 change:parierwaffepamod3 change:parierwaffepamod4 change:parierwaffe_ausgeruestet change:parierwaffepa1 change:parierwaffepa2 change:parierwaffepa3 change:parierwaffepa4", function() {
+   getAttrs(["Parierwaffe_Aktiv", "ParierwaffePAMod1", "ParierwaffePAMod2", "ParierwaffePAMod3", "ParierwaffePAMod4", "parierwaffe_ausgeruestet", "ParierwaffePA1", "ParierwaffePA2", "ParierwaffePA3", "ParierwaffePA4"], function(values) {
+		if (values.parierwaffe_ausgeruestet == 1) {
+			var aktiv = values.Parierwaffe_Aktiv;
+			if (aktiv == 1) {
+				setAttrs({
+					PA_Parierwaffe_Bonus: values.ParierwaffePAMod1,
+					Parierwaffe_PA_Aktiv_Ausgeruestet: values.ParierwaffePA1
+   				});
+			}
+			if (aktiv == 2) {
+				setAttrs({
+					PA_Parierwaffe_Bonus: values.ParierwaffePAMod2,
+					Parierwaffe_PA_Aktiv_Ausgeruestet: values.ParierwaffePA2
+   				});
+			}
+			if (aktiv == 3) {
+				setAttrs({
+					PA_Parierwaffe_Bonus: values.ParierwaffePAMod3,
+					Parierwaffe_PA_Aktiv_Ausgeruestet: values.ParierwaffePA3
+   				});
+			}
+			if (aktiv == 4) {
+				setAttrs({
+					PA_Parierwaffe_Bonus: values.ParierwaffePAMod4,
+					Parierwaffe_PA_Aktiv_Ausgeruestet: values.ParierwaffePA4
+   				});
+			}
+		} else {
+			setAttrs({
+				PA_Parierwaffe_Bonus: 0,
+				Parierwaffe_PA_Aktiv_Ausgeruestet: 0
+			});
+		}
+   });
+});
+
+on("change:sf_finte_1 change:sf_finte_2 change:sf_finte_3", function() {
+	getAttrs(["sf_finte_1", "sf_finte_2", "sf_finte_3"], function(values) {
+		if (values.sf_finte_3 == "1") {
+			setAttrs({
+				sf_finte: 1,
+				manoever_finte_1: 0,
+				manoever_finte_2: 0,
+				manoever_finte_3: 1
+			});
+		} else if (values.sf_finte_2 == "1") { 
+			setAttrs({
+				sf_finte: 1,
+				manoever_finte_1: 0,
+				manoever_finte_2: 1,
+				manoever_finte_3: 0
+			});
+		} else if (values.sf_finte_1 == "1") { 
+			setAttrs({
+				sf_finte: 1,
+				manoever_finte_1: 1,
+				manoever_finte_2: 0,
+				manoever_finte_3: 0
+			});
+		} else { 
+			setAttrs({
+				sf_finte: 0,
+				manoever_finte_1: 0,
+				manoever_finte_2: 0,
+				manoever_finte_3: 0
+			});
+		}
+	});
+});
+
+on("change:sf_praeziser_stich_1 change:sf_praeziser_stich_2 change:sf_praeziser_stich_3", function() {
+	getAttrs(["sf_praeziser_stich_1", "sf_praeziser_stich_2", "sf_praeziser_stich_3"], function(values) {
+		if (values.sf_praeziser_stich_3 == "1") {
+			setAttrs({
+				sf_praeziser_stich: 1,
+				manoever_praeziser_stich_1: 0,
+				manoever_praeziser_stich_2: 0,
+				manoever_praeziser_stich_3: 1
+			});
+		} else if (values.sf_praeziser_stich_2 == "1") { 
+			setAttrs({
+				sf_praeziser_stich: 1,
+				manoever_praeziser_stich_1: 0,
+				manoever_praeziser_stich_2: 1,
+				manoever_praeziser_stich_3: 0
+			});
+		} else if (values.sf_praeziser_stich_1 == "1") { 
+			setAttrs({
+				sf_praeziser_stich: 1,
+				manoever_praeziser_stich_1: 1,
+				manoever_praeziser_stich_2: 0,
+				manoever_praeziser_stich_3: 0
+			});
+		} else { 
+			setAttrs({
+				sf_praeziser_stich: 0,
+				manoever_praeziser_stich_1: 0,
+				manoever_praeziser_stich_2: 0,
+				manoever_praeziser_stich_3: 0
+			});
+		}
+	});
+});
+
+on("change:sf_wuchtschlag_1 change:sf_wuchtschlag_2 change:sf_wuchtschlag_3", function() {
+	getAttrs(["sf_wuchtschlag_1", "sf_wuchtschlag_2", "sf_wuchtschlag_3"], function(values) {
+		if (values.sf_wuchtschlag_3 == "1") {
+			setAttrs({
+				sf_wuchtschlag: 1,
+				manoever_wuchtschlag_1: 0,
+				manoever_wuchtschlag_2: 0,
+				manoever_wuchtschlag_3: 1
+			});
+		} else if (values.sf_wuchtschlag_2 == "1") { 
+			setAttrs({
+				sf_wuchtschlag: 1,
+				manoever_wuchtschlag_1: 0,
+				manoever_wuchtschlag_2: 1,
+				manoever_wuchtschlag_3: 0
+			});
+		} else if (values.sf_wuchtschlag_1 == "1") { 
+			setAttrs({
+				sf_wuchtschlag: 1,
+				manoever_wuchtschlag_1: 1,
+				manoever_wuchtschlag_2: 0,
+				manoever_wuchtschlag_3: 0
+			});
+		} else { 
+			setAttrs({
+				sf_wuchtschlag: 0,
+				manoever_wuchtschlag_1: 0,
+				manoever_wuchtschlag_2: 0,
+				manoever_wuchtschlag_3: 0
+			});
+		}
+	});
+});
+
+on("change:sf_rundumschlag_1 change:sf_rundumschlag_2", function() {
+	getAttrs(["sf_rundumschlag_1", "sf_rundumschlag_2"], function(values) {
+		if (values.sf_rundumschlag_2 == "1") { 
+			setAttrs({
+				sf_rundumschlag: 1,
+				manoever_rundumschlag_1: 0,
+				manoever_rundumschlag_2: 1
+			});
+		} else if (values.sf_rundumschlag_1 == "1") { 
+			setAttrs({
+				sf_rundumschlag: 1,
+				manoever_rundumschlag_1: 1,
+				manoever_rundumschlag_2: 0
+			});
+		} else { 
+			setAttrs({
+				sf_rundumschlag: 0,
+				manoever_rundumschlag_1: 0,
+				manoever_rundumschlag_2: 0
+			});
+		}
+	});
+});
+
+on("sheet:opened change:ff_wert", function() {
+	getAttrs(["FF_Wert"], function(values) {
+		setAttrs({
+			FKW_FK_Bonus_Leiteigenschaft: Math.floor(((values.FF_Wert - 8)/3))
+		});
+	});
+});
+
+on("change:sk_spezies change:mu_wert change:kl_wert change:in_wert change:vorteil_hohe_seelenkraft change:nachteil_niedrige_seelenkraft change:gegner_sheet", function() {
+	getAttrs(["SK_Spezies", "MU_Wert", "KL_Wert", "IN_Wert", "vorteil_hohe_seelenkraft", "nachteil_niedrige_seelenkraft", "gegner_sheet"], function(values) {
+		if (parseInt(values.gegner_sheet) != 1) {
+			var sk_spezies = parseInt(values.SK_Spezies);
+			var MU_Wert = parseInt(values.MU_Wert);
+			var KL_Wert = parseInt(values.KL_Wert);
+			var IN_Wert = parseInt(values.IN_Wert);
+			var Hohe_SK = parseInt(values.vorteil_hohe_seelenkraft);
+			var Niedrige_SK = parseInt(values.nachteil_niedrige_seelenkraft);
+			setAttrs({
+				SK_Grundwert: sk_spezies + Math.round((MU_Wert + KL_Wert + IN_Wert) / 6) + Hohe_SK - Niedrige_SK
+			});
+		}
+	});
+});
+
+on("change:zk_spezies change:ko_wert change:kk_wert change:vorteil_hohe_zaehigkeit change:nachteil_niedrige_zaehigkeit change:gegner_sheet", function() {
+	getAttrs(["ZK_Spezies", "KO_Wert", "KK_Wert", "vorteil_hohe_zaehigkeit", "nachteil_niedrige_zaehigkeit", "gegner_sheet"], function(values) {
+		if (parseInt(values.gegner_sheet) != 1) {
+			var zk_spezies = parseInt(values.ZK_Spezies);
+			var KO_Wert = parseInt(values.KO_Wert);
+			var KK_Wert = parseInt(values.KK_Wert);
+			var Hohe_ZK = parseInt(values.vorteil_hohe_zaehigkeit);
+			var Niedrige_ZK = parseInt(values.nachteil_niedrige_zaehigkeit);
+			setAttrs({
+				ZK_Grundwert: zk_spezies + Math.round((KO_Wert + KO_Wert + KK_Wert) / 6) + Hohe_ZK - Niedrige_ZK
+			});
+		}
+	});
+});
+
+on("change:ge_wert change:optpa_gw change:sf_verb_ausweichen_1 change:sf_verb_ausweichen_2 change:sf_verb_ausweichen_3 change:ges_be change:gegner_sheet", function() {
+	getAttrs(["GE_Wert", "optPA_GW", "sf_verb_ausweichen_1", "sf_verb_ausweichen_2", "sf_verb_ausweichen_3", "Ges_BE", "gegner_sheet"], function(values) {
+		if (parseInt(values.gegner_sheet) != 1) {
+			var GE_Wert = parseInt(values.GE_Wert);
+			var optPA = parseInt(values.optPA_GW);
+			var sf_verb_ausweichen = parseInt(values.sf_verb_ausweichen_1) + parseInt(values.sf_verb_ausweichen_2) + parseInt(values.sf_verb_ausweichen_3);
+			var Ges_BE = parseInt(values.Ges_BE);
+			setAttrs({
+				Ausweichen_Wert: Math.round(GE_Wert / 2) + (optPA / 2) + sf_verb_ausweichen - Ges_BE
+			});
+		}
+	});
+});
+
+on("change:mu_wert change:ge_wert change:sf_kampfreflexe_1 change:sf_kampfreflexe_2 change:sf_kampfreflexe_3 change:ges_be change:ruestungsabzuege change:gegner_sheet", function() {
+	getAttrs(["MU_Wert", "GE_Wert", "sf_kampfreflexe_1", "sf_kampfreflexe_2", "sf_kampfreflexe_3", "gegner_sheet", "Ges_BE", "RuestungsAbzuege"], function(values) {
+		if (parseInt(values.gegner_sheet) != 1) {
+			var MU_Wert = parseInt(values.MU_Wert);
+			var GE_Wert = parseInt(values.GE_Wert);
+			var sf_kampfreflexe = parseInt(values.sf_kampfreflexe_1) + parseInt(values.sf_kampfreflexe_2) + parseInt(values.sf_kampfreflexe_3);
+			var Ges_BE = parseInt(values.Ges_BE);
+			var Abzuege = parseInt(values.RuestungsAbzuege);
+			setAttrs({
+				INI_Wert: Math.round((MU_Wert + GE_Wert) / 2) + sf_kampfreflexe - Ges_BE + Abzuege
+			});
+		}
+	});
+});
+
+on("change:gs_spezies change:vorteil_flink change:nachteil_behaebig change:ges_be change:ruestungsabzuege change:gegner_sheet", function() {
+	getAttrs(["GS_Spezies", "vorteil_flink", "nachteil_behaebig", "Ges_BE", "RuestungsAbzuege", "gegner_sheet"], function(values) {
+		if (parseInt(values.gegner_sheet) != 1) {
+			var GS_Spezies = parseInt(values.GS_Spezies);
+			var flink = parseInt(values.vorteil_flink);
+			var behaebig = parseInt(values.nachteil_behaebig);
+			var Ges_BE = parseInt(values.Ges_BE);
+			var Abzuege = parseInt(values.RuestungsAbzuege);
+			setAttrs({
+				GS_Wert: GS_Spezies + flink - behaebig - Ges_BE + Abzuege
+			});
+		}
+	});
+});
+
+on("sheet:opened", function() {
+	getAttrs(["MU_Wert_Fix", "KL_Wert_Fix", "IN_Wert_Fix", "CH_Wert_Fix", "FF_Wert_Fix", "GE_Wert_Fix", "KK_Wert_Fix", "KO_Wert_Fix", "INI_Wert_Fix", "GS_Wert_Fix", "Spezies", "Tradition", "sf_belastungsgewoehnung_stufe", "sf_finte_stufe", "sf_wuchtschlag_stufe", "sf_praeziser_schuss_stufe", "sf_praeziser_stich_stufe", "sf_rundumschlag_stufe", "version"], function(values) {
+		if (values.version != "0.9") {
+			setAttrs({
+				MU_Wert: values.MU_Wert_Fix,
+				KL_Wert: values.KL_Wert_Fix,
+				IN_Wert: values.IN_Wert_Fix,
+				CH_Wert: values.CH_Wert_Fix,
+				FF_Wert: values.FF_Wert_Fix,
+				GE_Wert: values.GE_Wert_Fix,
+				KK_Wert: values.KK_Wert_Fix,
+				KO_Wert: values.KO_Wert_Fix,
+				INI_Wert: values.INI_Wert_Fix,
+				GS_Wert: values.GS_Wert_Fix,
+				version: "0.9"
+			});
+			if (values.Spezies == 3) {
+				setAttrs({
+					Spezies: "Mensch"
+				});
+			}
+			if (values.Spezies == 5) {
+				setAttrs({
+					Spezies: "Elf"
+				});
+			}
+			if (values.Spezies == 7) {
+				setAttrs({
+					Spezies: "Halbelf"
+				});
+			}
+			if (values.Spezies == 11) {
+				setAttrs({
+					Spezies: "Zwerg"
+				});
+			}
+			if (values.Tradition == 3) {
+				setAttrs({
+					Tradition: "Gildenmagier"
+				});
+			}
+			if (values.Tradition == 5) {
+				setAttrs({
+					Tradition: "Hexe"
+				});
+			}
+			if (values.Tradition == 6) {
+				setAttrs({
+					Tradition: "Elf"
+				});
+			}
+			if (values.Tradition == 11) {
+				setAttrs({
+					Tradition: "Goblinzauberinnen"
+				});
+			}
+			if (values.Tradition == 13) {
+				setAttrs({
+					Tradition: "Zibilja"
+				});
+			}
+			if (parseInt(values.sf_belastungsgewoehnung_stufe) >= 1) {
+				setAttrs({
+					sf_belastungsgewoehnung_1: 1
+				});
+			}
+			if (parseInt(values.sf_belastungsgewoehnung_stufe) >= 2) {
+				setAttrs({
+					sf_belastungsgewoehnung_2: 1
+				});
+			}
+			if (parseInt(values.sf_finte_stufe) >= 1) {
+				setAttrs({
+					sf_finte_1: 1
+				});
+			}
+			if (parseInt(values.sf_finte_stufe) >= 2) {
+				setAttrs({
+					sf_finte_2: 1
+				});
+			}
+			if (parseInt(values.sf_finte_stufe) == 3) {
+				setAttrs({
+					sf_finte_3: 1
+				});
+			}
+			if (parseInt(values.sf_wuchtschlag_stufe) >= 1) {
+				setAttrs({
+					sf_wuchtschlag_1: 1
+				});
+			}
+			if (parseInt(values.sf_wuchtschlag_stufe) >= 2) {
+				setAttrs({
+					sf_wuchtschlag_2: 1
+				});
+			}
+			if (parseInt(values.sf_wuchtschlag_stufe) == 3) {
+				setAttrs({
+					sf_wuchtschlag_3: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_schuss_stufe) >= 1) {
+				setAttrs({
+					sf_praeziser_schuss_1: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_schuss_stufe) >= 2) {
+				setAttrs({
+					sf_praeziser_schuss_2: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_schuss_stufe) == 3) {
+				setAttrs({
+					sf_praeziser_schuss_3: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_stich_stufe) >= 1) {
+				setAttrs({
+					sf_praeziser_stich_1: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_stich_stufe) >= 2) {
+				setAttrs({
+					sf_praeziser_stich_2: 1
+				});
+			}
+			if (parseInt(values.sf_praeziser_stich_stufe) == 3) {
+				setAttrs({
+					sf_praeziser_stich_3: 1
+				});
+			}
+			if (parseInt(values.sf_rundumschlag_stufe) >= 1) {
+				setAttrs({
+					sf_rundumschlag_1: 1
+				});
+			}
+			if (parseInt(values.sf_rundumschlag_stufe) == 2) {
+				setAttrs({
+					sf_rundumschlag_2: 1
+				});
+			}
+		}
+	});
+});
+
+</script>

--- a/Das_Schwarze_Auge_5/sheet.json
+++ b/Das_Schwarze_Auge_5/sheet.json
@@ -1,8 +1,8 @@
 {
 	"html": "dsa5_character_sheet_roll20.html",
 	"css": "dsa5_character_sheet_roll20.css",
-	"authors": "Patrick Gebhardt (gebhardthbs@web.de)",
-	"roll20userid": "592673",
+	"authors": "Patrick Gebhardt (gebhardthbs@web.de)", "Sönke Holsten (dsahalo@gmx.net)"
+	"roll20userid": "592673","115261"
 	"preview": "dsa5_character_sheet_roll20.png",
 	"instructions": "Charakterbogen fuer Das Schwarze Auge Regelwerk 5"
 }


### PR DESCRIPTION
**Allgemein**
- Einführung von Sheet Worker, d.h. viele Werte werden nunmehr per Sheet Worker statt "autocalculated field" berechnet. Dies erlaubt insbesondere auch mehr Flexibilität beim händischen Ändern von berechneten Werten. Es kann sein, dass durch die Umstellung einige Werte noch nicht neu berechnet wurden, hier kann aber durch kurzes hin- und herändern von abhängigen Werten eine Neuberechnung erzwungen werden. Die neue Version beinhaltet aber auch erstmalig ein Update-Skript, das dazu gedacht ist Änderungen von der alten auf die neue Version automatisiert zu übernehmen.

**Anzeige / UI**
- Konfigurationen Verstecke Magie und Verstecke Götterwirken: AE/KE werden jetzt im Tab Grundwerte ebenfalls ausgeblendet
- Konfigurationen zur Anzeige von Schilden, Parierwaffen und Fernkampf eingeführt (sind per Default ausgeblendet)
- Konfiguration zur Anzeige der Schildparade entfernt (stattdessen wird die Schildparade nun eingeblendet, sobald im Tab "Nahkampf" ein Schild als ausgerüstet markiert wird)
- Konfigurationen zur Anzeige von Notizen und Inventar
- Traditionsauswahl im Magie-Tab vereinfacht
- Aktive Nahkampfwaffe, Schild, Fernkampfwaffe und Rüstung nunmehr per Radio Button statt Checkbox auswählbar
- Überarbeitete Ansicht der aktiven Fernkampfwaffe
- Mehrstufige Kampfsonderfertigkeiten werden nunmehr jeweils pro Stufe einzeln aufgeführt und im Nahkampf-Tab kann nun nur noch die höchste aktivierte Stufe ausgewählt werden
- Anzeige zu Eigenschaften und Grundwerten etwas überarbeitet (auf Basis der Sheet Worker nun auch frei editierbar)

**Neue Features**

- Erfahrungsgrad: Auswahl füllt nun automatisch "AP Gesamt", sofern nicht bereits ein Wert händisch eingetragen wurde
- Optionalregel Kulturkunde: Wenn aktiviert, erscheint ein entsprechender Hinweis in den Tooltips für Gesellschaft- und Wissenstalente
- Parierwaffen werden nunmehr von Schilden getrennt geführt. Dies erlaubt zukünftig weitere Automatisierung von berechneten Werten und getrennte Behandlung von Parierwaffen und Schilden bei einigen Spezialregeln (bspw. "Beengte Umgebung" oder Gegner der Kategorien groß und riesig -> noch nicht implementiert)
- Rüstungsart: Beim Erfassen der Rüstung kann nun eine Rüstungsart ausgewählt werden, wodurch RS, BE und Zus. Abz. automatisch ausgefüllt werden (unter Berücksichtigung von Belastungsgewöhnung)
- Traditionsauswahl im Götterwirken-Tab führt nun auch automatisch zu Auswahl von passender Leiteigenschaft

**Fehlerbehebungen**
- Flugangriff steigert TP nun korrekt um 2
- Berechnung der maximalen Last funktioniert nun wieder korrekt
- Haltegriff wird nun im Nahkampf-Tab angezeigt
- Problem bei Berechnung der BE behoben