### PR TITLE
Fix SAG used instead of PER

### DIFF
--- a/ChroniquesGalactiques/cog.htm
+++ b/ChroniquesGalactiques/cog.htm
@@ -494,7 +494,7 @@
                             <option value="@{DEX}">DEX</option>
                             <option value="@{CON}">CON</option>
                             <option value="@{INT}">INT</option>
-                            <option value="@{SAG}">SAG</option>
+                            <option value="@{PER}">PER</option>
                             <option value="@{CHA}">CHA</option>
                         </select>+<input type="number" style="width:32px;" name="attr_jetcapadiv" value="0" title="Bonus divers" />
                     </td>


### PR DESCRIPTION
Le menu déroulant pour les jets de capacité liste SAG au lieu de PER.
@NathaTerrien 