### PR TITLE
skills dice roll fix

### DIFF
--- a/Fallout/Fallout 3.0.html
+++ b/Fallout/Fallout 3.0.html
@@ -221,7 +221,7 @@
             <td colspan="2" text-align="center">Base</td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-athleticism" value='/em @{character_name} rolls Small Guns skill [[1d100]], compared to [[@{athleticism}]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-athleticism" value='/em @{character_name} rolls Athleticism skill [[1d100]], compared to [[@{athleticism}]]' /></td>
             <td>Athleticism</td>
             <td><input name="attr_Checkbox1" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_athleticism" value="@{mod-athleticism} + @{base-athleticism}" disabled="true"/></td>
@@ -248,7 +248,7 @@
             <td><input type="text" class="sheet-number" name="attr_basetext-big_guns" value="(ST) + (ENx2) + (PE)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-detection" value='/em @{character_name} rolls Barter skill [[1d100]], compared to [[@{detection}]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-detection" value='/em @{character_name} rolls Detection skill [[1d100]], compared to [[@{detection}]]' /></td>
             <td>Detection</td>
             <td><input name="attr_Checkbox4" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_detection" value="@{mod-detection} + @{base-detection}" disabled="true"/></td>
@@ -383,7 +383,7 @@
             <td><input type="text" class="sheet-number" name="attr_basetext-steal" value="10 + (AG + AG)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-throwing" value='/em @{character_name} rolls Throwing skill [[1d100]], compared to [[@{small_guns}]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-throwing" value='/em @{character_name} rolls Throwing skill [[1d100]], compared to [[@{throwing}]]' /></td>
             <td>Throwing</td>
             <td><input name="attr_Checkbox19" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_throwing" value="@{mod-throwing} + @{base-throwing}" disabled="true"/></td>
@@ -401,7 +401,7 @@
             <td><input type="text" class="sheet-number" name="attr_basetext-traps" value="10 + (PE + AG)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-unarmed" value='/em @{character_name} rolls Unarmed skill [[1d100]], compared to [[@{traps}]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-unarmed" value='/em @{character_name} rolls Unarmed skill [[1d100]], compared to [[@{unarmed}]]' /></td>
             <td>Unarmed</td>
             <td><input name="attr_Checkbox21" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_unarmed" value="@{mod-unarmed} + @{base-unarmed}" disabled="true"/></td>


### PR DESCRIPTION
I was playing with this sheet and came across with some bugs related to skill roll section. I saw Unarmed skill using different skill's value changed that to original as well as throwing skill. So they are now using their own values for rolling. Athleticism and barter skills have bugs too. When rolling for them in the chat we saw them as wrong name. Like Barter skill was the name of smallguns how evet their values are correct, so I only changed names.