### PR TITLE
W20 Fix and upgrade

### DIFF
--- a/CWOD-W20/W20.html
+++ b/CWOD-W20/W20.html
@@ -27,8 +27,8 @@
         <h4 style="line-height:28px">Chronicle:</h4>
     </div>
     <div class="sheet-col" style="width:155px">
-        <input type="text" name="attr_player" />
         <input type="text" name="attr_character_name" />
+        <input type="text" name="attr_player" />
         <input type="text" name="attr_Chronicle" />
     </div>
     <div class="sheet-col" style="width:100px">
@@ -136,6 +136,7 @@
 <!--TAB 2 Attributes-->
 <div class="sheet-section-2">
     <br>
+    <!--Attributes-->
     <h1 style="text-align: center">Attributes</h1>
     <table style="width:840px">
         <tr>
@@ -259,8 +260,8 @@
         </tr>
     </table>
     <hr/>
+    <!--Attributes-->
     <h1 style="text-align: center">Abilities</h1>
-
     <div class="sheet-3colrow" style="width:840px">
         <div class="sheet-col" style="width:30%">
             <h3 style="text-align: center">Talents</h3>
@@ -699,20 +700,26 @@
         </div>
     </div>
     <hr/>
+    
+    <!--Dice Pools-->
     <div class="sheet-center">
-    <h3>Dice Pools</h3>
-        <table class="sheet-table">
+        <h3>Dice Pools</h3>
+        <table class="sheet-table" style="width:820px">
             <tr>
+                <td style="width:60px">Roll</td>
                 <td style="width:150px">Name</td>
+                <td style="width:80px">Specialization</td>
                 <td style="width:110px">Attribute</td>
                 <td style="width:110px">Ability</td>
-                <td style="width:60px">Roll</td>
+                <td style="width:60px">Mod</td>
+                <td style="width:60px">Difficulty</td>
+                <td style="width:80px">Query?</td>
                 <td style="width:80px">Specialization</td>
             </tr>
-        </table>
-        <table class="sheet-table">
             <tr>
+                <td style="width:60px"><button type='roll' name='roll_DP1roll' value="@{DicePoolroll-1}"></button></td>
                 <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-1" value=""/></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-1" value=""/></td>
                 <td style="width:110px">
                     <select name="attr_DPAtt1" style="width:110px"> 
                         <option value="0" selected></option> 
@@ -771,13 +778,31 @@
                         <option value="@{Other8}">Other8</option> 
                     </select>
                 </td>
-                <td style="width:60px"><button type='roll' name='roll_DP1roll' value='/em rolls @{DicePoolname-1} [[{(@{DPAtt1}+@{DPAbi1}+?{Pool Mod|0})d10s}>?{Difficulty|6}f1]]'></button></td>
-                <td style="width:80px"><button type='roll' name='roll_DP1roll' value='/em rolls @{DicePoolname-1} w/ Specialization [[{(@{DPAtt1}+@{DPAbi1}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f1]]'></button></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod-1' value='0'/></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff-1' value='6'/></td>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll-1" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-1} }} {{attr= Attribute @{DPAtt1} }} {{skill= Ability @{DPAbi1} }} {{mod= Modifier @{DicePoolMod-1} }}  {{wound= Wound @{injury}}} {{result= [[{(@{DPAtt1}+@{DPAbi1}+@{DicePoolMod-1} + @{injury})d10@{DicePoolspec1}s}>@{DicePoolDiff-1}f1]] }}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll-1" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-1}: @{Specname-1} }} {{attr= Attribute @{DPAtt1} }} {{skill= Ability @{DPAbi1} }} {{mod= Modifier @{DicePoolMod-1} }} {{wound= Wound @{injury}}}  {{result= [[{(@{DPAtt1}+@{DPAbi1}+@{DicePoolMod-1} + @{injury})d10@{DicePoolspec1}s}>?{Difficulty|6}f1]] }}"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec-1" value="" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec-1" value="!"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
             </tr>
             <tr>
+                <td style="width:60px"><button type='roll' name='roll_DP1roll-2' value="@{DicePoolroll-2}"></button></td>
                 <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-2" value=""/></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-2" value=""/></td>
                 <td style="width:110px">
-                    <select name="attr_DPAtt2" style="width:110px"> 
+                    <select name="attr_DPAtt-2" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Strength}">Strength</option> 
                         <option value="@{Dexterity}">Dexterity</option> 
@@ -791,7 +816,7 @@
                     </select>
                 </td>
                 <td style="width:110px">
-                    <select name="attr_DPAbi2" style="width:110px"> 
+                    <select name="attr_DPAbi-2" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Academics}">Academics</option> 
                         <option value="@{Alertness}">Alertness</option> 
@@ -834,13 +859,31 @@
                         <option value="@{Other8}">Other8</option> 
                     </select>
                 </td>
-                <td style="width:60px"><button type='roll' name='roll_DP2roll' value='/em rolls @{DicePoolname-2} [[{(@{DPAtt2}+@{DPAbi2}+?{Pool Mod|0})d10s}>?{Difficulty|6}f2]]'></button></td>
-                <td style="width:80px"><button type='roll' name='roll_DP2roll' value='/em rolls @{DicePoolname-2} w/ Specialization [[{(@{DPAtt2}+@{DPAbi2}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f2]]'></button></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod-2' value='0'/></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff-2' value='6'/></td>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll-2" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-2} }} {{attr= Attribute @{DPAtt-2} }} {{skill= Ability @{DPAbi-2} }} {{mod= Modifier @{DicePoolMod-2} }} {{wound= Wound @{injury}}} {{result= [[{(@{DPAtt-2}+@{DPAbi-2}+@{DicePoolMod-2} + @{injury})d10@{DicePoolspec-2}s}>@{DicePoolDiff-2}f1]] }}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll-2" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-2}: @{Specname-2} }} {{attr= Attribute @{DPAtt-2} }} {{skill= Ability @{DPAbi-2} }} {{mod= Modifier @{DicePoolMod-2} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-2}+@{DPAbi-2}+@{DicePoolMod-2} + @{injury})d10@{DicePoolspec-2}s}>?{Difficulty|6}f1]] }}"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec-2" value="" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec-2" value="!"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
             </tr>
             <tr>
+                <td style="width:60px"><button type='roll' name='roll_DP1roll-3' value="@{DicePoolroll-3}"></button></td>
                 <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-3" value=""/></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-3" value=""/></td>
                 <td style="width:110px">
-                    <select name="attr_DPAtt3" style="width:110px"> 
+                    <select name="attr_DPAtt-3" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Strength}">Strength</option> 
                         <option value="@{Dexterity}">Dexterity</option> 
@@ -854,7 +897,7 @@
                     </select>
                 </td>
                 <td style="width:110px">
-                    <select name="attr_DPAbi3" style="width:110px"> 
+                    <select name="attr_DPAbi-3" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Academics}">Academics</option> 
                         <option value="@{Alertness}">Alertness</option> 
@@ -897,13 +940,31 @@
                         <option value="@{Other8}">Other8</option> 
                     </select>
                 </td>
-                <td style="width:60px"><button type='roll' name='roll_DP3roll' value='/em rolls @{DicePoolname-3} [[{(@{DPAtt3}+@{DPAbi3}+?{Pool Mod|0})d10s}>?{Difficulty|6}f3]]'></button></td>
-                <td style="width:80px"><button type='roll' name='roll_DP3roll' value='/em rolls @{DicePoolname-3} w/ Specialization [[{(@{DPAtt3}+@{DPAbi3}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f3]]'></button></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod-3' value='0'/></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff-3' value='6'/></td>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll-3" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-3} }} {{attr= Attribute @{DPAtt-3} }} {{skill= Ability @{DPAbi-3} }} {{mod= Modifier @{DicePoolMod-3} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-3}+@{DPAbi-3}+@{DicePoolMod-3} + @{injury})d10@{DicePoolspec-3}s}>@{DicePoolDiff-3}f1]] }}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll-3" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-3}: @{Specname-3} }} {{attr= Attribute @{DPAtt-3} }} {{skill= Ability @{DPAbi-3} }} {{mod= Modifier @{DicePoolMod-3} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-3}+@{DPAbi-3}+@{DicePoolMod-3} + @{injury})d10@{DicePoolspec-3}s}>?{Difficulty|6}f1]] }}"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec-3" value="" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec-3" value="!"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
             </tr>
             <tr>
-                <td style="width:110px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-4" value=""/></td>
+                <td style="width:60px"><button type='roll' name='roll_DP1roll-4' value="@{DicePoolroll-4}"></button></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-4" value=""/></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-4" value=""/></td>
                 <td style="width:110px">
-                    <select name="attr_DPAtt4" style="width:110px"> 
+                    <select name="attr_DPAtt-4" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Strength}">Strength</option> 
                         <option value="@{Dexterity}">Dexterity</option> 
@@ -917,7 +978,7 @@
                     </select>
                 </td>
                 <td style="width:110px">
-                    <select name="attr_DPAbi4" style="width:110px"> 
+                    <select name="attr_DPAbi-4" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Academics}">Academics</option> 
                         <option value="@{Alertness}">Alertness</option> 
@@ -960,13 +1021,31 @@
                         <option value="@{Other8}">Other8</option> 
                     </select>
                 </td>
-                <td style="width:60px"><button type='roll' name='roll_DP4roll' value='/em rolls @{DicePoolname-4} [[{(@{DPAtt4}+@{DPAbi4}+?{Pool Mod|0})d10s}>?{Difficulty|6}f4]]'></button></td>
-                <td style="width:80px"><button type='roll' name='roll_DP4roll' value='/em rolls @{DicePoolname-4} w/ Specialization [[{(@{DPAtt4}+@{DPAbi4}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f4]]'></button></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod-4' value='0'/></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff-4' value='6'/></td>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll-4" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-4} }} {{attr= Attribute @{DPAtt-4} }} {{skill= Ability @{DPAbi-4} }} {{mod= Modifier @{DicePoolMod-4} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-4}+@{DPAbi-4}+@{DicePoolMod-4} + @{injury})d10@{DicePoolspec-4}s}>@{DicePoolDiff-4}f1]] }}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll-4" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-4}: @{Specname-4} }} {{attr= Attribute @{DPAtt-4} }} {{skill= Ability @{DPAbi-4} }} {{mod= Modifier @{DicePoolMod-4} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-4}+@{DPAbi-4}+@{DicePoolMod-4} + @{injury})d10@{DicePoolspec-4}s}>?{Difficulty|6}f1]] }}"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec-4" value="" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec-4" value="!"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
             </tr>
             <tr>
-                <td style="width:110px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-5" value=""/></td>
+                <td style="width:60px"><button type='roll' name='roll_DP1roll-5' value="@{DicePoolroll-5}"></button></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-5" value=""/></td>
+                <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-5" value=""/></td>
                 <td style="width:110px">
-                    <select name="attr_DPAtt5" style="width:110px"> 
+                    <select name="attr_DPAtt-5" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Strength}">Strength</option> 
                         <option value="@{Dexterity}">Dexterity</option> 
@@ -980,7 +1059,7 @@
                     </select>
                 </td>
                 <td style="width:110px">
-                    <select name="attr_DPAbi5" style="width:110px"> 
+                    <select name="attr_DPAbi-5" style="width:110px"> 
                         <option value="0" selected></option> 
                         <option value="@{Academics}">Academics</option> 
                         <option value="@{Alertness}">Alertness</option> 
@@ -1023,14 +1102,33 @@
                         <option value="@{Other8}">Other8</option> 
                     </select>
                 </td>
-                <td style="width:60px"><button type='roll' name='roll_DP5roll' value='/em rolls @{DicePoolname-5} [[{(@{DPAtt5}+@{DPAbi5}+?{Pool Mod|0})d10s}>?{Difficulty|6}f5]]'></button></td>
-                <td style="width:80px"><button type='roll' name='roll_DP5roll' value='/em rolls @{DicePoolname-5} w/ Specialization [[{(@{DPAtt5}+@{DPAbi5}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f5]]'></button></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod-5' value='0'/></td>
+                <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff-5' value='6'/></td>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll-5" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-5} }} {{attr= Attribute @{DPAtt-5} }} {{skill= Ability @{DPAbi-5} }} {{mod= Modifier @{DicePoolMod-5} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-5}+@{DPAbi-5}+@{DicePoolMod-5} + @{injury})d10@{DicePoolspec-5}s}>@{DicePoolDiff-5}f1]] }}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll-5" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname-5}: @{Specname-5} }} {{attr= Attribute @{DPAtt-5} }} {{skill= Ability @{DPAbi-5} }} {{mod= Modifier @{DicePoolMod-5} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt-5}+@{DPAbi-5}+@{DicePoolMod-5} + @{injury})d10@{DicePoolspec-5}s}>?{Difficulty|6}f1]] }}"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
+                <th style="width:80px">
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec-5" value="" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec-5" value="!"/> 
+                        <span class="sheet-Query sheet-no">No</span>
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                    </div>
+                </th>
             </tr>
         </table>
-        <fieldset class="repeating_dicepools">
-            <table class="sheet-table">
+        <hr>
+        <fieldset class="repeating_dicepool">
+            <table style="width:810px">
                 <tr>
-                    <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-" value=""/></td>
+                    <td style="width:60px"><button type='roll' name='roll_DP1roll' value="@{DicePoolroll}"></button></td>
+                    <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname" value=""/></td>
+                    <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname" value=""/></td>
                     <td style="width:110px">
                         <select name="attr_DPAtt" style="width:110px"> 
                             <option value="0" selected></option> 
@@ -1079,7 +1177,7 @@
                             <option value="@{Subterfuge}">Subterfuge</option> 
                             <option value="@{Survival}">Survival</option> 
                             <option value="@{Technology}">Technology</option> 
-                            <option value="@{Other}">Other</option> 
+                            <option value="@{Other1}">Other1</option> 
                             <option value="@{Other2}">Other2</option> 
                             <option value="@{Other3}">Other3</option> 
                             <option value="@{Other4}">Other4</option> 
@@ -1089,8 +1187,24 @@
                             <option value="@{Other8}">Other8</option> 
                         </select>
                     </td>
-                    <td style="width:60px"><button type='roll' name='roll_DProll' value='/em rolls @{DicePoolname-} [[{(@{DPAtt}+@{DPAbi}+?{Pool Mod|0})d10s}>?{Difficulty|6}f]]'></button></td>
-                    <td style="width:80px"><button type='roll' name='roll_DProll' value='/em rolls @{DicePoolname-} w/ Specialization [[{(@{DPAtt}+@{DPAbi}+?{Pool Mod|0})d10!s}>?{Difficulty|6}f]]'></button></td>
+                    <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolMod' value='0'/></td>
+                    <td style="width:60px"><input type='number' class="sheet-dicepool" name='attr_DicePoolDiff' value='6'/></td>
+                    <th style="width:80px">
+                        <div class="sheet-Query">
+                            <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolroll" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname} }} {{attr= Attribute @{DPAtt} }} {{skill= Ability @{DPAbi} }} {{mod= Modifier @{DicePoolMod} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt}+@{DPAbi}+@{DicePoolMod} + @{injury})d10@{DicePoolspec}s}>@{DicePoolDiff}f1]] }}" checked="checked" />
+                            <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolroll" value="&{template:wod} {{name= @{character_name} }} {{pool= @{DicePoolname}: @{Specname} }} {{attr= Attribute @{DPAtt} }} {{skill= Ability @{DPAbi} }} {{mod= Modifier @{DicePoolMod} }} {{wound= Wound @{injury} }} {{result= [[{(@{DPAtt}+@{DPAbi}+@{DicePoolMod} + @{injury})d10@{DicePoolspec}s}>?{Difficulty|6}f1]] }}"/> 
+                            <span class="sheet-Query sheet-no">No</span>
+                            <span class="sheet-Query sheet-yes">Yes</span>
+                        </div>
+                    </th>
+                    <th style="width:80px">
+                        <div class="sheet-Query">
+                            <input type="radio" class="sheet-Query sheet-no" name="attr_DicePoolspec" value="" checked="checked" />
+                            <input type="radio" class="sheet-Query sheet-yes" name="attr_DicePoolspec" value="!"/> 
+                            <span class="sheet-Query sheet-no">No</span>
+                            <span class="sheet-Query sheet-yes">Yes</span>
+                        </div>
+                    </th>
                 </tr>
             </table>
         </fieldset>
@@ -1504,7 +1618,7 @@
             </div>
         </div>
         <div class="sheet-col" style="width:250px" align="center">
-            <button type="roll" class="sheet-adv" value='Dice Pool 5\n/r {(@{Rage}+?{Pool Mod|0})d10}>?{Difficulty|6}f1'>Rage</button>
+            <button type="roll" class="sheet-adv" name="roll_Rage" value="&{template:wod} {{name= @{character_name} }} {{pool= Rage }} {{attr= Dice @{Rage} }} {{result= [[{(@{Rage}+?{Pool Mod|0})d10}>?{Difficulty|6}f1]] }}">Rage</button>
             <br>
             <div align="left" style="margin:0px 0px 0px 48px"> 
                 <input type="radio" class="sheet-normal" name="attr_Rage" value="1" checked /><span></span>
@@ -1533,7 +1647,7 @@
                 <input type="radio" class="sheet-normal" name="attr_Rage_Used" value="10" class=" used" /><span></span>
             </div>
             <br><br>
-            <button type='roll' class="sheet-adv" name='roll_Gnosisroll' value='Dice Pool 5\n/r {(@{Gnosis}+?{Pool Mod|0})d10}>?{Difficulty|6}f1'>Gnosis</button>
+            <button type="roll" class="sheet-adv" name="roll_Gnosis" value="&{template:wod} {{name= @{character_name} }} {{pool= Gnosis }} {{attr= Dice @{Gnosis} }} {{result= [[{(@{Gnosis}+?{Pool Mod|0})d10}>?{Difficulty|6}f1]] }}">Gnosis</button>
             <div align="left" style="margin:0px 0px 0px 48px">
                 <input type="radio" class="sheet-normal" name="attr_Gnosis" value="1" checked /><span></span>
                 <input type="radio" class="sheet-normal" name="attr_Gnosis" value="2" /><span></span>
@@ -1560,7 +1674,7 @@
                 <input type="radio" class="sheet-normal" name="attr_Gnosis_Used" value="10" class=" used"/><span></span>
             </div>
             <br><br>
-            <button type='roll' class="sheet-adv" name='roll_Willpowerroll' value='/em rolls Willpower \n/r {(@{Willpower}+?{Pool Mod|0})d10s}>?{Difficulty|6}f1'>Willpower</button>
+            <button type="roll" class="sheet-adv" name="roll_Willpower" value="&{template:wod} {{name= @{character_name} }} {{pool= Willpower }} {{attr= Dice @{Willpower} }} {{result= [[{(@{Willpower}+?{Pool Mod|0})d10}>?{Difficulty|6}f1]] }}">Willpower</button>
             <div align="left" style="margin:0px 0px 0px 48px">
                 <input type="radio" class="sheet-normal" name="attr_Willpower" value="1" checked/><span></span> 
                 <input type="radio" class="sheet-normal" name="attr_Willpower" value="2" /><span></span> 
@@ -1603,6 +1717,7 @@
 <!--TAB 4 Forms -->
 <div class="sheet-section-4">
     <br>   
+    <div  style="text-align:center; font-size:0.7em"><i>Click "Forms" for Changeing Breeds</i></div>
     <input type="checkbox" class="sheet-word" name="attr_switch" value="1"/><span>
         <h1 style="text-align: center">Forms</h1> 
     </span>
@@ -1612,15 +1727,21 @@
             <!-- Stuff in the visible area -->
             <table class="sheet-center sheet-shifter" style="width:800px">
                 <tr>
-                    <td><br><br><br></td>
+                    <td colspan="5">
+                        <br>
+                            <div style="text-align:center; font-size:0.8em; color: black; text-shadow:none;">
+                                <i>Click form name to change form</i>
+                            </div>
+                        <br>
+                    </td>
                 </tr>
                 <tr>
-                    <th>Homid</th>
-                    <th>Glabro</th>
-                    <th>Crinos</th>
-                    <th>Hispo</th>
-                    <th>Lupus</th>
-                </tr>
+                    <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="1" title="Man"checked/><span class="sheet-form_select">Homid</span></td>
+                    <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="2" title="Near-Man"/><span class="sheet-form_select">Glabro</span></td>
+                    <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="3" title="Hybrid"/><span class="sheet-form_select">Crinos</span></td>
+                    <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="4" title="Near-beast"/><span class="sheet-form_select">Hispo</span></td>
+                    <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="5" title="Beast"/><span class="sheet-form_select">Beast</span></td>
+                </trLupus
                 <tr>
                     <td><br><br><br></td>
                 </tr>
@@ -1632,11 +1753,11 @@
                     <td>Strength(+1)</h4></td>
                 </tr>
                 <tr>
-                    <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + 0" checked/><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + 2"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + 4"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + 3"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + 1"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Str" value="1" checked/><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Str" value="2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Str" value="3"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Str" value="4"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Str" value="5"  /><span></span></th>
                 </tr>
                 <tr>
                     <td>Dexterity(+0)</td>
@@ -1646,11 +1767,11 @@
                     <td>Dexterity(+2)</td>
                 </tr>
                 <tr>
-                    <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + 0" checked/><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + 0"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + 1"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + 2"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + 2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Dex" value="1" checked/><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Dex" value="2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Dex" value="3"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Dex" value="4"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Dex" value="5"  /><span></span></th>
                 </tr>
                 <tr>
                     <td>Stamina(+0)</td>
@@ -1660,11 +1781,11 @@
                     <td>Stamina(+2)</td>
                 </tr>
                 <tr>
-                    <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + 0" checked/><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + 2"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + 3"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + 2"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + 2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Sta" value="1" checked/><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Sta" value="2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Sta" value="3"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Sta" value="4"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Sta" value="5"  /><span></span></th>
                 </tr>
                 <tr>
                     <td>Appearance(+0)</td>
@@ -1674,11 +1795,11 @@
                     <td>Appearance(+0)</td>
                 </tr>
                 <tr>
-                    <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + 0" checked/><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + -1"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="0" /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + 0"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + 0"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_App" value="1" checked/><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_App" value="2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_App" value="3" /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_App" value="4"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_App" value="5"  /><span></span></th>
                 </tr>
                 <tr>
                     <td>Manipulation(+0)</td>
@@ -1688,11 +1809,11 @@
                     <td>Manipulation(-3)</td>
                 </tr>
                 <tr>
-                    <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + 0" checked/><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + -1"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + -3"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + -3"  /><span></span></th>
-                    <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + -3"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Manip" value="1" checked/><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Manip" value="2"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Manip" value="3"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Manip" value="4"  /><span></span></th>
+                    <th><input type="radio" class="sheet-forms" name="attr_Manip" value="5"  /><span></span></th>
                 </tr>
                 <tr>
                     <td></td>
@@ -1702,11 +1823,11 @@
                     <td>-2 Perception Diff.</td>
                 </tr>
                 <tr>
-                    <td><br></td>
-                    <td><br></td>
-                    <td><br></td>
-                    <td><br></td>
-                    <td><br></td>
+                    <td><input type="hidden" name="attr_Strength" value="0"/></td>
+                    <td><input type="hidden" name="attr_Dexterity" value="0"/></td>
+                    <td><input type="hidden" name="attr_Stamina" value="0"/></td>
+                    <td><input type="hidden" name="attr_Appearance" value="0"/></td>
+                    <td><input type="hidden" name="attr_Manipulation" value="0"/></td>
                 </tr>
                 <tr>
                     <td>Difficulty: 6</td>
@@ -1732,15 +1853,21 @@
 		<!-- Stuff in the hidden area -->
         <table class="sheet-center sheet-shifter" style="width:800px">
             <tr>
-                <td><br><br><br></td>
+                <td colspan="6">
+                    <br>
+                        <div style="text-align:center; font-size:0.8em; color: black; text-shadow:none;">
+                            <i>Click form name to change form</i>
+                        </div>
+                    <br>
+                </td>
             </tr>
             <tr>
                 <td></td>
-                <th>Man</th>
-                <th>Near-Man</th>
-                <th>Hybrid</th>
-                <th>Near-Beast</th>
-                <th>Beast</th>
+                <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="6" title="Man"/><span class="sheet-form_select">Man</span></td>
+                <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="7" title="Near-Man"/><span class="sheet-form_select">Near-Man</span></td>
+                <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="8" title="Hybrid"/><span class="sheet-form_select">Hybrid</span></td>
+                <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="9" title="Near-beast"/><span class="sheet-form_select">Near-beast</span></td>
+                <td><input type="radio" class="sheet-form_select" name="attr_current_form" value="10" title="Beast"/><span class="sheet-form_select">Beast</span></td>
             </tr>
             <tr>
                 <td><br></td>
@@ -1757,11 +1884,11 @@
                 <td><input type="number" class="sheet-shifter" name="attr_Strength-beast" value="0"/></td>
             </tr>
             <tr>
-                <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + @{Strength-human}"/><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + @{Strength-nearhuman}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + @{Strength-halfbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + @{Strength-nearbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Strength" value="@{Strength-base} + @{Strength-beast}"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Str" value="6"/><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Str" value="7"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Str" value="8"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Str" value="9"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Str" value="10"  /><span></span></th>
             </tr>
             <tr>
                 <td rowspan="2">Dexterity</td>
@@ -1772,11 +1899,11 @@
                 <td><input type="number" class="sheet-shifter" name="attr_Dexterity-beast" value="0"/></td>
             </tr>
             <tr>
-                <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + @{Dexterity-human}"/><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + @{Dexterity-nearhuman}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + @{Dexterity-halfbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + @{Dexterity-nearbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Dexterity" value="@{Dexterity-base} + @{Dexterity-beast}"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Dex" value="6"/><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Dex" value="7"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Dex" value="8"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Dex" value="9"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Dex" value="10"  /><span></span></th>
             </tr>
             <tr>
                 <td rowspan="2">Stamina</td>
@@ -1787,11 +1914,11 @@
                 <td><input type="number" class="sheet-shifter" name="attr_Stamina-beast" value="0"/></td>
             </tr>
             <tr>
-                <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + @{Stamina-human}"/><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + @{Stamina-nearhuman}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + @{Stamina-halfbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + @{Stamina-nearbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Stamina" value="@{Stamina-base} + @{Stamina-beast}"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Sta" value="6"/><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Sta" value="7"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Sta" value="8"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Sta" value="9"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Sta" value="10"  /><span></span></th>
             </tr>
             <tr>
                 <td rowspan="2">Appearance</td>
@@ -1802,11 +1929,11 @@
                 <td><input type="number" class="sheet-shifter" name="attr_Appearance-beast" value="0"/></td>
             </tr>
             <tr>
-                <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + @{Appearance-human}"/><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + @{Appearance-nearhuman}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + @{Appearance-halfbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + @{Appearance-nearbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Appearance" value="@{Appearance-base} + @{Appearance-beast}"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_App" value="6"/><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_App" value="7"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_App" value="8"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_App" value="9"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_App" value="10"  /><span></span></th>
             </tr>
             <tr>
                 <td rowspan="2">Manipulation</td>
@@ -1817,11 +1944,11 @@
                 <td><input type="number" class="sheet-shifter" name="attr_Manipulation-beast" value="0"/></td>
             </tr>
             <tr>
-                <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + @{Manipulation-human}"/><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + @{Manipulation-nearhuman}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + @{Manipulation-halfbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + @{Manipulation-nearbeast}"  /><span></span></th>
-                <th><input type="radio" class="sheet-forms" name="attr_Manipulation" value="@{Manipulation-base} + @{Manipulation-beast}"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Manip" value="6"/><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Manip" value="7"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Manip" value="8"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Manip" value="9"  /><span></span></th>
+                <th><input type="radio" class="sheet-forms" name="attr_Manip" value="10"  /><span></span></th>
             </tr>
             <tr>
                 <td><br></td>
@@ -1969,14 +2096,16 @@
             <th>Skill</th>
             <th>Attack<br>Modifier</th>
             <th>Attack<br>Difficulty</th>
+            <th>Query</th>
             <th>Damage</th>
             <th>Add<br>Strength?</th>
             <th>Range</th>
             <th>Rate</th>
             <th>Clip</th>
+            <th>Damage</th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-1}! [[{(@{weapon_attribute-1} + @{weapon_skill-1} + @{weapon_Modifier-1})d10}>@{weapon_Difficulty-1}f1]] successes to attack and deals [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1})d10}>6}]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_1" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-1} }} {{attr= Attribute @{weapon_attribute-1} }} {{skill= Skill @{weapon_skill-1}}} {{mod= Weapon @{weapon_Modifier-1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-1} + @{weapon_skill-1} + @{weapon_Modifier-1} + @{injury})d10}>@{weapon_Diff-1}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-1" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-1" value="0" >
                     <option value="0" selected></option> 
@@ -2007,14 +2136,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-1" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-1" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-1" value="@{weapon_Difficulty-1}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-1" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-1" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-1" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-1" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-1" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-1" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-1" value="0"/></th>>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-1" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-1} }} {{attr= Weapon @{weapon_Damage-1} }} {{skill= Stength @{weapon_StrengthDamage-1} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-2}! [[{(@{weapon_attribute-2} + @{weapon_skill-2} + @{weapon_Modifier-2})d10}>@{weapon_Difficulty-2}f1]] successes to attack and deals [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_2" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-2} }} {{attr= Attribute @{weapon_attribute-2} }} {{skill= Skill @{weapon_skill-2}}} {{mod= Weapon @{weapon_Modifier-2} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-2} + @{weapon_skill-2} + @{weapon_Modifier-2} + @{injury})d10}>@{weapon_Diff-2}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-2" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-2" value="0" >
                     <option value="0" selected></option> 
@@ -2045,14 +2183,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-2" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-2" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-2" value="@{weapon_Difficulty-2}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-2" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-2" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-2" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-2" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-2" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-2" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-2" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-2} }} {{attr= Weapon @{weapon_Damage-2} }} {{skill= Stength @{weapon_StrengthDamage-2} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-3}! [[{(@{weapon_attribute-3} + @{weapon_skill-3} + @{weapon_Modifier-3})d10}>@{weapon_Difficulty-3}f1]] successes to attack and deals [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_3" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-3} }} {{attr= Attribute @{weapon_attribute-3} }} {{skill= Skill @{weapon_skill-3}}} {{mod= Weapon @{weapon_Modifier-3} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-3} + @{weapon_skill-3} + @{weapon_Modifier-3} + @{injury})d10}>@{weapon_Diff-3}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-3" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-3" value="0" >
                     <option value="0" selected></option> 
@@ -2083,14 +2230,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-3" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-3" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-3" value="@{weapon_Difficulty-3}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-3" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-3" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-3" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-3" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-3" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-3" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-3" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-3} }} {{attr= Weapon @{weapon_Damage-3} }} {{skill= Stength @{weapon_StrengthDamage-3} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-4}! [[{(@{weapon_attribute-4} + @{weapon_skill-4} + @{weapon_Modifier-4})d10}>@{weapon_Difficulty-4}f1]] successes to attack and deals [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_4" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-4} }} {{attr= Attribute @{weapon_attribute-4} }} {{skill= Skill @{weapon_skill-4}}} {{mod= Weapon @{weapon_Modifier-4} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-4} + @{weapon_skill-4} + @{weapon_Modifier-4} + @{injury})d10}>@{weapon_Diff-4}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-4" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-4" value="0" >
                     <option value="0" selected></option> 
@@ -2121,14 +2277,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-4" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-4" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-4" value="@{weapon_Difficulty-4}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-4" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-4" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-4" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-4" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-4" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-4" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-4" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-4} }} {{attr= Weapon @{weapon_Damage-4} }} {{skill= Stength @{weapon_StrengthDamage-4} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-5}! [[{(@{weapon_attribute-5} + @{weapon_skill-5} + @{weapon_Modifier-5})d10}>@{weapon_Difficulty-5}f1]] successes to attack and deals [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_5" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-5} }} {{attr= Attribute @{weapon_attribute-5} }} {{skill= Skill @{weapon_skill-5}}} {{mod= Weapon @{weapon_Modifier-5} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-5} + @{weapon_skill-5} + @{weapon_Modifier-5} + @{injury})d10}>@{weapon_Diff-5}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-5" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-5" value="0" >
                     <option value="0" selected></option> 
@@ -2159,14 +2324,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-5" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-5" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-5" value="@{weapon_Difficulty-5}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-5" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-5" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-5" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-5" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-5" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-5" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-5" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-5} }} {{attr= Weapon @{weapon_Damage-5} }} {{skill= Stength @{weapon_StrengthDamage-5} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-6}! [[{(@{weapon_attribute-6} + @{weapon_skill-6} + @{weapon_Modifier-6})d10}>@{weapon_Difficulty-6}f1]] successes to attack and deals [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_6" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-6} }} {{attr= Attribute @{weapon_attribute-6} }} {{skill= Skill @{weapon_skill-6}}} {{mod= Weapon @{weapon_Modifier-6} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-6} + @{weapon_skill-6} + @{weapon_Modifier-6} + @{injury})d10}>@{weapon_Diff-6}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-6" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-6" value="0" >
                     <option value="0" selected></option> 
@@ -2197,14 +2371,23 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-6" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-6" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-6" value="@{weapon_Difficulty-6}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-6" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-6" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-6" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-6" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-6" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-6" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-6" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-6} }} {{attr= Weapon @{weapon_Damage-6} }} {{skill= Stength @{weapon_StrengthDamage-6} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
-            <th><button type="roll" class="sheet-weaponroll" value="/e attacks with @{weapon_name-7}! [[{(@{weapon_attribute-7} + @{weapon_skill-7} + @{weapon_Modifier-7})d10}>@{weapon_Difficulty-7f1}]] successes to attack and deals [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7})d10}>6}]]] damage"></button></th>
+            <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_7" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-7} }} {{attr= Attribute @{weapon_attribute-7} }} {{skill= Skill @{weapon_skill-7}}} {{mod= Weapon @{weapon_Modifier-7} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-7} + @{weapon_skill-7} + @{weapon_Modifier-7} + @{injury})d10}>@{weapon_Diff-7}f1]] }}"></button></th>
             <th><input type="text" class="sheet-textbox" name="attr_weapon_name-7" value=""/></th>
             <th><select class="sheet-select" style="width:110px" name="attr_weapon_attribute-7" value="0" >
                     <option value="0" selected></option> 
@@ -2235,195 +2418,324 @@
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-7" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-7" value="0"/></th>
+            <th>
+                <div class="sheet-Query">
+                    <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-7" value="@{weapon_Difficulty-7}" checked="checked" />
+                    <input type="radio" class="sheet-Query sheet-yes" name="attr_weapon_Diff-7" value="?{Attack Difficulty|6}" />
+                    <span class="sheet-Query sheet-yes">Yes</span>
+                    <span class="sheet-Query sheet-no">No</span>
+                </div>
+            </th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Damage-7" value="0"/></th>
             <th><input type="checkbox" class="sheet-soakbox" name="attr_weapon_StrengthDamage-7" value="@{Strength}"/><span></span></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-7" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-7" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-7" value="0"/></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-7" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-7} }} {{attr= Weapon @{weapon_Damage-7} }} {{skill= Stength @{weapon_StrengthDamage-7} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
         </tr>
     </table>
     <br>
-        <h3>Brawling</h3>
-    <table style="width:840px">
-        <tr>
-            <th>Maneuver</th>
-            <th>Dice Pool</th>
-            <th>Attack<br>Modifier</th>
-            <th>Attack<br>Difficulty</th>
-            <th>Damage</th>
-            <th>Damage<br>Modifier</th>
-            <th>Damage<br>Difficulty</th>
-            <th>Damage<br>Type</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Bite! [[{(@{Dexterity} + @{Brawl} + @{Bite_Mod-Attack})d10}>5f1]] successes to attack and deals [[{(@{Strength} + 1 + @{Bite_Mod-Damage})d10}>@{Bite_Difficulty}]] damage">Bite</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Attack" value="0"/></th>
-            <th>5</th>
-            <th>Strength +1</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_Bite_Difficulty" value="6"/></th>
-            <th>Aggravated</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Hispo Bite! [[ { (@{Dexterity} + @{Brawl} + @{HispoBite_Mod-Attack} )d10}>5f1]] successes to attack and deals [[ { ( @{Strength} + 2 + @{HispoBite_Mod-Damage} )d10 }>@{HispoBite_Difficulty} ]] damage">Hispo Bite</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Attack" value="0"/></th>
-            <th>5</th>
-            <th>Strength +2</th>
-            <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Difficulty" value="6"/></th>
-            <th>Aggravated</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Body Tackle! [[{(@{Dexterity} + @{Brawl} + @{BodyTackle_Mod-Attack})d10}>7f1]] successes to attack">Body Tackle</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Attack" value="0"/></th>
-            <th>7</th>
-            <th>Special</th>
-            <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Difficulty" value="6"/></th>
-            <th>Bashing</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with Claws! [[{(@{Dexterity} + @{Brawl} + @{Claw_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + 2 + @{Claw_Mod-Damage})d10}>@{Claw_Difficulty}]] damage">Claw</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Attack" value="0"/></th>
-            <th>6</th>
-            <th>Strength +2</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_Claw_Difficulty" value="6"/></th>
-            <th>Aggravated</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Grapple! [[{(@{Dexterity} + @{Brawl} + @{Grapple_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + @{Grapple_Mod-Damage})d10}>@{Grapple_Difficulty}]] damage">Grapple</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Attack" value="0"/></th>
-            <th>6</th>
-            <th>Strength</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_Grapple_Difficulty" value="6"/></th>
-            <th>Bashing</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Kick! [[{(@{Dexterity} + @{Brawl} + @{Kick_Mod-Attack})d10}>7f1]] successes to attack and deals [[{(@{Strength} + 1 + @{Kick_Mod-Damage})d10}>@{Kick_Difficulty}]] damage">Kick</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Attack" value="0"/></th>
-            <th>7</th>
-            <th>Strength +1</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_Kick_Difficulty" value="6"/></th>
-            <th>Bashing</th>
-        </tr>
-        <tr>
-            <th><button type="roll" class="sheet-adv" value="/e attacks with a Punch! [[{(@{Dexterity} + @{Brawl} + @{Punch_Mod-Attack})d10}>6f1]] successes to attack and deals [[{(@{Strength} + @{Punch_Mod-Damage})d10}>@{Punch_Difficulty}]] damage">Punch</button></th>
-            <th>Dex + Brawl</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Attack" value="0"/></th>
-            <th>6</th>
-            <th>Strength</th>
-            <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Damage" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_Punch_Difficulty" value="6"/></th>
-            <th>Bashing</th>
-        </tr>
-    </table>
+    <h3 style="text-align:center; display:inline">Brawling & Clawing</h3><input type="checkbox" class="sheet-claw" name="attr_claw-Brawling" checked/><span></span>
+    <div class="sheet-body">
+        <table style="width:840px">
+            <tr>
+                <th>Maneuver</th>
+                <th>Dice Pool</th>
+                <th>Attack<br>Modifier</th>
+                <th>Attack<br>Difficulty</th>
+                <th>Query</th>
+                <th>Damage</th>
+                <th>Damage<br>Modifier</th>
+                <th>Damage<br>Difficulty</th>
+                <th>Damage<br>Type</th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_bite" value="&{template:wod} {{name= @{character_name} }} {{attack= Bite }} {{attr= Dexterity @{Dexterity} }} {{mod= Modifier @{Bite_Mod-Attack} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{Bite_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Bite_Mod-Attack} + @{injury})d10}>@{Bite_At_Difficulty}f1]] }}">Bite</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Bite_At_Diff" value="5"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_Bite_At_Difficulty" value="@{Bite_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_Bite_At_Difficulty" value="?{Attack Difficulty|5}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength +1</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Bite_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-Bite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Bite }} {{attr= Bite [[1 + @{Bite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 1 + @{Bite_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Bite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_Hispobite" value="&{template:wod} {{name= @{character_name} }} {{attack= Hispo Bite }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{HispoBite_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{HispoBite_Mod-Attack} + @{injury})d10}>@{HispoBite_At_Difficulty}f1]] }}">HispoBite</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_HispoBite_At_Diff" value="5"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_HispoBite_At_Difficulty" value="@{HispoBite_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_HispoBite_At_Difficulty" value="?{Attack Difficulty|5}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength +2</th>
+                <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-HispoBite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Hispo Bite }} {{attr= HispoBite [[2 + @{HispoBite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 2 + @{HispoBite_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{HispoBite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_body_tackle" value="&{template:wod} {{name= @{character_name} }} {{attack= Body Tackle }} {{attr= Dexterity @{Dexterity} }} {{mod= Modifier @{BodyTackle_Mod-Attack} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{BodyTackle_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{BodyTackle_Mod-Attack} + @{injury})d10}>@{BodyTackle_At_Difficulty}f1]] }}">Body Tackle</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_At_Diff" value="7"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_BodyTackle_At_Difficulty" value="@{BodyTackle_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_BodyTackle_At_Difficulty" value="?{Attack Difficulty|7}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Special</th>
+                <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-BodyTackle" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Body Tackle }} {{attr= Body Tackle [[@{BodyTackle_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + @{BodyTackle_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{BodyTackle_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_Claw" value="&{template:wod} {{name= @{character_name} }} {{attack= Claw }} {{attr= Dexterity @{Dexterity} }} {{mod= Modifier @{Claw_Mod-Attack} }} {{skill= Brawl @{Brawl}}} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Claw_Mod-Attack} + @{injury})d10}>@{Claw_At_Difficulty}f1]] }}">Claw</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Claw_At_Diff" value="6"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_Claw_At_Difficulty" value="@{Claw_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_Claw_At_Difficulty" value="?{Attack Difficulty|6}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength +2</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Claw_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-Claw" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Claw }} {{attr= Claw [[2 + @{Claw_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 2 + @{Claw_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Claw_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_Grapple" value="&{template:wod} {{name= @{character_name} }} {{attack= Grapple }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Modifier @{Grapple_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Grapple_Mod-Attack} + @{injury})d10}>@{Grapple_At_Difficulty}f1]] }}">Grapple</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Grapple_At_Diff" value="6"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_Grapple_At_Difficulty" value="@{Grapple_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_Grapple_At_Difficulty" value="?{Attack Difficulty|6}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Grapple_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-Grapple" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Grapple }} {{attr= Grapple [[@{Grapple_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + @{Grapple_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Grapple_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_Kick" value="&{template:wod} {{name= @{character_name} }} {{attack= Kick }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{Kick_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Kick_Mod-Attack} + @{injury})d10}>@{Kick_At_Difficulty}f1]] }}">Kick</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Kick_At_Diff" value="7"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_Kick_At_Difficulty" value="@{Kick_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_Kick_At_Difficulty" value="?{Attack Difficulty|7}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength +1</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Kick_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-Kick" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Kick }} {{attr= Kick [[1 + @{Kick_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 1 + @{Kick_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Kick_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+            </tr>
+            <tr>
+                <th><button type="roll" class="sheet-adv" name="roll_Punch" value="&{template:wod} {{name= @{character_name} }} {{attack= Punch }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{Punch_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Punch_Mod-Attack} + @{injury})d10}>@{Punch_At_Difficulty}f1]] }}">Punch</button></th>
+                <th>Dex + Brawl</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Attack" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Punch_At_Diff" value="6"/></th>
+                <th>
+                    <div class="sheet-Query">
+                        <input type="radio" class="sheet-Query sheet-no" name="attr_Punch_At_Difficulty" value="@{Punch_At_Diff}" checked="checked" />
+                        <input type="radio" class="sheet-Query sheet-yes" name="attr_Punch_At_Difficulty" value="?{Attack Difficulty|6}" />
+                        <span class="sheet-Query sheet-yes">Yes</span>
+                        <span class="sheet-Query sheet-no">No</span>
+                    </div>
+                </th>
+                <th>Strength</th>
+                <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Damage" value="0"/></th>
+                <th><input type="number" class="sheet-textbox" name="attr_Punch_Difficulty" value="6"/></th>
+                <th><button type="roll" name="roll_damage-Punch" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Punch }} {{attr= Punch [[@{Punch_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} +  @{Punch_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Punch_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+            </tr>
+        </table>
+    </div>
     <hr/>
     <div class="sheet-2colrow" style="width:840px">
         <div class="sheet-col">
-        <h3 style="text-align: center">Health</h3>
-            <table class="sheet-center" style="width:50%">
+            <h3 style="text-align:center">Health, mk II</h3>
+            <table class="sheet-center">
                 <tr>
                     <th>Extra Bruised</th>
                     <td></td>
-                    <td><select name="attr_Bruised_extra">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_1" value="0" checked="checked"/>        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_1" value="0.1" />
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_1" value="0.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_1" value="0.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_1" value="0.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Bruised</th>
                     <td></td>
-                    <td><select name="attr_Bruised">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_2" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_2" value="0.1" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_2" value="0.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_2" value="0.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_2" value="0.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Hurt</th>
                     <td>-1</td>
-                    <td><select name="attr_Hurt"> 
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_3" value="0"/>        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_3" value="0.1" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_3" value="1.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_3" value="1.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_3" value="1.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Injured</th>
                     <td>-1</td>
-                    <td><select name="attr_Injured">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_4" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_4" value="0.1" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_4" value="1.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_4" value="1.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_4" value="1.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Wounded</th>
                     <td>-2</td>
-                    <td><select name="attr_Wounded">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_5" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_5" value="0.2" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_5" value="2.1" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_5" value="2.2" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_5" value="2.3" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Mauled</th>
                     <td>-2</td>
-                    <td><select name="attr_Mauled">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_6" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_6" value="0.2" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_6" value="2.1" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_6" value="2.2" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_6" value="2.3" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Crippled</th>
                     <td>-5</td>
-                    <td><select name="attr_Crippled">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_7" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_7" value="0.1" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_7" value="5.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_7" value="5.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_7" value="5.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
                 </tr>
                 <tr>
                     <th>Incapacitated</th>
                     <td></td>
-                    <td><select name="attr_Incapacitated">
-                        <option></option>
-                        <option value="Bashing">-</option>
-                        <option value="Leathal">/</option> 
-                        <option value="Aggravated">X</option>
-                        </select>
+                    <td>
+                        <div class="sheet-healthbox">
+                            <input type="radio" class="sheet-healthbox sheet-blackdot" name="attr_healthbox_8" value="0" />        
+                            <input type="radio" class="sheet-healthbox sheet-whitedot" name="attr_healthbox_8" value="0.1" checked="checked"/>
+                            <input type="radio" class="sheet-healthbox sheet-bashingdot" name="attr_healthbox_8" value="5.2" />
+                            <input type="radio" class="sheet-healthbox sheet-lethaldot" name="attr_healthbox_8" value="5.3" />
+                            <input type="radio" class="sheet-healthbox sheet-aggravateddot" name="attr_healthbox_8" value="5.4" />
+                                <span class="sheet-healthbox sheet-blackdot"></span>
+                                <span class="sheet-healthbox sheet-whitedot"></span>
+                                <span class="sheet-healthbox sheet-bashingdot"></span>
+                                <span class="sheet-healthbox sheet-lethaldot"></span>
+                                <span class="sheet-healthbox sheet-aggravateddot"></span>
+                        </div>
                     </td>
+                </tr>
+                <tr>
+                    <th>Wound Penalty</th>
+                    <td></td>
+                    <td><input type="number" class="sheet-textbox" name="attr_injury" value="0"/></td>
                 </tr>
             </table>
         </div>
         <div class="sheet-col">
         <h3 style="text-align: center">Armor & Soak</h3>
-            <table class="sheet-center" style="width:50%">
+            <table class="sheet-center" style="width:220px">
                 <tr>
                     <th>Armor Type</th>
                     <th>Rating</th>
@@ -2445,28 +2757,49 @@
                     <th>Apply Armor?</th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak bashing damage! [[ {(@{Stamina} + @{Soak_mod-Bashing} + @{Armor_toggle-Bashing})d10}>@{Soak_diff-Bashing}f1 ]]">Bashing</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_Bashing" value="@{Armor_toggle-Bashing}">Bashing</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Bashing" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Bashing" value="6" /></th>
-                    <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Bashing" value="@{armor-Rating}"/><span></span></th>
+                    <th>
+                        <div class="sheet-Query">
+                            <input type="radio" class="sheet-Query sheet-no" name="attr_Armor_toggle-Bashing" value="&{template:wod} {{name= @{character_name} }} {{pool= Bashing Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Bashing}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Bashing} )d10}>@{Soak_diff-Bashing}f1 ]] }}" checked="checked" />
+                            <input type="radio" class="sheet-Query sheet-yes" name="attr_Armor_toggle-Bashing" value="&{template:wod} {{name= @{character_name} }} {{skill= Armor [[@{armor-Rating}]] }} {{pool= Bashing Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Bashing}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Bashing} + @{armor-Rating})d10}>@{Soak_diff-Bashing}f1 ]] }}" />
+                            <span class="sheet-Query sheet-yes">Yes</span>
+                            <span class="sheet-Query sheet-no">No</span>
+                        </div>
+                    </th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_Lethal" value="/e tries to soak Lethal damage! [[ {(@{Stamina} + @{Soak_mod-Lethal} + @{Armor_toggle-Lethal})d10}>@{Soak_diff-Lethal}f1 ]]">Lethal</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_Lethal" value="@{Armor_toggle-Lethal}">Lethal</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Lethal" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Lethal" value="6" /></th>
-                    <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Lethal" value="@{armor-Rating}"/><span></span></th>
+                    <th>
+                        <div class="sheet-Query">
+                            <input type="radio" class="sheet-Query sheet-no" name="attr_Armor_toggle-Lethal" value="&{template:wod} {{name= @{character_name} }} {{pool= Lethal Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Lethal}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Lethal} )d10}>@{Soak_diff-Lethal}f1 ]] }}" checked="checked" />
+                            <input type="radio" class="sheet-Query sheet-yes" name="attr_Armor_toggle-Lethal" value="&{template:wod} {{name= @{character_name} }} {{skill= Armor [[@{armor-Rating}]] }} {{pool= Lethal Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Lethal}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Lethal} + @{armor-Rating})d10}>@{Soak_diff-Lethal}f1 ]] }}" />
+                            <span class="sheet-Query sheet-yes">Yes</span>
+                            <span class="sheet-Query sheet-no">No</span>
+                        </div>
+                    </th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_Aggravated" value="/e tries to soak Aggravated damage! [[ {(@{Stamina} + @{Soak_mod-Aggravated} + @{Armor_toggle-Aggravated})d10}>@{Soak_diff-Aggravated}f1 ]]">Aggravated</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_Aggravated" value="@{Armor_toggle-Aggravated}">Aggravated</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{Stamina}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-Aggravated" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-Aggravated" value="6" /></th>
-                     <th><input type="checkbox" class="sheet-soakbox" name="attr_Armor_toggle-Aggravated" value="@{armor-Rating}"/><span></span></th>
+                    <th>
+                        <div class="sheet-Query">
+                            <input type="radio" class="sheet-Query sheet-no" name="attr_Armor_toggle-Aggravated" value="&{template:wod} {{name= @{character_name} }} {{pool= Aggravated Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Aggravated}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Aggravated} )d10}>@{Soak_diff-Aggravated}f1 ]] }}" checked="checked" />
+                            <input type="radio" class="sheet-Query sheet-yes" name="attr_Armor_toggle-Aggravated" value="&{template:wod} {{name= @{character_name} }} {{skill= Armor [[@{armor-Rating}]] }} {{pool= Aggravated Soak}} {{attr= Stamina [[@{Stamina}]] }} {{mod= Modifier [[@{Soak_mod-Aggravated}]] }} {{result= [[ {(@{Stamina} + @{Soak_mod-Aggravated} + @{armor-Rating})d10}>@{Soak_diff-Aggravated}f1 ]] }}" />
+                            <span class="sheet-Query sheet-yes">Yes</span>
+                            <span class="sheet-Query sheet-no">No</span>
+                        </div>
+                    </th>
                 </tr>
                 <tr>
-                    <th><button type='roll' class="sheet-adv" name="attr_soak_bashing" value="/e tries to soak with armor only! [[ {(@{armor-Rating})d10}>@{Soak_diff-armor}f1 ]]">Armor Only</button></th>
+                    <th><button type='roll' class="sheet-adv" name="attr_soak_armor" value="&{template:wod} {{name= @{character_name} }} {{pool= Armor Only Soak}} {{attr= Armor [[@{armor-Rating}]] }} {{result= [[ {(@{armor-Rating})d10}>@{Soak_diff-armor}f1 ]]}} ">Armor Only</button></th>
                     <th><input type="number" class="sheet-textbox" name="attr_soak_attribute" value="@{armor-Rating}" disabled="true"/></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_mod-armor" value="0" /></th>
                     <th><input type="number" class="sheet-textbox" name="attr_Soak_diff-armor" value="6" /></th>
@@ -2475,3 +2808,444 @@
         </div>
     </div>
 </div>
+<div>
+    <rolltemplate class="sheet-rolltemplate-wod">
+    <table>
+        
+        {{#damage}} 
+        <tr>
+            <th>{{name}} deals damage with {{damage}}</th>
+        </tr>
+        {{/damage}}
+        
+        {{#attack}} 
+        <tr>
+            <th>{{name}} attack with {{attack}}</th>
+        </tr>
+        {{/attack}}
+        {{#pool}} 
+        <tr>
+            <th>{{name}} rolls {{pool}}</th>
+        </tr>
+        {{/pool}}
+        <tr>
+            <td class="sheet-attr">
+                {{attr}}
+                {{#skill}}<br>
+                 + {{skill}}
+                {{/skill}}
+                {{#mod}}<br>
+                 + {{mod}}
+                {{/mod}} 
+                {{#wound}}<br>
+                 + {{wound}}
+                {{/wound}}
+            </td>
+        </tr>
+        <tr>
+            <td class="sheet-result">
+                {{result}} Successes
+                {{#type}}
+                    <br><div style="color:red;">{{type}}</div>
+                {{/type}}
+            </td>        
+        </tr>
+    </table>
+</rolltemplate>
+</div>
+
+<script type="text/worker">
+on("change:current_form sheet:opened", function() {
+    getAttrs(['current_form', 'Strength-base', 'Dexterity-base', 'Stamina-base', 'Appearance-base', 'Manipulation-base'], function(values) {
+            if (values.current_form == 1 ) {
+                setAttrs({
+                    Str: 1,
+                    Dex: 1,
+                    Sta: 1,
+                    App: 1,
+                    Manip: 1
+                    
+        		})
+            }
+          	else if (values.current_form == 2 ) {
+                setAttrs({
+                    Str: 2,
+                    Dex: 2,
+                    Sta: 2,
+                    App: 2,
+                    Manip: 2
+                    
+                    
+        		})
+            }
+          	else if (values.current_form == 3 ) {
+                setAttrs({
+                    Str: 3,
+                    Dex: 3,
+                    Sta: 3,
+                    App: 3,
+                    Manip: 3
+                    
+                    
+        		})
+            }
+          	else if (values.current_form == 4 ) {
+                setAttrs({
+                    Str: 4,
+                    Dex: 4,
+                    Sta: 4,
+                    App: 4,
+                    Manip: 4
+                    
+        		})
+            }
+          	else if (values.current_form == 5 ) {
+                setAttrs({
+                    Str: 5,
+                    Dex: 5,
+                    Sta: 5,
+                    App: 5,
+                    Manip: 5
+					
+			    })
+            }
+            else if (values.current_form == 6 ) {
+                setAttrs({
+                    Str: 6,
+                    Dex: 6,
+                    Sta: 6,
+                    App: 6,
+                    Manip: 6
+                    
+        		})
+            }
+          	else if (values.current_form == 7 ) {
+                setAttrs({
+                    Str: 7,
+                    Dex: 7,
+                    Sta: 7,
+                    App: 7,
+                    Manip: 7
+                    
+                    
+        		})
+            }
+          	else if (values.current_form == 8 ) {
+                setAttrs({
+                    Str: 8,
+                    Dex: 8,
+                    Sta: 8,
+                    App: 8,
+                    Manip: 8
+                    
+                    
+        		})
+            }
+          	else if (values.current_form == 9 ) {
+                setAttrs({
+                    Str: 9,
+                    Dex: 9,
+                    Sta: 9,
+                    App: 9,
+                    Manip: 9
+                    
+        		})
+            }
+          	else if (values.current_form == 10 ) {
+                setAttrs({
+                    Str: 10,
+                    Dex: 10,
+                    Sta: 10,
+                    App: 10,
+                    Manip: 10
+					
+			    })
+            }
+        });
+    });
+on("change:Str change:'Strength-base' sheet:opened " , function() {
+    getAttrs(['Str', 'Strength-base', 'Strength-human', 'Strength-nearhuman', 'Strength-halfbeast', 'Strength-nearbeast', 'Strength-beast'], function(values) {
+            if (values.Str == 1 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + 0
+        		})
+            }
+          	else if (values.Str == 2 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + 2
+        		})
+            }
+          	else if (values.Str == 3 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + 4
+        		})
+            }
+          	else if (values.Str == 4 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + 3
+        		})
+            }
+          	else if (values.Str == 5 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + 1
+        		})
+            }
+          	else if (values.Str == 6 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + +values['Strength-human']
+        		})
+            }
+          	else if (values.Str == 7 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + +values['Strength-nearhuman']
+        		})
+            }
+          	else if (values.Str == 8 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + +values['Strength-halfbeast']
+        		})
+            }
+          	else if (values.Str == 9 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + +values['Strength-nearbeast']
+        		})
+            }
+          	else if (values.Str == 10 ) {
+                setAttrs({
+                    Strength: +values['Strength-base'] + +values['Strength-beast']
+        		})
+            }
+        });
+    });
+on("change:Dex change:'Dexterity-base' sheet:opened " , function() {
+    getAttrs(['Dex', 'Dexterity-base', 'Dexterity-human', 'Dexterity-nearhuman', 'Dexterity-halfbeast', 'Dexterity-nearbeast', 'Dexterity-beast'], function(values) {
+            if (values.Dex == 1 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + 0
+        		})
+            }
+          	else if (values.Dex == 2 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + 0
+        		})
+            }
+          	else if (values.Dex == 3 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + 1
+        		})
+            }
+          	else if (values.Dex == 4 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + 2
+        		})
+            }
+          	else if (values.Dex == 5 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + 2
+        		})
+            }
+          	else if (values.Dex == 6 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + +values['Dexterity-human']
+        		})
+            }
+          	else if (values.Dex == 7 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + +values['Dexterity-nearhuman']
+        		})
+            }
+          	else if (values.Dex == 8 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + +values['Dexterity-halfbeast']
+        		})
+            }
+          	else if (values.Dex == 9 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + +values['Dexterity-nearbeast']
+        		})
+            }
+          	else if (values.Dex == 10 ) {
+                setAttrs({
+                    Dexterity: +values['Dexterity-base'] + +values['Dexterity-beast']
+        		})
+            }
+        });
+    });
+on("change:Sta change:'Stamina-base' sheet:opened" , function() {
+    getAttrs(['Sta', 'Stamina-base', 'Stamina-human', 'Stamina-nearhuman', 'Stamina-halfbeast', 'Stamina-nearbeast', 'Stamina-beast'], function(values) {
+            if (values.Sta == 1 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + 0
+        		})
+            }
+          	else if (values.Sta == 2 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + 2
+        		})
+            }
+          	else if (values.Sta == 3 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + 3
+        		})
+            }
+          	else if (values.Sta == 4 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + 2
+        		})
+            }
+          	else if (values.Sta == 5 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + 2
+        		})
+            }
+          	else if (values.Sta == 6 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + +values['Stamina-human']
+        		})
+            }
+          	else if (values.Sta == 7 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + +values['Stamina-nearhuman']
+        		})
+            }
+          	else if (values.Sta == 8 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + +values['Stamina-halfbeast']
+        		})
+            }
+          	else if (values.Sta == 9 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + +values['Stamina-nearbeast']
+        		})
+            }
+          	else if (values.Sta == 10 ) {
+                setAttrs({
+                    Stamina: +values['Stamina-base'] + +values['Stamina-beast']
+        		})
+            }
+        });
+    });
+on("change:App change:'Appearance-base' sheet:opened" , function() {
+    getAttrs(['App', 'Appearance-base', 'Appearance-human', 'Appearance-nearhuman', 'Appearance-halfbeast', 'Appearance-nearbeast', 'Appearance-beast'], function(values) {
+            if (values.App == 1 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + 0
+        		})
+            }
+          	else if (values.App == 2 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + -1
+        		})
+            }
+          	else if (values.App == 3 ) {
+                setAttrs({
+                    Appearance: 0
+        		})
+            }
+          	else if (values.App == 4 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + 0
+        		})
+            }
+          	else if (values.App == 5 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + 0
+        		})
+            }
+          	else if (values.App == 6 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + +values['Appearance-human']
+        		})
+            }
+          	else if (values.App == 7 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + +values['Appearance-nearhuman']
+        		})
+            }
+          	else if (values.App == 8 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + +values['Appearance-halfbeast']
+        		})
+            }
+          	else if (values.App == 9 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + +values['Appearance-nearbeast']
+        		})
+            }
+          	else if (values.App == 10 ) {
+                setAttrs({
+                    Appearance: +values['Appearance-base'] + +values['Appearance-beast']
+        		})
+            }
+        });
+    });
+on("change:Manip change:'Manipulation-base' sheet:opened" , function() {
+    getAttrs(['Manip', 'Manipulation-base', 'Manipulation-human', 'Manipulation-nearhuman', 'Manipulation-halfbeast', 'Manipulation-nearbeast', 'Manipulation-beast'], function(values) {
+            if (values.Manip == 1 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + 0
+        		})
+            }
+          	else if (values.Manip == 2 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + -1
+        		})
+            }
+          	else if (values.Manip == 3 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + -3
+        		})
+            }
+          	else if (values.Manip == 4 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + -3
+        		})
+            }
+          	else if (values.Manip == 5 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + -3
+        		})
+            }
+          	else if (values.Manip == 6 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + +values['Manipulation-human']
+        		})
+            }
+          	else if (values.Manip == 7 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + +values['Manipulation-nearhuman']
+        		})
+            }
+          	else if (values.Manip == 8 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + +values['Manipulation-halfbeast']
+        		})
+            }
+          	else if (values.Manip == 9 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + +values['Manipulation-nearbeast']
+        		})
+            }
+          	else if (values.Manip == 10 ) {
+                setAttrs({
+                    Manipulation: +values['Manipulation-base'] + +values['Manipulation-beast']
+        		})
+            }
+        });
+    });
+   
+//  on("change:healthbox_1 change:healthbox_2 change:healthbox_3 change:healthbox_4 change:healthbox_5 change:healthbox_6 change:healthbox_7 change:healthbox_8 sheet:opened", function() {
+//    getAttrs(['healthbox_1', 'healthbox_2', 'healthbox_3', 'healthbox_4', 'healthbox_5', 'healthbox_6', 'healthbox_7', 'healthbox_8'], function(values) {
+//        setAttrs({ 
+//            injury: (Math.floor((+values.healthbox_1 + +values.healthbox_2 + +values.healthbox_3 + +values.healthbox_4 + +values.healthbox_5 + +values.healthbox_6 + +values.healthbox_7 + +values.healthbox_8)/100)) * -1
+//        });
+//    });
+//  });
+on("change:healthbox_1 change:healthbox_2 change:healthbox_3 change:healthbox_4 change:healthbox_5 change:healthbox_6 change:healthbox_7 change:healthbox_8 sheet:opened", function() {
+    getAttrs(['healthbox_1', 'healthbox_2', 'healthbox_3', 'healthbox_4', 'healthbox_5', 'healthbox_6', 'healthbox_7', 'healthbox_8'], function(values) {
+        setAttrs({ 
+            injury: ((Math.floor(Math.max.apply(null, Object.values(values)))) * -1) 
+        });
+    });
+});
+</script>


### PR DESCRIPTION
Fixed the player/name issue 
Added roll templates to pretty much everything.
Roll button for Gnosis, Rage, and all that are more visilbe
One click transformation is the name (Homid, Lupus, etc).  
Replaced health boxes, added wound penalties
Wound calculations all dice pools, weapon attack and damage, and claw weapon and damage.  Willpower, Gnosis, Rage and all soak roll are unaffected.
Put the Brawling combat stuff under a claw marker.
Rebuilt the common dice pools.  PUTTING THIS IN THE SHEET WILL REMOVE ALL PREVIOUS DICE POOLS.  And the players will have to replace them.  You can pick and choose if you want the query or not.  
Re-colored and renamed the attack and damage rolls, so its easier to find them.
...and I am sure I missed something.