### PR TITLE
Update DH2E 2017

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -106,7 +106,7 @@
                 <!-- WeaponSkill (WS) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_WS" type="roll" value="/me rolls Weapon Skill [[1d100]], Target: [[@{WeaponSkill} + ?{Target Modifier|0} ]]"><label>Weapon Skill (WS)</label></button>
+                        <button name="roll_WS" type="roll" value="/em rolls Weapon Skill with [[ (@{WeaponSkill}+ ?{Modifier|0} - 1d100)/10)]] additional degree(s) of success!"><label>Weapon Skill (WS)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_WeaponSkill" type="text" value="0">
@@ -130,7 +130,7 @@
                 <!-- BallisticSkill (BS) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_BS" type="roll" value="/me rolls Ballistic Skill [[1d100]], Target: [[@{BallisticSkill} + ?{Target Modifier|0} ]]"><label>Ballistic Skill (BS)</label></button>
+                        <button name="roll_BS" type="roll" value="/em rolls Ballistic Skill with [[ ([[@{BallisticSkill} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Ballistic Skill (BS)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_BallisticSkill" type="text" value="0">
@@ -154,7 +154,7 @@
                 <!-- Strength (S) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_S" type="roll" value="/me rolls Strength [[1d100]], Target: [[@{Strength} + ?{Target Modifier|0} ]]"><label>Strength (S)</label></button>
+                        <button name="roll_S" type="roll" value="/em rolls Strength with [[ ([[@{Strength} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Strength (S)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Strength" type="text" value="0">
@@ -178,7 +178,7 @@
                 <!-- Toughness (T) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_T" type="roll" value="/me rolls Toughness [[1d100]], Target: [[@{Toughness} + ?{Target Modifier|0} ]]"><label>Toughness (T)</label></button>
+                        <button name="roll_T" type="roll" value="/em rolls Toughness with [[ ([[@{Toughness} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Toughness (T)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Toughness" type="text" value="0">
@@ -202,7 +202,7 @@
                 <!-- Agility (Ag) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Ag" type="roll" value="/me rolls Agility [[1d100]], Target: [[@{Agility} + ?{Target Modifier|0} ]]"><label>Agility (Ag)</label></button>
+                        <button name="roll_Ag" type="roll" value="/em rolls Agility with [[ ([[@{Agility} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Agility (Ag)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Agility" type="text" value="0">
@@ -230,7 +230,7 @@
                 <!-- Intelligence (Int) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Int" type="roll" value="/me rolls Intelligence [[1d100]], Target: [[@{Intelligence} + ?{Target Modifier|0} ]]"><label>Intelligence (Int)</label></button>
+                        <button name="roll_Int" type="roll" value="/em rolls Intelligence with [[ ([[@{Intelligence} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Intelligence (Int)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Intelligence" type="text" value="0">
@@ -254,7 +254,7 @@
                 <!-- Perception (Per) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Per" type="roll" value="/me rolls Perception [[1d100]], Target: [[@{Perception} + ?{Target Modifier|0} ]]"><label>Perception (Per)</label></button>
+                        <button name="roll_Per" type="roll" value="/em rolls Perception with [[ ([[@{Perception} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Perception (Per)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Perception" type="text" value="0">
@@ -278,7 +278,7 @@
                 <!-- Willpower (WP) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_WP" type="roll" value="/me rolls Willpower [[1d100]], Target: [[@{Willpower} + ?{Target Modifier|0} ]]"><label>Willpower (WP)</label></button>
+                        <button name="roll_WP" type="roll" value="/em rolls Willpower with [[ ([[@{Willpower} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Willpower (WP)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Willpower" type="text" value="0">
@@ -302,7 +302,7 @@
                 <!-- Fellowship (Fel) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Fel" type="roll" value="/me rolls Fellowship [[1d100]], Target: [[@{Fellowship} + ?{Target Modifier|0} ]]"><label>Fellowship (Fel)</label></button>
+                        <button name="roll_Fel" type="roll" value="/em rolls Fellowship with [[ ([[@{Fellowship} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Fellowship (Fel)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Fellowship" type="text" value="0">
@@ -326,7 +326,7 @@
                 <!-- Influence (Ifl) -->
                 <div class="sheet-2colrow">
                     <div class="sheet-col">
-                        <button name="roll_Inf" type="roll" value="/me rolls Influence [[1d100]], Target: [[@{Influence} + ?{Target Modifier|0} ]]"><label>Influence (Inf)</label></button>
+                        <button name="roll_Inf" type="roll" value="/em rolls Influence with [[ ([[@{Influence} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Influence (Inf)</label></button>
                     </div>
                     <div class="sheet-col">
                         <input name="attr_Influence" type="text" value="0">
@@ -434,20 +434,21 @@
                     </div>
                 </div>
                 
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:5%"></div>
-                    <div class="sheet-item" style="width:13%"><label>WS</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutWS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>BS</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutBS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:7%"><label>S</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:7%"><label>T</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutT" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:11%"><label>Ag</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutAg" type="checkbox" value="1"></div>
-                </div>
-            </div>
+                <h3>Unnatural</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 13%;"><label>WS</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutWS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>BS</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutBS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 7%;"><label>S</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 7%;"><label>T</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutT" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 11%;"><label>Ag</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutAg" type="number" value="0" /></div>
+</div>
+</div>
     
             <div class="sheet-col sheet-fate">
                 <h3>Corruption (C)</h3>
@@ -496,19 +497,18 @@
                     </div>
                 </div>
                 
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:13%"><label>Int</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutInt" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>Per</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutPer" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>WP</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutWP" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:11%"><label>Fel</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutFel" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:10%"><label>Ifl</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutIfl" type="checkbox" value="1"></div>
-                </div>
-            </div>
+                <h3>Characteristics</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 13%;"><label>Int</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutInt" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>Per</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutPer" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>Wil</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutWP" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 11%;"><label>Fel</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutFel" type="number" value="0" /></div>
+</div>
+</div>
         </div>
     </div>
     
@@ -526,7 +526,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Acrobatics" type="roll" 
-                                    value="/em rolls Acrobatics [[1d100]], Target: [[@{AcrobaticsCharacteristic} + [[(-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Acrobatics with [[(((@{AcrobaticsCharacteristic} + [[-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4}]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Acrobatics</label>
                                 </button>
                             </div>
@@ -549,7 +549,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Athletics" type="roll" 
-                                    value="/em rolls Athletics [[1d100]], Target: [[@{AthleticsCharacteristic} + [[(-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Athletics with [[(((@{AthleticsCharacteristic} + [[(-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Athletics</label>
                                 </button>
                             </div>
@@ -572,7 +572,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Awareness" type="roll" 
-                                    value="/em rolls Awareness [[1d100]], Target: [[@{AwarenessCharacteristic} + [[(-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Awareness with [[(((@{AwarenessCharacteristic} + [[(-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Awareness</label>
                                 </button>
                             </div>
@@ -596,7 +596,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Charm" type="roll" 
-                                    value="/em rolls Charm [[1d100]], Target: [[@{CharmCharacteristic} + [[(-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Charm with [[(((@{CharmCharacteristic} + [[(-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Charm</label>
                                 </button>
                             </div>
@@ -619,7 +619,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Command" type="roll" 
-                                    value="/em rolls Command [[1d100]], Target: [[@{CommandCharacteristic} + [[(-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Command with [[(((@{CommandCharacteristic} + [[(-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Command</label>
                                 </button>
                             </div>
@@ -644,7 +644,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Commerce" type="roll" 
-                                    value="/em rolls Commerce [[1d100]], Target: [[@{CommerceCharacteristic} + [[(-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Commerce with [[(((@{CommerceCharacteristic} + [[(-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Commerce</label>
                                 </button>
                             </div>
@@ -667,7 +667,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Deceive" type="roll" 
-                                    value="/em rolls Deceive [[1d100]], Target: [[@{DeceiveCharacteristic} + [[(-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Deceive with [[(((@{DeceiveCharacteristic} + [[(-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Deceive</label>
                                 </button>
                             </div>
@@ -690,7 +690,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Dodge" type="roll" 
-                                    value="/em rolls Dodge [[1d100]], Target: [[@{DodgeCharacteristic} + [[(-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Dodge with [[(((@{DodgeCharacteristic} + [[(-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Dodge</label>
                                 </button>
                             </div>
@@ -712,7 +712,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Inquiry" type="roll" 
-                                    value="/em rolls Inquiry [[1d100]], Target: [[@{InquiryCharacteristic} + [[(-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Inquiry with [[(((@{InquiryCharacteristic} + [[(-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Inquiry</label>
                                 </button>
                             </div>
@@ -736,7 +736,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Interrogation" type="roll" 
-                                    value="/em rolls Interrogation [[1d100]], Target: [[@{InterrogationCharacteristic} + [[(-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Interrogation with [[(((@{InterrogationCharacteristic} + [[(-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Interrogation</label>
                                 </button>
                             </div>
@@ -759,7 +759,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Intimidate" type="roll" 
-                                    value="/em rolls Intimidate [[1d100]], Target: [[@{IntimidateCharacteristic} + [[(-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Intimidate with [[(((@{IntimidateCharacteristic} + [[(-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Intimidate</label>
                                 </button>
                             </div>
@@ -782,7 +782,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Logic" type="roll" 
-                                    value="/em rolls Logic [[1d100]], Target: [[@{LogicCharacteristic} + [[(-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Logic with [[(((@{LogicCharacteristic} + [[(-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Logic</label>
                                 </button>
                             </div>
@@ -801,11 +801,11 @@
                     </tr>
                     
                     <tr>
-                        <td>
+                        <td> 
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Medicae" type="roll" 
-                                    value="/em rolls Medicae [[1d100]], Target: [[@{MedicaeCharacteristic} + [[(-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Medicae with [[(((@{MedicaeCharacteristic} + [[(-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Medicae</label>
                                 </button>
                             </div>
@@ -843,7 +843,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_Surface" type="roll" 
-                                    value="/em rolls Navigate (Surface) [[1d100]], Target: [[@{NavigateCharacteristic} + [[(-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Navigate with [[(((@{NavigateCharacteristic} + [[(-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Surface</label>
                                 </button>
                             </div>
@@ -860,7 +860,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_Stellar" type="roll" 
-                                    value="/em rolls Navigate (Stellar) [[1d100]], Target: [[@{NavigateCharacteristic} + [[(-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Navigate (Stellar) with [[(((@{NavigateCharacteristic} + [[(-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Stellar</label>
                                 </button>
                             </div>
@@ -877,7 +877,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_Warp" type="roll" 
-                                    value="/em rolls Navigate (Warp) [[1d100]], Target: [[@{NavigateCharacteristic} + [[(-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Navigate (Warp) with [[(((@{NavigateCharacteristic} + [[(-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Warp</label>
                                 </button>
                             </div>
@@ -908,7 +908,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_Aeronautica" type="roll" 
-                                    value="/em rolls Operate (Aeronautica) [[1d100]], Target: [[@{OperateCharacteristic} + [[(-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Operate with [[(((@{OperateCharacteristic} + [[(-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Aeronautica</label>
                                 </button>
                             </div>
@@ -925,7 +925,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_OSurface" type="roll" 
-                                    value="/em rolls Operate (Surface) [[1d100]], Target: [[@{OperateCharacteristic} + [[(-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Operate (Surface) with [[(((@{OperateCharacteristic} + [[(-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Surface</label>
                                 </button>
                             </div>
@@ -942,7 +942,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:100%">
                                 <button name="roll_Voidship" type="roll" 
-                                    value="/em rolls Operate (Voidship) [[1d100]], Target: [[@{OperateCharacteristic} + [[(-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Operate (Voidship) with [[(((@{OperateCharacteristic} + [[(-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Voidship</label>
                                 </button>
                             </div>
@@ -959,7 +959,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Parry" type="roll" 
-                                    value="/em rolls Parry [[1d100]], Target: [[@{ParryCharacteristic} + [[(-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Parry with [[(((@{ParryCharacteristic} + [[(-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Parry</label>
                                 </button>
                             </div>
@@ -981,7 +981,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Psyniscience" type="roll" 
-                                    value="/em rolls Psyniscience [[1d100]], Target: [[@{PsyniscienceCharacteristic} + [[(-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Psyniscience with [[(((@{PsyniscienceCharacteristic} + [[(-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Psyniscience</label>
                                 </button>
                             </div>
@@ -1004,7 +1004,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Scrutiny" type="roll" 
-                                    value="/em rolls Scrutiny [[1d100]], Target: [[@{ScrutinyCharacteristic} + [[(-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scrutiny with [[(((@{ScrutinyCharacteristic} + [[(-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Scrutiny</label>
                                 </button>
                             </div>
@@ -1027,7 +1027,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Security" type="roll" 
-                                    value="/em rolls Security [[1d100]], Target: [[@{SecurityCharacteristic} + [[(-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Security with [[(((@{SecurityCharacteristic} + [[(-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Security</label>
                                 </button>
                             </div>
@@ -1050,7 +1050,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_SleightOfHand" type="roll" 
-                                    value="/em rolls SleightOfHand [[1d100]], Target: [[@{SleightOfHandCharacteristic} + [[(-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls SleightOfHand with [[(((@{SleightOfHandCharacteristic} + [[(-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>SleightOfHand</label>
                                 </button>
                             </div>
@@ -1073,7 +1073,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Stealth" type="roll" 
-                                    value="/em rolls Stealth [[1d100]], Target: [[@{StealthCharacteristic} + [[(-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Stealth with [[(((@{StealthCharacteristic} + [[(-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Stealth</label>
                                 </button>
                             </div>
@@ -1096,7 +1096,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_Survival" type="roll" 
-                                    value="/em rolls Survival [[1d100]], Target: [[@{SurvivalCharacteristic} + [[(-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Survival with [[(((@{SurvivalCharacteristic} + [[(-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Survival</label>
                                 </button>
                             </div>
@@ -1120,7 +1120,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:55%">
                                 <button name="roll_TechUse" type="roll" 
-                                    value="/em rolls Tech-Use [[1d100]], Target: [[@{TechUseCharacteristic} + [[(-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Tech-Use with [[(((@{TechUseCharacteristic} + [[(-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                     <label>Tech-Use</label>
                                 </button>
                             </div>
@@ -1163,7 +1163,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_1stLanguage" type="roll" 
-                                    value="/em rolls Linguistics:@{1stLanguage} [[1d100]], Target: [[@{LinguisticsCharacteristic} + [[(-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Linguistics:@{1stLanguage} with [[(((@{LinguisticsCharacteristic} + [[(-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1182,7 +1182,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_2ndLanguage" type="roll" 
-                                    value="/em rolls Linguistics:@{2ndLanguage} [[1d100]], Target: [[@{LinguisticsCharacteristic} + [[(-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Linguistics:@{2ndLanguage} with [[(((@{LinguisticsCharacteristic} + [[(-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1201,7 +1201,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_3rdLanguage" type="roll" 
-                                    value="/em rolls Linguistics:@{3rdLanguage} [[1d100]], Target: [[@{LinguisticsCharacteristic} + [[(-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Linguistics:@{3rdLanguage} with [[(((@{LinguisticsCharacteristic} + [[(-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1236,7 +1236,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_1stTrade" type="roll" 
-                                    value="/em rolls Trade:@{1stTrade} [[1d100]], Target: [[@{TradeCharacteristic} + [[(-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Trade:@{1stTrade} with [[(((@{TradeCharacteristic} + [[(-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1255,7 +1255,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_2ndTrade" type="roll" 
-                                    value="/em rolls Trade:@{2ndTrade} [[1d100]], Target: [[@{TradeCharacteristic} + [[(-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Trade:@{2ndTrade} with [[(((@{TradeCharacteristic} + [[(-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1274,7 +1274,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_3rdTrade" type="roll" 
-                                    value="/em rolls Trade:@{3rdTrade} [[1d100]], Target: [[@{TradeCharacteristic} + [[(-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Trade:@{3rdTrade} with [[(((@{TradeCharacteristic} + [[(-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1293,7 +1293,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_4thTrade" type="roll" 
-                                    value="/em rolls Trade:@{4thTrade} [[1d100]], Target: [[@{TradeCharacteristic} + [[(-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Trade:@{4thTrade} with [[(((@{TradeCharacteristic} + [[(-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1329,7 +1329,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_1stCommon" type="roll" 
-                                    value="/em rolls Common Lore:@{1stCommon} [[1d100]], Target: [[@{CommonLoreCharacteristic} + [[(-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Common Lore:@{1stCommon} with [[(((@{CommonLoreCharacteristic} + [[(-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1348,7 +1348,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_2ndCommon" type="roll" 
-                                    value="/em rolls Common Lore:@{2ndCommon} [[1d100]], Target: [[@{CommonLoreCharacteristic} + [[(-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Common Lore:@{2ndCommon} with [[(((@{CommonLoreCharacteristic} + [[(-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1367,7 +1367,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_3rdCommon" type="roll" 
-                                    value="/em rolls Common Lore:@{3rdCommon} [[1d100]], Target: [[@{CommonLoreCharacteristic} + [[(-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Common Lore:@{3rdCommon} with [[(((@{CommonLoreCharacteristic} + [[(-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1386,7 +1386,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_4thCommon" type="roll" 
-                                    value="/em rolls Common Lore:@{4thCommon} [[1d100]], Target: [[@{CommonLoreCharacteristic} + [[(-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Common Lore:@{4thCommon} with [[(((@{CommonLoreCharacteristic} + [[(-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1406,8 +1406,8 @@
                             <div class="sheet-item" style="width:60%"><label>Scholastic</label></div>
                             <div class="sheet-item" style="width:40%">
                                 <select class="charaselect" name="attr_ScholasticLoreCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
+                                    <option value="@{Intelligence}>(Int)</option>
+                                    <option value="@{Fellowship}>(Fel)</option>
                                 </select>
                             </div>
                         </div>    
@@ -1418,7 +1418,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_1stScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{1stScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{1stScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1436,7 +1436,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_2ndScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{2ndScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{2ndScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1454,7 +1454,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_3rdScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{3rdScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{3rdScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1472,7 +1472,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_4thScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{4thScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{4thScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1490,7 +1490,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_5thScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{5thScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{5thScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1508,7 +1508,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_6thScholastic" type="roll" 
-                                    value="/em rolls Scholastic Lore:@{6thScholastic} [[1d100]], Target: [[@{ScholasticLoreCharacteristic} + [[(-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Scholastic Lore:@{6thScholastic} with [[(((@{ScholasticLoreCharacteristic} + [[(-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1540,7 +1540,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_1stForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{1stForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{1stForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4})]] + ?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1558,7 +1558,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_2ndForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{2ndForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{2ndForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1576,7 +1576,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_3rdForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{3rdForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{3rdForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1594,7 +1594,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_4thForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{4thForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{4thForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1612,7 +1612,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_5thForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{5thForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{5thForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1630,7 +1630,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_6thForbidden" type="roll" 
-                                    value="/em rolls Forbidden Lore:@{6thForbidden} [[1d100]], Target: [[@{ForbiddenLoreCharacteristic} + [[(-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Forbidden Lore:@{6thForbidden} with [[(((@{ForbiddenLoreCharacteristic} + [[(-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1653,8 +1653,8 @@
                             <div class="sheet-item" style="width:60%"><label>Other</label></div>
                             <div class="sheet-item" style="width:40%">
                                 <select class="charaselect" name="attr_OtherLoreCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
+                                    <option value="@{Intelligence}>(Int)</option>
+                                    <option value="@{Fellowship}>(Fel)</option>
                                 </select>
                             </div>
                         </div>    
@@ -1668,7 +1668,7 @@
                         <div class="sheet-row">
                             <div class="sheet-item" style="width:20%">
                                 <button name="roll_Lore" type="roll" 
-                                    value="/em rolls Lore:@{OtherLore} [[1d100]], Target: [[@{OtherLoreCharacteristic} + [[(-20 + @{OtherLore1} + @{OtherLore2} + @{OtherLore3} + @{OtherLore4})]] + ?{Target Modifier|0} ]]">
+                                    value="/em rolls Lore:@{OtherLore} with [[(((@{OtherLoreCharacteristic} + [[(-20 + @{OtherLore1} + @{OtherLore2} + @{OtherLore3} + @{OtherLore4})]] +?{Target Modifier|0}))-1d100)/10 ]] additional degree(s) of success!">
                                 </button>
                             </div>
                             <div class="sheet-item" style="width:80%">
@@ -1682,7 +1682,7 @@
                         <td><input name="attr_OtherLore4" type="checkbox" value="10"></td>
                     </tr>
                 </table>
-			</fieldset>
+        	</fieldset>
             
             </div>   
         </div>
@@ -1747,138 +1747,64 @@
         <br>
         
         <h3>Melee Weapons</h3>
-        <fieldset class="repeating_meleeweapons">
-        <div class="sheet-quickborder">
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Name:</label>
-                </div>
-                <div class="sheet-item" style="width:55%">
-                    <input name="attr_meleeweaponname" type="text">
-                </div>
-                <div class="sheet-item" style="width:12%">
-                    <label>Class:</label>
-                </div>
-                <div class="sheet-item" style="width:19%">
-                    <input name="attr_meleeweaponclass" type="text">
-                </div>
-            </div>
-    
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Damage:</label>
-                </div>
-                <div class="sheet-item" style="width:20%">
-                    <input name="attr_meleeweapondamage" type="text">
-                </div>
-                <div class="sheet-item" style="width:12%">
-                    <label>Type:</label>
-                </div>
-                <div class="sheet-item" style="width:18%">
-                    <input name="attr_meleeweapontype" type="text">
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <label>Pen:</label>
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <input name="attr_meleeweaponpen" type="text" value="0">
-                </div>
-                <div class="sheet-item" style="width:16%">
-                    <button name="roll_meleedamage" type="roll" 
-                    value="/me does [[@{meleeweapondamage}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})">
-                        <label>Damage</label>
-                    </button>
-                </div>
-            </div>
-    
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Special:</label>
-                </div>
-                <div class="sheet-item" style="width:75%">
-                    <input name="attr_meleeweaponspecial" type="text">
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <button name="roll_meleehit" type="roll" 
-                    value="/em attacks with @{meleeweaponname}, and gets [[1d100]], Target: [[ @{WeaponSkill}+@{advanceWS}+?{Target Modifier|0}]]">
-                        <label>Hit</label>
-                    </button>
-                </div>
-            </div>
-        </div>
-        </fieldset>
+<fieldset class="repeating_meleeweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_meleeweaponname" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
+<div class="sheet-item" style="width: 19%;"><input name="attr_meleeweaponclass" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_meleeweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Type:</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 16%;"><button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+@{MutS}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})"> <label>Damage</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_meleeweaponspecial" type="text" /> </div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} with [[ ((@{WeaponSkill}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{Modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+</div>
+</fieldset>
         
-        <h3>Movement</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:20%">
-                <label>Half Move: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)">
-            </div>
-            <div class="sheet-item" style="width:20%">
-                <label>Full Move: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10))">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <label>Charge: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10))">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <label>Run: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10))">
-            </div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:28%">
-                <label>Fatigue</label>
-            </div>
-            <div class="sheet-item" style="width:20%">
-                <label>Threshold:</label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FatigueThreshold" type="number" value="floor(@{Willpower}/10)+floor(@{Toughness}/10)">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <label>Current: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input name="attr_Fatigue" type="number">
-            </div>
-        </div>
-        
-        <br>
+       <h3>Movement</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Half Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)+@{MutAg}+@{Size}" /></div>
+<div class="sheet-item" style="width: 20%;"><label>Full Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Charge: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Run: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 28%;"><label>Fatigue</label></div>
+<div class="sheet-item" style="width: 20%;"><label>Threshold:</label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FatigueThreshold" type="number" value="@{MutT}+floor(@{Toughness}/10)+@{MutWP}+floor(@{Willpower}/10)" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Current: </label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_Fatigue" type="number" /></div>
+</div>
+<br />
         
         <h3>Armour & Defence</h3>
         
-        <div class="sheet-2colrow">
-            <div class="sheet-col">
-                <div class="sheet-armourblock"></div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>Head</label> <input name="attr_HArmour" type="number"> <label>(1-10)</label> <input disabled="true" name="attr_HTotal" type="number" value="@{HArmour}+floor(@{Toughness}/10)">
-                </div><br>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>AR</label> <input name="attr_ArArmour" type="number"> <label>(11-20)</label> <input disabled="true" name="attr_ArTotal" type="number" value="@{ArArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>Body</label> <input name="attr_BArmour" type="number"> <label>(31-70)</label> <input disabled="true" name="attr_BTotal" type="number" value="@{BArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>AL</label> <input name="attr_AlArmour" type="number"> <label>(21-30)</label> <input disabled="true" name="attr_AlTotal" type="number" value="@{AlArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LR</label> <input name="attr_LrArmour" type="number"> <label>(71-85)</label> <input disabled="true" name="attr_LrTotal" type="number" value="@{LrArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LL</label> <input name="attr_LlArmour" type="number"> <label>(86-00)</label> <input disabled="true" name="attr_LlTotal" type="number" value="@{LlArmour}+floor(@{Toughness}/10)">
-                </div>
-            </div>
+      <div class="sheet-2colrow">
+<div class="sheet-col">
+<div class="sheet-armourblock">&nbsp;</div>
+<div class="sheet-quickborder sheet-armourblock"><label>Head</label> <input name="attr_HArmour" type="number" /> <label>(1-10)</label> <input disabled="disabled" name="attr_HTotal" type="number" value="@{HArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<br />
+<div class="sheet-quickborder sheet-armourblock"><label>AR</label> <input name="attr_ArArmour" type="number" /> <label>(11-20)</label> <input disabled="disabled" name="attr_ArTotal" type="number" value="@{ArArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>Body</label> <input name="attr_BArmour" type="number" /> <label>(31-70)</label> <input disabled="disabled" name="attr_BTotal" type="number" value="@{BArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>AL</label> <input name="attr_AlArmour" type="number" /> <label>(21-30)</label> <input disabled="disabled" name="attr_AlTotal" type="number" value="@{AlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LR</label> <input name="attr_LrArmour" type="number" /> <label>(71-85)</label> <input disabled="disabled" name="attr_LrTotal" type="number" value="@{LrArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LL</label> <input name="attr_LlArmour" type="number" /> <label>(86-00)</label> <input disabled="disabled" name="attr_LlTotal" type="number" value="@{LlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+</div>
+            
         
             <div class="sheet-col sheet-fate">
                 <h3>Wounds</h3>
@@ -1984,112 +1910,46 @@
         </fieldset>
         
         <h3>Ranged Weapons</h3>
-        <fieldset class="repeating_rangedweapons">
-        <div class="sheet-quickborder">
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:15%">
-                <label>Name:</label>
-            </div>
-            <div class="sheet-item" style="width:55%">
-                <input name="attr_rangedweaponname" type="text">
-            </div>
-            <div class="sheet-item" style="width:12%">
-                <label>Class:</label>
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <input name="attr_rangedweaponclass" type="text">
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:12%">
-                <label>Range:</label>
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_rangedweaponrange" type="text">
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <label>Damage:</label>
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <input name="attr_rangedweapondamage" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <label>Type:</label>
-            </div>
-            <div class="sheet-item" style="width:18%">
-                <input name="attr_rangedweapontype" type="text">
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <label>Pen:</label>
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <input name="attr_rangedweaponpen" type="text" value="0">
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:9%">
-                <label>RoF:</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponsingle" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponsemi" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponfull" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <label>Clip:</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponclip" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponclip_max" type="text" value="0">
-            </div>
-            
-            <div class="sheet-item" style="width:15%">
-                <label>Reload:</label>
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <input name="attr_rangedweaponreload" type="text">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})">
-
-                    <label>Damage</label>
-                </button>
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%">
-                <label>Special:</label>
-            </div>
-            <div class="sheet-item" style="width:65%">
-                <input name="attr_rangedweaponspecial" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <button name="roll_rangedhit" type="roll" 
-                    value="/em fires @{rangedweaponname} and gets [[1d100]], Target: [[@{BallisticSkill}+@{advanceBS}+?{Target Modifier|0}]]">
-                    <label>Hit</label>
-                </button>
-            </div>
-        </div>
-        </div>
-        </fieldset>
+<fieldset class="repeating_rangedweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_rangedweaponname" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponclass" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_rangedweaponrange" type="text" /></div>
+<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Type:</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_rangedweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 9%;"><label>Pen:</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_rangedweaponpen" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 9%;"><label>RoF:</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponsingle" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponsemi" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponfull" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 9%;"><label>Clip:</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponclip" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponclip_max" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 15%;"><label>Reload:</label></div>
+<div class="sheet-item" style="width: 16%;"><input name="attr_rangedweaponreload" type="text" /></div>
+<div class="sheet-item" style="width: 16%;"><button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})"> <label>Damage</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Special:</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_rangedweaponspecial" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} with [[((@{BallisticSkill} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0} ]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+</div>
+</div>
+</fieldset>
         
         <h3>Gear</h3>
         <div class="sheet-row">
@@ -2123,7 +1983,7 @@
                 <input name="attr_Carry_max" type="text">
             </div>
             <div class="sheet-item" style="width:30%">
-                <label>Current: </label>
+                <label style="width:10%">Current: </label>
             </div>
             <div class="sheet-item" style="width:10%">
                 <input name="attr_Carry" type="text">
@@ -2131,29 +1991,57 @@
         </div>
         
         <h3>Psychic Powers</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:40%">
-                <label>Psy Rating:</label>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 40%;"><label>Psy Rating:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyRating" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPower" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowerPage" type="text" /></div>
+</div>
+<fieldset class="repeating_PsyPowers">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPowers" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowersPage" type="text" /></div>
+</fieldset>
+<h3>Focus Power Test</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Willpower" type="roll" value="/em channels their power with [[ ([[@{Willpower} + (@{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Willpower</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Perception" type="roll" value="/em channels their power with [[ ([[@{Perception} + (@{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Perception</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_PsyniscienceCharacteristic" type="roll" value="/em channels their power with [[ ([[@{PsyniscienceCharacteristic} + (@{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Psyniscience</label> </button></div>
+</div>
+
+</div>
+</div>
+</div>
+</div>
             </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyRating" type="number">
-            </div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_PsyPower" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyPowerPage" type="text">
-            </div>
-        </div>
-        <fieldset class="repeating_PsyPowers">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_PsyPowers" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyPowersPage" type="text">
-            </div>
-        </fieldset>
-        
-    </div>
+            <div class="sheet-2colrow">
+<h3>Size</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 45%;"><select class="sizeselect" name="attr_Size">
+<option value="0">Average (4)</option>
+<option value="-3">Miniscule (1)</option>
+<option value="-2">Puny (2)</option>
+<option value="-1">Weedy (3)</option>
+<option value="1">Hulking (5)</option>
+<option value="2">Enormous (6)</option>
+<option value="3">Massive (7)</option>
+<option value="4">Immense (8)</option>
+<option value="5">Monumental (9)</option>
+<option value="6">Titanic (10)</option>
+</div>
+<div class="sheet-col">
+<h3>Special Weapons Dice Rolls</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 45%;">
+<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
+<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
+<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
+<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
+</div>
+</div>
+</div>


### PR DESCRIPTION
Large number of corrections in line with work carried out on Only War sheets including:

Characteristic advances no longer pick up on the chosen advances. This would previously happen in some but not all cases.

Replaced characteristic tickboxes with Unnatural Attributes numeric input

weapon skill damage picks up on unnatural strength

move speed picks up on unnatural agility

total armour soak picks up on unnatural toughness

fatigue threshhold picks up on unnatural toughness

Replace characteristic rolls with dialogue including additional degrees of success

Character size dropdown included, will directly influence stealth rolls and move speeds.

Updated to reflect degrees of success accurately (0 additional is a successful roll, 1 additional is an additional degree of success.

Rolls to hit with weapons in melee or ranged now provide dropdowns for difficulty modifiers, prompting for bonuses from aim or attack range as well as final modifier dependant on other conditions, simplifies the process.

The base of the sheet now includes common weapon damage formulas for special effects such as tearing, proven, primitive and 1d5 weapons. These can be placed in the current "Damage" fields without requiring additional code. 

Psychic power tests now correctly allow you to roll from willpower, psyniscience or perception based on the relevant button.
Depending on the psy level used vs your actual psy level. Using less than your full psy level gives a +10 to the test for every level less than your psy rating used.  pushing gives a -10 for every level above your base psy rating used.