### PR TITLE
PF legacy Init fix

### DIFF
--- a/Pathfinder (Old)/pathfinder-old.html
+++ b/Pathfinder (Old)/pathfinder-old.html
@@ -546,8 +546,8 @@
 						<span class="sheet-table-header">Misc</span>
 					</div>
 					<div class="sheet-table-row">
-						<span class="sheet-table-row-name" style="width:5%;"><button class="sheet-text-button" title="Roll-for-initiative" type="roll" name="roll_Roll-for-initiative" value="&{template:pf_check} {{name=@{target|character_name}'s}} {{check=Initiative Roll}} {{init=[[1d20 + [[ @{target|init} ]] + [[ 0.01 * @{target|init} ]] &{tracker}]]}}">Initiative</button></span>
-						<span class="sheet-table-data-center"><input title="init" type="number" name="attr_init" value="(@{DEX-mod} + @{init-misc})" disabled></span>
+						<span class="sheet-table-row-name" style="width:5%;"><button class="sheet-text-button" title="Roll-for-initiative" type="roll" name="roll_Roll-for-initiative" value="&{template:pf_check} {{name=@{character_name}'s}} {{check=Initiative Roll}} {{init=[[ ( 1d20 + [[ @{init} ]] [init] + [[ {(0.01 * [[ @{init} ]] ),0}kh1 ]] [tie-breaker] ) &{tracker} ]] }}">Initiative</button></span>
+						<span class="sheet-table-data-center"><input title="init" type="number" name="attr_init" value="(@{init-DEX} + @{init-misc})" disabled></span>
 						<span class="sheet-table-data-center"><input title="DEX-mod" type="number" name="attr_init-DEX" value="@{DEX-mod}" disabled></span>
 						<span class="sheet-table-data-center"><input title="init-misc" type="number" name="attr_init-misc" value="0"></span>
 					</div>
@@ -2310,13 +2310,15 @@
 			<div class="sheet-table-row">
 				<span class="sheet-table-header" style="text-align:left;"></span>
 				<span class="sheet-table-header" style="text-align:left;">Total</span>
+				<span class="sheet-table-header" style="text-align:left;">DEX</span>
 				<span class="sheet-table-header" style="text-align:left;">Misc</span>
 				<span class="sheet-table-header" style="text-align:left;"></span>
 				<span class="sheet-table-header" style="text-align:left;"></span>
 			</div>
 			<div class="sheet-table-row">				
-				<span class="sheet-table-data-left" style="width:5%;"><button style="font-size:100%;" title="NPC-Initiative-Roll" type="roll" name="roll_NPC-Initiative-Roll" value="/w gm &{template:pf_check} {{name=@{character_name}'s}} {{check=Initiative Roll}} {{init=[[1d20 + @{init} + 0.01 * @{init} &{tracker}]]}}">Init</button></span>
-				<span class="sheet-table-data-left" style="width:5%;"><input type="number" title="init" name="attr_init" value="@{DEX-mod} + @{init-misc}" disabled/></span>
+				<span class="sheet-table-data-left" style="width:5%;"><button style="font-size:100%;" title="NPC-Initiative-Roll" type="roll" name="roll_NPC-Initiative-Roll" value="/w gm &{template:pf_check} {{name=@{character_name}'s}} {{init=[[ ( 1d20 + [[ @{init} ]] [init] + [[ {(0.01 * [[ @{init} ]] ),0}kh1 ]] [tie-breaker] ) &{tracker} ]] }}">Init</button></span>
+				<span class="sheet-table-data-left" style="width:5%;"><input type="number" title="init" name="attr_init" value="(@{init-DEX} + @{init-misc})" disabled/></span>
+				<span class="sheet-table-data-left" style="width:5%;"><input title="DEX-mod" type="number" name="attr_init-DEX" value="@{DEX-mod}" disabled></span>
 				<span class="sheet-table-data-left" style="width:5%;"><input type="number" title="init-misc" name="attr_init-misc" value="0"/></span>
 				<span class="sheet-table-data-left" style="width:7%;"><b>Senses </b></span>
 				<span class="sheet-table-data-center"><input type="text" title="npc-senses" name="attr_npc-senses"/></span>


### PR DESCRIPTION
- init total and init-misc were being added to initiative rolls.
- removed the **target** requirement for PC initiative rolls.  Using target seemed unnecessary...
- fixed init value to use init-DEX instead of DEX-mod.
- matched NPC initiative macro to PC
- added DEX field near NPC init for clarity