### PR TITLE
fixed Initiative roll

### DIFF
--- a/Shadowrun-Anarchy/Shadowrun-Anarchy.html
+++ b/Shadowrun-Anarchy/Shadowrun-Anarchy.html
@@ -370,7 +370,7 @@
             <div class="sheet-item sheet-micro"></div>
             <div class="sheet-item sheet-puny">
                 <button class="sheet-hidden-roll" type="roll" name="roll_initiativeRoll" value="/roll [Initiative] (@{initiativeDice})d6" title="Initiative Roll">
-                    <input type="number" name="attr_initiativeDice" value="(@{initiative})" disabled="disabled"/>
+                    <input type="number" name="attr_initiativeDice" value="[[@{initiativeBase} + @{initiativeMod}]]" disabled="disabled"/>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
The auto-roller behaves strangely with nested formulas and was rolling 2 dice for this instead of the displayed number. As with the other rolls, I've expanded the formula into the roll itself and verified that the new behavior is correct.