### PR TITLE
Revert "Remove ABS calls in 13th Age Official"

### DIFF
--- a/13th Age Official/13th_Age_Official.html
+++ b/13th Age Official/13th_Age_Official.html
@@ -705,15 +705,23 @@
     </div>
     
 <!-- HIDDEN FIELDS USED FOR CALCULATIONS -->
-<input type="hidden" disabled="true" name="attr_AC-max-con-dex-wis" value="({@{CON-mod},@{DEX-mod},@{WIS-mod}}dl2)" />
-<input type="hidden" disabled="true" name="attr_AC-min-con-dex-wis" value="({@{CON-mod},@{DEX-mod},@{WIS-mod}}dh2)" />
-<input type="hidden" disabled="true" name="attr_PD-max-con-dex-str" value="({@{CON-mod},@{DEX-mod},@{STR-mod}}dl2)" />
-<input type="hidden" disabled="true" name="attr_PD-min-con-dex-str" value="({@{CON-mod},@{DEX-mod},@{STR-mod}}dh2)" />
-<input type="hidden" disabled="true" name="attr_MD-max-int-wis-cha" value="({@{INT-mod},@{WIS-mod},@{CHA-mod}}dl2)" />
-<input type="hidden" disabled="true" name="attr_MD-min-int-wis-cha" value="({@{INT-mod},@{WIS-mod},@{CHA-mod}}dh2)" />
-<input type="hidden" disabled="true" name="attr_HP-multiplier" value="(@{level}+2+{@{level}-4,0}dl1+{(@{level}-7)*2,0}dl1)" />
-<input type="hidden" disabled="true" name="attr_LVL-multiplier" value="({@{level}-0,@{level}-4,@{level}-7}>1)" />
-<input type="hidden" disabled="true" name="attr_E-DIE" value="[[&{noerror}({{@{tracker|Escalation Die},6}dh1,{0}}dl1)]][E-DIE]" />
+<input type="hidden" disabled="true" name="attr_AC-max-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) + abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_AC-max-con-dex-wis" value="(((@{AC-max-con-dex}) + (@{WIS-mod}) + abs((@{AC-max-con-dex}) - (@{WIS-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_AC-min-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) - abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_AC-min-con-dex-wis" value="(((@{AC-min-con-dex}) + (@{WIS-mod}) - abs((@{AC-min-con-dex}) - (@{WIS-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_PD-max-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) + abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_PD-max-con-dex-str" value="(((@{PD-max-con-dex}) + (@{STR-mod}) + abs((@{PD-max-con-dex}) - (@{STR-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_PD-min-con-dex" value="((((@{CON-mod}) + (@{DEX-mod})) - abs((@{CON-mod}) - (@{DEX-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_PD-min-con-dex-str" value="(((@{PD-min-con-dex}) + (@{STR-mod}) - abs((@{PD-min-con-dex}) - (@{STR-mod}))) / 2)" />    
+<input type="hidden" disabled="true" name="attr_MD-max-int-wis" value="((((@{INT-mod}) + (@{WIS-mod})) + abs((@{INT-mod}) - (@{WIS-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_MD-max-int-wis-cha" value="(((@{MD-max-int-wis}) + (@{CHA-mod}) + abs((@{MD-max-int-wis}) - (@{CHA-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_MD-min-int-wis" value="((((@{INT-mod}) + (@{WIS-mod})) - abs((@{INT-mod}) - (@{WIS-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_MD-min-int-wis-cha" value="(((@{MD-min-int-wis}) + (@{CHA-mod}) - abs((@{MD-min-int-wis}) - (@{CHA-mod}))) / 2)" />
+<input type="hidden" disabled="true" name="attr_HP-5-7" value="ceil(((((@{level}-4) + (0)) + abs((@{level}-4) - (0))) / 2)/1000000)*(@{level}-4)" />
+<input type="hidden" disabled="true" name="attr_HP-8-10" value="ceil(((((@{level}-7) + (0)) + abs((@{level}-7) - (0))) / 2)/1000000)*2*(@{level}-7)" />
+<input type="hidden" disabled="true" name="attr_HP-multiplier" value="@{level}+2+@{HP-5-7}+@{HP-8-10}" />
+<input type="hidden" disabled="true" name="attr_LVL-multiplier" value="(1+ceil(((((@{level}-4) + (0)) + abs((@{level}-4) - (0))) / 2)/1000000)+ceil(((((@{level}-7) + (0)) + abs((@{level}-7) - (0))) / 2)/1000000))" />
+<input type="hidden" disabled="true" name="attr_E-DIE" value="[[&{noerror}(((((@{tracker|Escalation Die}+0) + (6)) - abs((@{tracker|Escalation Die}+0) - (6))) / 2))]][E-DIE]" />
 
 </div>
 


### PR DESCRIPTION
https://github.com/Roll20/roll20-character-sheets/pull/1858 actually ends up breaking the value display. The system doesn't seem to support those types of calculations except for final roll calculations.

> This reverts commit 8453945106fc396fde964763d10799e16cc478ba.

> The character sheet display system doesn't support "drop" logic or
"success" logic.