### PR TITLE
MG: Fix and Update Weapon Fieldset

### DIFF
--- a/Stars_Without_Number/Stars_Without_Number.html
+++ b/Stars_Without_Number/Stars_Without_Number.html
@@ -87,7 +87,7 @@
       </div>
     </div>
     <div class="sheet-row">
-      <div class="sheet-col sheet-swn-min">Version 0.0.9</div>
+      <div class="sheet-col sheet-swn-min">Version 0.1.1</div>
     </div>
     <h3>Core Stats</h3>
     <div class="sheet-2colrow sheet-stats">
@@ -309,7 +309,7 @@
           <div class="sheet-col sheet-attribute-label"><label for="attr_str">STR</label></div>
           <div class="sheet-col">
             <input type="number" min="3" name="attr_str" class="sheet-stats-half">
-            <input type="number" min="-2" max="2" name="attr_strBonus" value="@{Str}" class="sheet-stats-half sheet-stat-bonus">
+            <input type="number" min="-2" max="2" name="attr_strBonus" value="0" class="sheet-stats-half sheet-stat-bonus">
           </div>
           <div class="sheet-col sheet-attribute-label"><label for="attr_int">INT</label></div>
           <div class="sheet-col">
@@ -1040,19 +1040,36 @@
 
     <div class="sheet-weapons-wrapper">
         <label>Weapon</label>
-        <label>Weapon AB</label>
-        <label>Damage Die</label>
+        <label class="sheet-weapons-short">Weapon AB</label>
+        <label class="sheet-weapons-short">Skill</label>
+        <label class="sheet-weapons-short">Attribute</label>
+        <label class="sheet-weapons-short">Damage</label>
         <label>Range</label>
         <label class="sheet-weapons-short">Ammo</label>
-        <label class="sheet-weapons-short">Attack</label>
         <br>
         <fieldset class="repeating_weapons">
             <input type="text" name="attr_weapon_name" style="width: 140px">
-            <input type="number" name="attr_weapon_attack" value="0" style="width: 140px">
-            <input type="text" name="attr_weapon_damage" style="width: 140px">
+            <input type="number" name="attr_weapon_attack" value="0" style="width: 95px">
+            <select class="inputbox" name="attr_weapon_skill_bonus" style="width: 95px; height: 25px">
+                <option value="@{skill_combat_energy}">Energy</option>
+                <option value="@{skill_combat_gunnery}">Gunnery</option>
+                <option value="@{skill_primitive}">Primitive</option>
+                <option value="@{skill_projectile}">Projectile</option>
+                <option value="@{skill_psitech}">Psitech</option>
+                <option value="@{skill_unarmed}">Unarmed</option>
+            </select>
+            <select class="inputbox" name="attr_attribute_mod" style="width: 95px; height: 25px">
+                <option value="@{strBonus}">STR</option>
+                <option value="@{dexBonus}">DEX</option>
+                <option value="@{conBonus}">CON</option>
+                <option value="@{intBonus}">INT</option>
+                <option value="@{wisBonus}">WIS</option>
+                <option value="@{chaBonus}">CHA</option>
+            </select>
+            <input type="text" name="attr_weapon_damage" style="width: 95px">
             <input type="text" name="attr_weapon_range" style="width: 140px">
-            <input type="number" name="attr_weapon_ammo"  style="width: 80px">
-            <button type="roll" name="roll_weapon_to_hit" value="/me &{template:attack} {{name=@{weapon_name}}} {{rollValue=[[1d20 + ?{AC|0} + @{attack_bonus} + @{weapon_attack} + ?{Attribute Modifier|0} + ?{Other Modifier|0}]]}} {{damage=[[@{weapon_damage}]]}}" ></button>
+            <input type="number" name="attr_weapon_ammo"  style="width: 95px">
+            <button type="roll" name="roll_weapon_to_hit" value="/me &{template:attack} {{name=@{weapon_name}}} {{rollValue=[[1d20 + ?{AC|0} + @{attack_bonus} + @{weapon_attack} + @{weapon_skill_bonus} + @{attribute_mod} + ?{Other Modifier|0}]]}} {{damage=[[@{weapon_damage} + @{attribute_mod}]]}}" ></button>
         </fieldset>
     </div>
 


### PR DESCRIPTION
Fixes the weapon fields to properly calculate attacks using attribute modifiers and skill levels. Also added drop down menus for these fields so they can be changed on the fly in certain circumstances. Minor Fix: the "Strength Modifier" will now default to 0 instead of being blank. Updated the sheet version to 0.1.1 as the original author informed me the version was wrong.