### PR TITLE
Nightshade Academy - Remove deprecated skills section

### DIFF
--- a/Nightshade Academy/nightshade.html
+++ b/Nightshade Academy/nightshade.html
@@ -176,21 +176,3 @@
 </div> <!-- .section-consequences -->
 
 <div class="sheet-break"></div>
-
-<div class="sheet-section-skills sheet-section sheet-half">
-	<div class="sheet-header">Skills (Deprecated)</div>
-	Transfer information to the other Skills section. This section will be removed later.
-	<fieldset class="repeating_skills">
-		<select class="sheet-skill-rating" name="attr_rating">
-			<option value="-1">Poor</option>
-			<option value="0">Average</option>
-			<option value="1">Good</option>
-			<option value="2">Great</option>
-			<option value="3">Epic</option>
-			<option value="4">Legendary</option>
-		</select>
-		<input class="sheet-skill-name" type="text" name="attr_skillname" />
-		<button type="roll" value="&{template:default} {{name=@{skillname}}} {{roll=[[4dF+@{rating}]]}}"></button>
-	</fieldset>
-</div> <!-- .section-skills -->
-<div class="sheet-break"></div>


### PR DESCRIPTION
Remove a skills section of the char sheet that has been replaced by a more usable UI and has been marked as deprecated with a warning not to use it since March.