### PR TITLE
DAS 4_1 bug fix

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6761,7 +6761,7 @@
                             <option value="@{AT_Speere}">Speere</option>
                             <option value="@{AT_Stabe}">Stäbe</option>
                             <option value="@{AT_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{AT_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{AT_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{AT_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><select name="attr_NKW_PA_typ1" style="width: 5em;" >
@@ -6782,7 +6782,7 @@
                             <option value="@{PA_Speere}">Speere</option>
                             <option value="@{PA_Stabe}">Stäbe</option>
                             <option value="@{PA_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{PA_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{PA_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{PA_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><input type="number" name="attr_NKW1_SchwellenwertKK"value="0"></td>
@@ -6821,7 +6821,7 @@
                             <option value="@{AT_Speere}">Speere</option>
                             <option value="@{AT_Stabe}">Stäbe</option>
                             <option value="@{AT_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{AT_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{AT_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{AT_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><select name="attr_NKW_PA_typ2" style="width: 5em;" >
@@ -6842,7 +6842,7 @@
                             <option value="@{PA_Speere}">Speere</option>
                             <option value="@{PA_Stabe}">Stäbe</option>
                             <option value="@{PA_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{PA_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{PA_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{PA_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><input type="number" name="attr_NKW2_SchwellenwertKK" value="0"></td>
@@ -6881,7 +6881,7 @@
                             <option value="@{AT_Speere}">Speere</option>
                             <option value="@{AT_Stabe}">Stäbe</option>
                             <option value="@{AT_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{AT_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{AT_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{AT_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><select name="attr_NKW_PA_typ3" style="width: 5em;" >
@@ -6902,7 +6902,7 @@
                             <option value="@{PA_Speere}">Speere</option>
                             <option value="@{PA_Stabe}">Stäbe</option>
                             <option value="@{PA_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{PA_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{PA_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{PA_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><input type="number" name="attr_NKW3_SchwellenwertKK" value="0"></td>
@@ -6941,7 +6941,7 @@
                             <option value="@{AT_Speere}">Speere</option>
                             <option value="@{AT_Stabe}">Stäbe</option>
                             <option value="@{AT_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{AT_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{AT_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{AT_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td style="width: 5em;"><select name="attr_NKW_PA_typ4" style="width: 5em;">
@@ -6962,7 +6962,7 @@
                             <option value="@{PA_Speere}">Speere</option>
                             <option value="@{PA_Stabe}">Stäbe</option>
                             <option value="@{PA_Zweihandflegel}">Zweihandflegel</option>
-                            <option value="@{PA_Zweihandhiebwaffen}">Zweihandhiebwaffen</option>
+                            <option value="@{PA_Zweihand-hiebwaffen}">Zweihandhiebwaffen</option>
                             <option value="@{PA_Zweihandschwerter}">Zweihandschwerter</option>
                         </select></td>
                     <td><input type="number" name="attr_NKW4_SchwellenwertKK" value="0"></td>


### PR DESCRIPTION
- fix for attr_NKW_AT_typ1 and attr_NKW_PA_typ1 not giving the
appropriate value for "Zweihandhiebwaffen";   renamed option values to
match the existing attribute names.  @{AT_zweihand-hiebwaffen} and
@{PA_zweihand-hiebwaffen}