### PR TITLE
Update apocalypse-world.html

### DIFF
--- a/AW2E/apocalypse-world.html
+++ b/AW2E/apocalypse-world.html
@@ -62,7 +62,7 @@
         <input type='checkbox' name='attr_coolHighlighted' value='1' class='sheet-highlight'><label class='sheet-highlight'>Highlighted</label>
         <div class="sheet-roll-box sheet-cf">
         <label class="sheet-buttonLbl">do something under fire:</label>
-        <button type='roll' value='&{template:aw} {{name=@{character_name}}} {{roll_name=Cool}} {{roll_mod=@{cool}}} {{result=[[2d6 + @{cool} - @{shattered}]]}}' name='roll_dsuf'></button>  
+        <button type='roll' value='&{template:aw} {{name=@{character_name}}} {{roll_name=Cool}} {{roll_mod=@{cool}}} {{result=[[2d6 + @{cool}]]}}' name='roll_dsuf'></button>  
         </div>  
           </div>
           <div class="sheet-attr-box">
@@ -482,7 +482,7 @@
             <input type="text" name="attr_classmovename" /> 
             <label class="sheet-stat">Stat:</label>
            <select name="attr_classmoves" class="sheet-moves">                
-                <option value="@{cool} - @{shattered}">Cool</option>
+                <option value="@{cool}">Cool</option>
                 <option value="@{hard}">Hard</option>
                 <option value="@{hot}">Hot</option>
                 <option value="@{sharp}">Sharp</option>
@@ -500,7 +500,7 @@
             <input type="text" name="attr_movename" /> 
             <label class="sheet-stat">Stat:</label>
            <select name="attr_moves" class="sheet-moves">                
-                <option value="@{cool} - @{shattered}">Cool</option>
+                <option value="@{cool}">Cool</option>
                 <option value="@{hard}">Hard</option>
                 <option value="@{hot}">Hot</option>
                 <option value="@{sharp}">Sharp</option>


### PR DESCRIPTION
The 'Shattered' attribute is no longer used in Apocalypse World 2nd Ed. With it still present it causes an error when rolling 'Cool'. Removed 'Shattered' to resolve the issue.