### PR TITLE
Update 11/30/2016

### DIFF
--- a/Naruto d20 Modern/Naruto d20 Modern.html
+++ b/Naruto d20 Modern/Naruto d20 Modern.html
@@ -337,20 +337,20 @@
             
             <br>
             <h4>Wealth</h4>
-            <table class="sheet-tableII" style="width:250px">        
+            <table class="sheet-tableII" style="width:300px">        
                 <tr>
                     <th></th>
-                    <th class="sheet-heading">Total</th>
-                    <th class="sheet-heading">Base</th>
-                    <th class="sheet-heading">Other</th>
-                    <th class="sheet-heading"></th>
-                    <th class="sheet-heading"></th>
+                    <th class="sheet-heading" style="width:70px">Total</th>
+                    <th class="sheet-heading" style="width:70px">Base</th>
+                    <th class="sheet-heading" style="width:70px">Other</th>
+                    <th class="sheet-heading" style="width:70px"></th>
+                    <th class="sheet-heading" style="width:70px"></th>
                 </tr>
                 <tr>
-                    <th><button type="roll" class="sheet-skillbtn" name="roll_Wealth" value="/e rolls Wealth [[1d20+@{Wealth}]]" >Wealth</button></th>
-                    <th><input type="number" class="sheet-ability" name="attr_Wealth" value="@{Wealth-Base}+@{Wealth-Other}" disabled="true"/></th>
-                    <td><input type="number" class="sheet-number" name="attr_Wealth-Base" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_Wealth-Other" value="0"/></td>
+                    <th><button type="roll" class="sheet-skillbtn" name="roll_Wealth" style="width:70px" value="/e rolls Wealth [[1d20+@{Wealth}]]" >Wealth</button></th>
+                    <th><input type="number" class="sheet-ability" name="attr_Wealth" style="width:70px" value="@{Wealth-Base}+@{Wealth-Other}" disabled="true"/></th>
+                    <td><input type="number" class="sheet-number" name="attr_Wealth-Base" style="width:70px" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_Wealth-Other" style="width:70px" value="0"/></td>
                 </tr>
             </table>
             
@@ -382,26 +382,25 @@
                     </tr>
                     <tr>
                         <th class="sheet-number" style="width:50px">D Rank</th>
-                        <td><input type="number" class="sheet-number" name="attr_D_Rank" style="width:100px" /></td>
+                        <td><input type="number" class="sheet-number" name="attr_D_Rank" style="width:100px" value"0"/></td>
                     </tr>
                     <tr>
                         <th class="sheet-number">C Rank</th>
-                        <td><input type="number" class="sheet-number" name="attr_C_Rank" style="width:100px" /></td>
+                        <td><input type="number" class="sheet-number" name="attr_C_Rank" style="width:100px" value"0"/></td>
                     </tr>
                     <tr>
                         <th class="sheet-number">B Rank</th>
-                        <td><input type="number" class="sheet-number" name="attr_B_Rank" style="width:100px" /></td>
+                        <td><input type="number" class="sheet-number" name="attr_B_Rank" style="width:100px" value"0"/></td>
                     </tr>
                     <tr>
                         <th class="sheet-number">A Rank</th>
-                        <td><input type="number" class="sheet-number" name="attr_A_Rank" style="width:100px" /></td>
+                        <td><input type="number" class="sheet-number" name="attr_A_Rank" style="width:100px" value"0"/></td>
                     </tr>
                     <tr>
                         <th class="sheet-number">S Rank</th>
-                        <td><input type="number" class="sheet-number" name="attr_S_Rank" style="width:100px" /></td>
+                        <td><input type="number" class="sheet-number" name="attr_S_Rank" style="width:100px" value"0"/></td>
                     </tr>
                 </table>
-            
         </div>
         
         <div class="sheet-col">
@@ -1714,12 +1713,12 @@
         </div>
         
         <div class='sheet-col'>
-            <h4>Hit Points, Chakra, Defense</h4>
+            <h4>Hit Points & Chakra</h4>
             <table class="sheet-tableII">
                 <tr>
                     <th></th>
                     <th class="sheet-heading">Max</th>
-                    <th class="sheet-heading">Class</th>
+                    <th class="sheet-heading">Hit Dice</th>
                     <th class="sheet-heading">Ability</th>
                     <th class="sheet-heading">Bonus</th>
                     <th class="sheet-heading">Other</th>
@@ -1727,10 +1726,10 @@
                 </tr>
                 <tr>
                     <th><div class="sheet-font">Hit Points</div></th>
-                    <th><input type="number" class="sheet-ability" name="attr_HitPoints_max" title="@{HitPoints_max}" value="@{HitPoints-Class}+@{HitPoints-Con}+@{HitPoints-Other}" disabled="true"/></th>
+                    <th><input type="number" class="sheet-ability" name="attr_HitPoints_max" title="@{HitPoints_max}" value="@{HitPoints-Class}+@{HitPoints-Ability}+@{HitPoints-Bonus}+@{HitPoints-Other}" disabled="true"/></th>
                     <td><input type="number" class="sheet-number" name="attr_HitPoints-Class" value="0"/></td>
-                    <td>
-                        <select class="sheet-number" name="attr_HitPoints_ability" title="@{HitPoints_ability}" style="width:95%">
+                    <td><input type="number" class="sheet-number" name="attr_HitPoints-Ability" value="(@{HitPoints-Mod})*(@{Character_Level})" disabled='true'/>
+                        <select class="sheet-number" name="attr_HitPoints-Mod" title="@{HitPoints-Mod}" style="width:95%">
                             <option value="@{Strength-mod}">Str</option>
                             <option value="@{Dexterity-mod}">Dex</option>
                             <option value="@{Constitution-mod}" selected>Con</option>
@@ -1739,17 +1738,16 @@
                             <option value="@{Charisma-mod}">Cha</option>
                         </select>
                     </td>
-                    <td><input type="number" class="sheet-number" name="attr_HitPoints-Con" value="(@{Constitution-mod})*(@{Character_Level})" disabled='true'/></td>
+                    <td><input type="number" class="sheet-number" name="attr_HitPoints-Bonus" value="0"/></td>
                     <td><input type="number" class="sheet-number" name="attr_HitPoints-Other" value="0"/></td>
-                    <div type="number" class="sheet-number" name="attr_HitPoints_max" title="@{HitPoints_max}" value="@{HitPoints-Class}+@{HitPoints-Con}+@{HitPoints-Other}" disabled="true"></div>
                     <td colspan="3"><input type="number" class="sheet-ability" name="attr_HitPoints" title="@{HitPoints}" value="0" style="width:95%"/></td>
                 </tr>
                 <tr>
                     <th><div class="sheet-font">Chakra Pool</div></th>
-                    <th><input type="number" class="sheet-ability" name="attr_ChakraPool_max" title="@{ChakraPool_max}" value="@{ChakraPool-Class}+@{ChakraPool-ability}+@{ChakraPool-Other}" disabled="true"/></th>
+                    <th><input type="number" class="sheet-ability" name="attr_ChakraPool_max" title="@{ChakraPool_max}" value="@{ChakraPool-Class}+@{ChakraPool-Ability}+@{ChakraPool-Bonus}+@{ChakraPool-Other}" disabled="true"/></th>
                     <td><input type="number" class="sheet-number" name="attr_ChakraPool-Class" value="(@{Character_Level}+1)*2" disabled='true'/></td>
-                    <td>
-                        <select class="sheet-number" name="attr_ChakraPool-mod" title="@{ChakraPool-mod}" style="width:95%">
+                    <td><input type="number" class="sheet-number" name="attr_ChakraPool-Ability" value="@{ChakraPool-Mod}*(@{Character_Level})" disabled='true'/>
+                        <select class="sheet-number" name="attr_ChakraPool-Mod" title="@{ChakraPool-Mod}" style="width:95%">
                             <option value="@{Strength-mod} ">Str</option>
                             <option value="@{Dexterity-mod} ">Dex</option>
                             <option value="@{Constitution-mod} " selected>Con</option>
@@ -1758,24 +1756,22 @@
                             <option value="@{Charisma-mod} ">Cha</option>
                         </select>
                     </td>
-                    <td><input type="number" class="sheet-number" name="attr_ChakraPool-ability" value="@{ChakraPool-mod}*(@{Character_Level})" disabled='true'/></td>
+                    <td><input type="number" class="sheet-number" name="attr_ChakraPool-Bonus" value="0"/></td>
                     <td><input type="number" class="sheet-number" name="attr_ChakraPool-Other" value="0"/></td>
-                    <div type="number" class="sheet-ability" name="attr_ChakraPool_max" title="@{ChakraPool_max}" value="@{ChakraPool-Class}+@{ChakraPool-ability}+@{ChakraPool-Other}" disabled="true"/></div>
-                    <td colspan="3"><input type="number" class="sheet-ability" name="attr_ChakraPool" title="@{ChakraPool}" value="@{ChakraPool_max}" style="width:95%"/></td>
+                    <td colspan="3"><input type="number" class="sheet-ability" name="attr_ChakraPool" title="@{ChakraPool}" value="0" style="width:95%"/></td>
                 </tr>
                 <tr>
                     <th><div class="sheet-font">Chakra Reserve</div></th>
                     <th><input type="number" class="sheet-ability" name="attr_ChakraReserve_max" title="@{ChakraReserve_max}" value="@{ChakraReserve-Class}+@{ChakraReserve-ability}+@{ChakraReserve-Other}" disabled="true"/></th>
-                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-Class" value="2*@{Character_Level}" disabled="true"/></td>
+                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-Class" value="2*(@{Character_Level})" disabled="true"/></td>
                     <td></td>
-                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-ability" value=""/></td>
-                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-Other" value=""/></td>
-                    <div type="number" class="sheet-ability" name="attr_ChakraReserve_max" title="@{ChakraReserve_max}" value="@{ChakraReserve-Class}+@{ChakraReserve-ability}+@{ChakraReserve-Other}" disabled="true"/></div>
+                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-ability" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_ChakraReserve-Other" value="0" ></td>
                     <td colspan="3"><input type="number" class="sheet-ability" name="attr_ChakraReserve" title="@{ChakraReserve}" value="0" style="width:95%"/></td>
                 </tr>
                 <tr>
                     <th><div class="sheet-font">Nature Energy</div></th>
-                    <th><input type="number" class="sheet-ability" name="attr_Nature_max" title="@{Nature_max}" value="(@{ChakraPool_max})/2" disabled="true"/></th>
+                    <th><input type="number" class="sheet-ability" name="attr_Nature_max" title="@{Nature_max}" value="floor((@{ChakraPool_max})/2)" disabled="true"/></th>
                     <td></td>
                     <td></td>
                     <td></td>
@@ -1793,6 +1789,7 @@
                 </tr>
             </table>
             <br>
+            <h4>Defenses</h4>
             <table class="sheet-tableII">
                 <tr>
                     <th></th>
@@ -1839,23 +1836,24 @@
                     <td><input type="number" class="sheet-number" name="attr_Defense-Size_Touch" value="0"/></td>
                     <td><input type="number" class="sheet-number" name="attr_Defense-Misc_Touch" value="0"/></td>
             </table>
-            <h4>Chakra Resistance</h4>
-                <table class="sheet-tableII">
-                    <tr>
-                        <th class="sheet-heading"/>Total</th>
-                        <th class="sheet-heading"/></th>
-                        <th class="sheet-heading"/>Base</th>
-                        <th class="sheet-heading"/>Class</th>
-                        <th class="sheet-heading"/>Other</th>
-                    </tr>
-                    <tr>
-                        <td><input type="number" class="sheet-number" name="attr_Resistance" value="[[@{Resistance-base}+@{Resistance-class}+@{Resistance-other}]]" disabled='true'/></td>
-                        <td><input type="number" class="sheet-number" name="attr_Resistance-base" value="0"/></td>
-                        <td><input type="number" class="sheet-number" name="attr_Resistance-class" value="0"/></td>
-                        <td><input type="number" class="sheet-number" name="attr_Resistance-other" value="0"/></td>
-                    </tr>
-                </table>
-            
+            <h4>Chakra Resistances</h4>
+                <fieldset class="repeating_resistances">    
+                    <table class="sheet-tableII">
+                        <tr>
+                            <th class="sheet-heading"/>Total</th>
+                            <th class="sheet-heading"/></th>
+                            <th class="sheet-heading"/>Base</th>
+                            <th class="sheet-heading"/>Class</th>
+                            <th class="sheet-heading"/>Other</th>
+                        </tr>
+                        <tr>
+                            <td><input type="number" class="sheet-number" name="attr_Resistance" value="[[@{Resistance-base}+@{Resistance-class}+@{Resistance-other}]]" disabled='true'/></td>
+                            <td><input type="number" class="sheet-number" name="attr_Resistance-base" value="0"/></td>
+                            <td><input type="number" class="sheet-number" name="attr_Resistance-class" value="0"/></td>
+                            <td><input type="number" class="sheet-number" name="attr_Resistance-other" value="0"/></td>
+                        </tr>
+                    </table>
+                </fieldset>
             <br>
             <h4>Armor/Protective Item</h4>
             <table class="sheet-tableII">
@@ -2147,6 +2145,63 @@
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-max" value="@{ChakraPool_max}" disabled='true' /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-current" value="@{ChakraPool}" disabled='true' /></td>
         </tr>
+        
+    <table class="sheet-tableII" style="width:350px">
+        <tr>
+            <th class="sheet-heading">Skill</th>
+            <th class="sheet-heading">Total</th>
+            <th class="sheet-heading">Ability</th>
+            <th class="sheet-heading">Ranks</th>
+            <th class="sheet-heading">Blood</th>
+            <th class="sheet-heading">Occu</th>
+            <th class="sheet-heading">Feats</th>
+            <th class="sheet-heading">Synergy</th>
+            <th class="sheet-heading">Items</th>
+            <th class="sheet-heading">Misc</th>
+        </tr>
+        <tr>
+            <td><button type="roll" class="sheet-btn" name="roll_ID_Chakra_Control" value="/e rolls Chakra Control ID [[1d20+@{ID_Chakra_Control}]]" >ID</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_ID_Chakra_Control" value="[[@{ID_Chakra_Control-ability}+@{ID_Chakra_Control-Ranks}+@{ID_Chakra_Control-Blood}+@{ID_Chakra_Control-Occu}+@{ID_Chakra_Control-Feats}+@{ID_Chakra_Control-Synergy}+@{ID_Chakra_Control-Items}+@{ID_Chakra_Control-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_ID_Chakra_Control-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}" selected>Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Ranks" value="@{Chakra_Control-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Chakra_Control-Misc" value="0"/></td>
+        </tr>
+        <tr>
+            <td><button type="roll" class="sheet-btn" name="roll_Learn_Chakra_Control" value="/e rolls Chakra Control Learn [[1d20+@{Learn_Chakra_Control}]]" >Learn</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_Learn_Chakra_Control" value="[[@{Learn_Chakra_Control-ability}+@{Learn_Chakra_Control-Ranks}+@{Learn_Chakra_Control-Blood}+@{Learn_Chakra_Control-Occu}+@{Learn_Chakra_Control-Feats}+@{Learn_Chakra_Control-Synergy}+@{Learn_Chakra_Control-Items}+@{Learn_Chakra_Control-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_Learn_Chakra_Control-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}" selected>Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Ranks" value="@{Chakra_Control-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Chakra_Control-Misc" value="0"/></td>
+        </tr>
+    </table>    
     </table>
     <br>
     <div class='sheet-2colrow'>
@@ -2466,8 +2521,8 @@
                     <option value="@{Strength-mod}">Strength</option>
                     <option value="@{Dexterity-mod}">Dexterity</option>
                     <option value="@{Constitution-mod}">Constitution</option>
-                    <option value="@{Intelligence-mod}">Intelligence</option>
-                    <option value="@{Wisdom-mod}" selected>Wisdom</option>
+                    <option value="@{Intelligence-mod}" selected>Intelligence</option>
+                    <option value="@{Wisdom-mod}">Wisdom</option>
                     <option value="@{Charisma-mod}">Charisma</option>
                 </select></td>
             <td><input type="number" class="sheet-number" name="attr_fu-DC-Bonus" value="0" /></td>    
@@ -2475,6 +2530,63 @@
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-max" value="@{ChakraPool_max}" disabled='true' /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-current" value="@{ChakraPool}" disabled='true' /></td>
         </tr>
+    <table class="sheet-tableII" style="width:350px">
+        <tr>
+            <th class="sheet-heading">Skill</th>
+            <th class="sheet-heading">Total</th>
+            <th class="sheet-heading">Ability</th>
+            <th class="sheet-heading">Ranks</th>
+            <th class="sheet-heading">Blood</th>
+            <th class="sheet-heading">Occu</th>
+            <th class="sheet-heading">Feats</th>
+            <th class="sheet-heading">Synergy</th>
+            <th class="sheet-heading">Items</th>
+            <th class="sheet-heading">Misc</th>
+        </tr>
+        <tr>                  
+            <td><button type="roll" class="sheet-btn" name="roll_ID_Fuinjutsu" value="/e rolls Fuinjutsu ID [[1d20+@{ID_Fuinjutsu}]]" >ID</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_ID_Fuinjutsu" value="[[@{ID_Fuinjutsu-ability}+@{ID_Fuinjutsu-Ranks}+@{ID_Fuinjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_ID_Fuinjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}"selected>Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+        </td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Ranks" value="@{Fuinjutsu-Ranks}" disabled='true'/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Blood" value="0"/></td>
+		   	<td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Occu" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Feats" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Syn" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Fuinjutsu-Misc" value="0" /></td>
+        </tr>
+		<tr>
+            <td><button type="roll" class="sheet-btn" name="roll_Learn_Fuinjutsu" value="/e rolls Fuinjutsu Learn [[1d20+@{Learn_Fuinjutsu}]]" >Learn</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_Learn_Fuinjutsu" value="[[@{Learn_Fuinjutsu-ability}+@{Learn_Fuinjutsu-Ranks}+@{Learn_Fuinjutsu-Blood}+@{Learn_Fuinjutsu-Occu}+@{Learn_Fuinjutsu-Feats}+@{Learn_Fuinjutsu-Synergy}+@{Learn_Fuinjutsu-Items}+@{Learn_Fuinjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_Learn_Fuinjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}" selected>Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Ranks" value="@{Fuinjutsu-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Fuinjutsu-Misc" value="0"/></td>
+        </tr>
+
+    </table>
     </table>
     <br>
     <div class='sheet-2colrow'>
@@ -2796,14 +2908,70 @@
                     <option value="@{Dexterity-mod}">Dexterity</option>
                     <option value="@{Constitution-mod}">Constitution</option>
                     <option value="@{Intelligence-mod}">Intelligence</option>
-                    <option value="@{Wisdom-mod}" selected>Wisdom</option>
-                    <option value="@{Charisma-mod}">Charisma</option>
+                    <option value="@{Wisdom-mod}">Wisdom</option>
+                    <option value="@{Charisma-mod}"selected>Charisma</option>
                 </select></td>
             <td><input type="number" class="sheet-number" name="attr_ge-DC-Bonus" value="0" /></td>    
             <td><input type="number" class="sheet-number" name="attr_ge-Known" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-max" value="@{ChakraPool_max}" disabled='true' /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-current" value="@{ChakraPool}" disabled='true' /></td>
         </tr>
+        <table class="sheet-tableII" style="width:350px">
+        <tr>
+            <th class="sheet-heading">Skill</th>
+            <th class="sheet-heading">Total</th>
+            <th class="sheet-heading">Ability</th>
+            <th class="sheet-heading">Ranks</th>
+            <th class="sheet-heading">Blood</th>
+            <th class="sheet-heading">Occu</th>
+            <th class="sheet-heading">Feats</th>
+            <th class="sheet-heading">Synergy</th>
+            <th class="sheet-heading">Items</th>
+            <th class="sheet-heading">Misc</th>
+        </tr>
+        <tr>                  
+            <td><button type="roll" class="sheet-btn" name="roll_ID_Genjutsu" value="/e rolls Genjutsu ID [[1d20+@{ID_Genjutsu}]]" >ID</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_ID_Genjutsu" value="[[@{ID_Genjutsu-ability}+@{ID_Genjutsu-Ranks}+@{ID_Genjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_ID_Genjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}"selected>Cha</option>
+                </select>
+        </td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Ranks" value="@{Genjutsu-Ranks}" disabled='true'/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Blood" value="0"/></td>
+		   	<td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Occu" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Feats" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Syn" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Genjutsu-Misc" value="0" /></td>
+        </tr>
+		<tr>
+            <td><button type="roll" class="sheet-btn" name="roll_Learn_Genjutsu" value="/e rolls Genjutsu Learn [[1d20+@{Learn_Genjutsu}]]" >Learn</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_Learn_Genjutsu" value="[[@{Learn_Genjutsu-ability}+@{Learn_Genjutsu-Ranks}+@{Learn_Genjutsu-Blood}+@{Learn_Genjutsu-Occu}+@{Learn_Genjutsu-Feats}+@{Learn_Genjutsu-Synergy}+@{Learn_Genjutsu-Items}+@{Learn_Genjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_Learn_Genjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}"selected>Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Ranks" value="@{Genjutsu-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Genjutsu-Misc" value="0"/></td>
+        </tr>
+        </table>
     </table>
     <br>
     <div class='sheet-2colrow'>
@@ -3124,8 +3292,8 @@
                     <option value="@{Strength-mod}">Strength</option>
                     <option value="@{Dexterity-mod}">Dexterity</option>
                     <option value="@{Constitution-mod}">Constitution</option>
-                    <option value="@{Intelligence-mod}">Intelligence</option>
-                    <option value="@{Wisdom-mod}" selected>Wisdom</option>
+                    <option value="@{Intelligence-mod}"selected>Intelligence</option>
+                    <option value="@{Wisdom-mod}">Wisdom</option>
                     <option value="@{Charisma-mod}">Charisma</option>
                 </select></td>
             <td><input type="number" class="sheet-number" name="attr_ni-DC-Bonus" value="0" /></td>    
@@ -3133,6 +3301,62 @@
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-max" value="@{ChakraPool_max}" disabled='true' /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-current" value="@{ChakraPool}" disabled='true' /></td>
         </tr>
+        <table class="sheet-tableII" style="width:350px">
+        <tr>
+            <th class="sheet-heading">Skill</th>
+            <th class="sheet-heading">Total</th>
+            <th class="sheet-heading">Ability</th>
+            <th class="sheet-heading">Ranks</th>
+            <th class="sheet-heading">Blood</th>
+            <th class="sheet-heading">Occu</th>
+            <th class="sheet-heading">Feats</th>
+            <th class="sheet-heading">Synergy</th>
+            <th class="sheet-heading">Items</th>
+            <th class="sheet-heading">Misc</th>
+        </tr>
+        <tr>                  
+            <td><button type="roll" class="sheet-btn" name="roll_ID_Ninjutsu" value="/e rolls Ninjutsu ID [[1d20+@{ID_Ninjutsu}]]" >ID</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_ID_Ninjutsu" value="[[@{ID_Ninjutsu-ability}+@{ID_Ninjutsu-Ranks}+@{ID_Ninjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_ID_Ninjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}"selected>Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+        </td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Ranks" value="@{Ninjutsu-Ranks}" disabled='true'/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Blood" value="0"/></td>
+		   	<td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Occu" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Feats" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Syn" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Ninjutsu-Misc" value="0" /></td>
+        </tr>
+		<tr>
+            <td><button type="roll" class="sheet-btn" name="roll_Learn_Ninjutsu" value="/e rolls Ninjutsu Learn [[1d20+@{Learn_Ninjutsu}]]" >Learn</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_Learn_Ninjutsu" value="[[@{Learn_Ninjutsu-ability}+@{Learn_Ninjutsu-Ranks}+@{Learn_Ninjutsu-Blood}+@{Learn_Ninjutsu-Occu}+@{Learn_Ninjutsu-Feats}+@{Learn_Ninjutsu-Synergy}+@{Learn_Ninjutsu-Items}+@{Learn_Ninjutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_Learn_Ninjutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}">Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}"selected>Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Ranks" value="@{Ninjutsu-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Ninjutsu-Misc" value="0"/></td>
+        </tr>
+        </table>
     </table>
     <br>
     <div class='sheet-2colrow'>
@@ -3451,11 +3675,11 @@
             <td><input type="number" class="sheet-number" name="attr_ta-Character_Level" title="@{ta-Character_Level}" value="0" /></td>
             <td>
                 <select class="sheet-number" name="attr_ta-Attribute" title="@{ta-Attribute}" >
-                    <option value="@{Strength-mod}">Strength</option>
+                    <option value="@{Strength-mod}"selected>Strength</option>
                     <option value="@{Dexterity-mod}">Dexterity</option>
                     <option value="@{Constitution-mod}">Constitution</option>
                     <option value="@{Intelligence-mod}">Intelligence</option>
-                    <option value="@{Wisdom-mod}" selected>Wisdom</option>
+                    <option value="@{Wisdom-mod}" >Wisdom</option>
                     <option value="@{Charisma-mod}">Charisma</option>
                 </select></td>
             <td><input type="number" class="sheet-number" name="attr_ta-DC-Bonus" value="0" /></td>    
@@ -3463,6 +3687,62 @@
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-max" value="@{ChakraPool_max}" disabled='true' /></td>
             <td><input type="number" class="sheet-number" name="attr_ChakraPool-current" value="@{ChakraPool}" disabled='true' /></td>
         </tr>
+        	<table class="sheet-tableII" style="width:350px">
+        <tr>
+            <th class="sheet-heading">Skill</th>
+            <th class="sheet-heading">Total</th>
+            <th class="sheet-heading">Ability</th>
+            <th class="sheet-heading">Ranks</th>
+            <th class="sheet-heading">Blood</th>
+            <th class="sheet-heading">Occu</th>
+            <th class="sheet-heading">Feats</th>
+            <th class="sheet-heading">Synergy</th>
+            <th class="sheet-heading">Items</th>
+            <th class="sheet-heading">Misc</th>
+        </tr>
+        <tr>                  
+            <td><button type="roll" class="sheet-btn" name="roll_ID_Taijutsu" value="/e rolls Taijutsu ID [[1d20+@{ID_Taijutsu}]]" >ID</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_ID_Taijutsu" value="[[@{ID_Taijutsu-ability}+@{ID_Taijutsu-Ranks}+@{ID_Taijutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_ID_Taijutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}"selected>Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+        </td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Ranks" value="@{Taijutsu-Ranks}" disabled='true'/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Blood" value="0"/></td>
+		   	<td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Occu" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Feats" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Syn" value="0"/></td>
+			<td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_ID_Taijutsu-Misc" value="0" /></td>
+        </tr>
+		<tr>
+            <td><button type="roll" class="sheet-btn" name="roll_Learn_Taijutsu" value="/e rolls Taijutsu Learn [[1d20+@{Learn_Taijutsu}]]" >Learn</button></td>
+            <td><input type="number" class="sheet-ability" name="attr_Learn_Taijutsu" value="[[@{Learn_Taijutsu-ability}+@{Learn_Taijutsu-Ranks}+@{Learn_Taijutsu-Blood}+@{Learn_Taijutsu-Occu}+@{Learn_Taijutsu-Feats}+@{Learn_Taijutsu-Synergy}+@{Learn_Taijutsu-Items}+@{Learn_Taijutsu-Misc}]]" disabled="true"/></td>
+            <td>
+                <select class="sheet-number" name="attr_Learn_Taijutsu-ability" style="width:40px;">
+                    <option value="@{Strength-mod}"selected>Str</option>
+                    <option value="@{Dexterity-mod}">Dex</option>
+                    <option value="@{Constitution-mod}">Con</option>
+                    <option value="@{Intelligence-mod}">Int</option>
+                    <option value="@{Wisdom-mod}">Wis</option>
+                    <option value="@{Charisma-mod}">Cha</option>
+                </select>
+            </td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Ranks" value="@{Taijutsu-Ranks}" disabled='true'/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Blood" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Occu" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Feats" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Synergy" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Items" value="0"/></td>
+            <td><input type="number" class="sheet-number" name="attr_Learn_Taijutsu-Misc" value="0"/></td>
+        </tr>
+	</table>
     </table>
     <br>
     <div class='sheet-2colrow'>

--- a/Naruto d20 Modern/Naruto d20 Modern.html
+++ b/Naruto d20 Modern/Naruto d20 Modern.html
@@ -1972,7 +1972,7 @@
         <h3>Feats & Talents</h3>
         <div class='sheet-col'>
             <h4>Level Feats</h4>
-            <fieldset class="repeating_Level_Feats">
+            <fieldset class="repeating_LevelFeats">
                 <table class="sheet-table">
                     <tr>
                         <td><button type="roll" class="sheet-btn" name="roll_Feat-show" value="&{template:show}{{character= @{character_name}}}  {{title= @{LFeat-name}}}{{details= @{LFeat-details}}}" style="width:60px;">Show</button></td>
@@ -1990,7 +1990,7 @@
                 </div>
             </fieldset>
             <h4>Class Feats</h4>
-            <fieldset class="repeating_Class_Feats">
+            <fieldset class="repeating_ClassFeats">
                 <table class="sheet-table">
                     <tr>
                         <td><button type="roll" class="sheet-btn" name="roll_CFeat-show" value="&{template:show}{{character= @{character_name}}}  {{title= @{CFeat-name}}}{{details= @{CFeat-details}}}" style="width:60px;">Show</button></td>
@@ -2008,7 +2008,7 @@
                 </div>
             </fieldset>
             <h4>Free Feats</h4>
-            <fieldset class="repeating_Free_Feats">
+            <fieldset class="repeating_FreeFeats">
                 <table class="sheet-table">
                     <tr>
                         <td><button type="roll" class="sheet-btn" name="roll_FFeat-show" value="&{template:show}{{character= @{character_name}}}  {{title= @{FFeat-name}}}{{details= @{FFeat-details}}}" style="width:60px;">Show</button></td>
@@ -2024,11 +2024,12 @@
                         </tr>
                     </table>
                 </div>
-            </fieldset><h4>Flaws</h4>
-            <fieldset class="repeating_Flaw_Feats">
+            </fieldset>
+            <h4>Flaws</h4>
+            <fieldset class="repeating_Flaws">
                 <table class="sheet-table">
                     <tr>
-                        <td><button type="roll" class="sheet-btn" name="roll_Flaw-show" value="&{template:show}{{character= @{character_name}}}  {{title= @{Flaw-name}}}{{details= @{Flaw-details}}}" style="width:60px;">Show</button></td>
+                        <td><button type="roll" class="sheet-btn" name="roll_Flaws-show" value="&{template:show}{{character= @{character_name}}}  {{title= @{Talent-name}}}{{details= @{Flaw-details}}}" style="width:60px;">Show</button></td>
                         <td><input type="text" class="sheet-number" name="attr_Flaw-name" placeholder="Flaw Name" style="width:200px;"/></td>
                         <th><input type="checkbox" class="sheet-bigcheck" name="attr_Flaw-show" value="1"/><span></span></th>
                     </tr>


### PR DESCRIPTION
-Fixed Chakra Reserve calculations finally (I hope).
-Added repeating table for additional resistances
-Added a ID and Learn roll button for each category of technique
-Reorganized the ability score modifier sections for HP and Chakra Pool
-added a floor() function to Nature Energy to round down to the nearest
whole number
-expanded the width of the Wealth category in case players decide to use
currently over a Wealth check
-fixed the default selected item on multiple instances in the
technique's section