### PR TITLE
Remove ABS calls in 13th Age Official

### DIFF
--- a/13th Age Official/13th_Age_Official.html
+++ b/13th Age Official/13th_Age_Official.html
@@ -705,23 +705,15 @@
     </div>
     
 <!-- HIDDEN FIELDS USED FOR CALCULATIONS -->
-<input type="hidden" disabled="true" name="attr_AC-max-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) + abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_AC-max-con-dex-wis" value="(((@{AC-max-con-dex}) + (@{WIS-mod}) + abs((@{AC-max-con-dex}) - (@{WIS-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_AC-min-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) - abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_AC-min-con-dex-wis" value="(((@{AC-min-con-dex}) + (@{WIS-mod}) - abs((@{AC-min-con-dex}) - (@{WIS-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_PD-max-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) + abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_PD-max-con-dex-str" value="(((@{PD-max-con-dex}) + (@{STR-mod}) + abs((@{PD-max-con-dex}) - (@{STR-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_PD-min-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) - abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_PD-min-con-dex-str" value="(((@{PD-min-con-dex}) + (@{STR-mod}) - abs((@{PD-min-con-dex}) - (@{STR-mod}))) / 2)" />    
-<input type="hidden" disabled="true" name="attr_MD-max-int-wis" value="((((@{INT-mod}) + (@{WIS-mod})) + abs((@{INT-mod}) - (@{WIS-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_MD-max-int-wis-cha" value="(((@{MD-max-int-wis}) + (@{CHA-mod}) + abs((@{MD-max-int-wis}) - (@{CHA-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_MD-min-int-wis" value="((((@{INT-mod}) + (@{WIS-mod})) - abs((@{INT-mod}) - (@{WIS-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_MD-min-int-wis-cha" value="(((@{MD-min-int-wis}) + (@{CHA-mod}) - abs((@{MD-min-int-wis}) - (@{CHA-mod}))) / 2)" />
-<input type="hidden" disabled="true" name="attr_HP-5-7" value="ceil(((((@{level}-4) + (0)) + abs((@{level}-4) - (0))) / 2)/1000000)*(@{level}-4)" />
-<input type="hidden" disabled="true" name="attr_HP-8-10" value="ceil(((((@{level}-7) + (0)) + abs((@{level}-7) - (0))) / 2)/1000000)*2*(@{level}-7)" />
-<input type="hidden" disabled="true" name="attr_HP-multiplier" value="@{level}+2+@{HP-5-7}+@{HP-8-10}" />
-<input type="hidden" disabled="true" name="attr_LVL-multiplier" value="(1+ceil(((((@{level}-4) + (0)) + abs((@{level}-4) - (0))) / 2)/1000000)+ceil(((((@{level}-7) + (0)) + abs((@{level}-7) - (0))) / 2)/1000000))" />
-<input type="hidden" disabled="true" name="attr_E-DIE" value="[[&{noerror}(((((@{tracker|Escalation Die}+0) + (6)) - abs((@{tracker|Escalation Die}+0) - (6))) / 2))]][E-DIE]" />
+<input type="hidden" disabled="true" name="attr_AC-max-con-dex-wis" value="({@{CON-mod},@{DEX-mod},@{WIS-mod}}dl2)" />
+<input type="hidden" disabled="true" name="attr_AC-min-con-dex-wis" value="({@{CON-mod},@{DEX-mod},@{WIS-mod}}dh2)" />
+<input type="hidden" disabled="true" name="attr_PD-max-con-dex-str" value="({@{CON-mod},@{DEX-mod},@{STR-mod}}dl2)" />
+<input type="hidden" disabled="true" name="attr_PD-min-con-dex-str" value="({@{CON-mod},@{DEX-mod},@{STR-mod}}dh2)" />
+<input type="hidden" disabled="true" name="attr_MD-max-int-wis-cha" value="({@{INT-mod},@{WIS-mod},@{CHA-mod}}dl2)" />
+<input type="hidden" disabled="true" name="attr_MD-min-int-wis-cha" value="({@{INT-mod},@{WIS-mod},@{CHA-mod}}dh2)" />
+<input type="hidden" disabled="true" name="attr_HP-multiplier" value="(@{level}+2+{@{level}-4,0}dl1+{(@{level}-7)*2,0}dl1)" />
+<input type="hidden" disabled="true" name="attr_LVL-multiplier" value="({@{level}-0,@{level}-4,@{level}-7}>1)" />
+<input type="hidden" disabled="true" name="attr_E-DIE" value="[[&{noerror}({{@{tracker|Escalation Die},6}dh1,{0}}dl1)]][E-DIE]" />
 
 </div>
 


### PR DESCRIPTION
I don't have the ability to directly test these changes and how they interact with other operations, but the calculations themselves work and have a rather dramatic performance gain. I encountered issues as a GM using the AC/MD/PD and serious delays in UI responsiveness after attempting to execute macros using those values.

Using the history, first use of ABS in 13th age sheets comes from ea32475ee90052d49bc375a8f7bef643675cfcff.

Commit message explanation copied here:

> This commit removes calls to ABS in internal attributes in favor
of other built-in functionality: dice calculations.

> Calls to ABS suffer from performance issues, with AC/MD/PD calls
taking upwards of 10 seconds. When changing these to use the
built-in dice calculations, there are no noticable performance
issues.

> The built-in dice functions are treated as clamp operations,
providing concise min and max operators, and tests, providing
level-range operations.

> Min and max operators are used rather directly for calculating
the middle-mod for stats. They are also used to clamp the
escalation die to [0, 6] range.

> The max operator is used to form baselines for health
multipliers, with higher health "overflowing" from 0 when the
level matches the next change in step-size.

> The level multiplier for stats in damage rolls is calculated
by performing 3 tests, adding together the successes to form
the [1, 3] range of multiplier. A level of at least 1 is assumed
during the calculation, and that test is kept for reading
clarity.