### PR TITLE
Fix hench HP

### DIFF
--- a/AD&D_2E/2ESheet.html
+++ b/AD&D_2E/2ESheet.html
@@ -880,7 +880,7 @@ Current weight:<input type="number" name="attr_gearweighttotal" class="sheet-nob
             <td><input type="text" name="attr_henchatknum" class="sheet-short"></td>
             <td>&nbsp;<input type="text" name="attr_henchthac" class="sheet-short"></td>
             <td><input type="text" name="attr_henchdmg" class="sheet-short"></td>
-            <td><input type="number" name="attr_henchhp" class="sheet-tiny" value="@{HP}"/>/<input type="number" name="attr_henchhpmax" class="sheet-tiny" /></td>
+            <td><input type="number" name="attr_henchhp" class="sheet-nobut" value="@{HP}"/>/<input type="number" name="attr_henchhpmax" class="sheet-nobut" /></td>
             <td><input type="text" name="attr_henchnotes"></td>
     </tr>
 </table>
@@ -893,7 +893,7 @@ Current weight:<input type="number" name="attr_gearweighttotal" class="sheet-nob
             <td><input type="text" name="attr_henchatknum" class="sheet-short"></td>
             <td><input type="text" name="attr_henchthac" class="sheet-short"></td>
             <td><input type="text" name="attr_henchdmg" class="sheet-short"></td>
-            <td><input type="number" name="attr_henchhp" class="sheet-tiny" value="@{HP}"/>/<input type="number" name="attr_henchhpmax" class="sheet-tiny" /></td>
+            <td><input type="number" name="attr_henchhp" class="sheet-nobut" value="@{HP}"/>/<input type="number" name="attr_henchhpmax" class="sheet-nobut" /></td>
             <td><input type="text" name="attr_henchnotes"></td>
     </tr>
 </table>


### PR DESCRIPTION
In Firefox the HP was not visible for henchmen, changing this to use the same class as other number fields such as current weight fixed this
issue.