### PR TITLE
D&D3.5: Flatfooted/Immobile AC calc fix + Ability Notes

### DIFF
--- a/D&D_3-5/charsheet_3-5.css
+++ b/D&D_3-5/charsheet_3-5.css
@@ -10,6 +10,7 @@
 .sheet-pc-savemacros-show:not(:checked)~.sheet-pc-savemacros {display:none;}  
 .sheet-pc-baseattackmacros-show:not(:checked)~.sheet-pc-baseattackmacros {display:none;}
 .sheet-pc-statblock-show:not(:checked)~.sheet-pc-statblock {display:none;} 
+.sheet-pc-abilitymacros-show:not(:checked)~.sheet-pc-abilitymacros {display:none;} 
 .sheet-pc-equipment-show:not(:checked)~.sheet-pc-equipment {display:none;} 
 .sheet-pc-acequipment-show:not(:checked)~.sheet-pc-acequipment {display:none;} 
 .sheet-pc-acother-show:not(:checked)~.sheet-pc-acother {display:none;} 

--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -2,9 +2,9 @@
 <!-- by Diana P. -->
 <!-- based on Pathfinder sheets from Barry R., Sam, Brian, and Justin N. -->
 <!-- with lots of help from Toby-->
-<!-- Version 2.7.2 3/15/16 (Sheetworkers for Attributes, encumbrance calcs, and inventory cost/weight calculation)-->
+<!-- Version 2.7.3 5/12/16 (Sheetworkers for Attributes, encumbrance calcs, and inventory cost/weight calculation)-->
 
-<input type="hidden" name="attr_currentsheetversion" title="currentsheetversion" value="7.2"/>
+<input type="hidden" name="attr_currentsheetversion" title="currentsheetversion" value="7.3"/>
 <input type="radio" class="sheet-switch-pc-show sheet-switch" title="npc-show" name="attr_npc-show" value="1" checked /><span style="text-align: left;">PC &nbsp; &nbsp; &nbsp; &nbsp;</span>
 <input type="radio" class="sheet-switch-npc-show sheet-switch" title="npc-show" name="attr_npc-show" value="2" /><span style="text-align: left;">NPC</span>
 
@@ -95,11 +95,13 @@
 		<input type="checkbox" class="sheet-pc-statblock-show sheet-arrow" title="statblock-show" name="attr_statblock-show" value="1" checked /><span style="text-align: left;">Abilities</span>
 		<div class="sheet-pc-statblock">
 			<!-- Stat block -->
-			<table>
+			<table cellpadding="0" cellspacing="0">
 				<tr>
-					<td>
-						<div style="display:table;width:39%;float:left;">
-							<span class="sheet-table-name">Ability Scores</span>
+					<td style="text-align: left;" >
+						<table cellpadding="0" cellspacing="0">
+							<tr><td style="text-align: left;">
+							<span class="sheet-table-name" style="width: 315px;">Ability Scores</span>
+							<input type="checkbox" class="sheet-pc-abilitymacros-show sheet-arrow" title="abilitymacros-show" name="attr_abilitymacros-show" value="1" /><!--span style="text-align: left;"></span-->
 							<div class="sheet-table-row">
 								<span class="sheet-table-header">Ability</span>
 								<span class="sheet-table-header">Total</span>
@@ -109,68 +111,88 @@
 								<span class="sheet-table-header">Temp</span>
 							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">STR</span>
+								<span class="sheet-table-row-name" style="width: 60px;">STR</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str" value="0" title="str" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-mod" value="0" title="str-mod" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-base" value="10" title="str-base"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-misc" value="0" title="str-misc"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-temp" value="0" title="str-temp"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="str-macro (modify to modify roll macro)" name="attr_str-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Strength check:}} {{checkroll= [[ 1d20 + @{str-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_strcheck" title="strcheck" value="@{str-macro}"></button></span>
 							</div>
+							<div class="sheet-pc-abilitymacros" colspan="7">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_strnote" title="strnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_str-macro" title="str-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Strength check:}} {{checkroll= [[ 1d20 + @{str-mod} ]] }} {{notes=@{strnote} }}</textarea></span>
+							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">DEX</span>
+								<span class="sheet-table-row-name" style="width: 60px;">DEX</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex" title="dex" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-mod" title="dex-mod" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-base" title="dex-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-misc" title="dex-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-temp" title="dex-temp" value="0"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="dex-macro (modify to modify roll macro)" name="attr_dex-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Dexterity check:}} {{checkroll= [[ 1d20 + @{dex-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_dexcheck" title="dexcheck" value="@{dex-macro}"></button></span>
 							</div>
+							<div class="sheet-pc-abilitymacros">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_dexnote" title="dexnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_dex-macro" title="dex-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Dexterity check:}} {{checkroll= [[ 1d20 + @{dex-mod} ]] }} {{notes=@{dexnote} }}</textarea></span>
+							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">CON</span>
+								<span class="sheet-table-row-name" style="width: 60px;">CON</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con" title="con" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-mod" title="con-mod" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-base" title="con-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-misc" title="con-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-temp" title="con-temp" value="0"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="con-macro (modify to modify roll macro)" name="attr_con-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Constitution check:}} {{checkroll= [[ 1d20 + @{con-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_concheck" title="concheck" value="@{con-macro}"></button></span>
 							</div>
+							<div class="sheet-pc-abilitymacros">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_connote" title="connote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_con-macro" title="con-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Constitution check:}} {{checkroll= [[ 1d20 + @{con-mod} ]] }} {{notes=@{connote} }}</textarea></span>
+							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">INT</span>
+								<span class="sheet-table-row-name" style="width: 60px;">INT</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int" title="int" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-mod" title="int-mod" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-base" title="int-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-misc" title="int-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-temp" title="int-temp" value="0"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="int-macro (modify to modify roll macro)" name="attr_int-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Intelligence check:}} {{checkroll= [[ 1d20 + @{int-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_intcheck" title="intcheck" value="@{int-macro}"></button></span>
 							</div>
+							<div class="sheet-pc-abilitymacros">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_intnote" title="intnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_int-macro" title="int-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Intelligence check:}} {{checkroll= [[ 1d20 + @{int-mod} ]] }} {{notes=@{intnote} }}</textarea></span>
+							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">WIS</span>
+								<span class="sheet-table-row-name" style="width: 60px;">WIS</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis" title="wis" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-mod" title="wis-mod" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-base" title="wis-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-misc" title="wis-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-temp" title="wis-temp" value="0"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="wis-macro (modify to modify roll macro)" name="attr_wis-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Wisdom check:}} {{checkroll= [[ 1d20 + @{wis-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_wischeck" title="wischeck" value="@{wis-macro}"></button></span>
 							</div>
+							<div class="sheet-pc-abilitymacros">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_wisnote" title="wisnote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_wis-macro" title="wis-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Wisdom check:}} {{checkroll= [[ 1d20 + @{wis-mod} ]] }} {{notes=@{wisnote} }}</textarea></span>
+							</div>
 							<div class="sheet-table-row">
-								<span class="sheet-table-row-name">CHA</span>
+								<span class="sheet-table-row-name" style="width: 60px;">CHA</span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha" title="cha" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-mod" title="cha-mod" value="0" readonly="readonly"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-base" title="cha-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-misc" title="cha-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-temp" title="cha-temp" value="0"></span>
-								<span class="sheet-table-data-center"><textarea rows="1" cols="35" style="width: 35px; height: 18px;" title="cha-macro (modify to modify roll macro)" name="attr_cha-macro">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Charisma check:}} {{checkroll= [[ 1d20 + @{cha-mod} ]] }}</textarea></span>
 								<span class="sheet-table-data-center"><button type="roll" name="attr_chacheck" title="chacheck" value="@{cha-macro}"></button></span>
 							</div>
-						</div>
+							<div class="sheet-pc-abilitymacros">
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_chanote" title="chanote (Enter a note for the notes field.)" placeholder="Note"></textarea></span>
+								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_cha-macro" title="cha-macro (modify to modify roll macro)">&{template:DnD35StdRoll} {{abilityflag=true}} {{name=@{character_name} }} {{check=Charisma check:}} {{checkroll= [[ 1d20 + @{cha-mod} ]] }} {{notes=@{chanote} }}</textarea></span>
+							</div>
+							<input type="checkbox" class="sheet-pc-abilitymacros-show sheet-arrow" title="abilitymacros-show" name="attr_abilitymacros-show" value="1" /><span style="text-align: left;">Show Ability Macros</span>
+							</td></tr> 
+						</table>
 					</td>
-					<td>
+					<td  style="vertical-align:top;">
 						<table>
 							<tr>
 								<td rowspan=3 style="width: 50px;"> &nbsp; &nbsp; &nbsp; &nbsp; </td>
@@ -1193,7 +1215,7 @@
 								<td style="width: 45px;"><input type="text" name="attr_dexbonus" title="dexbonus" style="width: 45px;" value="@{dex-mod}" disabled="true" /></td>
 								<td style="width: 25px;">Y </td>
 								<td style="width: 45px;"><input type="text" name="attr_dexacbonus" title="dexacbonus" style="width: 45px;" value="@{armorclassdexmod}" disabled="true" />
-								<input type="hidden" name="attr_dexacpenalty" title="dexacpenalty" value="( [[ 0-floor((0-@{dex-mod}-0.1)/(abs(0-@{dex-mod}-0.1)+0.001))*0 -floor((@{dex-mod}+0.1-0)/(abs(@{dex-mod}+0.1-0)+0.001))*@{dex-mod} ]] )" disabled="true" />
+								<input type="hidden" name="attr_dexacpenalty" title="dexacpenalty" value="( [[ (0-floor((@{dex-mod} +0.1)/(abs(@{dex-mod}+0.1) +0.001))*@{dex-mod}) ]] )" disabled="true" />
 								<input type="hidden" name="attr_armordexmod" title="armordexmod (either dex-mod or max dex from AC items section below; whichever is lower)" value="(ceil((@{dex-mod} -@{acitemdex}*(100-99*@{armorworn}))/10000000000)*@{acitemdex} - floor((@{dex-mod} -@{acitemdex}*(100-99*@{armorworn})-1)/10000000000)*@{dex-mod} )" disabled="true"/> 
 								<input type="hidden" name="attr_armorclassdexmod" title="armorclassdexmod (either dex-mod, max dex from AC items section, or max dex from encumbrance; whichever is lower)" value="(ceil((@{armordexmod}-@{encumbrmaxdex})/10000000000)*@{encumbrmaxdex} - floor((@{armordexmod}-@{encumbrmaxdex}-1)/10000000000)*@{armordexmod})" disabled="true" /></td>
 									<!--Special Thanks to Aaron I. for the dex/maxdex calculation!-->
@@ -3569,7 +3591,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right">Abilities:</td>
-			<td class="sheet-table-left"> Str:<input style="width: 40px;" type="text" name="attr_npcstr" title="npcstr" placeholder="Str">, &nbsp; &nbsp; Dex:<input style="width: 40px;" type="text" name="attr_npcdex" title="npcdex" placeholder="Dex">, &nbsp; &nbsp; Con:<input style="width: 40px;" type="text" name="attr_npccon" title="npccon" placeholder="Con">, &nbsp; &nbsp; Int:<input style="width: 40px;" type="text" name="attr_npcint" title="npcint" placeholder="Int">, &nbsp; &nbsp; Wis:<input style="width: 40px;" type="text" name="attr_npcwis" title="npcwis" placeholder="Wis">, &nbsp; &nbsp; Cha:<input style="width: 40px;" type="text" name="attr_npccha" title="npccha" placeholder="Cha"> </td>
+			<td class="sheet-table-left"> Str:<input style="width: 3em;" type="text" name="attr_npcstr" title="npcstr" placeholder="Str">(+<input style="width: 2em;" type="text" name="attr_npcstr-mod" title="npcstr-mod" value="0">), &nbsp; &nbsp; Dex:<input style="width: 3em;" type="text" name="attr_npcdex" title="npcdex" placeholder="Dex">(+<input style="width: 2em;" type="text" name="attr_npcdex-mod" title="npcdex-mod" value="0">), &nbsp; &nbsp; Con:<input style="width: 3em;" type="text" name="attr_npccon" title="npccon" placeholder="Con">(+<input style="width: 2em;" type="text" name="attr_npccon-mod" title="npccon-mod" value="0">), &nbsp; &nbsp; Int:<input style="width: 3em;" type="text" name="attr_npcint" title="npcint" placeholder="Int">(+<input style="width: 2em;" type="text" name="attr_npcint-mod" title="npcint-mod" value="0">), &nbsp; &nbsp; Wis:<input style="width: 3em;" type="text" name="attr_npcwis" title="npcwis" placeholder="Wis">(+<input style="width: 2em;" type="text" name="attr_npcwis-mod" title="npcwis-mod" value="0">), &nbsp; &nbsp; Cha:<input style="width: 3em;" type="text" name="attr_npccha" title="npccha" placeholder="Cha">(+<input style="width: 2em;" type="text" name="attr_npccha-mod" title="npccha-mod" value="0">) </td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right">Skills:</td>
@@ -4063,7 +4085,7 @@
 
 </div>
 <br>
-<p style="font-size: 0.8em;">D&D3.5e Character Sheet v2.<span name="attr_sheetversion" title="sheetversion" ></span> 03/15/16 by Diana P.</p>
+<p style="font-size: 0.8em;">D&D3.5e Character Sheet v2.<span name="attr_sheetversion" title="sheetversion" ></span> 05/12/16 by Diana P.</p>
 <p style="font-size: 0.8em;">Repeating section calculations with sheetworkers done using TheAaronSheet :: <a href="https://github.com/shdwjk/TheAaronSheet">https://github.com/shdwjk/TheAaronSheet</a></p>
 
 


### PR DESCRIPTION
Add Notes section for Ability Stats and moved them and the macro to a toggle-hidden area, adjusted/fixed calculation for dex penalties for flatfooted and immobile AC.