### PR TITLE
Urgent fixes in defense and skill systems.

### DIFF
--- a/MAGUS_UTK/MAGUS_UTK.html
+++ b/MAGUS_UTK/MAGUS_UTK.html
@@ -183,7 +183,7 @@
 			<tr>
 				<td style='text-align: center'><button type='roll' value='&{template:default} {{name=@{karakterNev} kezdeményezés!}} {{Dobás=[[d10+@{karakterKE}+?{+/- módosítók?|0} &{tracer}]]}}'></button>
 				<td style='text-align: center'><button type='roll' value='&{template:default} {{name=Pusztakezes támadás!}} {{Dobás=[[d100+@{karakterTE}+?{+/- módosítók?|0}]]}} {{Sebzés=[[?{Sebzés?|0}}}'></button>
-				<td style='text-align: center'><button type='roll' value='&{template:default} {{name=Pusztakezes védekezés!}} {{Dobás=[[d100+@{karakterVE}+?{+/- módosítók?|0}]]}}'></button>
+				<td style='text-align: center'><button type='roll' value='&{template:default} {{name=Pusztakezes védekezés!}} {{Dobás=[[@{karakterVE}+?{+/- módosítók?|0}]]}}'></button>
 				<td style='text-align: center'><button type='roll' value='&{template:default} {{name=Alap célzás!}} {{Dobás=[[d100+@{karakterCE}+?{+/- módosítók?|0}]]}} {{Sebzés=[[?{Sebzés?|0}}}'></button>
 		</table>
 	</div>
@@ -304,13 +304,13 @@
 				<input type='checkbox' value='1' name='attr_fegyverFegyvertörés' label='Fegyvertörés' />
 		</div>
 		<div class='sheet-fegyverAdatCella' style='width: 5%;'>
-			<span class='sheet-fegyverAdatFejlec'>Lefegy.</span>
+			<span class='sheet-fegyverAdatFejlec'>Átütés</span>
 				<input type='checkbox' value='1' name='attr_fegyverAtutes' label='Átütés' />
 		</div>
 		<br clear='both' />
 		<span class='sheet-spanDobasNev'><button type='roll' value='&{template:default} {{name=@{fegyverNev} - kezdeményezés!}} {{Dobás=[[d10+@{fegyverKE}+@{karakterKE}+?{+/- módosítók?|0}]]}}'></button>Kezdeményezés</span>
 		<span class='sheet-spanDobasNev'><button type='roll' value='&{template:default} {{name=@{fegyverNev} - támadás!}} {{Dobás=[[d100+@{karakterTE}+@{fegyverTE}+?{+/- módosítók?|0}]]}} {{Sebzés=[[@{fegyverSebzesKockaDarab}d@{fegyverSebzesKockaOldal}+@{fegyverSebzesModosito}+?{Sebzés módosító?|0}]]}}'></button>Támadás</span>
-		<span class='sheet-spanDobasNev'><button type='roll' value='&{template:default} {{name=@{fegyverNev} - védekezés!}} {{Dobás=[[d100+@{karakterVE}+@{fegyverVE}+?{+/- módosítók?|0}]]}}'></button>Védekezés</span>
+		<span class='sheet-spanDobasNev'><button type='roll' value='&{template:default} {{name=@{fegyverNev} - védekezés!}} {{Dobás=[[@{karakterVE}+@{fegyverVE}+?{+/- módosítók?|0}]]}}'></button>Védekezés</span>
 		<span class='sheet-spanDobasNev'><button type='roll' value='&{template:default} {{name=@{fegyverNev} - támadás!}} {{Dobás=[[d100+@{karakterCE}+@{fegyverCE}+?{+/- módosítók?|0}]]}} {{Sebzés=[[@{fegyverSebzesKockaDarab}d@{fegyverSebzesKockaOldal}+@{fegyverSebzesModosito}+?{Sebzés módosító?|0}]]}}'></button>Célzás</span> 
 		<br clear='both' />
 	</fieldset>
@@ -332,7 +332,7 @@
 		</div>
 		<div class='sheet-kepzettsegAdatCella' style='width: 15%'>
 			<span class='sheet-kepzettsegAdatFejlec'>Dobás</span>
-			<button type='roll' value='&{template:default} {{name=@{kepzettseg5Nev} próba!}} {{Célszám=[[?{Tulajdonság?|Erő (alap), @{eroAlap} | Erő (módosított), @{eroMod} | Gyorsaság (alap), @{gyorsasagAlap} | Gyorsaság (módosított), @{gyorsasagMod} | Ügyesség (alap), @{ugyessegAlap} | Ügyesség (módosított), @{ugyessegMod} | Állóképesség (alap), @{allokepessegAlap} | Állóképesség (módosított), @{allokepessegMod} | Egészség (alap), @{egeszsegAlap} | Egészség (módosított), @{egeszsegMod} | Karizma (alap), @{karizmaAlap} | Karizma (módosított), @{karizmaMod} | Intelligencia (alap), @{intelligenciaAlap} | Intelligencia (módosított), @{intelligenciaMod} | Akaraterő (alap), @{akarateroAlap} | Akaraterő (módosított), @{akarateroMod} | Asztrál (alap), @{asztralAlap} | Asztrál (módosított), @{asztralMod} | Érzékelés (alap), @{erzekelesAlap} | Érzékelés (módosított), @{erzekelesMod}}-10+@{kepzettseg5Fok}-2+?{+/- módosítók?|0}]]}} {{Dobás=[[d10]]}}'></button>
+			<button type='roll' value='&{template:default} {{name=@{kepzettseg5Nev} próba!}} {{Célszám=[[?{Tulajdonság?|Erő (alap), @{eroAlap} | Erő (módosított), @{eroMod} | Gyorsaság (alap), @{gyorsasagAlap} | Gyorsaság (módosított), @{gyorsasagMod} | Ügyesség (alap), @{ugyessegAlap} | Ügyesség (módosított), @{ugyessegMod} | Állóképesség (alap), @{allokepessegAlap} | Állóképesség (módosított), @{allokepessegMod} | Egészség (alap), @{egeszsegAlap} | Egészség (módosított), @{egeszsegMod} | Karizma (alap), @{karizmaAlap} | Karizma (módosított), @{karizmaMod} | Intelligencia (alap), @{intelligenciaAlap} | Intelligencia (módosított), @{intelligenciaMod} | Akaraterő (alap), @{akarateroAlap} | Akaraterő (módosított), @{akarateroMod} | Asztrál (alap), @{asztralAlap} | Asztrál (módosított), @{asztralMod} | Érzékelés (alap), @{erzekelesAlap} | Érzékelés (módosított), @{erzekelesMod}}-10+@{kepzettseg5Fok}+?{+/- módosítók?|0}]]}} {{Dobás=[[d10]]}}'></button>
 		</div>
 		<br clear='both' />
 	</fieldset>
@@ -416,7 +416,7 @@
 				<td><input type='number' name='attr_pajzsTE' ><button type='roll' value='&{template:default} {{name=@{pajzsNev} - támadás!}} {{Dobás=[[d100+@{karakterTE}+@{pajzsTE}+?{+/- módosítók?|0}]]}} {{Sebzés=[[@{pajzsSebzesKockaDarab}d@{pajzsSebzesKockaOldal}+@{pajzsSebzesModosito}+?{Sebzés módosító?|0}]]}}'></button>
 			<tr>
 				<th>VÉ
-				<td><input type='number' name='attr_pajzsVE' ><button type='roll' value='&{template:default} {{name=@{pajzsNev} - védekezés!}} {{Dobás=[[d100+@{karakterVE}+@{pajzsVE}+?{+/- módosítók?|0}]]}}'></button>
+				<td><input type='number' name='attr_pajzsVE' ><button type='roll' value='&{template:default} {{name=@{pajzsNev} - védekezés!}} {{Dobás=[[@{karakterVE}+@{pajzsVE}+?{+/- módosítók?|0}]]}}'></button>
 			<tr>
 				<th>Sebzés
 				<td><input type='number' name='attr_pajzsSebzesKockaDarab' />k<input type='number' name='attr_pajzsSebzesKockaOldal' />+<input type='number' name='attr_pajzsSebzesModosito' />


### PR DESCRIPTION
1. Modify the defense system, which earlier used a d100 instead of a constant value of 60.

2. Fix the skill system, where throws added a [Skill level]-2 modifier to every skill throw. However, as it turns out, there are a few skills, for which this is not applicable, so the skills will require the players to input their modifiers via a prompt.

3. Change the title of the last column of the weapon tables from "Lefegy." to "Átütés". It was a duplicate.