### PR TITLE
Minor fixes

### DIFF
--- a/Deadlands Classic/deadlandsclassic.css
+++ b/Deadlands Classic/deadlandsclassic.css
@@ -2,7 +2,7 @@
 margin: auto;
 }
 .sheet-big {
-    width: 80%;
+    width: calc(100%-3px);
     display: inline-block;
     text-align: center;
 }

--- a/Deadlands Classic/deadlandsclassic.html
+++ b/Deadlands Classic/deadlandsclassic.html
@@ -3,8 +3,8 @@
   <div class="sheet-3colrow">
   <div class="sheet-col">
     <div>
-      <div class="sheet-row">
-      <h2>Name:</h2>
+      <div class="sheet-row sheet-h2">
+      Name:
       </div>
       <div class="sheet-row sheet-big">
       <input type="text" name="attr_charname">
@@ -15,8 +15,8 @@
     <img src="http://i.imgur.com/IRCeOyE.png">
   </div><div class="sheet-col">
     <div>
-      <div class="sheet-row">
-      <h2>Occupation:</h2>
+      <div class="sheet-row sheet-h2">
+      Occupation:
       </div>
       <div class="sheet-row sheet-big">
       <input type="text" name="attr_charocc"></div>
@@ -53,7 +53,7 @@
   <td><p><b>Scrutinize</b></p></td><td><input type="number" name="attr_scrutinizelvl" style="width: 40px"></td>
 </tr>
   <tr>
-  <td><p><b>Search</b></p></td><td><input type="number" name="attr_searchlvl" style="width: 40px" value="1"></td>
+  <td><p><b>Search(1)</b></p></td><td><input type="number" name="attr_searchlvl" style="width: 40px" value="1"></td>
 </tr><tr>
   <td><p><b>Trackin'</b></p></td><td><input type="number" name="attr_trackinlvl" style="width: 40px"></td>
 </tr><tr>
@@ -123,7 +123,7 @@
 
 40px"></td></tr><tr><td><input type="text" name="attr_academia2name"></td><td><input type="number" name="attr_academia2lvl" style="width: 40px"></td></tr><tr>
   <td><p><b>Area Knowledge</b></p></td></tr><tr>
-  <td><p>Home County</p></td>
+  <td><p>Home County(2)</p></td>
   <td><input type="number" name="attr_akhomecountylvl" style="width: 40px" value="2"></td>
 </tr><tr><td><input type="text" name="attr_areakno2name"></td><td><input type="number" name="attr_areakno2lvl" style="width: 40px"></td></tr><tr>
   <td><p><b>Demolition</b></p></td><td><input type="number" name="attr_demolitionlvl" style="width: 40px"></td>
@@ -230,7 +230,7 @@
       </select></td>
      </tr>
 <tr>
-  <td><p><b>Climbin'</b></p></td><td><input type="number" name="attr_climbinlvl" style="width: 40px" value="1"></td>
+  <td><p><b>Climbin'(1)</b></p></td><td><input type="number" name="attr_climbinlvl" style="width: 40px" value="1"></td>
 </tr>
 <tr>
   <td><p><b>Dodge</b></p></td><td><input type="number" name="attr_dodgelvl" style="width: 40px"></td>
@@ -256,7 +256,7 @@
   <tr><td><p><b>Horse Ridin'</b></p></td><td><input type="number" name="attr_horselvl" style="width: 40px"></td>
 </tr>
 <tr>
-  <td><p><b>Sneak</b></p></td><td><input type="number" name="attr_sneaklvl" style="width: 40px" value="1"></td>
+  <td><p><b>Sneak(1)</b></p></td><td><input type="number" name="attr_sneaklvl" style="width: 40px" value="1"></td>
 </tr>
 <tr>
   <td><p><b>Swimmin'</b></p></td><td><input type="number" name="attr_swimminlvl" style="width: 40px"></td>
@@ -364,7 +364,7 @@
 </div><!-- Combat Stuff -->
 <div class="sheet-2colrow">
   <div class="sheet-col">
-    <div><h2>Shootin Irons &amp; Such</h2></div>
+    <div class="sheet-h2">Shootin Irons &amp; Such</div>
 <div>
 <table>
   <tbody>
@@ -398,7 +398,7 @@
 </tbody>
 </table>
 </div>
-<div><h2>Hand-To-Hand Weapons</h2></div>
+<div class="sheet-h2">Hand-To-Hand Weapons</div>
 <div>
 <table>
   <tbody>
@@ -969,10 +969,6 @@
   <div class="sheet-item sheet-small"><input type="text" name="attr_spelltn"></div>
   <div class="sheet-item sheet-huge"><input type="text" name="attr_spellnotes"></div>
   </fieldset><div class="repcontainer" data-groupname="repeating_spells"></div>
-<div class="repcontrol" data-groupname="repeating_spells">
-  <button class="btn repcontrol_edit">Modify</button><button class="btn repcontrol_add" style="display: inline-block;">+Add</button></div>
-
-</div>
 </div>
 </div>
 <!-- Other Stuff-->

--- a/Deadlands Classic/sheet.json
+++ b/Deadlands Classic/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Kevin Justus",
 	"roll20userid": "129882",
 	"preview": "deadlandsclassic.png",
-	"instructions": "The layout is basic, and based mainly on the 2nd Printing core book's sheet. If you wanna update this stuff to make it less of a mess, lemme know.(Preferably only if you plan to keep it compatible with the original game.)"
+	"instructions": "A sheet for Deadlands Classic, based on the one in the back of the 2nd Printing of the Player's Guide."
 }


### PR DESCRIPTION
This just removes the redundant repeating fieldset buttons, adds the default values for some aptitudes in parenthesis next to the  aptitude name, and some other minor cosmetic fixes, on the Deadlands Classic sheet.