### PR TITLE
Pathfinder v.63

### DIFF
--- a/Pathfinder-Neceros/pathfinder-neceros.css
+++ b/Pathfinder-Neceros/pathfinder-neceros.css
@@ -1595,7 +1595,7 @@ input[type="number"].sheet-entry-wide {
 .sheet-options-show:not(:checked)~.sheet-options,
 .sheet-misc-show:not(:checked)~.sheet-misc,
 .sheet-extra-damage-show:not(:checked) ~ .sheet-extra-damage,
-.sheet-iterations-show:checked ~ .sheet-iterative_attack_section,
+.sheet-iterations-show:not(:checked) ~ .sheet-iterative_attack_section,
 .sheet-ack-button:checked ~ .sheet-announcements,
 .sheet-id-show:not(:checked) ~ .sheet-repeating-id,
 .sheet-mythic-show:not(:checked)  ~ .sheet-section-mythic,

--- a/Pathfinder-Neceros/pathfinder-neceros.html
+++ b/Pathfinder-Neceros/pathfinder-neceros.html
@@ -8,6 +8,7 @@
 <label class="sheet-showsect" data-i18n-title="show-announcements" data-i18n="announcements">Announcements</label>
 <input style="float:right;" type="checkbox" name="attr_expandall" aria-label="Expand All" data-i18n-aria-label="expand-all" aria-describedby="Acts like a button. Expands all areas and then resets."  value="1" tabindex="0"/>
 <label style="float:right;margin-right:.5em;margin-left:1em;" data-i18n="expand-all" >Expand All</label>
+
 <div role="contentinfo" aria-label="Announces changes to sheet" data-i18n-aria-label="announcements" class="sheet-announcements sheet-selectable" >
 	<div class="sheet-footer" style="text-align:left; padding:5px; margin:5px;">
 		<h2 style="font-weight:bold;"><span data-i18n="announcements">Announcements</span> 0.62:</h2>
@@ -1005,9 +1006,9 @@
 		<h2 class="sheet-clickheader sheet-showsect"><label   title="Click to expand" data-i18n-title="showsect-cmd" data-i18n="abilities">Abilities</label></h2>
 		<div class="sheet-h2-section sheet-abilities">
 			<div role="menubar" class="sheet-abilitiesnav sheet-tabs" aria-label="Abilities" data-i18n-aria-label="abilities"  ></div>
-			<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_abilities_tab" value="0"  data-i18n-title="class-features" data-i18n-aria-label="class-features"/>
+			<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_abilities_tab" value="0"  data-i18n-title="class-features" data-i18n-aria-label="class-features" checked="checked"/>
 			<label role="menuitem" class="sheet-tab sheet-tab0"   data-i18n-title="class-features" data-i18n="class-features">Class Features</label>
-			<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_abilities_tab" value="1"  data-i18n-title="feats" data-i18n-aria-label="feats" checked="checked" />
+			<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_abilities_tab" value="1"  data-i18n-title="feats" data-i18n-aria-label="feats" />
 			<label role="menuitem" class="sheet-tab sheet-tab1"   data-i18n-title="feats" title="feats" data-i18n="feats">Feats</label>
 			<input type="radio" class="sheet-tabinput sheet-tab2" name="attr_abilities_tab" value="2"  data-i18n-title="racial-traits" data-i18n-aria-label="racial-traits"/>
 			<label role="menuitem" class="sheet-tab sheet-tab2"   data-i18n-title="racial-traits" title="Racial Traits" data-i18n="racial-traits">Racial Traits</label>
@@ -1450,7 +1451,7 @@
 								<option value="( ((@{CHA-mod} + [[ @{max-dex-source} ]]) - abs(@{CHA-mod} - [[ @{max-dex-source} ]])) / 2 )" data-i18n="charisma-abbrv">CHA</option>
 							</select>
 						</span>
-						<input type="hidden" name="attr_CMD-DEX" value="4">
+						<input type="hidden" name="attr_CMD-DEX" value="0">
 						<input type="checkbox" name="attr_nodex-toggle" class="sheet-warn-mshow" value="1"/>
 						<input type="checkbox" name="attr_maxdex-toggle" class="sheet-warn-show" value="1"/>
 						<span class="sheet-table-cell sheet-highlight"><input title="@{CMD-DEX}" type="number" name="attr_CMD-DEX-display" value="0" class="sheet-calc" readonly="readonly"></span>
@@ -1753,7 +1754,7 @@
 				<span class="sheet-table-header" data-i18n="proficiency-abbrv">Prof</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{armor3-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor3-equipped" value="1" checked="checked" /><b title="Worn Armor" data-i18n="worn-armor">&nbsp;&nbsp;Worn Armor</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{armor3-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor3-equipped" value="1" checked="checked" /><b title="Worn Armor" data-i18n="worn-armor">Worn Armor</b></label></span>
 				<span class="sheet-table-cell"><input title="@{armor3}" type="text" name="attr_armor3" value="" placeholder="Worn Armor" data-i18n-placeholder="worn-armor" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{armor3-acbonus}" type="number" name="attr_armor3-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{armor3-max-dex}" type="number" name="attr_armor3-max-dex" value="99" min="0" /></span>
@@ -1774,7 +1775,7 @@
 				</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{armor-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor-equipped" value="1" /><b title="Additional Armor" data-i18n="armor-one">&nbsp;&nbsp;Armor 1</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{armor-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor-equipped" value="1" /><b title="Additional Armor" data-i18n="armor-one">Armor 1</b></label></span>
 				<span class="sheet-table-cell"><input title="@{armor}" type="text" name="attr_armor" placeholder="Armor 1" data-i18n-placeholder="armor-one" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{armor-acbonus}" type="number" name="attr_armor-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{armor-max-dex}" type="number" name="attr_armor-max-dex" value="99" min="0" /></span>
@@ -1795,7 +1796,7 @@
 				</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{armor2-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor2-equipped" value="1" /><b title="Alternate Armor" data-i18n="armor-two">&nbsp;&nbsp;Armor 2</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{armor2-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_armor2-equipped" value="1" /><b title="Alternate Armor" data-i18n="armor-two">Armor 2</b></label></span>
 				<span class="sheet-table-cell"><input title="@{armor2}" type="text" name="attr_armor2" placeholder="Armor 2" data-i18n-placeholder="armor-two" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{armor2-acbonus}" type="number" name="attr_armor2-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{armor2-max-dex}" type="number" name="attr_armor2-max-dex" value="99" min="0" /></span>
@@ -1816,7 +1817,7 @@
 				</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{shield3-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield3-equipped" value="1" checked="checked" /><b title="Worn Shield" data-i18n="worn-shield">&nbsp;&nbsp;Worn Shield</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{shield3-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield3-equipped" value="1" checked="checked" /><b title="Worn Shield" data-i18n="worn-shield">Worn Shield</b></label></span>
 				<span class="sheet-table-cell"><input title="@{shield3}" type="text" name="attr_shield3" value="" placeholder="Worn Shield" data-i18n-placeholder="worn-shield" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{shield3-acbonus}" type="number" name="attr_shield3-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{shield3-max-dex}" type="number" name="attr_shield3-max-dex" value="99" min="0" max="99" /></span>
@@ -1836,7 +1837,7 @@
 				</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{shield-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield-equipped" value="1" /><b title="Additional Shield" data-i18n="shield-one">&nbsp;&nbsp;Shield 1</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{shield-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield-equipped" value="1" /><b title="Additional Shield" data-i18n="shield-one">Shield 1</b></label></span>
 				<span class="sheet-table-cell"><input title="@{shield}" type="text" name="attr_shield" placeholder="Shield 1" data-i18n-placeholder="shield-one" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{shield-acbonus}" type="number" name="attr_shield-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{shield-max-dex}" type="number" name="attr_shield-max-dex" value="99" min="0" /></span>
@@ -1856,7 +1857,7 @@
 				</span>
 			</div>
 			<div class="sheet-table-row">
-				<span class="sheet-table-cell sheet-left"><label><input title="@{shield2-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield2-equipped" value="1" /><b title="Alternate Shield" data-i18n="shield-two">&nbsp;&nbsp;Shield 2</b></label></span>
+				<span class="sheet-table-cell sheet-left"><label><input title="@{shield2-equipped}" type="checkbox" class="sheet-boldlabel-check" name="attr_shield2-equipped" value="1" /><b title="Alternate Shield" data-i18n="shield-two">Shield 2</b></label></span>
 				<span class="sheet-table-cell"><input title="@{shield2}" type="text" name="attr_shield2" placeholder="Shield 2" data-i18n-placeholder="shield-two" class="sheet-detail-medium" /></span>
 				<span class="sheet-table-cell"><input title="@{shield2-acbonus}" type="number" name="attr_shield2-acbonus" value="0" min="0" /></span>
 				<span class="sheet-table-cell"><input title="@{shield2-max-dex}" type="number" name="attr_shield2-max-dex" value="99" min="0" max="99" /></span>
@@ -2390,7 +2391,7 @@
 						<input type="hidden" name="attr_damage_macro" value="[[ @{total-damage} ]] [total] + [[ @{damage_macro_insert} ]] [macro] + [[ @{damage-type_macro_insert} ]] [type] + [[ @{global_damage_macro_insert} ]] [global]" />
 
 						<div class="sheet-sect sheet-expand">
-							<input type="checkbox" class="sheet-showarrow sheet-extra-damage-show" name="attr_add-damage-show" value="1"title="Add additional, precision, or extra critical damage" data-i18n-title="additional-damage-title" aria-label="Show Additional Damage" data-i18n-aria-label="additional-damage" aria-i18n-describedby="Add additional, precision, or extra critical damage" checked="checked"/>
+							<input type="checkbox" class="sheet-showarrow sheet-extra-damage-show" name="attr_add-damage-show" value="1" title="Add additional, precision, or extra critical damage" data-i18n-title="additional-damage-title" aria-label="Show Additional Damage" data-i18n-aria-label="additional-damage" aria-i18n-describedby="Add additional, precision, or extra critical damage" checked="checked"/>
 							<label class="sheet-showsect sheet-extra-damage-showlabel" data-i18n="additional-damage">Additional Damage</label>
 							<input type="checkbox" class="sheet-showarrow sheet-iterations-show" title="iterative-attacks-title" data-i18n-title="iterative-attacks-title" aria-label="Show Iterative Attacks" aria-describedby="Add additional attacks for this weapon."  name="attr_iterative-attacks-show" value="1" checked="checked"/>
 							<label class="sheet-showsect sheet-iterations-showlabel" data-i18n="iterative-attacks">Iterative Attacks</label>
@@ -6637,13 +6638,13 @@
 		<label class="sheet-showsect"   title="Click to expand" data-i18n-title="showsect-cmd" data-i18n="spellcasting-classes">Spellcasting Classes</label>
 		<div class="sheet-h2-section">
 			<div role="menubar" class="sheet-spellclassnav sheet-tabs" aria-label="spellcasting classes"  data-i18n-aria-label="spellcasting-classes"  ></div>
-			<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_spellclass_tab" value="0"  data-i18n-title="spell-class-zero" data-i18n-aria-label=""spell-class-zero"/>
+			<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_spellclass_tab" value="0"  data-i18n-title="spell-class-zero" data-i18n-aria-label="spell-class-zero" checked="checked"/>
 			<label role="menuitem" class="sheet-tab sheet-tab0"   data-i18n-title="spell-class-zero" title="Spell Class 0" data-i18n="spell-class-zero">Spell Class 0</label>
-			<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_spellclass_tab" value="1"  data-i18n-title="spell-class-one" data-i18n-aria-label=""spell-class-one" checked="checked" />
+			<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_spellclass_tab" value="1"  data-i18n-title="spell-class-one" data-i18n-aria-label="spell-class-one" />
 			<label role="menuitem" class="sheet-tab sheet-tab1"   data-i18n-title="spell-class-one" title="Spell Class 1" data-i18n="spell-class-one">Spell Class 1</label>
-			<input type="radio" class="sheet-tabinput sheet-tab2" name="attr_spellclass_tab" value="2"  data-i18n-title="spell-class-two" data-i18n-aria-label=""spell-class-two"/>
+			<input type="radio" class="sheet-tabinput sheet-tab2" name="attr_spellclass_tab" value="2"  data-i18n-title="spell-class-two" data-i18n-aria-label="spell-class-two"/>
 			<label role="menuitem" class="sheet-tab sheet-tab2"   data-i18n-title="spell-class-two" title="Spell Class 2" data-i18n="spell-class-two">Spell Class 2</label>
-			<input type="radio" class="sheet-tabinput sheet-tab99" name="attr_spellclass_tab" value="99"  data-i18n-title="all" data-i18n-aria-label=""all"/>
+			<input type="radio" class="sheet-tabinput sheet-tab99" name="attr_spellclass_tab" value="99"  data-i18n-title="all" data-i18n-aria-label="all"/>
 			<label role="menuitem" class="sheet-tab sheet-tab99"   data-i18n-title="all" title="All" data-i18n="all">All</label>
 <!-- Spell Class 0 -->
 			<h2 class="sheet-section0 sheet-nontable-name"><span name="attr_spellclass-0-name"></span></h2>
@@ -7172,7 +7173,7 @@
 								</span>
 								<span class="sheet-table-cell"><input title="@{spellclass-1-level-0-misc}" type="number" name="attr_spellclass-1-level-0-misc" value="0" /></span>
 								<span class="sheet-divider-lg">|</span>
-								<span class="sheet-table-cell sheet-spontaneous"><input title="@{spellclass-1-level-0-spells-known}" type="number" name="attr_spellclass-1-level-1-spells-known" value="0" /></span>
+								<span class="sheet-table-cell sheet-spontaneous"><input title="@{spellclass-1-level-0-spells-known}" type="number" name="attr_spellclass-1-level-0-spells-known" value="0" /></span>
 								<span class="sheet-table-cell"><input title="@{spellclass-1-level-0-total-listed}" type="number" name="attr_spellclass-1-level-0-total-listed" value="0" class="sheet-calc" readonly="readonly" /></span>
 							</div>
 							<div class="sheet-table-row">
@@ -7884,15 +7885,16 @@
 		<h1 data-i18n="npc" class="sheet-offscreen">NPC</h1>
 		<div class="sheet-compendium-drop-target">
 			<div class="sheet-nontable-name" style="display: table;padding-left: 0;margin-bottom: 0;line-height: 1em;margin-top: 0;">
-				<span class="sheet-table-cell" style="width: 70%;text-align: left;"><input type="text" title="character_name" name="attr_character_name" style="background-color: black ; color: white ; font-weight: bold" accept="Name"></span>
+				<span class="sheet-table-cell" style="width: 60%;text-align: left;"><input type="text" title="character_name" name="attr_character_name" style="background-color: black ; color: white ; font-weight: bold" accept="Name"></span>
 				<span class="sheet-table-cell sheet-right"><b data-i18n="is-npc-check-caps">IS NPC</b><b>:</b></span>
 				<span class="sheet-table-cell">
 					<input type="checkbox" title="@{is-npc}" name="attr_is_npc" value="1" style="background-color: black ; color: white ; font-weight: bold ; vertical-align: text-top">
 				</span>
 				<span class="sheet-table-cell sheet-right" style=""><b data-i18n="challenge-rating-abbrv">CR</b></span>
-				<span class="sheet-table-cell" style=""><input type="number" title="@{npc-cr}" name="attr_npc-cr" accept="CR" style="background-color: black;color: white;font-weight: bold;vertical-align: text-top;"></span>
+				<span class="sheet-table-cell" style=""><input type="text" title="@{npc-cr}" name="attr_npc-cr" style="background-color: black;color: white;font-weight: bold;vertical-align: text-top;"></span>
 				<input type="checkbox" class="sheet-mythic-show" name="attr_mythic-adventures-show" value="1" role="presentation">
-				<span class="sheet-table-cell sheet-section-mythic"><b title="Mythic Rank" data-i18n="mythic-rating-abbrv">MR</b></span><span class="sheet-table-cell sheet-right sheet-section-mythic"><input type="number" title="npc-mythic-mr" name="attr_npc-mythic-mr" style="background-color: black ; color: white ; font-weight: bold ; vertical-align: text-top"></span>
+				<span class="sheet-table-cell sheet-section-mythic"><b title="Mythic Rank" data-i18n="mythic-rating-abbrv">MR</b></span><span class="sheet-table-cell sheet-right sheet-section-mythic"><input type="text" title="npc-mythic-mr" name="attr_npc-mythic-mr" style="background-color: black ; color: white ; font-weight: bold ; vertical-align: text-top"></span>
+<input type="hidden" name="attr_cr_compendium" accept="CR" style="width:10%;" value=""/>	
 			</div>
 			<div class="sheet-center" role="section" aria-label="top npc section">
 				<div class="sheet-left">
@@ -8581,13 +8583,13 @@
 
 					<h4 data-i18n="spellcasting-classes">Spellcasting Classes</h4>
 					<div role="menubar" class="sheet-spellclassnav sheet-tabs" aria-label="spellcasting classes"  data-i18n-aria-label="spellcasting-classes"  ></div>
-					<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_npc_spellclass_tab" value="0"  data-i18n-title="spell-class-zero" data-i18n-aria-label=""spell-class-zero"/>
+					<input type="radio" class="sheet-tabinput sheet-tab0" name="attr_npc_spellclass_tab" value="0"  data-i18n-title="spell-class-zero" data-i18n-aria-label="spell-class-zero" checked="checked"/>
 					<label role="menuitem" class="sheet-tab sheet-tab0"   data-i18n-title="spell-class-zero" title="Spell Class 0" data-i18n="spell-class-zero">Spell Class 0</label>
-					<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_npc_spellclass_tab" value="1"  data-i18n-title="spell-class-one" data-i18n-aria-label=""spell-class-one" checked="checked" />
+					<input type="radio" class="sheet-tabinput sheet-tab1" name="attr_npc_spellclass_tab" value="1"  data-i18n-title="spell-class-one" data-i18n-aria-label="spell-class-one"  />
 					<label role="menuitem" class="sheet-tab sheet-tab1"   data-i18n-title="spell-class-one" title="Spell Class 1" data-i18n="spell-class-one">Spell Class 1</label>
-					<input type="radio" class="sheet-tabinput sheet-tab2" name="attr_npc_spellclass_tab" value="2"  data-i18n-title="spell-class-two" data-i18n-aria-label=""spell-class-two"/>
+					<input type="radio" class="sheet-tabinput sheet-tab2" name="attr_npc_spellclass_tab" value="2"  data-i18n-title="spell-class-two" data-i18n-aria-label="spell-class-two"/>
 					<label role="menuitem" class="sheet-tab sheet-tab2"   data-i18n-title="spell-class-two" title="Spell Class 2" data-i18n="spell-class-two">Spell Class 2</label>
-					<input type="radio" class="sheet-tabinput sheet-tab99" name="attr_npc_spellclass_tab" value="99"  data-i18n-title="all" data-i18n-aria-label=""all"/>
+					<input type="radio" class="sheet-tabinput sheet-tab99" name="attr_npc_spellclass_tab" value="99"  data-i18n-title="all" data-i18n-aria-label="all"/>
 					<label role="menuitem" class="sheet-tab sheet-tab99"   data-i18n-title="all" title="All" data-i18n="all">All</label>
 
 					<div class="sheet-section0 sheet-section-spellclass-0 sheet-table">
@@ -10639,7 +10641,7 @@
 <div role="contentinfo" aria-label="Help links and footer information" data-i18n-aria-label="footer-aria" class="sheet-footer" style="margin-top:2em;" >
 	<div class="sheet-table">
 		<div class="sheet-table-row">
-			<span class="sheet-table-cell"><span data-i18n="footer-info">Created by Samuel Marino w/contributions by Vince, Chris Buchholz, Magik, James W. | Last updated:</span> <i>08.08.2016&nbsp;&nbsp;</i>v.<input type="text" style="width:2.5em; height:1.4em; vertical-align:top; padding:0px 2px 0 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="A non-blank version indicates attributes have been successfully recalculated."></span>
+			<span class="sheet-table-cell"><span data-i18n="footer-info">Created by Samuel Marino w/contributions by Vince, Chris Buchholz, Magik, James W. | Last updated:</span> <i>08.13.2016&nbsp;&nbsp;</i>v.<input type="text" style="width:2.5em; height:1.4em; vertical-align:top; padding:0px 2px 0 2px; border:none;" name="attr_PFSheet_Version" value="0" class="sheet-calc" readonly="readonly" title="A non-blank version indicates attributes have been successfully recalculated."></span>
 		</div>
 		<div class="sheet-table-row" style="font-size:.8em;">
 			<label style="font-weight:inherit;"><b data-i18n="questions-feedback">Questions/Feedback?:</b><span class="sheet-selectable" style="padding-left:1em;">http://tinyurl.com/PF-Thread</span></label>
@@ -13552,7 +13554,7 @@ var SWUtils = SWUtils || (function () {
 var PFSheet = PFSheet || (function () {
     'use strict';
 
-    var version = 0.62,
+    var version = 0.63,
 
 	/* isOptionTemplateReversed - for dropdowns in templates where value is before equals */
 	isOptionTemplateReversed = function(spellOptionKey){
@@ -14227,14 +14229,14 @@ var PFSheet = PFSheet || (function () {
 
 	
 	updateNPCFromCompendium = function(eventInfo){
-		getAttrs(["npc-cr"],function(v){
+		getAttrs(["cr_compendium","npc-cr"],function(v){
 			var newCR = "",matches;
-			if (v["npc-cr"]){
-				matches = v["npc-cr"].match(/\d+/);
+			if (v["cr_compendium"]){
+				matches = v["cr_compendium"].match(/\d+/);
 				if (matches){
 					newCR=matches[0];
 					if (newCR !== v["npc-cr"]){
-						setAttrs({"npc-cr":newCR},{silent:true});
+						setAttrs({"npc-cr":newCR,"cr_compendium":""},{silent:true});
 					}
 				}
 			}
@@ -19842,7 +19844,7 @@ var PFEventHandler = PFEventHandler || (function () {
 		})
 	);
 
-	on("change:size_display change:npc-cr change:npc-hd change:npc-hd2",
+	on("change:size_display change:cr_compendium change:npc-hd change:npc-hd2",
 		TAS.callback(function eventUpdateNPCPage2(eventInfo){
 			if(eventInfo.sourceType==="player"){
 				TAS.debug("caught " + eventInfo.sourceAttribute + " event: " + eventInfo.sourceType);


### PR DESCRIPTION
1. fix "spells known" on spellclass tab 1 for spell levels 0 and 1 (row 0 was displaying row 1)
2. fix tab 1 was defaultinstead of tab 0 for class features and spellcasting classes
3. change cr import so it won't overwrite user changes, made CR and Metadata ranks text fields
4. removed nonbreaking space codes from in front of armor and shield placeholders
5. fixed width of "is npc" checkbox label
6. fixed "iterative attacks" arrow which was not changing