### PR TITLE
Display bugfixes, better radio functionality

### DIFF
--- a/Blades-in-the-Dark/README.md
+++ b/Blades-in-the-Dark/README.md
@@ -10,14 +10,20 @@ Report any problems, suggestions or features by sending a private message on Rol
 
 ## Todo
 * Change to only show crit value if there are more than one 6 in the roll.
-* Convert Coin, Bandolier, and Recovery checkboxes in the character tab to left-fillable radio buttons for consistency.
-* Convert Load on the playbook tab to a radio button - can't have multiple loads simultaneously.
-* Wrap the 8-clock track at 4 ticks to allow for wider input boxes for the clock descriptions.
 * Add a Name field for Cohorts?
 * Add a repeatable Item field for items that have no load?
 * Add a button to the Crew sheet to roll Heat for Entanglements - display with a roll template to make it easy for the GM to look up the results?
+* Display the Clocks tab for Crew sheets as well as Character sheets
+* Add a min-width to rows that shouldn't be wrapped when the sheet's width is narrow.
 
 ## Changelog
+
+### 0.0.9
+* Added display formatting for Turf to overlay on Rep nicely.
+* Converted some checkboxes to radios - Load, Friends, Contacts, Recovery, Bandoliers
+* Improved layout for Clock tab
+* Bugfixes
+    - Windows Chrome no longer wraps the Crew claims map badly
 
 ### 0.0.8
 * Added a button to Indulge in Vice 

--- a/Blades-in-the-Dark/blades.css
+++ b/Blades-in-the-Dark/blades.css
@@ -203,10 +203,6 @@ input[type=checkbox].sheet-friend:checked + span {
   background: #007700;
 }
 
-.sheet-clock-col {
- width: 350px;
-}
-
 input[type=checkbox].sheet-rival:checked + span {
   background: #770000;
 }
@@ -419,6 +415,40 @@ input.sheet-carry + span {
   margin-left: 15px;
 }
 
+.sheet-clock4desc,
+.sheet-clock6desc {
+  width: 290px;
+  margin-right: -16px;
+  margin-bottom: 30px;
+}
+
+.sheet-clockcol {
+  margin-right: 25px;
+}
+
+
+input.sheet-clockdesc {
+  width: 290px;
+}
+
+.sheet-clock4tick {
+  width: 100px;
+}
+
+.sheet-clock6tick {
+  width: 150px;
+}
+
+.sheet-clock4tick hr,
+.sheet-clock6tick hr {
+  opacity: 0;
+  margin: 0;
+}
+
+.repeating_4clocks,
+.repeating_8clocks {
+  margin-right: 20px;
+}
 
 
 /* Crew Sheet Field Layout And Formatting */
@@ -626,9 +656,8 @@ input.sheet-zero + span::before
     top: 5px;
 }
 
-input[type=radio].sheet-radioindent,
-input[type=radio].sheet-radioindent + span {
-  margin-left: 5px;
+input[type=radio].sheet-radioindent {
+  margin-left: 11px;
 }
 
 /* Crew Upgrades */

--- a/Blades-in-the-Dark/blades.css
+++ b/Blades-in-the-Dark/blades.css
@@ -1,818 +1,822 @@
-/* Blades in the Dark CSS v0.0.9 */
-
-/* Header Formatting */
-.sheet-gametitleimg {float: left; }
-.sheet-alignright {text-align: right; }
-.sheet-typeselector {}
-.sheet-aligncenter {text-align: center;}
-
-/* Tabs for switching between different content sections */
-.sheet-tab-content {
-  display: none;
-}
-
-input.sheet-tab-char:checked ~ div.sheet-tab-char,
-input.sheet-tab-playbook:checked ~ div.sheet-tab-playbook,
-input.sheet-tab-clocks:checked ~ div.sheet-tab-clocks,
-input.sheet-tab-crew:checked ~ div.sheet-tab-crew,
-input.sheet-tab-factions:checked ~ div.sheet-tab-factions {
-  display: block;
-}
-
-input.sheet-tab {
-  opacity: 0;
-  width: 100px;
-  height: 20px;
-  margin-bottom: 5px;
-  cursor: pointer;
-  z-index: 1;
-  position: absolute;
-}
-
-input.sheet-tab + span {
-  border: solid 1px #a7a7a7;
-  border-bottom-color: #ffffff;
-  text-align: center;
-  display: inline-block;
-
-  background: #000000;
-  color: #ffffff;
-
-  width: 100px;
-  height: 20px;
-  font-size: 18px;
-}
-
-input.sheet-tab:checked + span {
-  background: #ffffff;
-  color: #000000;
-}
-
-input[type=radio].sheet-tab-char,
-input[type=radio].sheet-tab-char + span {
-    left: 0px;
-}
-
-input[type=radio].sheet-tab-playbook,
-input[type=radio].sheet-tab-playbook + span {
-    left: 110px;
-}
-
-
-/* Char/Crew Button Functionality */
-div.sheet-type-crew { display: none; }
-input.sheet-typeselector:checked ~ div.sheet-type-crew { display: block;}
-input.sheet-typeselector:checked ~ div.sheet-type-character { display: none; }
-
-/* Char/Crew Button Appearance */
-input.sheet-typeselector {
-  opacity: 0;
-  width: 100px;
-  height: 20px;
-  margin-bottom: 5px;
-  cursor: pointer;
-  z-index: 1;
-}
-
-input.sheet-typeselector + span {
-  border: solid 1px #a7a7a7;
-  border-bottom-color: #ffffff;
-  text-align: center;
-  display: inline-block;
-
-  background: #cccccc;
-  color: #000000;
-
-  width: 100px;
-  height: 20px;
-  font-size: 18px;
-}
-
-input.sheet-typeselector,
-input.sheet-typeselector + span {
-    position: absolute;
-    right: 0;
-}
-
-input.sheet-typeselector + span::before {
-  content: "Character";
-}
-
-input.sheet-typeselector:checked + span::before {
-  content: "Crew";
-}
-
-/* Trauma Options */
-input.sheet-trauma-check {
-  opacity: 0;
-  width: 80px;
-  height: 20px;
-  cursor: pointer;
-  z-index: 1;
-}
-
-input.sheet-trauma-check + span {
-  border: solid thin #a7a7a7;
-  text-align: center;
-  display: inline-block;
-
-  background: white;
-  color: #000000;
-
-  width: 80px;
-  height: 20px;
-  line-height: 22px;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-input.sheet-trauma-check:checked + span {
-  color: #ff0000;
-}
-
-.sheet-trauma-container {
-    position: relative;
-    /* This allows us to absolutely position within each of the column
-    containers so that we can overlap the checkbox and the span. */
-    width: 80px;
-    margin-left: 10px;
-    margin-right: 10px;
-}
-
-input.sheet-trauma-check,
-input.sheet-trauma-check + span {
-    position: absolute;
-    left: 0;
-}
-
-/* Other Options */
-input[type=checkbox].sheet-check,
-input[type=checkbox].sheet-check-first {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  z-index: 2;
-  opacity: 1;
-  position: relative;
-  opacity: 0;
-}
-
-input[type=checkbox].sheet-check + span,
-input[type=checkbox].sheet-check-first + span {
-  display: inline-block;
-  background: #ffffff;
-  background: white;
-  width: 16px;
-  height: 16px;
-  position: relative;
-  left: -16px;
-  top: 5px;
-  z-index: 1;
-  border: solid thin #000000;
-}
-
-input[type=checkbox].sheet-check,
-input.sheet-friend-info,
-input.sheet-item-info,
-input.sheet-crew-ability-name,
-input.sheet-crew-upgrade-info,
-input.sheet-contact-friend-info
-{
-  margin-left: -16px;
-}
-
-.sheet-check-last + span {
-    margin-right: -16px;
-}
-
-input[type=checkbox].sheet-check:checked + span,
-input[type=checkbox].sheet-check-first:checked + span {
-  background: black;
-}
-
-input[type=checkbox].sheet-friend + span {
-  border: solid thin #007700;
-}
-
-input[type=checkbox].sheet-rival + span {
-  border: solid thin #770000;
-}
-
-input[type=checkbox].sheet-friend:checked + span {
-  background: #007700;
-}
-
-input[type=checkbox].sheet-rival:checked + span {
-  background: #770000;
-}
-
-input[type=checkbox].sheet-item-onebox {
-    /* Extra indentation so that we align nicely with the two-box and three-box
-    items below*/
-    margin-left: 42px;
-}
-
-input[type=checkbox].sheet-item-twobox {
-    /* Extra indentation so that we align nicely with the two-box and three-box
-    items below*/
-    margin-left: 21px;
-}
-
-input.sheet-item-info {
-    width: 155px;
-    margin-right: 15px;
-}
-
-.sheet-turfrow {
-  margin-bottom: -13px;
-}
-
-.sheet-turfrow-outer {
-  margin: auto;
-}
-
-label.sheet-turf-label, label.sheet-rep-label {
-  width: 25px;
-}
-
-label.sheet-wanted-label, label.sheet-coin-label {
-  width: 40px;
-  text-align: right;
-  margin-left: -20px;
-  margin-right: -10px;
-}
-
-label.sheet-heat-label, label.sheet-vault-label {
-  width: 40px;
-  text-align: right;
-  margin-left: 6px;
-  margin-right: -27px;
-}
-
-label.sheet-tier-label, label.sheet-hold-label {
-  width: 20px;
-  text-align: right;
-  margin-left: 6px;
-  margin-right: -13px;
-}
-
-input[type=checkbox].sheet-turf:checked + span {
-  background: darkred;
-  height: 38px;
-  position: relative;
-  top: 27px;
-  margin-top: -23px;
-  z-index: 3;
-}
-
-/* Character Tab */
-h1 {
-  text-align: center;
-}
-
-.sheet-version {
-  text-align: left;
-  font-size: 10px;
-}
-
-label {
-  line-height: 25px;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-label.sheet-alias, label.sheet-background {
-  margin-left: 10px;
-}
-
-input.sheet-name, input.sheet-alias {
-  width: 350px;
-}
-
-input.sheet-look {
-  margin-left: 5px;
-  width: 771px;
-}
-
-input.sheet-heritage, input.sheet-background {
-  width: 312px;
-}
-
-input.sheet-vice {
-  width: 699px;
-}
-
-label.sheet-trauma {
-  margin-left: 25px;
-}
-
-input.sheet-stress, input.sheet-trauma, input.sheet-stash,
-input.sheet-insight, input.sheet-prowess, input.sheet-resolve {
-  width: 25px;
-  text-align: center;
-  font-size: 16px;
-}
-
-h3 {
-  text-align: center;
-}
-
-h5 {
-  line-height: 27px;
-}
-
-.sheet-harm-full {
-  width: 424px;
-}
-
-label.sheet-armor, input.sheet-spec, label.sheet-coin,
-label.sheet-stash {
-  margin-left: 35px;
-}
-
-label.sheet-heavy {
-  margin-left: 18px;
-}
-
-input.sheet-spec {
-  width: 175px;
-}
-
-/* Playbook Tab */
-input.sheet-ability-name {
-  width: 125px;
-  text-align: center;
-  font-weight: bold;
-  margin-left: -16px;
-}
-
-input.sheet-ability-info {
-  width: 292px;
-}
-
-input.sheet-xp-goal {
-  width: 416px;
-}
-
-.sheet-xp-conditions {
-  width: 440px;
-}
-.sheet-actions {
-  margin-left: 35px;
-}
-
-h4 {
-  line-height: 27px;
-}
-
-.sheet-actions-hr {
-  margin-top: 5px;
-  margin-bottom: 5px;
-}
-
-input.sheet-insight {
-  margin-left: 175px;
-}
-
-input.sheet-prowess {
-  margin-left: 159px;
-}
-
-input.sheet-resolve {
-  margin-left: 164px;
-}
-
-.sheet-secondary-actions {
-  margin-left: 35px;
-}
-
-.sheet-insight-actions {
-  margin-left: 33px;
-}
-
-.sheet-prowess-actions {
-  margin-left: 20px;
-}
-
-.sheet-resolve-actions {
-  margin-left: 10px;
-}
-
-.sheet-loads {
-  margin-left: 10px;
-}
-
-input.sheet-carry {
-  margin-left: 10px;
-}
-
-input.sheet-carry + span {
-  margin-right: -16px;
-}
-
-.sheet-bandolier {
-  margin-left: 15px;
-}
-
-.sheet-clock4desc,
-.sheet-clock6desc {
-  width: 290px;
-  margin-right: -16px;
-  margin-bottom: 30px;
-}
-
-.sheet-clockcol {
-  margin-right: 25px;
-}
-
-
-input.sheet-clockdesc {
-  width: 290px;
-}
-
-.sheet-clock4tick {
-  width: 100px;
-}
-
-.sheet-clock6tick {
-  width: 150px;
-}
-
-.sheet-clock4tick hr,
-.sheet-clock6tick hr {
-  opacity: 0;
-  margin: 0;
-}
-
-.repeating_4clocks,
-.repeating_8clocks {
-  margin-right: 20px;
-}
-
-
-/* Crew Sheet Field Layout And Formatting */
-input.sheet-crew-name, input.sheet-crew-reputation {
-  width: 330px;
-}
-
-input.sheet-crew-lair {
-  width: 782px;
-}
-
-
-/* Claims Map */
-
-.sheet-map-row-claims {
-    margin-left: 51px;
-    width: 742px;
-    min-width: 742px;
-    max-width: 742px;
-}
-
-.sheet-map-row-claims textarea {
-    width: 130px;
-    height: 60px;
-    margin: 0px;
-    padding: 0px;
-    background: #cccccc;
-    z-index: 0;
-    position: relative;
-    resize: none;
-}
-
-.sheet-map-claim, .sheet-map-connector {
-    display: inline-block;
-    vertical-align: middle;
-    text-align: center;
-      margin: -3px;
-}
-
-.sheet-connector-row {
-  margin-bottom: -20px;
-  margin-left: 48px;
-  width: 762px;
-  min-width: 762px;
-  max-width: 762px;
-}
-
-
-
-/* Hide right-connector checkbox */
-input.sheet-connector-check[type="checkbox"]
-{
+  /* Blades in the Dark CSS v0.0.9 */
+
+  /* Header Formatting */
+  .sheet-gametitleimg {float: left; }
+  .sheet-alignright {text-align: right; }
+  .sheet-typeselector {}
+  .sheet-aligncenter {text-align: center;}
+
+  /* Tabs for switching between different content sections */
+  .sheet-tab-content {
+    display: none;
+  }
+
+  input.sheet-tab-char:checked ~ div.sheet-tab-char,
+  input.sheet-tab-playbook:checked ~ div.sheet-tab-playbook,
+  input.sheet-tab-clocks:checked ~ div.sheet-tab-clocks,
+  input.sheet-tab-crew:checked ~ div.sheet-tab-crew,
+  input.sheet-tab-factions:checked ~ div.sheet-tab-factions {
+    display: block;
+  }
+
+  input.sheet-tab {
     opacity: 0;
-    width: 16px;
-    height: 16px;
-    position: relative;
-    top: -2px;
-    left: 15px;
-    margin: -10px;
-    cursor: pointer;
-    z-index: 2;
-}
-
-/* Hide right-connector when unchecked */
-input.sheet-connector-check[type="checkbox"] + span::before
-{
-    opacity: 0;
-    display: inline-block;
-    width: 30px;
-    height: 20px;    
-    content: "";
-}
-
-/* Show right-connector when checked */
-input.sheet-connector-check[type="checkbox"]:checked + span::before
-{
-    opacity: 1;
-    content: "";
-    width: 30px;
+    width: 100px;
     height: 20px;
-    background: #cccccc;
-    z-index: -1;
-    border: 1px 0px 1px 0px;
-    position: relative;
-    left: -1px;
-}
-
-/* Row for the down-connectors */
-.sheet-down-connector {
-  width: 132px;
-  display: inline-block;
-  margin-right: 17px;
-  margin-left: 0px;
-  height: 30px;
-  text-align:center;
-}
-
-.sheet-notfirstrow {
-  margin-top: 15px;
-}
-
-
-/* Hide down-connector checkbox */
-input.sheet-down-connector-check[type="checkbox"]
-{
-    opacity: 0;
-    position: relative;
-    cursor: pointer;
-    z-index: 2;
-    width: 16px;
-    height: 36px;
-    top: -12px;
-    left: 8px;
-
-}
-
-
-/* Hide down-connector when unchecked */
-input.sheet-down-connector-check[type="checkbox"] + span::before
-{
-    opacity: 0;
-    display: inline-block;
-    content: "";
-    background: green;
-    position: relative;
-    z-index: 1;
-    width: 16px;
-    height: 26px;
-    top: 1px;
-    left: -8px;
-}
-
-
-/* Show down-connector when checked */
-input.sheet-down-connector-check[type="checkbox"]:checked + span::before
-{
-    opacity: 1;
-    display: inline-block;
-    content: "";
-    background: #cccccc;
-    position: relative;
-    z-index: 1;
-    width: 16px;
-    height: 26px;
-    top: 0px;
-    left: -8px;
-}
-
-/* Left-fillable radio buttons - Hide actual radio */
-input.sheet-leftradio[type="radio"]
-{
-    opacity: 0;
-    width: 16px;
-    height: 16px;
-    position: relative;
-    top: -2px;
-    left: 8px;
-    margin: -9px;
+    margin-bottom: 5px;
     cursor: pointer;
     z-index: 1;
-}
+    position: absolute;
+  }
 
-/* Show fake radio buttons for left-fillable */
-input.sheet-leftradio[type="radio"] + span::before
-{
-    width: 16px;
-    height: 16px;
-    content: "";
+  input.sheet-tab + span {
+    border: solid 1px #a7a7a7;
+    border-bottom-color: #ffffff;
+    text-align: center;
     display: inline-block;
-    border: solid thin #000000;
+
     background: #000000;
-    position: relative;
-    top: 5px;
-}
+    color: #ffffff;
 
-input.sheet-leftradiolast[type="radio"] + span::before {
-  margin-right: 0px;
-}
+    width: 100px;
+    height: 20px;
+    font-size: 18px;
+  }
 
-/* Remove dot from all radios _after_ selected one */
-/* Ensure that your radio groups are encapsulated in a div, otherwise they will interfere with each other */
-input.sheet-leftradio[type="radio"]:checked ~ input.sheet-leftradio[type="radio"] + span::before
-{    
-    content: "";
+  input.sheet-tab:checked + span {
     background: #ffffff;
-}
+    color: #000000;
+  }
+
+  input[type=radio].sheet-tab-char,
+  input[type=radio].sheet-tab-char + span {
+      left: 0px;
+  }
+
+  input[type=radio].sheet-tab-playbook,
+  input[type=radio].sheet-tab-playbook + span {
+      left: 110px;
+  }
 
 
-/* Empty radio - used for clearing the line*/
-input.sheet-zero:checked + span::before
-{
+  /* Char/Crew Button Functionality */
+  div.sheet-type-crew { display: none; }
+  input.sheet-typeselector:checked ~ div.sheet-type-crew { display: block;}
+  input.sheet-typeselector:checked ~ div.sheet-type-character { display: none; }
+
+  /* Char/Crew Button Appearance */
+  input.sheet-typeselector {
     opacity: 0;
-}
-
-input.sheet-zero:hover + span::before
-{
-    opacity: 0.25;
-    font-size: 12px;
-    content: "✖";
-    text-indent: 0.5px;
-    position:relative;
-    top: 2px;
-}
-
-input.sheet-zero + span::before
-{
-    opacity: 0;
-    position: relative;
-    top: 5px;
-}
-
-input[type=radio].sheet-radioindent {
-  margin-left: 11px;
-}
-
-/* Crew Upgrades */
-.sheet-lair-upgrade-info, .sheet-quality-upgrade-info {
-    width: 170px;
-}
-
-.sheet-crew-upgrade-info {
-    width: 160px;
-    margin-right: 15px;
-}
-
-.sheet-linkedbox + span::after {
-  content: "-";
-  line-height: 24px;
-  position: relative;
-  left: 16px;
-  font-size: 15px;
-  top: -4px;
-}
-
-.sheet-crew-ability-name {
-    width: 125px;
-}
-
-.sheet-crew-ability-info {
-    width: 680px;
-}
-
-.sheet-advancement-descr {
-    width: 335px;
-}
-
-.sheet-contact-friend-info, .sheet-friend-info {
-    width: 155px;
-    margin-right: 15px;
-}
-
-textarea.sheet-cohort-notes {
-  width: 200px;
-  height: 50px;
-}
-
-.sheet-cohort-label, .sheet-crew-advancement-label {
-  display: inline;
-  margin-right: -11px;
-}
-
-select.sheet-cohort-health {
-  width: 100px;
-}
-
-.sheet-freejob textarea, .repeating_freejob textarea {
-  width: 330px;
-  height: 50px;
-}
-
-.sheet-freejob-name {
-  width: 194px;
-}
-
-.sheet-freejobs {
-  width: 340px;
-  margin-bottom: 10px;
-  margin-right: 20px;
-}
-
-.sheet-faction-section {
-  margin: 30px;
-}
-
-select.sheet-faction-status, 
-select.sheet-faction-tier, 
-select.sheet-faction-hold {
-    width: 45px;
-}
-
-
-.sheet-war-description {
-  width: 350px;
-}
-
-input.sheet-knifeimg[type="radio"] {
-    opacity: 1;
+    width: 100px;
+    height: 20px;
+    margin-bottom: 5px;
+    cursor: pointer;
     z-index: 1;
-}
+  }
 
+  input.sheet-typeselector + span {
+    border: solid 1px #a7a7a7;
+    border-bottom-color: #ffffff;
+    text-align: center;
+    display: inline-block;
 
-.sheet-claim-checkboxes {
+    background: #cccccc;
+    color: #000000;
+
+    width: 100px;
+    height: 20px;
+    font-size: 18px;
+  }
+
+  input.sheet-typeselector,
+  input.sheet-typeselector + span {
+      position: absolute;
+      right: 0;
+  }
+
+  input.sheet-typeselector + span::before {
+    content: "Character";
+  }
+
+  input.sheet-typeselector:checked + span::before {
+    content: "Crew";
+  }
+
+  /* Trauma Options */
+  input.sheet-trauma-check {
+    opacity: 0;
+    width: 80px;
+    height: 20px;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  input.sheet-trauma-check + span {
+    border: solid thin #a7a7a7;
+    text-align: center;
+    display: inline-block;
+
+    background: white;
+    color: #000000;
+
+    width: 80px;
+    height: 20px;
+    line-height: 22px;
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  input.sheet-trauma-check:checked + span {
+    color: #ff0000;
+  }
+
+  .sheet-trauma-container {
+      position: relative;
+      /* This allows us to absolutely position within each of the column
+      containers so that we can overlap the checkbox and the span. */
+      width: 80px;
+      margin-left: 10px;
+      margin-right: 10px;
+  }
+
+  input.sheet-trauma-check,
+  input.sheet-trauma-check + span {
+      position: absolute;
+      left: 0;
+  }
+
+  /* Other Options */
+  input.sheet-check,
+  input.sheet-check-first {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    z-index: 3;
+    opacity: 1;
     position: relative;
-}
+    opacity: 0;
+  }
 
-input.sheet-claim-claimed1,
-input.sheet-claim-claimed2,
-input.sheet-claim-claimed3,
-input.sheet-claim-claimed4,
-input.sheet-claim-claimed5 {
-  position: absolute;
-}
+  input.sheet-check + span,
+  input.sheet-check-first + span {
+    display: inline-block;
+    background: #ffffff;
+    background: white;
+    width: 16px;
+    height: 16px;
+    position: relative;
+    left: -16px;
+    top: 5px;
+    z-index: 1;
+    border: solid thin #000000;
+  }
 
-input.sheet-claim-claimed1 {left: 166px;}
-input.sheet-claim-claimed2 {left: 319px;}
-input.sheet-claim-claimed3 {left: 473px;}
-input.sheet-claim-claimed4 {left: 626px;}
-input.sheet-claim-claimed5 {left: 779px;}
+  input.sheet-check,
+  input.sheet-friend-info,
+  input.sheet-item-info,
+  input.sheet-crew-ability-name,
+  input.sheet-crew-upgrade-info,
+  input.sheet-contact-friend-info
+  {
+    margin-left: -16px;
+  }
 
-.sheet-claimsection { margin-bottom: -70px;}
-.sheet-claims-checks1 { position: relative; top: -171px; }
-.sheet-claims-checks2 { position: relative; top: -91px; }
-.sheet-claims-checks3 { position: relative; top: -9px; }
+  .sheet-check-last + span {
+      margin-right: -16px;
+  }
+
+  input.sheet-check:checked + span,
+  input.sheet-check-first:checked + span {
+    background: black;
+  }
+
+  input.sheet-friend + span {
+    border: solid thin #007700;
+  }
+
+  input.sheet-rival + span {
+    border: solid thin #770000;
+  }
+
+  input.sheet-friend:checked + span {
+    background: #007700;
+  }
+
+  input.sheet-rival:checked + span {
+    background: #770000;
+  }
+
+  input[type=checkbox].sheet-item-onebox {
+      /* Extra indentation so that we align nicely with the two-box and three-box
+      items below*/
+      margin-left: 42px;
+  }
+
+  input[type=checkbox].sheet-item-twobox {
+      /* Extra indentation so that we align nicely with the two-box and three-box
+      items below*/
+      margin-left: 21px;
+  }
+
+  input.sheet-item-info {
+      width: 155px;
+      margin-right: 15px;
+  }
+
+  .sheet-turfrow {
+    margin-bottom: -13px;
+  }
+
+  .sheet-turfrow-outer {
+    margin: auto;
+  }
+
+  label.sheet-turf-label, label.sheet-rep-label {
+    width: 25px;
+  }
+
+  label.sheet-wanted-label, label.sheet-coin-label {
+    width: 40px;
+    text-align: right;
+    margin-left: -20px;
+    margin-right: -10px;
+  }
+
+  label.sheet-heat-label, label.sheet-vault-label {
+    width: 40px;
+    text-align: right;
+    margin-left: 6px;
+    margin-right: -27px;
+  }
+
+  input.sheet-vault2.sheet-leftradio.sheet-zero {
+    margin-left: -18px;
+  }
+
+  label.sheet-tier-label, label.sheet-hold-label {
+    width: 20px;
+    text-align: right;
+    margin-left: 6px;
+    margin-right: -13px;
+  }
+
+  input[type=checkbox].sheet-turf:checked + span {
+    background: darkred;
+    height: 36px;
+    position: relative;
+    top: 26px;
+    margin-top: -27px;
+    z-index: 2;
+  }
+
+  /* Character Tab */
+  h1 {
+    text-align: center;
+  }
+
+  .sheet-version {
+    text-align: left;
+    font-size: 10px;
+  }
+
+  label {
+    line-height: 25px;
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  label.sheet-alias, label.sheet-background {
+    margin-left: 10px;
+  }
+
+  input.sheet-name, input.sheet-alias {
+    width: 350px;
+  }
+
+  input.sheet-look {
+    margin-left: 5px;
+    width: 771px;
+  }
+
+  input.sheet-heritage, input.sheet-background {
+    width: 312px;
+  }
+
+  input.sheet-vice {
+    width: 699px;
+  }
+
+  label.sheet-trauma {
+    margin-left: 25px;
+  }
+
+  input.sheet-stress, input.sheet-trauma, input.sheet-stash,
+  input.sheet-insight, input.sheet-prowess, input.sheet-resolve {
+    width: 25px;
+    text-align: center;
+    font-size: 16px;
+  }
+
+  h3 {
+    text-align: center;
+  }
+
+  h5 {
+    line-height: 27px;
+  }
+
+  .sheet-harm-full {
+    width: 424px;
+  }
+
+  label.sheet-armor, input.sheet-spec, label.sheet-coin,
+  label.sheet-stash {
+    margin-left: 35px;
+  }
+
+  label.sheet-heavy {
+    margin-left: 18px;
+  }
+
+  input.sheet-spec {
+    width: 175px;
+  }
+
+  /* Playbook Tab */
+  input.sheet-ability-name {
+    width: 125px;
+    text-align: center;
+    font-weight: bold;
+    margin-left: -16px;
+  }
+
+  input.sheet-ability-info {
+    width: 292px;
+  }
+
+  input.sheet-xp-goal {
+    width: 416px;
+  }
+
+  .sheet-xp-conditions {
+    width: 440px;
+  }
+  .sheet-actions {
+    margin-left: 35px;
+  }
+
+  h4 {
+    line-height: 27px;
+  }
+
+  .sheet-actions-hr {
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+
+  input.sheet-insight {
+    margin-left: 175px;
+  }
+
+  input.sheet-prowess {
+    margin-left: 159px;
+  }
+
+  input.sheet-resolve {
+    margin-left: 164px;
+  }
+
+  .sheet-secondary-actions {
+    margin-left: 35px;
+  }
+
+  .sheet-insight-actions {
+    margin-left: 33px;
+  }
+
+  .sheet-prowess-actions {
+    margin-left: 20px;
+  }
+
+  .sheet-resolve-actions {
+    margin-left: 10px;
+  }
+
+  .sheet-loads {
+    margin-left: 10px;
+  }
+
+  input.sheet-carry {
+    margin-left: 10px;
+  }
+
+  input.sheet-carry + span {
+    margin-right: -16px;
+  }
+
+  .sheet-bandolier {
+    margin-left: 15px;
+  }
+
+  .sheet-clock4desc,
+  .sheet-clock6desc {
+    width: 280px;
+    margin-right: -16px;
+    margin-bottom: 30px;
+  }
+
+  .sheet-clockcol {
+    margin-right: 25px;
+  }
 
 
-/* Roll template */
+  input.sheet-clockdesc {
+    width: 280px;
+  }
 
-.sheet-rolltemplate-bitd table {
-    width: 240px;
-    padding: 2px;
-    border: 1px solid;
-    background: url(https://i.imgur.com/DCcJ8p2.jpg);
-    background-size: 240px;
-    background-repeat: no-repeat;
+  .sheet-clock4tick {
+    width: 100px;
+  }
+
+  .sheet-clock6tick {
+    width: 150px;
+  }
+
+  .sheet-clock4tick hr,
+  .sheet-clock6tick hr {
+    opacity: 0;
+    margin: 0;
+  }
+
+  .repeating_4clocks,
+  .repeating_8clocks {
+    margin-right: 20px;
+  }
+
+
+  /* Crew Sheet Field Layout And Formatting */
+  input.sheet-crew-name, input.sheet-crew-reputation {
+    width: 330px;
+  }
+
+  input.sheet-crew-lair {
+    width: 782px;
+  }
+
+
+  /* Claims Map */
+
+  .sheet-map-row-claims {
+      margin-left: 51px;
+      width: 745px;
+      min-width: 745px;
+      max-width: 745px;
+  }
+
+  .sheet-map-row-claims textarea {
+      width: 130px;
+      height: 60px;
+      margin: 0px;
+      padding: 0px;
+      background: #cccccc;
+      z-index: 0;
+      position: relative;
+      resize: none;
+  }
+
+  .sheet-map-claim, .sheet-map-connector {
+      display: inline-block;
+      vertical-align: middle;
+      text-align: center;
+        margin: -3px;
+  }
+
+  .sheet-connector-row {
+    margin-bottom: -20px;
+    margin-left: 48px;
+    width: 762px;
+    min-width: 762px;
+    max-width: 762px;
+  }
+
+
+
+  /* Hide right-connector checkbox */
+  input.sheet-connector-check[type="checkbox"]
+  {
+      opacity: 0;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      top: -2px;
+      left: 15px;
+      margin: -10px;
+      cursor: pointer;
+      z-index: 2;
+  }
+
+  /* Hide right-connector when unchecked */
+  input.sheet-connector-check[type="checkbox"] + span::before
+  {
+      opacity: 0;
+      display: inline-block;
+      width: 30px;
+      height: 20px;    
+      content: "";
+  }
+
+  /* Show right-connector when checked */
+  input.sheet-connector-check[type="checkbox"]:checked + span::before
+  {
+      opacity: 1;
+      content: "";
+      width: 30px;
+      height: 20px;
+      background: #cccccc;
+      z-index: -1;
+      border: 1px 0px 1px 0px;
+      position: relative;
+      left: -1px;
+  }
+
+  /* Row for the down-connectors */
+  .sheet-down-connector {
+    width: 132px;
+    display: inline-block;
+    margin-right: 17px;
+    margin-left: 0px;
+    height: 30px;
+    text-align:center;
+  }
+
+  .sheet-notfirstrow {
+    margin-top: 15px;
+  }
+
+
+  /* Hide down-connector checkbox */
+  input.sheet-down-connector-check[type="checkbox"]
+  {
+      opacity: 0;
+      position: relative;
+      cursor: pointer;
+      z-index: 2;
+      width: 16px;
+      height: 36px;
+      top: -12px;
+      left: 8px;
+
+  }
+
+
+  /* Hide down-connector when unchecked */
+  input.sheet-down-connector-check[type="checkbox"] + span::before
+  {
+      opacity: 0;
+      display: inline-block;
+      content: "";
+      background: green;
+      position: relative;
+      z-index: 1;
+      width: 16px;
+      height: 26px;
+      top: 1px;
+      left: -8px;
+  }
+
+
+  /* Show down-connector when checked */
+  input.sheet-down-connector-check[type="checkbox"]:checked + span::before
+  {
+      opacity: 1;
+      display: inline-block;
+      content: "";
+      background: #cccccc;
+      position: relative;
+      z-index: 1;
+      width: 16px;
+      height: 26px;
+      top: 0px;
+      left: -8px;
+  }
+
+  /* Left-fillable radio buttons - Hide actual radio */
+  input.sheet-leftradio[type="radio"]
+  {
+      opacity: 0;
+      width: 16px;
+      height: 16px;
+      position: relative;
+      top: -2px;
+      left: 8px;
+      margin: -9px;
+      cursor: pointer;
+      z-index: 1;
+  }
+
+  /* Show fake radio buttons for left-fillable */
+  input.sheet-leftradio[type="radio"] + span::before
+  {
+      width: 16px;
+      height: 16px;
+      content: "";
+      display: inline-block;
+      border: solid thin #000000;
+      background: #000000;
+      position: relative;
+      top: 5px;
+  }
+
+  input.sheet-leftradiolast[type="radio"] + span::before {
+    margin-right: 0px;
+  }
+
+  /* Remove dot from all radios _after_ selected one */
+  /* Ensure that your radio groups are encapsulated in a div, otherwise they will interfere with each other */
+  input.sheet-leftradio[type="radio"]:checked ~ input.sheet-leftradio[type="radio"] + span::before
+  {    
+      content: "";
+      background: #ffffff;
+  }
+
+
+  /* Empty radio - used for clearing the line*/
+  input.sheet-zero:checked + span::before
+  {
+      opacity: 0;
+  }
+
+  input.sheet-zero:hover + span::before
+  {
+      opacity: 0.25;
+      font-size: 12px;
+      content: "✖";
+      text-indent: 0.5px;
+      position:relative;
+      top: 2px;
+  }
+
+  input.sheet-zero + span::before
+  {
+      opacity: 0;
+      position: relative;
+      top: 5px;
+  }
+
+  input[type=radio].sheet-radioindent {
+    margin-left: 11px;
+  }
+
+  /* Crew Upgrades */
+  .sheet-lair-upgrade-info, .sheet-quality-upgrade-info {
+      width: 170px;
+  }
+
+  .sheet-crew-upgrade-info {
+      width: 160px;
+      margin-right: 13px;
+  }
+
+  .sheet-linkedbox + span::after {
+    content: "-";
+    line-height: 24px;
+    position: relative;
+    left: 16px;
+    font-size: 15px;
+    top: -4px;
+  }
+
+  .sheet-crew-ability-name {
+      width: 125px;
+  }
+
+  .sheet-crew-ability-info {
+      width: 680px;
+  }
+
+  .sheet-advancement-descr {
+      width: 335px;
+  }
+
+  .sheet-contact-friend-info, .sheet-friend-info {
+      width: 155px;
+      margin-right: 15px;
+  }
+
+  textarea.sheet-cohort-notes {
+    width: 200px;
+    height: 50px;
+  }
+
+  .sheet-cohort-label, .sheet-crew-advancement-label {
+    display: inline;
+    margin-right: -11px;
+  }
+
+  select.sheet-cohort-health {
+    width: 100px;
+  }
+
+  .sheet-freejob textarea, .repeating_freejob textarea {
+    width: 330px;
+    height: 50px;
+  }
+
+  .sheet-freejob-name {
+    width: 194px;
+  }
+
+  .sheet-freejobs {
+    width: 340px;
+    margin-bottom: 10px;
+    margin-right: 20px;
+  }
+
+  .sheet-faction-section {
+    margin: 30px;
+  }
+
+  select.sheet-faction-status, 
+  select.sheet-faction-tier, 
+  select.sheet-faction-hold {
+      width: 45px;
+  }
+
+
+  .sheet-war-description {
+    width: 350px;
+  }
+
+  input.sheet-knifeimg[type="radio"] {
+      opacity: 1;
+      z-index: 1;
+  }
+
+
+  .sheet-claim-checkboxes {
+      position: relative;
+  }
+
+  input.sheet-claim-claimed1,
+  input.sheet-claim-claimed2,
+  input.sheet-claim-claimed3,
+  input.sheet-claim-claimed4,
+  input.sheet-claim-claimed5 {
+    position: absolute;
+  }
+
+  input.sheet-claim-claimed1 {left: 166px;}
+  input.sheet-claim-claimed2 {left: 319px;}
+  input.sheet-claim-claimed3 {left: 473px;}
+  input.sheet-claim-claimed4 {left: 626px;}
+  input.sheet-claim-claimed5 {left: 779px;}
+
+  .sheet-claimsection { margin-bottom: -70px;}
+  .sheet-claims-checks1 { position: relative; top: -171px; }
+  .sheet-claims-checks2 { position: relative; top: -91px; }
+  .sheet-claims-checks3 { position: relative; top: -9px; }
+
+
+  /* Roll template */
+
+  .sheet-rolltemplate-bitd table {
+      width: 240px;
+      padding: 2px;
+      border: 1px solid;
+      background: url(https://i.imgur.com/DCcJ8p2.jpg);
+      background-size: 240px;
+      background-repeat: no-repeat;
+      font-family: "Times New Roman", Times, serif;
+      min-height: 85px;
+  }
+   
+  .sheet-rolltemplate-bitd th {
+    color: darkred;
+    padding-left: 5px;
+    line-height: 1.6em;
+    font-size: 1.2em;
+    text-align: left;
     font-family: "Times New Roman", Times, serif;
-    min-height: 85px;
-}
- 
-.sheet-rolltemplate-bitd th {
-  color: darkred;
-  padding-left: 5px;
-  line-height: 1.6em;
-  font-size: 1.2em;
-  text-align: left;
-  font-family: "Times New Roman", Times, serif;
-  font-variant: small-caps;
-  width: 180px;
-}
- 
-.sheet-rolltemplate-bitd .sheet-subheader {
-  color: black;
-  font-size: 1.5em;
-  font-style: bold;
-  font-family: "Times New Roman", Times, serif;
-}
- 
-.sheet-rolltemplate-bitd td {
-  padding-left: 5px;
-  font-family: "Times New Roman", Times, serif;
-}
+    font-variant: small-caps;
+    width: 180px;
+  }
+   
+  .sheet-rolltemplate-bitd .sheet-subheader {
+    color: black;
+    font-size: 1.5em;
+    font-style: bold;
+    font-family: "Times New Roman", Times, serif;
+  }
+   
+  .sheet-rolltemplate-bitd td {
+    padding-left: 5px;
+    font-family: "Times New Roman", Times, serif;
+  }
 
-.sheet-rolltemplate-bitd .sheet-result {
-  font-size: 3em;
-  vertical-align: center;
-  text-align: center;
-  font-family: "Times New Roman", Times, serif;
-}
+  .sheet-rolltemplate-bitd .sheet-result {
+    font-size: 3em;
+    vertical-align: center;
+    text-align: center;
+    font-family: "Times New Roman", Times, serif;
+  }

--- a/Blades-in-the-Dark/blades.css
+++ b/Blades-in-the-Dark/blades.css
@@ -1,3 +1,5 @@
+/* Blades in the Dark CSS v0.0.9 */
+
 /* Header Formatting */
 .sheet-gametitleimg {float: left; }
 .sheet-alignright {text-align: right; }
@@ -189,25 +191,6 @@ input[type=checkbox].sheet-check-first:checked + span {
   background: black;
 }
 
-input.sheet-armor:before, input.sheet-cohort-armor:before , input.sheet-coin:before,
-input.sheet-recovery:before, input.sheet-ability:before,
-input.sheet-friend:before, input.sheet-rival:before,
-input.sheet-item:before, input.sheet-carry:before, 
-input.sheet-turf:before, input.sheet-rep:before, input.sheet-clock:before {
-  content: "";
-  display: inline-block;
-  background: #ffffff;
-  width: 15px;
-  height: 15px;
-}
-
-input.sheet-armor:before, input.sheet-cohort-armor:before , input.sheet-coin:before,
-input.sheet-recovery:before, input.sheet-ability:before,
-input.sheet-item:before, input.sheet-carry:before, 
-input.sheet-turf:before, input.sheet-rep:before, input.sheet-clock:before {
-border: solid thin #000000;
-}
-
 input[type=checkbox].sheet-friend + span {
   border: solid thin #007700;
 }
@@ -222,10 +205,6 @@ input[type=checkbox].sheet-friend:checked + span {
 
 .sheet-clock-col {
  width: 350px;
-}
-
-input.sheet-friend:checked::before {
-  background: #007700;
 }
 
 input[type=checkbox].sheet-rival:checked + span {
@@ -280,6 +259,15 @@ label.sheet-tier-label, label.sheet-hold-label {
   text-align: right;
   margin-left: 6px;
   margin-right: -13px;
+}
+
+input[type=checkbox].sheet-turf:checked + span {
+  background: darkred;
+  height: 38px;
+  position: relative;
+  top: 27px;
+  margin-top: -23px;
+  z-index: 1;
 }
 
 /* Character Tab */

--- a/Blades-in-the-Dark/blades.css
+++ b/Blades-in-the-Dark/blades.css
@@ -415,10 +415,6 @@
     margin-right: -16px;
   }
 
-  .sheet-bandolier {
-    margin-left: 15px;
-  }
-
   .sheet-clock4desc,
   .sheet-clock6desc {
     width: 280px;
@@ -602,7 +598,7 @@
   }
 
   /* Left-fillable radio buttons - Hide actual radio */
-  input.sheet-leftradio[type="radio"]
+  input.sheet-leftradio
   {
       opacity: 0;
       width: 16px;
@@ -616,7 +612,7 @@
   }
 
   /* Show fake radio buttons for left-fillable */
-  input.sheet-leftradio[type="radio"] + span::before
+  input.sheet-leftradio + span::before
   {
       width: 16px;
       height: 16px;
@@ -666,6 +662,14 @@
 
   input[type=radio].sheet-radioindent {
     margin-left: 11px;
+  }
+
+  input.sheet-bandolier {
+    margin-left: -27px;
+  }
+
+  .sheet-bandoliers {
+    display: inline-block;
   }
 
   /* Crew Upgrades */

--- a/Blades-in-the-Dark/blades.css
+++ b/Blades-in-the-Dark/blades.css
@@ -263,7 +263,7 @@ input[type=checkbox].sheet-turf:checked + span {
   position: relative;
   top: 27px;
   margin-top: -23px;
-  z-index: 1;
+  z-index: 3;
 }
 
 /* Character Tab */
@@ -465,7 +465,9 @@ input.sheet-crew-lair {
 
 .sheet-map-row-claims {
     margin-left: 51px;
-    width: 740px;
+    width: 742px;
+    min-width: 742px;
+    max-width: 742px;
 }
 
 .sheet-map-row-claims textarea {
@@ -489,7 +491,9 @@ input.sheet-crew-lair {
 .sheet-connector-row {
   margin-bottom: -20px;
   margin-left: 48px;
-  width: 760px;
+  width: 762px;
+  min-width: 762px;
+  max-width: 762px;
 }
 
 

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -595,16 +595,22 @@
 
             <div class="sheet-row">
               <div class="sheet-col"><h4>Bandolier</h4></div>
-              <input type="checkbox" name="attr_bandolier1_1" class="sheet-item sheet-check-first"><span></span>
-              <input type="checkbox" name="attr_bandolier1_2" class="sheet-item sheet-check"><span></span>
-              <input type="checkbox" name="attr_bandolier1_3" class="sheet-item sheet-check"><span></span>
-              <input type="checkbox" name="attr_bandolier1_4" class="sheet-item sheet-check"><span></span>
+              <div class="sheet-bandoliers">
+              <input type="radio" name="attr_bandolier1" value=0 class="sheet-item sheet-clock sheet-leftradio sheet-zero sheet-bandolier" checked="checked"><span></span>
+              <input type="radio" name="attr_bandolier1" value=1 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier1" value=2 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier1" value=3 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier1" value=4 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              </div>
 
-              <div class="sheet-col sheet-bandolier"><h4>Bandolier</h4></div>
-              <input type="checkbox" name="attr_bandolier2_1" class="sheet-item sheet-check-first"><span></span>
-              <input type="checkbox" name="attr_bandolier2_2" class="sheet-item sheet-check"><span></span>
-              <input type="checkbox" name="attr_bandolier2_3" class="sheet-item sheet-check"><span></span>
-              <input type="checkbox" name="attr_bandolier2_4" class="sheet-item sheet-check"><span></span>
+              <div class="sheet-col"><h4>Bandolier</h4></div>
+              <div class="sheet-bandoliers">
+              <input type="radio" name="attr_bandolier2" value=0 class="sheet-item sheet-clock sheet-leftradio sheet-zero sheet-bandolier" checked="checked"><span></span>
+              <input type="radio" name="attr_bandolier2" value=1 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier2" value=2 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier2" value=3 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              <input type="radio" name="attr_bandolier2" value=4 class="sheet-item sheet-clock sheet-leftradio"><span></span>
+              </div>
             </div>
 
             <div class="sheet-row">

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -188,10 +188,11 @@
       <!--Coin-->
       <div class="sheet-row">
         <div class="sheet-col"><label for="attr_coin" class="sheet-coin">Coin:</label></div>
-        <input type="checkbox" name="attr_coin1" class="sheet-coin sheet-check-first"><span></span>
-        <input type="checkbox" name="attr_coin2" class="sheet-coin sheet-check"><span></span>
-        <input type="checkbox" name="attr_coin3" class="sheet-coin sheet-check"><span></span>
-        <input type="checkbox" name="attr_coin4" class="sheet-coin sheet-check"><span></span>
+        <input type="radio" name="attr_coin" value=0 class="sheet-coin sheet-clock sheet-leftradio sheet-zero" checked="checked"><span></span>
+        <input type="radio" name="attr_coin" value=1 class="sheet-coin sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_coin" value=2 class="sheet-coin sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_coin" value=3 class="sheet-coin sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_coin" value=4 class="sheet-coin sheet-clock sheet-leftradio"><span></span>
       </div>
 
       <!--Stash-->

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -147,14 +147,15 @@
       <!--Recovery-->
       <div class="sheet-row">
         <div class="sheet-col"><label for="attr_recovery" class="sheet-recovery">Recovery:</label></div>
-        <input type="checkbox" name="attr_recovery1" class="sheet-recovery sheet-check-first"><span></span>
-        <input type="checkbox" name="attr_recovery2" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery3" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery4" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery5" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery6" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery7" class="sheet-recovery sheet-check"><span></span>
-        <input type="checkbox" name="attr_recovery8" class="sheet-recovery sheet-check"><span></span>
+        <input type="radio" name="attr_recovery" value=0 class="sheet-recovery sheet-clock sheet-leftradio sheet-zero" checked="checked"><span></span>
+        <input type="radio" name="attr_recovery" value=1 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=2 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=3 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=4 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=5 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=6 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=7 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
+        <input type="radio" name="attr_recovery" value=8 class="sheet-recovery sheet-clock sheet-leftradio"><span></span>
       </div>
     </div>
 

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -513,21 +513,21 @@
             </div>
 
             <div class="sheet-row">
-              <input type="checkbox" name="attr_friend1" class="sheet-friend sheet-check-first"><span></span>
-              <input type="checkbox" name="attr_rival1" class="sheet-rival sheet-check"><span></span>
+              <input type="radio" name="attr_friend1" class="sheet-friend sheet-check-first"><span></span>
+              <input type="radio" name="attr_friend1" class="sheet-rival sheet-check"><span></span>
               <input type="text" name="attr_friend_info1" class="sheet-friend-info">
             </div>
 
             <div class="sheet-row">
-              <input type="checkbox" name="attr_friend2" class="sheet-friend sheet-check-first"><span></span>
-              <input type="checkbox" name="attr_rival2" class="sheet-rival sheet-check"><span></span>
+              <input type="radio" name="attr_friend2" class="sheet-friend sheet-check-first"><span></span>
+              <input type="radio" name="attr_friend2" class="sheet-rival sheet-check"><span></span>
               <input type="text" name="attr_friend_info2" class="sheet-friend-info">
             </div>
 
             <fieldset class="repeating_friend">
               <div class="sheet-row">
-                <input type="checkbox" name="attr_friend" class="sheet-friend sheet-check-first"><span></span>
-                <input type="checkbox" name="attr_rival" class="sheet-rival sheet-check"><span></span>
+                <input type="radio" name="attr_friend" class="sheet-friend sheet-check-first"><span></span>
+                <input type="radio" name="attr_friend" class="sheet-rival sheet-check"><span></span>
                 <input type="text" name="attr_friend_info" class="sheet-friend-info">
               </div>
             </fieldset>
@@ -577,11 +577,11 @@
 
             <div class="sheet-row sheet-load">
               <div class="sheet-col"><h3>Load</h3></div>
-              <input type="checkbox" name="attr_load_light" class="sheet-carry sheet-check-first"><span></span>
+              <input type="radio" name="attr_load" value="3" class="sheet-carry sheet-check-first"><span></span>
               <div class="sheet-col"><h4>3 light</h4></div>
-              <input type="checkbox" name="attr_load_normal" class="sheet-carry sheet-check-first"><span></span>
+              <input type="radio" name="attr_load" value="5" class="sheet-carry sheet-check-first"><span></span>
               <div class="sheet-col"><h4>5 normal</h4></div>
-              <input type="checkbox" name="attr_load_heavy" class="sheet-carry sheet-check-first"><span></span>
+              <input type="radio" name="attr_load" value="6" class="sheet-carry sheet-check-first"><span></span>
               <div class="sheet-col"><h4>6 heavy</h4></div>
             </div>
 
@@ -1338,8 +1338,8 @@
         </div>
 
         <div class="sheet-row">
-          <input type="checkbox" name="attr_contact_friend1" class="sheet-friend sheet-check-first"><span></span>
-          <input type="checkbox" name="attr_contact_rival1" class="sheet-rival sheet-check"><span></span>
+          <input type="radio" name="attr_contact_friend1" class="sheet-friend sheet-check-first"><span></span>
+          <input type="radio" name="attr_contact_friend1" class="sheet-rival sheet-check"><span></span>
           <input type="text" name="attr_contact_friend_info1" class="sheet-contact-friend-info">
 
         </div>
@@ -1347,8 +1347,8 @@
         <div class="sheet-row">
           <fieldset class="repeating_contact">
             <div class="sheet-row">
-              <input type="checkbox" name="attr_contact_friend" class="sheet-friend sheet-check-first"><span></span>
-              <input type="checkbox" name="attr_contact_rival" class="sheet-rival sheet-check"><span></span>
+              <input type="radio" name="attr_contact_friend" class="sheet-friend sheet-check-first"><span></span>
+              <input type="radio" name="attr_contact_friend" class="sheet-rival sheet-check"><span></span>
               <input type="text" name="attr_contact_friend_info" class="sheet-contact-friend-info">
             </div>
           </fieldset>

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -1,6 +1,6 @@
 <!--Title & Version-->
 <h1 class="sheet-gametitleimg"><img src="http://i.imgur.com/8BlXrMx.png" alt="Blades in the Dark"></h1>
-<div class="sheet-alignright">Version 0.0.8</div>
+<div class="sheet-alignright">Version 0.0.9</div>
 <input type="checkbox" name="attr_sheet_type"class="sheet-typeselector" value="1"><span></span>
 <hr>
 

--- a/Blades-in-the-Dark/blades.html
+++ b/Blades-in-the-Dark/blades.html
@@ -682,22 +682,29 @@
   
   <!--Clocks Tab-->
   <div class="sheet-tab-content sheet-tab-clocks">
-    <div class="sheet-2colrow">
-        <div class="sheet-col">
+    <div class="sheet-row">
+        <div class="sheet-col sheet-clockcol">
             <h3>4 Clocks</h3>
             <fieldset class="repeating_4clocks">
-                <input type="text" name="attr_4_clockdesc"/>
+              <div class="sheet-col sheet-clock4desc">
+                <input type="text" name="attr_4_clockdesc" class="sheet-clockdesc" />
+              </div>
+              <div class="sheet-col sheet-clock4tick">
                 <input type="radio" class="sheet-clock sheet-leftradio sheet-zero" name="attr_4_clock" value="0" checked="checked" /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_4_clock" value=1 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_4_clock" value=2 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_4_clock" value=3 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_4_clock" value=4 /><span></span>
+              </div>
             </fieldset>
         </div>
          <div class="sheet-col">
             <h3>6 Clocks</h3>
             <fieldset class="repeating_6clocks">
-                <input type="text" name="attr_6_clockdesc"/>
+              <div class="sheet-col sheet-clock6desc">
+                <input type="text" name="attr_6_clockdesc" class="sheet-clockdesc" />
+              </div>
+              <div class="sheet-col sheet-clock6tick">
                 <input type="radio" class="sheet-clock sheet-leftradio sheet-zero" name="attr_6_clock" value="0" checked="checked" /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_6_clock" value=1 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_6_clock" value=2 /><span></span>
@@ -705,32 +712,38 @@
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_6_clock" value=4 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_6_clock" value=5 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_6_clock" value=6 /><span></span>
+              </div>
             </fieldset>
         </div>
     </div>
-    <div class="sheet-2colrow">
-         <div class="sheet-col">
+    <div class="sheet-row">
+         <div class="sheet-col sheet-clockcol">
             <h3>8 Clocks</h3>
             <fieldset class="repeating_8clocks">
-                <input type="text" name="attr_8_clockdesc"/>
+              <div class="sheet-col sheet-clock4desc">
+                <input type="text" name="attr_8_clockdesc" class="sheet-clockdesc" />
+              </div>
+              <div class="sheet-col sheet-clock4tick">
                 <input type="radio" class="sheet-clock sheet-leftradio sheet-zero" name="attr_8_clock" value="0" checked="checked" /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=1 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=2 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=3 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=4 /><span></span>
-                <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=5 /><span></span>
+                <hr />
+                <input type="radio" class="sheet-clock sheet-leftradio sheet-radioindent" name="attr_8_clock" value=5 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=6 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=7 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_8_clock" value=8 /><span></span>
+              </div>
             </fieldset>
         </div>
          <div class="sheet-col">
             <h3>12 Clocks</h3>
             <fieldset class="repeating_12clocks">
-              <div class="sheet-col">
-                <input type="text" name="attr_12_clockdesc"/>
+              <div class="sheet-col sheet-clock6desc">
+                <input type="text" name="attr_12_clockdesc" class="sheet-clockdesc"/>
               </div>
-              <div class="sheet-col">
+              <div class="sheet-col sheet-clock6tick">
                 <input type="radio" class="sheet-clock sheet-leftradio sheet-zero" name="attr_12_clock" value="0" checked="checked" /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=1 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=2 /><span></span>
@@ -738,7 +751,7 @@
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=4 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=5 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=6 /><span></span>
-                <br />
+                <hr />
                 <input type="radio" class="sheet-clock sheet-leftradio sheet-radioindent" name="attr_12_clock" value=7 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=8 /><span></span>
                 <input type="radio" class="sheet-clock sheet-leftradio" name="attr_12_clock" value=9 /><span></span>
@@ -750,7 +763,6 @@
         </div>
     </div>
   </div> <!--End Clocks Tab-->
-  
 </div>
 
 <!-- Crew Sheet -->
@@ -1588,8 +1600,6 @@
     </div>
 
   </div>
-
-
 </div>
 
 <!--  Template Example

--- a/Blades-in-the-Dark/sheet.json
+++ b/Blades-in-the-Dark/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Stephen Malone, Flamewolf, Matthew Harris Glover, Phalanks",
 	"roll20userid": "552705,477370,299095,843545",
 	"preview": "blades.png",
-	"instructions": "*The Insight, Prowess, and Resolve rolls are for resistance rolls. The result shown is 6 minus the corresponding attribute rating.\r*If the total dice pool for a roll is less than or equal to 0, then the roll automatically rolls 2d6 and shows the lowest roll."
+	"instructions": "*Use the Character/Crew selector in the upper right to switch between character sheet modes.\r*The Insight, Prowess, and Resolve rolls are for resistance rolls. The result shown is 6 minus the corresponding attribute rating.\r*If the total dice pool for a roll is less than or equal to 0, then the roll automatically rolls 2d6 and shows the lowest roll.\r*The Indulge Vice roll will choose the correct (ie lowest) resistance roll and will roll that value.  If that value is zero, it will roll 2d6 and show the lowest result."
 }


### PR DESCRIPTION
### 0.0.9
* Added display formatting for Turf to overlay on Rep nicely.
* Converted some checkboxes to radios
   -Friends
   -Contacts
   -Load (left-fillable track)
   -Recovery (left-fillable track)
   -Bandoliers (left-fillable track)
* Improved layout for Clock tab
* Bugfixes
    - Windows Chrome no longer wraps the Crew claims map badly