### PR TITLE
Update Only War C

### DIFF
--- a/Only War/Only War.html
+++ b/Only War/Only War.html
@@ -74,7 +74,7 @@
 <div class="sheet-2colrow"><!-- Left Column (Characteristics) -->
 <div class="sheet-col"><!-- WeaponSkill (WS) -->
 <div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_WS" type="roll" value="/em rolls Weapon Skill with [[ ([[@{WeaponSkill} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Weapon Skill (WS)</label></button></div>
+<div class="sheet-col"><button name="roll_WS" type="roll" value="/em rolls Weapon Skill with [[ ([[@{WeaponSkill}+ ?{Modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"><label>Weapon Skill (WS)</label></button></div>
 <div class="sheet-col"><input name="attr_WeaponSkill" type="text" value="0" /></div>
 </div>
 <div class="sheet-row">
@@ -1151,9 +1151,8 @@
 </div>
 <div class="sheet-row">
 <div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
-<div class="sheet-item" style="width: 75%;"><input name="attr_meleeweaponspecial" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/me uses @{meleeweaponname} Roll: [[ (([[@{WeaponSkill}]] + ?{Modifier|0}) -1d100)/10]] additional degree(s) of success!"> <label>Hit</label> </button></div>
-</div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_meleeweaponspecial" type="text" /> </div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} with [[ (([[@{WeaponSkill}+ ?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
 </div>
 </fieldset>
 <h3>Movement</h3>
@@ -1186,6 +1185,33 @@
 <div class="sheet-quickborder sheet-armourblock"><label>AL</label> <input name="attr_AlArmour" type="number" /> <label>(21-30)</label> <input disabled="disabled" name="attr_AlTotal" type="number" value="@{AlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
 <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LR</label> <input name="attr_LrArmour" type="number" /> <label>(71-85)</label> <input disabled="disabled" name="attr_LrTotal" type="number" value="@{LrArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
 <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LL</label> <input name="attr_LlArmour" type="number" /> <label>(86-00)</label> <input disabled="disabled" name="attr_LlTotal" type="number" value="@{LlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+
+<br />
+<div class="sheet-row">
+    <div class="sheet-row"></div>
+<h3>Size</h3>
+<div class="sheet-item" style="width: 70%;"><select class="sizeselect" name="attr_Size">
+<option value="0">Average (4)</option>
+<option value="-3">Miniscule (1)</option>
+<option value="-2">Puny (2)</option>
+<option value="-1">Weedy (3)</option>
+<option value="1">Hulking (5)</option>
+<option value="2">Enormous (6)</option>
+<option value="3">Massive (7)</option>
+<option value="4">Immense (8)</option>
+<option value="5">Monumental (9)</option>
+<option value="6">Titanic (10)</option>
+</select>
+
+
+<div></div>
+
+<div></div>
+
+
+
+</div>
+</div>
 </div>
 <div class="sheet-col sheet-fate">
 <h3>Wounds</h3>
@@ -1283,7 +1309,7 @@
 <div class="sheet-row">
 <div class="sheet-item" style="width: 25%;"><label>Special:</label></div>
 <div class="sheet-item" style="width: 65%;"><input name="attr_rangedweaponspecial" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} Roll: [[ (([[@{BallisticSkill}]] + ?{Modifier|0}) -1d100)/10]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} with [[(([[@{BallisticSkill} + ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
 </div>
 </div>
 </fieldset>
@@ -1307,7 +1333,7 @@
                 <input name="attr_Carry_max" type="text">
             </div>
             <div class="sheet-item" style="width:30%">
-                <label>Current: </label>
+                                <label>Current: </label>
             </div>
             <div class="sheet-item" style="width:10%">
                 <input name="attr_Carry" type="text">
@@ -1353,16 +1379,21 @@
 </div>
 </div>
 </div>
-<h3>Size</h3>
+<div class="sheet-2colrow">
+
+</div>
+<div></div>
+<div class="sheet-col">
+<h3>Special Weapons Dice Rolls</h3>
 <div class="sheet-row">
-<div class="sheet-item" style="width: 45%;"><select class="sizeselect" name="attr_Size">
-<option value="-3">Miniscule (1)</option>
-<option value="-2">Puny (2)</option>
-<option value="-1">Weedy (3)</option>
-<option value="0">Average (4)</option>
-<option value="1">Hulking (5)</option>
-<option value="2">Enormous (6)</option>
-<option value="3">Massive (7)</option>
-<option value="4">Immense (8)</option>
-<option value="5">Monumental (9)</option>
-<option value="6">Titanic (10)</option>
+<div class="sheet-item" style="width: 45%;">
+<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
+<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
+<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
+<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
+</div>
+</div>
+
+
+
+

--- a/Only War/Only War.html
+++ b/Only War/Only War.html
@@ -1202,6 +1202,18 @@
 <option value="5">Monumental (9)</option>
 <option value="6">Titanic (10)</option>
 </select>
+<br />
+
+
+    
+    <h3>Special Rolls</h3>
+<div class="sheet-item" style="width: 70%;">
+<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
+<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
+<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
+<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
+</div>
+
 
 
 <div></div>
@@ -1374,26 +1386,9 @@
 <fieldset class="repeating_Comrade_Special_Abilities">
 <div class="sheet-item" style="width: 95%;"><input name="attr_more_Comrade_Special_Abilities" type="text" /></div>
 </fieldset>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sheet-2colrow">
 
 </div>
-<div></div>
-<div class="sheet-col">
-<h3>Special Weapons Dice Rolls</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 45%;">
-<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
-<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
-<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
-<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
 </div>
 </div>
-
-
-
+</div>
 


### PR DESCRIPTION
Rolls to hit now provide dropdowns for difficulty modifiers, prompting for bonuses from aim or attack range as well as final modifier dependant on other conditions, simplifies the process.

The base of the sheet now includes common weapon damage formulas for special effects such as tearing, proven, primitive and 1d5 weapons. These can be placed in the current "Damage" fields without requiring additional code. 

Position of Size dropdown now more aesthetically pleasing.