### PR TITLE
Bug fixes for Fallout 2.0 rolling system

### DIFF
--- a/Fallout (classic_pnp 2)/Fallout 2.0.html
+++ b/Fallout (classic_pnp 2)/Fallout 2.0.html
@@ -49,7 +49,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-strength" value='/em @{character_name} rolls Strength [[1d12]], compared to [[ @{strength} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-strength" value='/em @{character_name} rolls Strength [[1d10]], compared to [[ @{strength} + ?{Modifier|0} ]]' /></td>
             <td>Strength (ST)</td>
             <td><input type="number" class="sheet-number" name="attr_strength" value='@{strength_mod} + @{strength_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_strength_mod" value="0" /></td>
@@ -59,7 +59,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-perception" value='/em @{character_name} rolls Perception [[1d12]], compared to [[ @{perception} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-perception" value='/em @{character_name} rolls Perception [[1d10]], compared to [[ @{perception} + ?{Modifier|0} ]]' /></td>
             <td>Perception (PE)</td>
             <td><input type="number" class="sheet-number" name="attr_perception" value='@{perception_mod} + @{perception_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_perception_mod" value="0" /></td>
@@ -69,7 +69,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-endurance" value='/em @{character_name} rolls endurance [[1d12]], compared to [[ @{endurance} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-endurance" value='/em @{character_name} rolls endurance [[1d10]], compared to [[ @{endurance} + ?{Modifier|0} ]]' /></td>
             <td>Endurance (EN)</td>
             <td><input type="number" class="sheet-number" name="attr_endurance" value='@{endurance_mod} + @{endurance_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_endurance_mod" value="0" /></td>
@@ -79,7 +79,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-charisma" value='/em @{character_name} rolls Charisma [[1d12]], compared to [[ @{charisma} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-charisma" value='/em @{character_name} rolls Charisma [[1d10]], compared to [[ @{charisma} + ?{Modifier|0} ]]' /></td>
             <td>Charisma (CH)</td>
             <td><input type="number" class="sheet-number" name="attr_charisma" value='@{charisma_mod} + @{charisma_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_charisma_mod" value="0" /></td>
@@ -89,7 +89,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-intelligence" value='/em @{character_name} rolls Intelligence [[1d12]], compared to [[ @{intelligence} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-intelligence" value='/em @{character_name} rolls Intelligence [[1d10]], compared to [[ @{intelligence} + ?{Modifier|0} ]]' /></td>
             <td>Intelligence (IN)</td>
             <td><input type="number" class="sheet-number" name="attr_intelligence" value='@{intelligence_mod} + @{intelligence_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_intelligence_mod" value="0" /></td>
@@ -99,7 +99,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-agility" value='/em @{character_name} rolls Agility [[1d12]], compared to [[ @{agility} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-agility" value='/em @{character_name} rolls Agility [[1d10]], compared to [[ @{agility} + ?{Modifier|0} ]]' /></td>
             <td>Agility (AG)</td>
             <td><input type="number" class="sheet-number" name="attr_agility" value='@{agility_mod} + @{agility_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_agility_mod" value="0" /></td>
@@ -109,7 +109,7 @@
         </tr>
         <tr>
             <td>
-			<button class="sheet-skill_button" type='roll' name="attr_roll-luck" value='/em @{character_name} rolls Luck [[1d12]], compared to [[ @{luck} + ?{Modifier|0} ]]' /></td>
+			<button class="sheet-skill_button" type='roll' name="attr_roll-luck" value='/em @{character_name} rolls Luck [[1d10]], compared to [[ @{luck} + ?{Modifier|0} ]]' /></td>
             <td>Luck (LU)</td>
             <td><input type="number" class="sheet-number" name="attr_luck" value='@{luck_mod} + @{luck_base}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_luck_mod" value="0" /></td>
@@ -237,7 +237,7 @@
             <td colspan="2" text-align="center">Base</td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-barter" value='/em @{character_name} rolls Barter skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{barter} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-barter" value='/em @{character_name} rolls Barter skill [[1d100]], compared to [[@{barter}]]' /></td>
             <td>Barter</td>
             <td><input name="attr_tagskill1" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_barter" value="@{mod-barter} + @{base-barter} + 20*@{tagskill1}" disabled="true"/></td>
@@ -248,7 +248,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-barter" value="CH x 4" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-big_guns" value='/em @{character_name} rolls Big Guns skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{big_guns} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-big_guns" value='/em @{character_name} rolls Big Guns skill [[1d100]], compared to [[@{big_guns}]]' /></td>
             <td>Big Guns</td>
             <td><input name="attr_tagskill2" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_big_guns" value="@{mod-big_guns} + @{base-big_guns} + 20*@{tagskill2}" disabled="true"/></td>
@@ -259,7 +259,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-big_guns" value="2 x AG" readonly /></td>
         </tr>
         <tr>
-            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-doctor" value='/em @{character_name} rolls doctor skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{doctor} + ?{Modifier|0} ]]' /></td>
+            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-doctor" value='/em @{character_name} rolls doctor skill [[1d100]], compared to [[@{doctor}]]' /></td>
             <td style="height: 30px">Doctor</td>
             <td style="height: 30px">
 			<input name="attr_tagskill3" value="1" type="checkbox"></td>
@@ -271,7 +271,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-doctor" readonly value="5 + PE + IN" /></td>
         </tr>
         <tr>
-            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-energy_weapons" value='/em @{character_name} rolls Energy Weapons skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{energy_weapons} + ?{Modifier|0} ]]' /></td>
+            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-energy_weapons" value='/em @{character_name} rolls Energy Weapons skill [[1d100]], compared to [[@{energy_weapons}]]' /></td>
             <td style="height: 30px">Energy Weapons</td>
             <td style="height: 30px">
 			<input name="attr_tagskill4" value="1" type="checkbox"></td>
@@ -283,7 +283,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-energy_weapons" value="2 x AG" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-firstaid" value='/em @{character_name} rolls firstaid skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{firstaid} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-firstaid" value='/em @{character_name} rolls firstaid skill [[1d100]], compared to [[@{firstaid}]]' /></td>
             <td>First Aid</td>
             <td><input name="attr_tagskill5" value="1" type="checkbox"></td>
             <td>
@@ -296,7 +296,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-firstaid" value="(PE + EN) x 2" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-gambling" value='/em @{character_name} rolls Gambling skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{gambling} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-gambling" value='/em @{character_name} rolls Gambling skill [[1d100]], compared to [[@{gambling}]]' /></td>
             <td>Gambling</td>
             <td><input name="attr_tagskill6" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_gambling" value="@{mod-gambling} + @{base-gambling} + 20*@{tagskill6}" disabled="true"/></td>
@@ -307,7 +307,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-gambling" value="5 x  LU" readonly style="height: 22px" /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-lockpick" value='/em @{character_name} rolls Lockpick skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{lockpick} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-lockpick" value='/em @{character_name} rolls Lockpick skill [[1d100]], compared to [[@{lockpick}]]' /></td>
             <td>Lockpick</td>
             <td><input name="attr_tagskill7" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_lockpick" value="@{mod-lockpick} + @{base-lockpick} + 20*@{tagskill7}" disabled="true"/></td>
@@ -318,7 +318,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-lockpick" value="10 + (PE + AG)" readonly /></td>
         </tr>
         <tr>
-            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-melee_weapons" value='/em @{character_name} rolls Melee Weapons skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{melee_weapons} + ?{Modifier|0} ]]' /></td>
+            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-melee_weapons" value='/em @{character_name} rolls Melee Weapons skill [[1d100]], compared to [[@{melee_weapons}]]' /></td>
             <td style="height: 30px">Melee Weapons</td>
             <td style="height: 30px">
 			<input name="attr_tagskill8" value="1" type="checkbox"></td>
@@ -330,7 +330,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-melee_weapons" value="20 + 2 x (AG+STR)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-outdoorsman" value='/em @{character_name} rolls Outdoorsman skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{outdoorsman} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-outdoorsman" value='/em @{character_name} rolls Outdoorsman skill [[1d100]], compared to [[@{outdoorsman}]]' /></td>
             <td>Outdoorsman</td>
             <td><input name="attr_tagskill9" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_outdoorsman" value="@{mod-outdoorsman} + @{base-outdoorsman} + 20*@{tagskill9}" disabled="true"/></td>
@@ -341,7 +341,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-outdoorsman" value="2 x  (EN + IN)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-pilot" value='/em @{character_name} rolls Pilot skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{pilot} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-pilot" value='/em @{character_name} rolls Pilot skill [[1d100]], compared to [[@{pilot}]]' /></td>
             <td>Pilot</td>
             <td><input name="attr_tagskill10" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_pilot" value="@{mod-pilot} + @{base-pilot} + 20*@{tagskill10}" disabled="true"/></td>
@@ -352,7 +352,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-pilot" value="2 x  (AG + PE)" readonly /></td>
         </tr>
         <tr>
-            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-repair" value='/em @{character_name} rolls Repair skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{repair} + ?{Modifier|0} ]]' /></td>
+            <td style="height: 30px"><button class="sheet-skill_button" type='roll' name="attr_roll-repair" value='/em @{character_name} rolls Repair skill [[1d100]], compared to [[@{repair}]]' /></td>
             <td style="height: 30px">Repair</td>
             <td style="height: 30px">
 			<input name="attr_tagskill11" value="1" type="checkbox"></td>
@@ -364,7 +364,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-repair" value="3 x IN" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-science" value='/em @{character_name} rolls Science skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{science} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-science" value='/em @{character_name} rolls Science skill [[1d100]], compared to [[@{science}]]' /></td>
             <td>Science</td>
             <td><input name="attr_tagskill12" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_science" value="@{mod-science} + @{base-science} + 20*@{tagskill12}" disabled="true"/></td>
@@ -375,7 +375,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-science" value="4 x IN" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-small_guns" value='/em @{character_name} rolls Small Guns skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{small_guns} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-small_guns" value='/em @{character_name} rolls Small Guns skill [[1d100]], compared to [[@{small_guns}]]' /></td>
             <td>Small Guns</td>
             <td><input name="attr_tagskill13" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_small_guns" value="@{mod-small_guns} + @{base-small_guns} + 20*@{tagskill13}" disabled="true"/></td>
@@ -386,7 +386,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-small_guns" value="5 + (4 x AG)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-sneak" value='/em @{character_name} rolls Sneak skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{sneak} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-sneak" value='/em @{character_name} rolls Sneak skill [[1d100]], compared to [[@{sneak}]]' /></td>
             <td>Sneak</td>
             <td><input name="attr_tagskill14" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_sneak" value="@{mod-sneak} + @{base-sneak} + 20*@{tagskill14}" disabled="true"/></td>
@@ -397,7 +397,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-sneak" value="5 + 3 x AG" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-speech" value='/em @{character_name} rolls Speech skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{speech} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-speech" value='/em @{character_name} rolls Speech skill [[1d100]], compared to [[@{speech}]]' /></td>
             <td>Speech</td>
             <td><input name="attr_tagskill15" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_speech" value="@{mod-speech} + @{base-speech} + 20*@{tagskill15}" disabled="true"/></td>
@@ -408,7 +408,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-speech" value="5 x CH" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-steal" value='/em @{character_name} rolls Steal skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{steal} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-steal" value='/em @{character_name} rolls Steal skill [[1d100]], compared to [[@{steal}]]' /></td>
             <td>Steal</td>
             <td><input name="attr_tagskill16" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_steal" value="@{mod-steal} + @{base-steal} + 20*@{tagskill16}" disabled="true"/></td>
@@ -419,7 +419,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-steal" value="3 x AG" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-throwing" value='/em @{character_name} rolls Throwing skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{throwing} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-throwing" value='/em @{character_name} rolls Throwing skill [[1d100]], compared to [[@{throwing}]]' /></td>
             <td>Throwing</td>
             <td><input name="attr_tagskill17" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_throwing" value="@{mod-throwing} + @{base-throwing} + 20*@{tagskill17}" disabled="true"/></td>
@@ -430,7 +430,7 @@
 			<input type="text" class="sheet-number" name="attr_basetext-throwing" value="4 x AG" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-traps" value='/em @{character_name} rolls Traps skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{traps} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-traps" value='/em @{character_name} rolls Traps skill [[1d100]], compared to [[@{traps}]]' /></td>
             <td>Traps</td>
             <td><input name="attr_tagskill18" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_traps" value="@{mod-traps} + @{base-traps} + 20*@{tagskill18}" disabled="true"/></td>
@@ -439,7 +439,7 @@
             <td><input type="text" class="sheet-number" name="attr_basetext-traps" value="10 + (PE + AG)" readonly /></td>
         </tr>
         <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-unarmed" value='/em @{character_name} rolls Unarmed skill [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{unarmed} + ?{Modifier|0} ]]' /></td>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-unarmed" value='/em @{character_name} rolls Unarmed skill [[1d100]], compared to [[@{unarmed}]]' /></td>
             <td>Unarmed</td>
             <td><input name="attr_tagskill19" value="1" type="checkbox"></td>
             <td><input type="number" class="sheet-number" name="attr_unarmed" value="@{mod-unarmed} + @{base-unarmed} + 20*@{tagskill19}" disabled="true"/></td>
@@ -611,7 +611,7 @@
                     <td class="sheet-thin">Range</td>
                 </tr>
                 <tr>
-                    <td><button type='roll' class="sheet-skill_button" name="attr_weapon_roll-left" value='/em @{character_name} rolls attacks with @{weapon_name-left}! Roll of [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{weapon_select-left} + ?{Modifier|0} ]], dealing [[(@{weapon_number_dice-left}@{weapon_damage_die-left}) + @{weapon_damage_bonus-left}]] points of damage, if they hit.'></button></td>
+                    <td><button type='roll' class="sheet-skill_button" name="attr_weapon_roll-left" value='/em @{character_name} rolls attacks with @{weapon_name-left}! Roll of [[1d100]], compared to [[@{weapon_select-left}]], dealing [[(@{weapon_number_dice-left}@{weapon_damage_die-left}) + @{weapon_damage_bonus-left}]] points of damage, if they hit.'></button></td>
                     <td colspan="3"><input type="text" class="sheet-number" name="attr_weapon_name-left" /></td>
                     <td><input type="number" class="sheet-number" name="attr_weapon_range-left" /></td>
                 </tr>
@@ -699,7 +699,7 @@
                     <td class="sheet-thin">Range</td>
                 </tr>
                 <tr>
-                    <td><button class="sheet-skill_button" type='roll' name="attr_weapon_roll-right" value='/em @{character_name} rolls attacks with @{weapon_name-right}! Roll of [[ 1d100cf>96<cs[[@{luck}]] ]], compared to [[ @{weapon_select-right} + ?{Modifier|0} ]], dealing [[(@{weapon_number_dice-right}@{weapon_damage_die-right}) + @{weapon_damage_bonus-right}]] points of damage, if they hit.'></button></td>
+                    <td><button class="sheet-skill_button" type='roll' name="attr_weapon_roll-right" value='/em @{character_name} rolls attacks with @{weapon_name-right}! Roll of [[1d100]], compared to [[@{weapon_select-right}]], dealing [[(@{weapon_number_dice-right}@{weapon_damage_die-right}) + @{weapon_damage_bonus-right}]] points of damage, if they hit.'></button></td>
                     <td colspan="3"><input type="text" class="sheet-number" name="attr_weapon_name-right" /></td>
                     <td><input type="number" class="sheet-number" name="attr_weapon_range-right" /></td>
                 </tr>


### PR DESCRIPTION
1- Roll button for statics was 12. Due to Fallout PnP I changed it back to 10, as it should be.
2- When you roll for skills, the dice was always rolling 1. Not more not less. Now I change it to 1d100 and modifiers so it will roll as it should be.
3- Same as 2, but this time it was for weapons both left hand and right hand. I changed them to 1d100, so now they will work just fine.