### PR TITLE
Pathfinder 1 line emergency fix

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -12961,7 +12961,7 @@ var PFSheet = PFSheet || (function () {
 	
 	setBuff = function(id,col){
 		var idStr = getRepeatingIDStr(id)
-		, prefix = "repeating_weapon_" + idStr+"buff-"+col;
+		, prefix = "repeating_buff_" + idStr+"buff-"+col;
 		TAS.debug("prefix=" + prefix);
 		if (abilities.indexOf(col)>=0){
 			//set error flag if they set ability buff to a negative number


### PR DESCRIPTION
One line is causing red attack rows to be created. This fixes the one line, so people wont' see tons of red attacks at the con, if you push this out. 