### PR TITLE
Update Labels, power drop down options, and allow some fields to be player input

### DIFF
--- a/D&D_4E/D&D_4E.html
+++ b/D&D_4E/D&D_4E.html
@@ -43,7 +43,7 @@
         <!-- Left --> <!-- Hit Points, Movement, Action Points, Ability Scores, and Senses -->
         <div class="sheet-col">
             <!-- Hit Points -->
-			<div class="sheet-toggle-container">
+    		<div class="sheet-toggle-container">
 				<input type="checkbox" class="sheet-toggle">
 				<label class="sheet-headtwo">Hit Points</label>
 				<div class="sheet-statblock">
@@ -71,13 +71,13 @@
 							<input type="text" name="attr_hp_max" value="0"/>
 						</div>
 						<div class="sheet-item sheet-small">
-							<input type="text" name="attr_hp-bloodied" value="floor(@{hp|max}/2)" disabled = "true"/>
+							<input type="text" name="attr_hp-bloodied" value="0"/>
 						</div>
 						<div class="sheet-item sheet-tiny">
 							<input type="text" name="attr_surge-value-bonus" value="0"/>
 						</div>
                         <div class="sheet-item sheet-tiny">
-							<input type="text" name="attr_surge-value" value="floor(@{hp|max}/4)+@{surge-value-bonus}" disabled = "true"/>
+							<input type="text" name="attr_surge-value" value="0"/>
 						</div>
 						<div class="sheet-item sheet-small">
 							<input type="text" name="attr_surges_max" value="0"/>
@@ -446,7 +446,7 @@
 							<input type="text" name="attr_ac-ten" value="10+@{halflevel}" disabled = "true"/>
 						</div>
                         <div class="sheet-item sheet-puny sheet-black">
-							<input type="text" name="attr_ac-ability" value="@{ac-highest}" disabled = "true"/>
+							<input type="text" name="attr_ac-ability" value="0"/>
 						</div>
 						<div class="sheet-item sheet-puny sheet-black">
 							<input type="text" name="attr_ac-armor" value="0"/>
@@ -479,7 +479,7 @@
 							<input type="text" name="attr_fort-ten" value="10+@{halflevel}" disabled = "true"/>
 						</div>
                         <div class="sheet-item sheet-puny sheet-black">
-							<input type="text" name="attr_fort-ability" value="@{fort-highest}" disabled = "true"/>
+							<input type="text" name="attr_fort-ability" value="0"/>
 						</div>
 						<div class="sheet-item sheet-puny sheet-black">
 							<input type="text" name="attr_fort-armor" value="0"/>
@@ -512,7 +512,7 @@
 							<input type="text" name="attr_ref-ten" value="10+@{halflevel}" disabled = "true"/>
 						</div>
                         <div class="sheet-item sheet-puny sheet-black">
-							<input type="text" name="attr_ref-ability" value="@{ref-highest}" disabled = "true"/>
+							<input type="text" name="attr_ref-ability" value="0"/>
 						</div>
 						<div class="sheet-item sheet-puny sheet-black">
 							<input type="text" name="attr_ref-armor" value="0"/>
@@ -545,7 +545,7 @@
 							<input type="text" name="attr_will-ten" value="10+@{halflevel}" disabled = "true"/>
 						</div>
                         <div class="sheet-item sheet-puny sheet-black">
-							<input type="text" name="attr_will-ability" value="@{will-highest}" disabled = "true"/>
+							<input type="text" name="attr_will-ability" value="0"/>
 						</div>
 						<div class="sheet-item sheet-puny sheet-black">
 							<input type="text" name="attr_will-armor" value="0"/>
@@ -1967,16 +1967,17 @@
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-[number]-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -1986,7 +1987,8 @@
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-[number]-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -1997,22 +1999,56 @@
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-[number]-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
-                                    </select>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
+									</select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-[number]-weapon-dice">
@@ -2060,8 +2096,7 @@
                             </div>
                             <textarea name="attr_power-[number]-macro">/me uses @{power-[number]-name}
 [[1d20+@{power-[number]-attack}]] vs @{power-[number]-def} 
-Hit: [[(1*@{power-[number]-weapon-num-dice})d@{power-[number]-weapon-dice}+@{power-[number]-damage}]] Damage
-Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
+Hit: [[(1*@{power-[number]-weapon-num-dice})d@{power-[number]-weapon-dice}+@{power-[number]-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power [number]</label>
@@ -2172,16 +2207,17 @@ Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-1-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -2191,7 +2227,8 @@ Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-1-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -2202,26 +2239,66 @@ Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-1-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-1-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -2265,8 +2342,7 @@ Hit: [[1d6+@{power-[number]-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-1-macro">/me uses @{power-1-name}
 [[1d20+@{power-1-attack}]] vs @{power-1-def} 
-Hit: [[(1*@{power-1-weapon-num-dice})d@{power-1-weapon-dice}+@{power-1-damage}]] Damage
-Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
+Hit: [[(1*@{power-1-weapon-num-dice})d@{power-1-weapon-dice}+@{power-1-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 1</label>
@@ -2373,16 +2449,17 @@ Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-2-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -2392,7 +2469,8 @@ Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-2-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -2403,26 +2481,66 @@ Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-2-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-2-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -2466,8 +2584,7 @@ Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-2-macro">/me uses @{power-2-name}
 [[1d20+@{power-2-attack}]] vs @{power-2-def} 
-Hit: [[(1*@{power-2-weapon-num-dice})d@{power-2-weapon-dice}+@{power-2-damage}]] Damage
-Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
+Hit: [[(1*@{power-2-weapon-num-dice})d@{power-2-weapon-dice}+@{power-2-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 2</label>
@@ -2574,16 +2691,17 @@ Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-3-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -2593,7 +2711,8 @@ Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-3-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -2604,26 +2723,66 @@ Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-3-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-3-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -2667,8 +2826,7 @@ Hit: [[1d6+@{power-2-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-3-macro">/me uses @{power-3-name}
 [[1d20+@{power-3-attack}]] vs @{power-3-def} 
-Hit: [[(1*@{power-3-weapon-num-dice})d@{power-3-weapon-dice}+@{power-3-damage}]] Damage
-Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
+Hit: [[(1*@{power-3-weapon-num-dice})d@{power-3-weapon-dice}+@{power-3-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 3</label>
@@ -2775,16 +2933,17 @@ Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-4-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -2794,7 +2953,8 @@ Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-4-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -2805,26 +2965,66 @@ Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-4-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-4-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -2868,8 +3068,7 @@ Hit: [[1d6+@{power-3-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-4-macro">/me uses @{power-4-name}
 [[1d20+@{power-4-attack}]] vs @{power-4-def} 
-Hit: [[(1*@{power-4-weapon-num-dice})d@{power-4-weapon-dice}+@{power-4-damage}]] Damage
-Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
+Hit: [[(1*@{power-4-weapon-num-dice})d@{power-4-weapon-dice}+@{power-4-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 4</label>
@@ -2976,16 +3175,17 @@ Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-5-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -2995,7 +3195,8 @@ Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-5-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -3006,26 +3207,66 @@ Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-5-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-5-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -3069,8 +3310,7 @@ Hit: [[1d6+@{power-4-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-5-macro">/me uses @{power-5-name}
 [[1d20+@{power-5-attack}]] vs @{power-5-def} 
-Hit: [[(1*@{power-5-weapon-num-dice})d@{power-5-weapon-dice}+@{power-5-damage}]] Damage
-Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
+Hit: [[(1*@{power-5-weapon-num-dice})d@{power-5-weapon-dice}+@{power-5-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 5</label>
@@ -3177,16 +3417,17 @@ Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-6-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -3196,7 +3437,8 @@ Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-6-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -3207,26 +3449,66 @@ Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-6-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-6-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -3270,8 +3552,7 @@ Hit: [[1d6+@{power-5-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-6-macro">/me uses @{power-6-name}
 [[1d20+@{power-6-attack}]] vs @{power-6-def} 
-Hit: [[(1*@{power-6-weapon-num-dice})d@{power-6-weapon-dice}+@{power-6-damage}]] Damage
-Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
+Hit: [[(1*@{power-6-weapon-num-dice})d@{power-6-weapon-dice}+@{power-6-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 6</label>
@@ -3378,16 +3659,17 @@ Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-7-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -3397,7 +3679,8 @@ Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-7-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -3408,26 +3691,66 @@ Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-7-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-7-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -3471,8 +3794,7 @@ Hit: [[1d6+@{power-6-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-7-macro">/me uses @{power-7-name}
 [[1d20+@{power-7-attack}]] vs @{power-7-def} 
-Hit: [[(1*@{power-7-weapon-num-dice})d@{power-7-weapon-dice}+@{power-7-damage}]] Damage
-Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
+Hit: [[(1*@{power-7-weapon-num-dice})d@{power-7-weapon-dice}+@{power-7-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 7</label>
@@ -3579,16 +3901,17 @@ Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-8-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -3598,7 +3921,8 @@ Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-8-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -3609,26 +3933,66 @@ Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-8-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-8-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -3672,8 +4036,7 @@ Hit: [[1d6+@{power-7-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-8-macro">/me uses @{power-8-name}
 [[1d20+@{power-8-attack}]] vs @{power-8-def} 
-Hit: [[(1*@{power-8-weapon-num-dice})d@{power-8-weapon-dice}+@{power-8-damage}]] Damage
-Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
+Hit: [[(1*@{power-8-weapon-num-dice})d@{power-8-weapon-dice}+@{power-8-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 8</label>
@@ -3780,16 +4143,17 @@ Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-9-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -3799,7 +4163,8 @@ Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-9-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -3810,26 +4175,66 @@ Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-9-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-9-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -3873,8 +4278,7 @@ Hit: [[1d6+@{power-8-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-9-macro">/me uses @{power-9-name}
 [[1d20+@{power-9-attack}]] vs @{power-9-def} 
-Hit: [[(1*@{power-9-weapon-num-dice})d@{power-9-weapon-dice}+@{power-9-damage}]] Damage
-Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
+Hit: [[(1*@{power-9-weapon-num-dice})d@{power-9-weapon-dice}+@{power-9-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 9</label>
@@ -3981,16 +4385,17 @@ Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-10-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -4000,7 +4405,8 @@ Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-10-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -4011,26 +4417,66 @@ Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-10-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-10-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -4074,8 +4520,7 @@ Hit: [[1d6+@{power-9-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-10-macro">/me uses @{power-10-name}
 [[1d20+@{power-10-attack}]] vs @{power-10-def} 
-Hit: [[(1*@{power-10-weapon-num-dice})d@{power-10-weapon-dice}+@{power-10-damage}]] Damage
-Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
+Hit: [[(1*@{power-10-weapon-num-dice})d@{power-10-weapon-dice}+@{power-10-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 10</label>
@@ -4182,16 +4627,17 @@ Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-11-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -4201,7 +4647,8 @@ Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-11-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -4212,26 +4659,66 @@ Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-11-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-11-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -4275,8 +4762,7 @@ Hit: [[1d6+@{power-10-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-11-macro">/me uses @{power-11-name}
 [[1d20+@{power-11-attack}]] vs @{power-11-def} 
-Hit: [[(1*@{power-11-weapon-num-dice})d@{power-11-weapon-dice}+@{power-11-damage}]] Damage
-Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
+Hit: [[(1*@{power-11-weapon-num-dice})d@{power-11-weapon-dice}+@{power-11-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 11</label>
@@ -4383,16 +4869,17 @@ Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-12-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -4402,7 +4889,8 @@ Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-12-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -4413,26 +4901,66 @@ Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-12-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-12-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -4476,8 +5004,7 @@ Hit: [[1d6+@{power-11-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-12-macro">/me uses @{power-12-name}
 [[1d20+@{power-12-attack}]] vs @{power-12-def} 
-Hit: [[(1*@{power-12-weapon-num-dice})d@{power-12-weapon-dice}+@{power-12-damage}]] Damage
-Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
+Hit: [[(1*@{power-12-weapon-num-dice})d@{power-12-weapon-dice}+@{power-12-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 12</label>
@@ -4584,16 +5111,17 @@ Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-13-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -4603,7 +5131,8 @@ Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-13-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -4614,26 +5143,66 @@ Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-13-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-13-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -4677,8 +5246,7 @@ Hit: [[1d6+@{power-12-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-13-macro">/me uses @{power-13-name}
 [[1d20+@{power-13-attack}]] vs @{power-13-def} 
-Hit: [[(1*@{power-13-weapon-num-dice})d@{power-13-weapon-dice}+@{power-13-damage}]] Damage
-Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
+Hit: [[(1*@{power-13-weapon-num-dice})d@{power-13-weapon-dice}+@{power-13-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 13</label>
@@ -4785,16 +5353,17 @@ Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-14-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -4804,7 +5373,8 @@ Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-14-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -4815,26 +5385,66 @@ Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-14-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-14-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -4878,8 +5488,7 @@ Hit: [[1d6+@{power-13-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-14-macro">/me uses @{power-14-name}
 [[1d20+@{power-14-attack}]] vs @{power-14-def} 
-Hit: [[(1*@{power-14-weapon-num-dice})d@{power-14-weapon-dice}+@{power-14-damage}]] Damage
-Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
+Hit: [[(1*@{power-14-weapon-num-dice})d@{power-14-weapon-dice}+@{power-14-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 14</label>
@@ -4986,16 +5595,17 @@ Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-15-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -5005,7 +5615,8 @@ Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-15-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -5016,26 +5627,66 @@ Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-15-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-15-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -5079,8 +5730,7 @@ Hit: [[1d6+@{power-14-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-15-macro">/me uses @{power-15-name}
 [[1d20+@{power-15-attack}]] vs @{power-15-def} 
-Hit: [[(1*@{power-15-weapon-num-dice})d@{power-15-weapon-dice}+@{power-15-damage}]] Damage
-Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
+Hit: [[(1*@{power-15-weapon-num-dice})d@{power-15-weapon-dice}+@{power-15-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 15</label>
@@ -5187,16 +5837,17 @@ Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-16-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -5206,7 +5857,8 @@ Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-16-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -5217,26 +5869,66 @@ Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-16-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-16-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -5280,8 +5972,7 @@ Hit: [[1d6+@{power-15-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-16-macro">/me uses @{power-16-name}
 [[1d20+@{power-16-attack}]] vs @{power-16-def} 
-Hit: [[(1*@{power-16-weapon-num-dice})d@{power-16-weapon-dice}+@{power-16-damage}]] Damage
-Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
+Hit: [[(1*@{power-16-weapon-num-dice})d@{power-16-weapon-dice}+@{power-16-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 16</label>
@@ -5388,16 +6079,17 @@ Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-17-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -5407,7 +6099,8 @@ Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-17-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -5418,26 +6111,66 @@ Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-17-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-17-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -5481,8 +6214,7 @@ Hit: [[1d6+@{power-16-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-17-macro">/me uses @{power-17-name}
 [[1d20+@{power-17-attack}]] vs @{power-17-def} 
-Hit: [[(1*@{power-17-weapon-num-dice})d@{power-17-weapon-dice}+@{power-17-damage}]] Damage
-Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
+Hit: [[(1*@{power-17-weapon-num-dice})d@{power-17-weapon-dice}+@{power-17-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 17</label>
@@ -5589,16 +6321,17 @@ Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-18-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -5608,7 +6341,8 @@ Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-18-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -5619,26 +6353,66 @@ Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-18-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-18-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -5682,8 +6456,7 @@ Hit: [[1d6+@{power-17-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-18-macro">/me uses @{power-18-name}
 [[1d20+@{power-18-attack}]] vs @{power-18-def} 
-Hit: [[(1*@{power-18-weapon-num-dice})d@{power-18-weapon-dice}+@{power-18-damage}]] Damage
-Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
+Hit: [[(1*@{power-18-weapon-num-dice})d@{power-18-weapon-dice}+@{power-18-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 18</label>
@@ -5790,16 +6563,17 @@ Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-19-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -5809,7 +6583,8 @@ Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-19-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -5820,26 +6595,66 @@ Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-19-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-19-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -5883,8 +6698,7 @@ Hit: [[1d6+@{power-18-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-19-macro">/me uses @{power-19-name}
 [[1d20+@{power-19-attack}]] vs @{power-19-def} 
-Hit: [[(1*@{power-19-weapon-num-dice})d@{power-19-weapon-dice}+@{power-19-damage}]] Damage
-Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
+Hit: [[(1*@{power-19-weapon-num-dice})d@{power-19-weapon-dice}+@{power-19-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 19</label>
@@ -5991,16 +6805,17 @@ Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-20-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -6010,7 +6825,8 @@ Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-20-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -6021,26 +6837,66 @@ Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-20-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-20-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -6084,8 +6940,7 @@ Hit: [[1d6+@{power-19-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-20-macro">/me uses @{power-20-name}
 [[1d20+@{power-20-attack}]] vs @{power-20-def} 
-Hit: [[(1*@{power-20-weapon-num-dice})d@{power-20-weapon-dice}+@{power-20-damage}]] Damage
-Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
+Hit: [[(1*@{power-20-weapon-num-dice})d@{power-20-weapon-dice}+@{power-20-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 20</label>
@@ -6192,16 +7047,17 @@ Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-21-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -6211,7 +7067,8 @@ Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-21-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -6222,26 +7079,66 @@ Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-21-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-21-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -6285,8 +7182,7 @@ Hit: [[1d6+@{power-20-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-21-macro">/me uses @{power-21-name}
 [[1d20+@{power-21-attack}]] vs @{power-21-def} 
-Hit: [[(1*@{power-21-weapon-num-dice})d@{power-21-weapon-dice}+@{power-21-damage}]] Damage
-Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
+Hit: [[(1*@{power-21-weapon-num-dice})d@{power-21-weapon-dice}+@{power-21-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 21</label>
@@ -6393,16 +7289,17 @@ Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-22-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -6412,7 +7309,8 @@ Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-22-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -6423,26 +7321,66 @@ Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-22-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-22-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -6486,8 +7424,7 @@ Hit: [[1d6+@{power-21-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-22-macro">/me uses @{power-22-name}
 [[1d20+@{power-22-attack}]] vs @{power-22-def} 
-Hit: [[(1*@{power-22-weapon-num-dice})d@{power-22-weapon-dice}+@{power-22-damage}]] Damage
-Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
+Hit: [[(1*@{power-22-weapon-num-dice})d@{power-22-weapon-dice}+@{power-22-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 22</label>
@@ -6594,16 +7531,17 @@ Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-23-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -6613,7 +7551,8 @@ Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-23-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -6624,26 +7563,66 @@ Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-23-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-23-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -6687,8 +7666,7 @@ Hit: [[1d6+@{power-22-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-23-macro">/me uses @{power-23-name}
 [[1d20+@{power-23-attack}]] vs @{power-23-def} 
-Hit: [[(1*@{power-23-weapon-num-dice})d@{power-23-weapon-dice}+@{power-23-damage}]] Damage
-Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
+Hit: [[(1*@{power-23-weapon-num-dice})d@{power-23-weapon-dice}+@{power-23-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 23</label>
@@ -6795,16 +7773,17 @@ Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-24-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -6814,7 +7793,8 @@ Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-24-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -6825,26 +7805,66 @@ Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-24-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-24-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -6888,8 +7908,7 @@ Hit: [[1d6+@{power-23-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-24-macro">/me uses @{power-24-name}
 [[1d20+@{power-24-attack}]] vs @{power-24-def} 
-Hit: [[(1*@{power-24-weapon-num-dice})d@{power-24-weapon-dice}+@{power-24-damage}]] Damage
-Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
+Hit: [[(1*@{power-24-weapon-num-dice})d@{power-24-weapon-dice}+@{power-24-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 24</label>
@@ -6996,16 +8015,17 @@ Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-25-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -7015,7 +8035,8 @@ Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-25-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -7026,26 +8047,66 @@ Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-25-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-25-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -7089,8 +8150,7 @@ Hit: [[1d6+@{power-24-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-25-macro">/me uses @{power-25-name}
 [[1d20+@{power-25-attack}]] vs @{power-25-def} 
-Hit: [[(1*@{power-25-weapon-num-dice})d@{power-25-weapon-dice}+@{power-25-damage}]] Damage
-Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
+Hit: [[(1*@{power-25-weapon-num-dice})d@{power-25-weapon-dice}+@{power-25-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 25</label>
@@ -7197,16 +8257,17 @@ Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-26-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -7216,7 +8277,8 @@ Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-26-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -7227,26 +8289,66 @@ Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-26-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-26-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -7290,8 +8392,7 @@ Hit: [[1d6+@{power-25-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-26-macro">/me uses @{power-26-name}
 [[1d20+@{power-26-attack}]] vs @{power-26-def} 
-Hit: [[(1*@{power-26-weapon-num-dice})d@{power-26-weapon-dice}+@{power-26-damage}]] Damage
-Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
+Hit: [[(1*@{power-26-weapon-num-dice})d@{power-26-weapon-dice}+@{power-26-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 26</label>
@@ -7398,16 +8499,17 @@ Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-27-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -7417,7 +8519,8 @@ Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-27-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -7428,26 +8531,66 @@ Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-27-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-27-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -7491,8 +8634,7 @@ Hit: [[1d6+@{power-26-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-27-macro">/me uses @{power-27-name}
 [[1d20+@{power-27-attack}]] vs @{power-27-def} 
-Hit: [[(1*@{power-27-weapon-num-dice})d@{power-27-weapon-dice}+@{power-27-damage}]] Damage
-Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
+Hit: [[(1*@{power-27-weapon-num-dice})d@{power-27-weapon-dice}+@{power-27-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 27</label>
@@ -7599,16 +8741,17 @@ Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-28-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -7618,7 +8761,8 @@ Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-28-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -7629,26 +8773,66 @@ Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-28-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-28-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -7692,8 +8876,7 @@ Hit: [[1d6+@{power-27-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-28-macro">/me uses @{power-28-name}
 [[1d20+@{power-28-attack}]] vs @{power-28-def} 
-Hit: [[(1*@{power-28-weapon-num-dice})d@{power-28-weapon-dice}+@{power-28-damage}]] Damage
-Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
+Hit: [[(1*@{power-28-weapon-num-dice})d@{power-28-weapon-dice}+@{power-28-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 28</label>
@@ -7800,16 +8983,17 @@ Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-29-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -7819,7 +9003,8 @@ Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-29-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -7830,26 +9015,66 @@ Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-29-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-29-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -7893,8 +9118,7 @@ Hit: [[1d6+@{power-28-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-29-macro">/me uses @{power-29-name}
 [[1d20+@{power-29-attack}]] vs @{power-29-def} 
-Hit: [[(1*@{power-29-weapon-num-dice})d@{power-29-weapon-dice}+@{power-29-damage}]] Damage
-Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
+Hit: [[(1*@{power-29-weapon-num-dice})d@{power-29-weapon-dice}+@{power-29-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 29</label>
@@ -8001,16 +9225,17 @@ Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-30-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -8020,7 +9245,8 @@ Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-30-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -8031,26 +9257,66 @@ Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-30-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-30-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -8094,8 +9360,7 @@ Hit: [[1d6+@{power-29-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-30-macro">/me uses @{power-30-name}
 [[1d20+@{power-30-attack}]] vs @{power-30-def} 
-Hit: [[(1*@{power-30-weapon-num-dice})d@{power-30-weapon-dice}+@{power-30-damage}]] Damage
-Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
+Hit: [[(1*@{power-30-weapon-num-dice})d@{power-30-weapon-dice}+@{power-30-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 30</label>
@@ -8202,16 +9467,17 @@ Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-31-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -8221,7 +9487,8 @@ Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-31-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -8232,26 +9499,66 @@ Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-31-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-31-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -8295,8 +9602,7 @@ Hit: [[1d6+@{power-30-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-31-macro">/me uses @{power-31-name}
 [[1d20+@{power-31-attack}]] vs @{power-31-def} 
-Hit: [[(1*@{power-31-weapon-num-dice})d@{power-31-weapon-dice}+@{power-31-damage}]] Damage
-Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
+Hit: [[(1*@{power-31-weapon-num-dice})d@{power-31-weapon-dice}+@{power-31-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 31</label>
@@ -8403,16 +9709,17 @@ Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-32-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -8422,7 +9729,8 @@ Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-32-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -8433,26 +9741,66 @@ Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-32-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-32-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -8496,8 +9844,7 @@ Hit: [[1d6+@{power-31-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-32-macro">/me uses @{power-32-name}
 [[1d20+@{power-32-attack}]] vs @{power-32-def} 
-Hit: [[(1*@{power-32-weapon-num-dice})d@{power-32-weapon-dice}+@{power-32-damage}]] Damage
-Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
+Hit: [[(1*@{power-32-weapon-num-dice})d@{power-32-weapon-dice}+@{power-32-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 32</label>
@@ -8604,16 +9951,17 @@ Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-33-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -8623,7 +9971,8 @@ Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-33-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -8634,26 +9983,66 @@ Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-33-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-33-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -8697,8 +10086,7 @@ Hit: [[1d6+@{power-32-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-33-macro">/me uses @{power-33-name}
 [[1d20+@{power-33-attack}]] vs @{power-33-def} 
-Hit: [[(1*@{power-33-weapon-num-dice})d@{power-33-weapon-dice}+@{power-33-damage}]] Damage
-Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
+Hit: [[(1*@{power-33-weapon-num-dice})d@{power-33-weapon-dice}+@{power-33-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 33</label>
@@ -8805,16 +10193,17 @@ Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-34-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -8824,7 +10213,8 @@ Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-34-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -8835,26 +10225,66 @@ Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-34-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-34-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -8898,8 +10328,7 @@ Hit: [[1d6+@{power-33-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-34-macro">/me uses @{power-34-name}
 [[1d20+@{power-34-attack}]] vs @{power-34-def} 
-Hit: [[(1*@{power-34-weapon-num-dice})d@{power-34-weapon-dice}+@{power-34-damage}]] Damage
-Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
+Hit: [[(1*@{power-34-weapon-num-dice})d@{power-34-weapon-dice}+@{power-34-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 34</label>
@@ -9006,16 +10435,17 @@ Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-35-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -9025,7 +10455,8 @@ Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-35-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -9036,26 +10467,66 @@ Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-35-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-35-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -9099,8 +10570,7 @@ Hit: [[1d6+@{power-34-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-35-macro">/me uses @{power-35-name}
 [[1d20+@{power-35-attack}]] vs @{power-35-def} 
-Hit: [[(1*@{power-35-weapon-num-dice})d@{power-35-weapon-dice}+@{power-35-damage}]] Damage
-Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
+Hit: [[(1*@{power-35-weapon-num-dice})d@{power-35-weapon-dice}+@{power-35-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 35</label>
@@ -9207,16 +10677,17 @@ Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-36-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -9226,7 +10697,8 @@ Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-36-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -9237,26 +10709,66 @@ Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-36-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-36-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -9300,8 +10812,7 @@ Hit: [[1d6+@{power-35-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-36-macro">/me uses @{power-36-name}
 [[1d20+@{power-36-attack}]] vs @{power-36-def} 
-Hit: [[(1*@{power-36-weapon-num-dice})d@{power-36-weapon-dice}+@{power-36-damage}]] Damage
-Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
+Hit: [[(1*@{power-36-weapon-num-dice})d@{power-36-weapon-dice}+@{power-36-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 36</label>
@@ -9408,16 +10919,17 @@ Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-37-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -9427,7 +10939,8 @@ Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-37-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -9438,26 +10951,66 @@ Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-37-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-37-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -9501,8 +11054,7 @@ Hit: [[1d6+@{power-36-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-37-macro">/me uses @{power-37-name}
 [[1d20+@{power-37-attack}]] vs @{power-37-def} 
-Hit: [[(1*@{power-37-weapon-num-dice})d@{power-37-weapon-dice}+@{power-37-damage}]] Damage
-Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
+Hit: [[(1*@{power-37-weapon-num-dice})d@{power-37-weapon-dice}+@{power-37-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 37</label>
@@ -9609,16 +11161,17 @@ Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-38-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -9628,7 +11181,8 @@ Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-38-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -9639,26 +11193,66 @@ Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-38-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-38-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -9702,8 +11296,7 @@ Hit: [[1d6+@{power-37-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-38-macro">/me uses @{power-38-name}
 [[1d20+@{power-38-attack}]] vs @{power-38-def} 
-Hit: [[(1*@{power-38-weapon-num-dice})d@{power-38-weapon-dice}+@{power-38-damage}]] Damage
-Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
+Hit: [[(1*@{power-38-weapon-num-dice})d@{power-38-weapon-dice}+@{power-38-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 38</label>
@@ -9810,16 +11403,17 @@ Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-39-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -9829,7 +11423,8 @@ Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-39-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -9840,26 +11435,66 @@ Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-39-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-39-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -9903,8 +11538,7 @@ Hit: [[1d6+@{power-38-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-39-macro">/me uses @{power-39-name}
 [[1d20+@{power-39-attack}]] vs @{power-39-def} 
-Hit: [[(1*@{power-39-weapon-num-dice})d@{power-39-weapon-dice}+@{power-39-damage}]] Damage
-Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
+Hit: [[(1*@{power-39-weapon-num-dice})d@{power-39-weapon-dice}+@{power-39-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 39</label>
@@ -10011,16 +11645,17 @@ Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-40-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -10030,7 +11665,8 @@ Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-40-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -10041,26 +11677,66 @@ Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-40-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-40-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -10104,8 +11780,7 @@ Hit: [[1d6+@{power-39-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-40-macro">/me uses @{power-40-name}
 [[1d20+@{power-40-attack}]] vs @{power-40-def} 
-Hit: [[(1*@{power-40-weapon-num-dice})d@{power-40-weapon-dice}+@{power-40-damage}]] Damage
-Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
+Hit: [[(1*@{power-40-weapon-num-dice})d@{power-40-weapon-dice}+@{power-40-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 40</label>
@@ -10212,16 +11887,17 @@ Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-41-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -10231,7 +11907,8 @@ Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-41-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -10242,26 +11919,66 @@ Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-41-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-41-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -10305,8 +12022,7 @@ Hit: [[1d6+@{power-40-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-41-macro">/me uses @{power-41-name}
 [[1d20+@{power-41-attack}]] vs @{power-41-def} 
-Hit: [[(1*@{power-41-weapon-num-dice})d@{power-41-weapon-dice}+@{power-41-damage}]] Damage
-Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
+Hit: [[(1*@{power-41-weapon-num-dice})d@{power-41-weapon-dice}+@{power-41-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 41</label>
@@ -10413,16 +12129,17 @@ Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-42-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -10432,7 +12149,8 @@ Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-42-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -10443,26 +12161,66 @@ Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-42-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-42-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -10506,8 +12264,7 @@ Hit: [[1d6+@{power-41-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-42-macro">/me uses @{power-42-name}
 [[1d20+@{power-42-attack}]] vs @{power-42-def} 
-Hit: [[(1*@{power-42-weapon-num-dice})d@{power-42-weapon-dice}+@{power-42-damage}]] Damage
-Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
+Hit: [[(1*@{power-42-weapon-num-dice})d@{power-42-weapon-dice}+@{power-42-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 42</label>
@@ -10614,16 +12371,17 @@ Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-43-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -10633,7 +12391,8 @@ Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-43-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -10644,26 +12403,66 @@ Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-43-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-43-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -10707,8 +12506,7 @@ Hit: [[1d6+@{power-42-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-43-macro">/me uses @{power-43-name}
 [[1d20+@{power-43-attack}]] vs @{power-43-def} 
-Hit: [[(1*@{power-43-weapon-num-dice})d@{power-43-weapon-dice}+@{power-43-damage}]] Damage
-Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
+Hit: [[(1*@{power-43-weapon-num-dice})d@{power-43-weapon-dice}+@{power-43-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 43</label>
@@ -10815,16 +12613,17 @@ Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-44-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -10834,7 +12633,8 @@ Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-44-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -10845,26 +12645,66 @@ Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-44-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-44-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -10908,8 +12748,7 @@ Hit: [[1d6+@{power-43-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-44-macro">/me uses @{power-44-name}
 [[1d20+@{power-44-attack}]] vs @{power-44-def} 
-Hit: [[(1*@{power-44-weapon-num-dice})d@{power-44-weapon-dice}+@{power-44-damage}]] Damage
-Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
+Hit: [[(1*@{power-44-weapon-num-dice})d@{power-44-weapon-dice}+@{power-44-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 44</label>
@@ -11016,16 +12855,17 @@ Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-45-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -11035,7 +12875,8 @@ Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-45-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -11046,26 +12887,66 @@ Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-45-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-45-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -11109,8 +12990,7 @@ Hit: [[1d6+@{power-44-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-45-macro">/me uses @{power-45-name}
 [[1d20+@{power-45-attack}]] vs @{power-45-def} 
-Hit: [[(1*@{power-45-weapon-num-dice})d@{power-45-weapon-dice}+@{power-45-damage}]] Damage
-Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
+Hit: [[(1*@{power-45-weapon-num-dice})d@{power-45-weapon-dice}+@{power-45-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 45</label>
@@ -11217,16 +13097,17 @@ Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-46-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -11236,7 +13117,8 @@ Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-46-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -11247,26 +13129,66 @@ Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-46-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-46-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -11310,8 +13232,7 @@ Hit: [[1d6+@{power-45-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-46-macro">/me uses @{power-46-name}
 [[1d20+@{power-46-attack}]] vs @{power-46-def} 
-Hit: [[(1*@{power-46-weapon-num-dice})d@{power-46-weapon-dice}+@{power-46-damage}]] Damage
-Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
+Hit: [[(1*@{power-46-weapon-num-dice})d@{power-46-weapon-dice}+@{power-46-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 46</label>
@@ -11418,16 +13339,17 @@ Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-47-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -11437,7 +13359,8 @@ Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-47-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -11448,26 +13371,66 @@ Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-47-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-47-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -11511,8 +13474,7 @@ Hit: [[1d6+@{power-46-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-47-macro">/me uses @{power-47-name}
 [[1d20+@{power-47-attack}]] vs @{power-47-def} 
-Hit: [[(1*@{power-47-weapon-num-dice})d@{power-47-weapon-dice}+@{power-47-damage}]] Damage
-Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
+Hit: [[(1*@{power-47-weapon-num-dice})d@{power-47-weapon-dice}+@{power-47-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 47</label>
@@ -11619,16 +13581,17 @@ Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-48-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -11638,7 +13601,8 @@ Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-48-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -11649,26 +13613,66 @@ Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-48-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-48-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -11712,8 +13716,7 @@ Hit: [[1d6+@{power-47-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-48-macro">/me uses @{power-48-name}
 [[1d20+@{power-48-attack}]] vs @{power-48-def} 
-Hit: [[(1*@{power-48-weapon-num-dice})d@{power-48-weapon-dice}+@{power-48-damage}]] Damage
-Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
+Hit: [[(1*@{power-48-weapon-num-dice})d@{power-48-weapon-dice}+@{power-48-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 48</label>
@@ -11820,16 +13823,17 @@ Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-49-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -11839,7 +13843,8 @@ Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-49-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -11850,26 +13855,66 @@ Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-49-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-49-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -11913,8 +13958,7 @@ Hit: [[1d6+@{power-48-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-49-macro">/me uses @{power-49-name}
 [[1d20+@{power-49-attack}]] vs @{power-49-def} 
-Hit: [[(1*@{power-49-weapon-num-dice})d@{power-49-weapon-dice}+@{power-49-damage}]] Damage
-Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
+Hit: [[(1*@{power-49-weapon-num-dice})d@{power-49-weapon-dice}+@{power-49-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 49</label>
@@ -12021,16 +14065,17 @@ Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-50-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -12040,7 +14085,8 @@ Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-50-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -12051,26 +14097,66 @@ Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-50-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-50-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -12114,8 +14200,7 @@ Hit: [[1d6+@{power-49-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-50-macro">/me uses @{power-50-name}
 [[1d20+@{power-50-attack}]] vs @{power-50-def} 
-Hit: [[(1*@{power-50-weapon-num-dice})d@{power-50-weapon-dice}+@{power-50-damage}]] Damage
-Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
+Hit: [[(1*@{power-50-weapon-num-dice})d@{power-50-weapon-dice}+@{power-50-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 50</label>
@@ -12222,16 +14307,17 @@ Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-51-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -12241,7 +14327,8 @@ Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-51-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -12252,26 +14339,66 @@ Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-51-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-51-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -12315,8 +14442,7 @@ Hit: [[1d6+@{power-50-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-51-macro">/me uses @{power-51-name}
 [[1d20+@{power-51-attack}]] vs @{power-51-def} 
-Hit: [[(1*@{power-51-weapon-num-dice})d@{power-51-weapon-dice}+@{power-51-damage}]] Damage
-Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
+Hit: [[(1*@{power-51-weapon-num-dice})d@{power-51-weapon-dice}+@{power-51-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 51</label>
@@ -12423,16 +14549,17 @@ Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-52-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -12442,7 +14569,8 @@ Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-52-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -12453,26 +14581,66 @@ Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-52-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-52-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -12516,8 +14684,7 @@ Hit: [[1d6+@{power-51-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-52-macro">/me uses @{power-52-name}
 [[1d20+@{power-52-attack}]] vs @{power-52-def} 
-Hit: [[(1*@{power-52-weapon-num-dice})d@{power-52-weapon-dice}+@{power-52-damage}]] Damage
-Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
+Hit: [[(1*@{power-52-weapon-num-dice})d@{power-52-weapon-dice}+@{power-52-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 52</label>
@@ -12624,16 +14791,17 @@ Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-53-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -12643,7 +14811,8 @@ Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-53-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -12654,26 +14823,66 @@ Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-53-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-53-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -12717,8 +14926,7 @@ Hit: [[1d6+@{power-52-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-53-macro">/me uses @{power-53-name}
 [[1d20+@{power-53-attack}]] vs @{power-53-def} 
-Hit: [[(1*@{power-53-weapon-num-dice})d@{power-53-weapon-dice}+@{power-53-damage}]] Damage
-Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
+Hit: [[(1*@{power-53-weapon-num-dice})d@{power-53-weapon-dice}+@{power-53-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 53</label>
@@ -12825,16 +15033,17 @@ Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-54-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -12844,7 +15053,8 @@ Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-54-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -12855,26 +15065,66 @@ Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-54-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-54-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -12918,8 +15168,7 @@ Hit: [[1d6+@{power-53-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-54-macro">/me uses @{power-54-name}
 [[1d20+@{power-54-attack}]] vs @{power-54-def} 
-Hit: [[(1*@{power-54-weapon-num-dice})d@{power-54-weapon-dice}+@{power-54-damage}]] Damage
-Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
+Hit: [[(1*@{power-54-weapon-num-dice})d@{power-54-weapon-dice}+@{power-54-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 54</label>
@@ -13026,16 +15275,17 @@ Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-55-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -13045,7 +15295,8 @@ Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-55-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -13056,26 +15307,66 @@ Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-55-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-55-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -13119,8 +15410,7 @@ Hit: [[1d6+@{power-54-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-55-macro">/me uses @{power-55-name}
 [[1d20+@{power-55-attack}]] vs @{power-55-def} 
-Hit: [[(1*@{power-55-weapon-num-dice})d@{power-55-weapon-dice}+@{power-55-damage}]] Damage
-Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
+Hit: [[(1*@{power-55-weapon-num-dice})d@{power-55-weapon-dice}+@{power-55-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 55</label>
@@ -13227,16 +15517,17 @@ Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-56-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -13246,7 +15537,8 @@ Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-56-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -13257,26 +15549,66 @@ Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-56-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-56-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -13320,8 +15652,7 @@ Hit: [[1d6+@{power-55-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-56-macro">/me uses @{power-56-name}
 [[1d20+@{power-56-attack}]] vs @{power-56-def} 
-Hit: [[(1*@{power-56-weapon-num-dice})d@{power-56-weapon-dice}+@{power-56-damage}]] Damage
-Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
+Hit: [[(1*@{power-56-weapon-num-dice})d@{power-56-weapon-dice}+@{power-56-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 56</label>
@@ -13428,16 +15759,17 @@ Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-57-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -13447,7 +15779,8 @@ Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-57-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -13458,26 +15791,66 @@ Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-57-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-57-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -13521,8 +15894,7 @@ Hit: [[1d6+@{power-56-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-57-macro">/me uses @{power-57-name}
 [[1d20+@{power-57-attack}]] vs @{power-57-def} 
-Hit: [[(1*@{power-57-weapon-num-dice})d@{power-57-weapon-dice}+@{power-57-damage}]] Damage
-Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
+Hit: [[(1*@{power-57-weapon-num-dice})d@{power-57-weapon-dice}+@{power-57-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 57</label>
@@ -13629,16 +16001,17 @@ Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-58-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -13648,7 +16021,8 @@ Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-58-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -13659,26 +16033,66 @@ Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-58-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-58-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -13722,8 +16136,7 @@ Hit: [[1d6+@{power-57-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-58-macro">/me uses @{power-58-name}
 [[1d20+@{power-58-attack}]] vs @{power-58-def} 
-Hit: [[(1*@{power-58-weapon-num-dice})d@{power-58-weapon-dice}+@{power-58-damage}]] Damage
-Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
+Hit: [[(1*@{power-58-weapon-num-dice})d@{power-58-weapon-dice}+@{power-58-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 58</label>
@@ -13830,16 +16243,17 @@ Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-59-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -13849,7 +16263,8 @@ Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-59-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -13860,26 +16275,66 @@ Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-59-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-59-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -13923,8 +16378,7 @@ Hit: [[1d6+@{power-58-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-59-macro">/me uses @{power-59-name}
 [[1d20+@{power-59-attack}]] vs @{power-59-def} 
-Hit: [[(1*@{power-59-weapon-num-dice})d@{power-59-weapon-dice}+@{power-59-damage}]] Damage
-Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
+Hit: [[(1*@{power-59-weapon-num-dice})d@{power-59-weapon-dice}+@{power-59-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 59</label>
@@ -14031,16 +16485,17 @@ Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-60-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -14050,7 +16505,8 @@ Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-60-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -14061,26 +16517,66 @@ Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-60-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-60-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -14124,8 +16620,7 @@ Hit: [[1d6+@{power-59-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-60-macro">/me uses @{power-60-name}
 [[1d20+@{power-60-attack}]] vs @{power-60-def} 
-Hit: [[(1*@{power-60-weapon-num-dice})d@{power-60-weapon-dice}+@{power-60-damage}]] Damage
-Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
+Hit: [[(1*@{power-60-weapon-num-dice})d@{power-60-weapon-dice}+@{power-60-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 60</label>
@@ -14232,16 +16727,17 @@ Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-61-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -14251,7 +16747,8 @@ Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-61-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -14262,26 +16759,66 @@ Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-61-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-61-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -14325,8 +16862,7 @@ Hit: [[1d6+@{power-60-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-61-macro">/me uses @{power-61-name}
 [[1d20+@{power-61-attack}]] vs @{power-61-def} 
-Hit: [[(1*@{power-61-weapon-num-dice})d@{power-61-weapon-dice}+@{power-61-damage}]] Damage
-Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
+Hit: [[(1*@{power-61-weapon-num-dice})d@{power-61-weapon-dice}+@{power-61-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 61</label>
@@ -14433,16 +16969,17 @@ Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-62-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -14452,7 +16989,8 @@ Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-62-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -14463,26 +17001,66 @@ Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-62-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-62-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -14526,8 +17104,7 @@ Hit: [[1d6+@{power-61-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-62-macro">/me uses @{power-62-name}
 [[1d20+@{power-62-attack}]] vs @{power-62-def} 
-Hit: [[(1*@{power-62-weapon-num-dice})d@{power-62-weapon-dice}+@{power-62-damage}]] Damage
-Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
+Hit: [[(1*@{power-62-weapon-num-dice})d@{power-62-weapon-dice}+@{power-62-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 62</label>
@@ -14634,16 +17211,17 @@ Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-63-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -14653,7 +17231,8 @@ Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-63-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -14664,26 +17243,66 @@ Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-63-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-63-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -14727,8 +17346,7 @@ Hit: [[1d6+@{power-62-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-63-macro">/me uses @{power-63-name}
 [[1d20+@{power-63-attack}]] vs @{power-63-def} 
-Hit: [[(1*@{power-63-weapon-num-dice})d@{power-63-weapon-dice}+@{power-63-damage}]] Damage
-Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
+Hit: [[(1*@{power-63-weapon-num-dice})d@{power-63-weapon-dice}+@{power-63-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 63</label>
@@ -14835,16 +17453,17 @@ Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-64-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -14854,7 +17473,8 @@ Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-64-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -14865,26 +17485,66 @@ Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-64-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-64-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -14928,8 +17588,7 @@ Hit: [[1d6+@{power-63-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-64-macro">/me uses @{power-64-name}
 [[1d20+@{power-64-attack}]] vs @{power-64-def} 
-Hit: [[(1*@{power-64-weapon-num-dice})d@{power-64-weapon-dice}+@{power-64-damage}]] Damage
-Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
+Hit: [[(1*@{power-64-weapon-num-dice})d@{power-64-weapon-dice}+@{power-64-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 64</label>
@@ -15036,16 +17695,17 @@ Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-65-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -15055,7 +17715,8 @@ Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-65-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -15066,26 +17727,66 @@ Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-65-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-65-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -15129,8 +17830,7 @@ Hit: [[1d6+@{power-64-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-65-macro">/me uses @{power-65-name}
 [[1d20+@{power-65-attack}]] vs @{power-65-def} 
-Hit: [[(1*@{power-65-weapon-num-dice})d@{power-65-weapon-dice}+@{power-65-damage}]] Damage
-Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
+Hit: [[(1*@{power-65-weapon-num-dice})d@{power-65-weapon-dice}+@{power-65-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 65</label>
@@ -15237,16 +17937,17 @@ Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-66-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -15256,7 +17957,8 @@ Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-66-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -15267,26 +17969,66 @@ Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-66-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-66-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -15330,8 +18072,7 @@ Hit: [[1d6+@{power-65-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-66-macro">/me uses @{power-66-name}
 [[1d20+@{power-66-attack}]] vs @{power-66-def} 
-Hit: [[(1*@{power-66-weapon-num-dice})d@{power-66-weapon-dice}+@{power-66-damage}]] Damage
-Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
+Hit: [[(1*@{power-66-weapon-num-dice})d@{power-66-weapon-dice}+@{power-66-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 66</label>
@@ -15438,16 +18179,17 @@ Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-67-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -15457,7 +18199,8 @@ Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-67-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -15468,26 +18211,66 @@ Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-67-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-67-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -15531,8 +18314,7 @@ Hit: [[1d6+@{power-66-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-67-macro">/me uses @{power-67-name}
 [[1d20+@{power-67-attack}]] vs @{power-67-def} 
-Hit: [[(1*@{power-67-weapon-num-dice})d@{power-67-weapon-dice}+@{power-67-damage}]] Damage
-Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
+Hit: [[(1*@{power-67-weapon-num-dice})d@{power-67-weapon-dice}+@{power-67-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 67</label>
@@ -15639,16 +18421,17 @@ Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-68-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -15658,7 +18441,8 @@ Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-68-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -15669,26 +18453,66 @@ Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-68-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-68-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -15732,8 +18556,7 @@ Hit: [[1d6+@{power-67-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-68-macro">/me uses @{power-68-name}
 [[1d20+@{power-68-attack}]] vs @{power-68-def} 
-Hit: [[(1*@{power-68-weapon-num-dice})d@{power-68-weapon-dice}+@{power-68-damage}]] Damage
-Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
+Hit: [[(1*@{power-68-weapon-num-dice})d@{power-68-weapon-dice}+@{power-68-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 68</label>
@@ -15840,16 +18663,17 @@ Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-69-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -15859,7 +18683,8 @@ Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-69-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -15870,26 +18695,66 @@ Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-69-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-69-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -15933,8 +18798,7 @@ Hit: [[1d6+@{power-68-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-69-macro">/me uses @{power-69-name}
 [[1d20+@{power-69-attack}]] vs @{power-69-def} 
-Hit: [[(1*@{power-69-weapon-num-dice})d@{power-69-weapon-dice}+@{power-69-damage}]] Damage
-Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
+Hit: [[(1*@{power-69-weapon-num-dice})d@{power-69-weapon-dice}+@{power-69-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 69</label>
@@ -16041,16 +18905,17 @@ Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-70-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -16060,7 +18925,8 @@ Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-70-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -16071,26 +18937,66 @@ Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-70-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-70-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -16134,8 +19040,7 @@ Hit: [[1d6+@{power-69-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-70-macro">/me uses @{power-70-name}
 [[1d20+@{power-70-attack}]] vs @{power-70-def} 
-Hit: [[(1*@{power-70-weapon-num-dice})d@{power-70-weapon-dice}+@{power-70-damage}]] Damage
-Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
+Hit: [[(1*@{power-70-weapon-num-dice})d@{power-70-weapon-dice}+@{power-70-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 70</label>
@@ -16242,16 +19147,17 @@ Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-71-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -16261,7 +19167,8 @@ Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-71-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -16272,26 +19179,66 @@ Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-71-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-71-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -16335,8 +19282,7 @@ Hit: [[1d6+@{power-70-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-71-macro">/me uses @{power-71-name}
 [[1d20+@{power-71-attack}]] vs @{power-71-def} 
-Hit: [[(1*@{power-71-weapon-num-dice})d@{power-71-weapon-dice}+@{power-71-damage}]] Damage
-Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
+Hit: [[(1*@{power-71-weapon-num-dice})d@{power-71-weapon-dice}+@{power-71-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 71</label>
@@ -16443,16 +19389,17 @@ Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-72-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -16462,7 +19409,8 @@ Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-72-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -16473,26 +19421,66 @@ Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-72-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-72-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -16536,8 +19524,7 @@ Hit: [[1d6+@{power-71-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-72-macro">/me uses @{power-72-name}
 [[1d20+@{power-72-attack}]] vs @{power-72-def} 
-Hit: [[(1*@{power-72-weapon-num-dice})d@{power-72-weapon-dice}+@{power-72-damage}]] Damage
-Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
+Hit: [[(1*@{power-72-weapon-num-dice})d@{power-72-weapon-dice}+@{power-72-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 72</label>
@@ -16644,16 +19631,17 @@ Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-73-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -16663,7 +19651,8 @@ Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-73-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -16674,26 +19663,66 @@ Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-73-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-73-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -16737,8 +19766,7 @@ Hit: [[1d6+@{power-72-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-73-macro">/me uses @{power-73-name}
 [[1d20+@{power-73-attack}]] vs @{power-73-def} 
-Hit: [[(1*@{power-73-weapon-num-dice})d@{power-73-weapon-dice}+@{power-73-damage}]] Damage
-Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
+Hit: [[(1*@{power-73-weapon-num-dice})d@{power-73-weapon-dice}+@{power-73-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 73</label>
@@ -16845,16 +19873,17 @@ Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-74-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -16864,7 +19893,8 @@ Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-74-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -16875,26 +19905,66 @@ Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-74-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-74-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -16938,8 +20008,7 @@ Hit: [[1d6+@{power-73-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-74-macro">/me uses @{power-74-name}
 [[1d20+@{power-74-attack}]] vs @{power-74-def} 
-Hit: [[(1*@{power-74-weapon-num-dice})d@{power-74-weapon-dice}+@{power-74-damage}]] Damage
-Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
+Hit: [[(1*@{power-74-weapon-num-dice})d@{power-74-weapon-dice}+@{power-74-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 74</label>
@@ -17046,16 +20115,17 @@ Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-75-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -17065,7 +20135,8 @@ Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-75-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -17076,26 +20147,66 @@ Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-75-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-75-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -17139,8 +20250,7 @@ Hit: [[1d6+@{power-74-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-75-macro">/me uses @{power-75-name}
 [[1d20+@{power-75-attack}]] vs @{power-75-def} 
-Hit: [[(1*@{power-75-weapon-num-dice})d@{power-75-weapon-dice}+@{power-75-damage}]] Damage
-Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
+Hit: [[(1*@{power-75-weapon-num-dice})d@{power-75-weapon-dice}+@{power-75-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 75</label>
@@ -17247,16 +20357,17 @@ Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-76-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -17266,7 +20377,8 @@ Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-76-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -17277,26 +20389,66 @@ Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-76-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-76-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -17340,8 +20492,7 @@ Hit: [[1d6+@{power-75-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-76-macro">/me uses @{power-76-name}
 [[1d20+@{power-76-attack}]] vs @{power-76-def} 
-Hit: [[(1*@{power-76-weapon-num-dice})d@{power-76-weapon-dice}+@{power-76-damage}]] Damage
-Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
+Hit: [[(1*@{power-76-weapon-num-dice})d@{power-76-weapon-dice}+@{power-76-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 76</label>
@@ -17448,16 +20599,17 @@ Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-77-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -17467,7 +20619,8 @@ Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-77-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -17478,26 +20631,66 @@ Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-77-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-77-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -17541,8 +20734,7 @@ Hit: [[1d6+@{power-76-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-77-macro">/me uses @{power-77-name}
 [[1d20+@{power-77-attack}]] vs @{power-77-def} 
-Hit: [[(1*@{power-77-weapon-num-dice})d@{power-77-weapon-dice}+@{power-77-damage}]] Damage
-Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
+Hit: [[(1*@{power-77-weapon-num-dice})d@{power-77-weapon-dice}+@{power-77-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 77</label>
@@ -17649,16 +20841,17 @@ Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-78-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -17668,7 +20861,8 @@ Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-78-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -17679,26 +20873,66 @@ Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-78-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-78-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -17742,8 +20976,7 @@ Hit: [[1d6+@{power-77-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-78-macro">/me uses @{power-78-name}
 [[1d20+@{power-78-attack}]] vs @{power-78-def} 
-Hit: [[(1*@{power-78-weapon-num-dice})d@{power-78-weapon-dice}+@{power-78-damage}]] Damage
-Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
+Hit: [[(1*@{power-78-weapon-num-dice})d@{power-78-weapon-dice}+@{power-78-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 78</label>
@@ -17850,16 +21083,17 @@ Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-79-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -17869,7 +21103,8 @@ Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-79-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -17880,26 +21115,66 @@ Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-79-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-79-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -17943,8 +21218,7 @@ Hit: [[1d6+@{power-78-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-79-macro">/me uses @{power-79-name}
 [[1d20+@{power-79-attack}]] vs @{power-79-def} 
-Hit: [[(1*@{power-79-weapon-num-dice})d@{power-79-weapon-dice}+@{power-79-damage}]] Damage
-Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
+Hit: [[(1*@{power-79-weapon-num-dice})d@{power-79-weapon-dice}+@{power-79-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 79</label>
@@ -18051,16 +21325,17 @@ Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-80-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -18070,7 +21345,8 @@ Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-80-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -18081,26 +21357,66 @@ Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-80-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-80-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -18144,8 +21460,7 @@ Hit: [[1d6+@{power-79-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-80-macro">/me uses @{power-80-name}
 [[1d20+@{power-80-attack}]] vs @{power-80-def} 
-Hit: [[(1*@{power-80-weapon-num-dice})d@{power-80-weapon-dice}+@{power-80-damage}]] Damage
-Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
+Hit: [[(1*@{power-80-weapon-num-dice})d@{power-80-weapon-dice}+@{power-80-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 80</label>
@@ -18252,16 +21567,17 @@ Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-81-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -18271,7 +21587,8 @@ Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-81-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -18282,26 +21599,66 @@ Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-81-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-81-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -18345,8 +21702,7 @@ Hit: [[1d6+@{power-80-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-81-macro">/me uses @{power-81-name}
 [[1d20+@{power-81-attack}]] vs @{power-81-def} 
-Hit: [[(1*@{power-81-weapon-num-dice})d@{power-81-weapon-dice}+@{power-81-damage}]] Damage
-Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
+Hit: [[(1*@{power-81-weapon-num-dice})d@{power-81-weapon-dice}+@{power-81-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 81</label>
@@ -18453,16 +21809,17 @@ Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-82-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -18472,7 +21829,8 @@ Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-82-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -18483,26 +21841,66 @@ Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-82-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-82-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -18546,8 +21944,7 @@ Hit: [[1d6+@{power-81-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-82-macro">/me uses @{power-82-name}
 [[1d20+@{power-82-attack}]] vs @{power-82-def} 
-Hit: [[(1*@{power-82-weapon-num-dice})d@{power-82-weapon-dice}+@{power-82-damage}]] Damage
-Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
+Hit: [[(1*@{power-82-weapon-num-dice})d@{power-82-weapon-dice}+@{power-82-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 82</label>
@@ -18654,16 +22051,17 @@ Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-83-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -18673,7 +22071,8 @@ Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-83-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -18684,26 +22083,66 @@ Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-83-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-83-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -18747,8 +22186,7 @@ Hit: [[1d6+@{power-82-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-83-macro">/me uses @{power-83-name}
 [[1d20+@{power-83-attack}]] vs @{power-83-def} 
-Hit: [[(1*@{power-83-weapon-num-dice})d@{power-83-weapon-dice}+@{power-83-damage}]] Damage
-Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
+Hit: [[(1*@{power-83-weapon-num-dice})d@{power-83-weapon-dice}+@{power-83-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 83</label>
@@ -18855,16 +22293,17 @@ Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-84-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -18874,7 +22313,8 @@ Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-84-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -18885,26 +22325,66 @@ Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-84-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-84-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -18948,8 +22428,7 @@ Hit: [[1d6+@{power-83-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-84-macro">/me uses @{power-84-name}
 [[1d20+@{power-84-attack}]] vs @{power-84-def} 
-Hit: [[(1*@{power-84-weapon-num-dice})d@{power-84-weapon-dice}+@{power-84-damage}]] Damage
-Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
+Hit: [[(1*@{power-84-weapon-num-dice})d@{power-84-weapon-dice}+@{power-84-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 84</label>
@@ -19056,16 +22535,17 @@ Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-85-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -19075,7 +22555,8 @@ Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-85-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -19086,26 +22567,66 @@ Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-85-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-85-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -19149,8 +22670,7 @@ Hit: [[1d6+@{power-84-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-85-macro">/me uses @{power-85-name}
 [[1d20+@{power-85-attack}]] vs @{power-85-def} 
-Hit: [[(1*@{power-85-weapon-num-dice})d@{power-85-weapon-dice}+@{power-85-damage}]] Damage
-Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
+Hit: [[(1*@{power-85-weapon-num-dice})d@{power-85-weapon-dice}+@{power-85-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 85</label>
@@ -19257,16 +22777,17 @@ Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-86-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -19276,7 +22797,8 @@ Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-86-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -19287,26 +22809,66 @@ Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-86-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-86-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -19350,8 +22912,7 @@ Hit: [[1d6+@{power-85-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-86-macro">/me uses @{power-86-name}
 [[1d20+@{power-86-attack}]] vs @{power-86-def} 
-Hit: [[(1*@{power-86-weapon-num-dice})d@{power-86-weapon-dice}+@{power-86-damage}]] Damage
-Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
+Hit: [[(1*@{power-86-weapon-num-dice})d@{power-86-weapon-dice}+@{power-86-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 86</label>
@@ -19458,16 +23019,17 @@ Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-87-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -19477,7 +23039,8 @@ Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-87-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -19488,26 +23051,66 @@ Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-87-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-87-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -19551,8 +23154,7 @@ Hit: [[1d6+@{power-86-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-87-macro">/me uses @{power-87-name}
 [[1d20+@{power-87-attack}]] vs @{power-87-def} 
-Hit: [[(1*@{power-87-weapon-num-dice})d@{power-87-weapon-dice}+@{power-87-damage}]] Damage
-Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
+Hit: [[(1*@{power-87-weapon-num-dice})d@{power-87-weapon-dice}+@{power-87-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 87</label>
@@ -19659,16 +23261,17 @@ Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-88-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -19678,7 +23281,8 @@ Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-88-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -19689,26 +23293,66 @@ Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-88-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-88-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -19752,8 +23396,7 @@ Hit: [[1d6+@{power-87-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-88-macro">/me uses @{power-88-name}
 [[1d20+@{power-88-attack}]] vs @{power-88-def} 
-Hit: [[(1*@{power-88-weapon-num-dice})d@{power-88-weapon-dice}+@{power-88-damage}]] Damage
-Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
+Hit: [[(1*@{power-88-weapon-num-dice})d@{power-88-weapon-dice}+@{power-88-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 88</label>
@@ -19860,16 +23503,17 @@ Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-89-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -19879,7 +23523,8 @@ Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-89-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -19890,26 +23535,66 @@ Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-89-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-89-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -19953,8 +23638,7 @@ Hit: [[1d6+@{power-88-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-89-macro">/me uses @{power-89-name}
 [[1d20+@{power-89-attack}]] vs @{power-89-def} 
-Hit: [[(1*@{power-89-weapon-num-dice})d@{power-89-weapon-dice}+@{power-89-damage}]] Damage
-Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
+Hit: [[(1*@{power-89-weapon-num-dice})d@{power-89-weapon-dice}+@{power-89-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 89</label>
@@ -20061,16 +23745,17 @@ Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-90-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -20080,7 +23765,8 @@ Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-90-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -20091,26 +23777,66 @@ Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-90-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-90-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -20154,8 +23880,7 @@ Hit: [[1d6+@{power-89-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-90-macro">/me uses @{power-90-name}
 [[1d20+@{power-90-attack}]] vs @{power-90-def} 
-Hit: [[(1*@{power-90-weapon-num-dice})d@{power-90-weapon-dice}+@{power-90-damage}]] Damage
-Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
+Hit: [[(1*@{power-90-weapon-num-dice})d@{power-90-weapon-dice}+@{power-90-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 90</label>
@@ -20262,16 +23987,17 @@ Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-91-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -20281,7 +24007,8 @@ Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-91-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -20292,26 +24019,66 @@ Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-91-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-91-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -20355,8 +24122,7 @@ Hit: [[1d6+@{power-90-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-91-macro">/me uses @{power-91-name}
 [[1d20+@{power-91-attack}]] vs @{power-91-def} 
-Hit: [[(1*@{power-91-weapon-num-dice})d@{power-91-weapon-dice}+@{power-91-damage}]] Damage
-Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
+Hit: [[(1*@{power-91-weapon-num-dice})d@{power-91-weapon-dice}+@{power-91-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 91</label>
@@ -20463,16 +24229,17 @@ Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-92-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -20482,7 +24249,8 @@ Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-92-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -20493,26 +24261,66 @@ Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-92-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-92-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -20556,8 +24364,7 @@ Hit: [[1d6+@{power-91-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-92-macro">/me uses @{power-92-name}
 [[1d20+@{power-92-attack}]] vs @{power-92-def} 
-Hit: [[(1*@{power-92-weapon-num-dice})d@{power-92-weapon-dice}+@{power-92-damage}]] Damage
-Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
+Hit: [[(1*@{power-92-weapon-num-dice})d@{power-92-weapon-dice}+@{power-92-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 92</label>
@@ -20664,16 +24471,17 @@ Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-93-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -20683,7 +24491,8 @@ Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-93-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -20694,26 +24503,66 @@ Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-93-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-93-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -20757,8 +24606,7 @@ Hit: [[1d6+@{power-92-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-93-macro">/me uses @{power-93-name}
 [[1d20+@{power-93-attack}]] vs @{power-93-def} 
-Hit: [[(1*@{power-93-weapon-num-dice})d@{power-93-weapon-dice}+@{power-93-damage}]] Damage
-Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
+Hit: [[(1*@{power-93-weapon-num-dice})d@{power-93-weapon-dice}+@{power-93-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 93</label>
@@ -20865,16 +24713,17 @@ Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-94-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -20884,7 +24733,8 @@ Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-94-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -20895,26 +24745,66 @@ Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-94-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-94-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -20958,8 +24848,7 @@ Hit: [[1d6+@{power-93-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-94-macro">/me uses @{power-94-name}
 [[1d20+@{power-94-attack}]] vs @{power-94-def} 
-Hit: [[(1*@{power-94-weapon-num-dice})d@{power-94-weapon-dice}+@{power-94-damage}]] Damage
-Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
+Hit: [[(1*@{power-94-weapon-num-dice})d@{power-94-weapon-dice}+@{power-94-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 94</label>
@@ -21066,16 +24955,17 @@ Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-95-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -21085,7 +24975,8 @@ Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-95-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -21096,26 +24987,66 @@ Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-95-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-95-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -21159,8 +25090,7 @@ Hit: [[1d6+@{power-94-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-95-macro">/me uses @{power-95-name}
 [[1d20+@{power-95-attack}]] vs @{power-95-def} 
-Hit: [[(1*@{power-95-weapon-num-dice})d@{power-95-weapon-dice}+@{power-95-damage}]] Damage
-Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
+Hit: [[(1*@{power-95-weapon-num-dice})d@{power-95-weapon-dice}+@{power-95-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 95</label>
@@ -21267,16 +25197,17 @@ Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-96-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -21286,7 +25217,8 @@ Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-96-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -21297,26 +25229,66 @@ Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-96-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-96-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -21360,8 +25332,7 @@ Hit: [[1d6+@{power-95-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-96-macro">/me uses @{power-96-name}
 [[1d20+@{power-96-attack}]] vs @{power-96-def} 
-Hit: [[(1*@{power-96-weapon-num-dice})d@{power-96-weapon-dice}+@{power-96-damage}]] Damage
-Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
+Hit: [[(1*@{power-96-weapon-num-dice})d@{power-96-weapon-dice}+@{power-96-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 96</label>
@@ -21468,16 +25439,17 @@ Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-97-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -21487,7 +25459,8 @@ Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-97-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -21498,26 +25471,66 @@ Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-97-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-97-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -21561,8 +25574,7 @@ Hit: [[1d6+@{power-96-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-97-macro">/me uses @{power-97-name}
 [[1d20+@{power-97-attack}]] vs @{power-97-def} 
-Hit: [[(1*@{power-97-weapon-num-dice})d@{power-97-weapon-dice}+@{power-97-damage}]] Damage
-Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
+Hit: [[(1*@{power-97-weapon-num-dice})d@{power-97-weapon-dice}+@{power-97-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 97</label>
@@ -21669,16 +25681,17 @@ Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-98-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -21688,7 +25701,8 @@ Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-98-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -21699,26 +25713,66 @@ Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-98-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-98-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -21762,8 +25816,7 @@ Hit: [[1d6+@{power-97-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-98-macro">/me uses @{power-98-name}
 [[1d20+@{power-98-attack}]] vs @{power-98-def} 
-Hit: [[(1*@{power-98-weapon-num-dice})d@{power-98-weapon-dice}+@{power-98-damage}]] Damage
-Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
+Hit: [[(1*@{power-98-weapon-num-dice})d@{power-98-weapon-dice}+@{power-98-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 98</label>
@@ -21870,16 +25923,17 @@ Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-99-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -21889,7 +25943,8 @@ Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-99-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -21900,26 +25955,66 @@ Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-99-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-99-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -21963,8 +26058,7 @@ Hit: [[1d6+@{power-98-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-99-macro">/me uses @{power-99-name}
 [[1d20+@{power-99-attack}]] vs @{power-99-def} 
-Hit: [[(1*@{power-99-weapon-num-dice})d@{power-99-weapon-dice}+@{power-99-damage}]] Damage
-Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
+Hit: [[(1*@{power-99-weapon-num-dice})d@{power-99-weapon-dice}+@{power-99-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 99</label>
@@ -22071,16 +26165,17 @@ Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Attack Weapon</label> 
+                                    <label>Weapon Attack Bonus</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Damage Weapon</label> 
+                                    <label>Weapon Damage Bonus</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-100-weapon-attack">
-                                        <option value="@{weapon-1-attack}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-attack}">Weapon One</option>
                                         <option value="@{weapon-2-attack}">Weapon Two</option>
                                         <option value="@{weapon-3-attack}">Weapon Three</option>
                                         <option value="@{weapon-4-attack}">Weapon Four</option>
@@ -22090,7 +26185,8 @@ Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-100-weapon-damage">
-                                        <option value="@{weapon-1-damage}" selected="selected">Weapon One</option>
+                                        <option value=0 selected="selected">None</option>
+                                        <option value="@{weapon-1-damage}">Weapon One</option>
                                         <option value="@{weapon-2-damage}">Weapon Two</option>
                                         <option value="@{weapon-3-damage}">Weapon Three</option>
                                         <option value="@{weapon-4-damage}">Weapon Four</option>
@@ -22101,26 +26197,66 @@ Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
                             </div>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon # of Dice</label> 
+                                    <label># of Dice</label> 
                                 </div>
                                 <div class="sheet-item sheet-large">
-                                    <label>Weapon Dice Size</label> 
+                                    <label>Damage Dice Size</label> 
                                 </div>
                             </div>
                             <div class="sheet-row">
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-100-weapon-num-dice">
-                                        <option value="@{weapon-1-num-dice}" selected="selected">Weapon One</option>
-                                        <option value="@{weapon-2-num-dice}">Weapon Two</option>
-                                        <option value="@{weapon-3-num-dice}">Weapon Three</option>
-                                        <option value="@{weapon-4-num-dice}">Weapon Four</option>
-                                        <option value="@{weapon-5-num-dice}">Weapon Five</option>
-                                        <option value="@{weapon-6-num-dice}">Weapon Six</option>
+                                        <option value=1 selected="selected">One</option>
+                                        <option value=2>Two</option>
+                                        <option value=3>Three</option>
+                                        <option value=4>Four</option>
+                                        <option value=5>Five</option>
+                                        <option value=6>Six</option>
+										<option value=7>Seven</option>
+                                        <option value=8>Eight</option>
+                                        <option value=9>Nine</option>
+                                        <option value=10>Ten</option>
+										<option value="@{weapon-1-num-dice}">1*Weapon One</option>
+                                        <option value="@{weapon-2-num-dice}">1*Weapon Two</option>
+                                        <option value="@{weapon-3-num-dice}">1*Weapon Three</option>
+                                        <option value="@{weapon-4-num-dice}">1*Weapon Four</option>
+                                        <option value="@{weapon-5-num-dice}">1*Weapon Five</option>
+                                        <option value="@{weapon-6-num-dice}">1*Weapon Six</option>
+										<option value="2*@{weapon-1-num-dice}">2*Weapon One</option>
+                                        <option value="2*@{weapon-2-num-dice}">2*Weapon Two</option>
+                                        <option value="2*@{weapon-3-num-dice}">2*Weapon Three</option>
+                                        <option value="2*@{weapon-4-num-dice}">2*Weapon Four</option>
+                                        <option value="2*@{weapon-5-num-dice}">2*Weapon Five</option>
+                                        <option value="2*@{weapon-6-num-dice}">2*Weapon Six</option>
+										<option value="3*@{weapon-1-num-dice}">3*Weapon One</option>
+                                        <option value="3*@{weapon-2-num-dice}">3*Weapon Two</option>
+                                        <option value="3*@{weapon-3-num-dice}">3*Weapon Three</option>
+                                        <option value="3*@{weapon-4-num-dice}">3*Weapon Four</option>
+                                        <option value="3*@{weapon-5-num-dice}">3*Weapon Five</option>
+                                        <option value="3*@{weapon-6-num-dice}">3*Weapon Six</option>
+										<option value="4*@{weapon-1-num-dice}">4*Weapon One</option>
+                                        <option value="4*@{weapon-2-num-dice}">4*Weapon Two</option>
+                                        <option value="4*@{weapon-3-num-dice}">4*Weapon Three</option>
+                                        <option value="4*@{weapon-4-num-dice}">4*Weapon Four</option>
+                                        <option value="4*@{weapon-5-num-dice}">4*Weapon Five</option>
+                                        <option value="4*@{weapon-6-num-dice}">4*Weapon Six</option>
+										<option value="5*@{weapon-1-num-dice}">5*Weapon One</option>
+                                        <option value="5*@{weapon-2-num-dice}">5*Weapon Two</option>
+                                        <option value="5*@{weapon-3-num-dice}">5*Weapon Three</option>
+                                        <option value="5*@{weapon-4-num-dice}">5*Weapon Four</option>
+                                        <option value="5*@{weapon-5-num-dice}">5*Weapon Five</option>
+                                        <option value="5*@{weapon-6-num-dice}">5*Weapon Six</option>
                                     </select>
                                 </div>
                                 <div class="sheet-item sheet-large">
                                     <select name="attr_power-100-weapon-dice">
-                                        <option value="@{weapon-1-dice}" selected="selected">Weapon One</option>
+                                        <option value=4 selected="selected">d4</option>
+                                        <option value=6>d6</option>
+                                        <option value=8>d8</option>
+                                        <option value=10>d10</option>
+                                        <option value=12>d12</option>
+                                        <option value=20>d20</option>
+										<option value="@{weapon-1-dice}">Weapon One</option>
                                         <option value="@{weapon-2-dice}">Weapon Two</option>
                                         <option value="@{weapon-3-dice}">Weapon Three</option>
                                         <option value="@{weapon-4-dice}">Weapon Four</option>
@@ -22164,8 +26300,7 @@ Hit: [[1d6+@{power-99-damage}]] Damage</textarea>
                             </div>
                             <textarea name="attr_power-100-macro">/me uses @{power-100-name}
 [[1d20+@{power-100-attack}]] vs @{power-100-def} 
-Hit: [[(1*@{power-100-weapon-num-dice})d@{power-100-weapon-dice}+@{power-100-damage}]] Damage
-Hit: [[1d6+@{power-100-damage}]] Damage</textarea>
+Hit: [[(1*@{power-100-weapon-num-dice})d@{power-100-weapon-dice}+@{power-100-damage}]] Damage</textarea>
                             <div class="sheet-header">
                                 <div class="sheet-item sheet-huge">
                                     <label>Power 100</label>
@@ -22209,8 +26344,7 @@ Hit: [[(1*@{power-1-weapon-num-dice})d@{power-1-weapon-dice}+@{power-1-damage}]]
                     </div>
                 </div>
                 <textarea class="sheet-text-large">/me uses @{power-1-name}
-[[1d20+@{power-1-attack}]] vs @{power-1-def} 
-Hit: [[1d6+@{power-1-damage}]] Damage</textarea>
+[[1d20+@{power-1-attack}]] vs @{power-1-def}</textarea>
                 <div class="sheet-header">
                     <div class="sheet-item sheet-huge">
                         <label>Token Action Macro</label>


### PR DESCRIPTION
Updated the following fields to be player input:
Bloodied, Surge Value, Fort/Ref/Will Ability value

Updated the following names:
"Attack Weapon" -> "Weapon Attack Bonus"
"Damage Weapon" -> "Weapon Damage Bonus"
"Weapon # of Dice" -> "# of Dice"
"Weapon Dice Size" -> "Damage Dice Size"

Added the following options to power dropdown options:
None option for "Weapon Attack Bonus"
None option for "Weapon Damage Bonus"
1-10, and 1-5*WeaponX for "# of Dice"
d4, d6, d8, d10, d12, and d20 for "Damage Dice Size"
Removed Extra line in powers (d6+power damage)