### PR TITLE
Fixes an issue with the Rogue Trader character sheet

### DIFF
--- a/Rogue_Trader/RogueTrader.html
+++ b/Rogue_Trader/RogueTrader.html
@@ -410,22 +410,7 @@
                     <button type="roll" name="roll_psycicpower_push" style="width: 50px" value="/me calls on the might of the Warp!\n [[((((?{Pushed Psy Rating|1}*@{psy}*5)+?{Bonus Psy Rating|0}*5)+@{wp})+?{Modifier|0}-1d100)/10]] degree(s) of success!">
 					<label>Push</label>
 				</button>
-			</div>
-		<!-- Psychic Disciplines -->   
-		<h4>Psychic Disciplines</h4>
-			<fieldset class="repeating_psychicdiscipline">
-            	<div class="sheet-row">
-                    <div class="sheet-item" style="width:37.5%"><label>Psychic Discipline</label></div>
-                    <div class="sheet-item sheet-morebig sheet-brackets"><input type="text" name="attr_reppsychicdiscipline" /></div>              
-                </div>                
-            </fieldset>
-		<!-- Psychic Techniques -->     
-		<h4>Psychic Techniques</h4>		
-            <fieldset class="repeating_disciplinepsychicpowers">
-                <div class="sheet-row">
-                	<div class="sheet-item" style="width:38%"><label>Psychic Technique</label></div>
-                    <div class="sheet-item sheet-morebig sheet-brackets"><input type="text" name="attr_repdisciplinepsychicpower" /></div>          
-                </div>
+			</div>   
                 <!-- Psychic Disciplines -->
                 <h4>Psychic Disciplines</h4>
                 <fieldset class="repeating_psychicdiscipline">


### PR DESCRIPTION
There was an issue with some duplicated stuff and incorrect tabbing that was causing issues with the Psychic Powers part of the sheet, making it so that you could never use it correct due to there being two instances of Psychic Disciplines and Psychic Techniques at all times.