### PR TITLE
Bug fixes

### DIFF
--- a/Fallout 3.5/Fallout 3.5.html
+++ b/Fallout 3.5/Fallout 3.5.html
@@ -115,35 +115,35 @@
             <td>Action Points</td>
             <td><input type="number" class="sheet-number" name="attr_actionpoints" value='@{mod-actionpoints} + @{base-actionpoints}' disabled="true"/></td>
             <td><input type="number" class="sheet-number" name="attr_mod-actionpoints" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-actionpoints" value='(floor(@{agility}/2))+5' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-actionpoints" value='(floor((@{agility_mod} + @{agility_base})/2))+5' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-actionpoints" value="5 + (AG/2, round down)" readonly /></td>
         </tr>
         <tr>
             <td>Carry Weight</td>
             <td><input type="number" class="sheet-number" name="attr_carry_weight" value='@{mod-carry_weight} + @{base-carry_weight}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-carry_weight" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-carry_weight" value='(25 + @{strength}*20)' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-carry_weight" value='(25 + (@{strength_mod} + @{strength_base})*20)' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-carry_weight" value="25 + (ST x20)" readonly /></td>
         </tr>
         <tr>
             <td>Critical Chance</td>
             <td><input type="number" class="sheet-number" name="attr_critical_chance" value='@{mod-critical_chance} + @{base-critical_chance}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-critical_chance" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-critical_chance" value="@{luck}" disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-critical_chance" value="(@{luck_mod} + @{luck_base})" disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-critical_chance" value="(LU)" readonly /></td>
         </tr>
         <tr>
             <td>Healing Rate</td>
             <td><input type="number" class="sheet-number" name="attr_healing_rate" value='@{mod-healing_rate} + @{base-healing_rate}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-healing_rate" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-healing_rate" value='floor(@{endurance}/3)' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-healing_rate" value='floor((@{endurance_mod} + @{endurance_base})/3)' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-healing_rate" value="(EN/3, round down)" readonly /></td>
         </tr>
         <tr>
             <td>Implant Endurance </td>
             <td><input type="number" class="sheet-number" name="attr_implant_endurance" value='@{mod-implant_endurance} + @{base-implant_endurance}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-implant_endurance" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-implant_endurance" value="@{endurance}*10" disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-implant_endurance" value="((@{endurance_mod} + @{endurance_base})*10)" disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-implant_endurance" value="10x(EN)" readonly /></td>
         </tr>
         <tr>
@@ -171,21 +171,21 @@
             <td>Resistance, Poison</td>
             <td><input type="number" class="sheet-number" name="attr_resistance_poison" value='@{mod-resistance_poison} + @{base-resistance_poison}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-resistance_poison" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-resistance_poison" value='(@{endurance}*5)' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-resistance_poison" value='((@{endurance_mod} + @{endurance_base})*5)' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-resistance_poison" value="(EN x5)" readonly /></td>
         </tr>
         <tr>
             <td>Resistance, Radiation</td>
             <td><input type="number" class="sheet-number" name="attr_resistance_radiation" value='@{mod-resistance_radiation} + @{base-resistance_radiation}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-resistance_radiation" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-resistance_radiation" value='(@{endurance}*2)' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-resistance_radiation" value='((@{endurance_mod} + @{endurance_base})*2)' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-resistance_radiation" value="(EN x2)" readonly /></td>
         </tr>
         <tr>
             <td>Sequence</td>
             <td><input type="number" class="sheet-number" name="attr_sequence" value='@{mod-sequence} + @{base-sequence}' disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-sequence" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-sequence" value='(@{perception}*2)' disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-sequence" value='((@{perception_mod} + @{perception_base})*2)' disabled="true" /></td>
             <td><input type="text"   class="sheet-number" name="attr_basetext-sequence" value="(PE x2)" readonly /></td>
         </tr>
     </table>
@@ -205,7 +205,7 @@
             <td>Perks</td>
             <td>Every <input type="number" class="sheet-number" name="attr_perks" value="" style="width:100px" /> level(s)</td>
             <td>Skill Points per level</td>
-            <td><input type="number" class="sheet-number" name="attr_skill_per_level" value='(0 + (@{intelligence}*3))' style="width:100px" disabled="true" /></td>
+            <td><input type="number" class="sheet-number" name="attr_skill_per_level" value='((@{intelligence_mod} + @{intelligence_base})*3)' style="width:100px" disabled="true" /></td>
         </tr>
     </table>
 </div>
@@ -249,10 +249,19 @@
             <td><input type="text" class="sheet-number" name="attr_basetext-pilot" value="(AG + PE)" readonly /></td>
         </tr>
         <tr>
+            <td><button class="sheet-skill_button" type='roll' name="attr_roll-gambling" value='/em @{character_name} rolls Gambling skill [[1d100]], compared to [[@{gambling}]]' /></td>
+            <td>Gambling</td>
+            <td><input name="attr_tagskill4" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_gambling" value="@{mod-gambling} + @{base-gambling} + 20*@{tagskill4}" disabled="true"/></td>
+            <td><input type="number" class="sheet-number"name="attr_mod-gambling" value="0" /></td>
+            <td><input type="number" class="sheet-number" name="attr_base-gambling" value="5 + @{luck} + @{luck}" disabled="true" /></td>
+            <td><input type="text" class="sheet-number" name="attr_basetext-gambling" value="5 + (LK) + (LK)" readonly /></td>
+        </tr>
+        <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-small_guns" value='/em @{character_name} rolls Small Guns skill [[1d100]], compared to [[@{small_guns}]]' /></td>
             <td>Small Guns</td>
-            <td><input name="attr_tagskill4" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_small_guns" value="@{mod-small_guns} + @{base-small_guns} + 20*@{tagskill4}" disabled="true"/></td>
+            <td><input name="attr_tagskill5" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_small_guns" value="@{mod-small_guns} + @{base-small_guns} + 20*@{tagskill5}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-small_guns" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-small_guns" value="5 + @{perception} + @{perception}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-small_guns" value="5 + (PE + PE)" readonly /></td>
@@ -260,8 +269,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-big_guns" value='/em @{character_name} rolls Big Guns skill [[1d100]], compared to [[@{big_guns}]]' /></td>
             <td>Big Guns</td>
-            <td><input name="attr_tagskill5" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_big_guns" value="@{mod-big_guns} + @{base-big_guns} + 20*@{tagskill5}" disabled="true"/></td>
+            <td><input name="attr_tagskill6" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_big_guns" value="@{mod-big_guns} + @{base-big_guns} + 20*@{tagskill6}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-big_guns" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-big_guns" value="@{strength} + @{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-big_guns" value="(ST) + (PE) + (AG)" readonly /></td>
@@ -269,8 +278,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-energy_weapons" value='/em @{character_name} rolls Energy Weapons skill [[1d100]], compared to [[@{energy_weapons}]]' /></td>
             <td>Energy Weapons</td>
-            <td><input name="attr_tagskill6" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_energy_weapons" value="@{mod-energy_weapons} + @{base-energy_weapons} + 20*@{tagskill6}" disabled="true"/></td>
+            <td><input name="attr_tagskill7" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_energy_weapons" value="@{mod-energy_weapons} + @{base-energy_weapons} + 20*@{tagskill7}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-energy_weapons" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-energy_weapons" value="5 + @{perception} + @{perception}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-energy_weapons" value="5 + (PE + PE)" readonly /></td>
@@ -278,8 +287,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-melee_weapons" value='/em @{character_name} rolls Melee Weapons skill [[1d100]], compared to [[@{melee_weapons}]]' /></td>
             <td>Melee Weapons</td>
-            <td><input name="attr_tagskill7" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_melee_weapons" value="@{mod-melee_weapons} + @{base-melee_weapons} + 20*@{tagskill7}" disabled="true"/></td>
+            <td><input name="attr_tagskill8" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_melee_weapons" value="@{mod-melee_weapons} + @{base-melee_weapons} + 20*@{tagskill8}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-melee_weapons" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-melee_weapons" value="@{strength} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-melee_weapons" value="(ST + AG)" readonly /></td>
@@ -287,8 +296,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-unarmed" value='/em @{character_name} rolls Unarmed skill [[1d100]], compared to [[@{unarmed}]]' /></td>
             <td>Unarmed</td>
-            <td><input name="attr_tagskill8" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_unarmed" value="@{mod-unarmed} + @{base-unarmed} + 20*@{tagskill8}" disabled="true"/></td>
+            <td><input name="attr_tagskill9" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_unarmed" value="@{mod-unarmed} + @{base-unarmed} + 20*@{tagskill9}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-unarmed" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-unarmed" value="@{strength} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-unarmed" value="(ST + AG)" readonly /></td>
@@ -296,8 +305,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-throwing" value='/em @{character_name} rolls Throwing skill [[1d100]], compared to [[@{throwing}]]' /></td>
             <td>Throwing</td>
-            <td><input name="attr_tagskill9" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_throwing" value="@{mod-throwing} + @{base-throwing} + 20*@{tagskill9}" disabled="true"/></td>
+            <td><input name="attr_tagskill10" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_throwing" value="@{mod-throwing} + @{base-throwing} + 20*@{tagskill10}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-throwing" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-throwing" value="@{strength} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-throwing" value="(ST + AG)" readonly /></td>
@@ -305,8 +314,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-traps" value='/em @{character_name} rolls Traps skill [[1d100]], compared to [[@{traps}]]' /></td>
             <td>Traps</td>
-            <td><input name="attr_tagskill10" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_traps" value="@{mod-traps} + @{base-traps} + 20*@{tagskill10}" disabled="true"/></td>
+            <td><input name="attr_tagskill11" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_traps" value="@{mod-traps} + @{base-traps} + 20*@{tagskill11}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-traps" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-traps" value="@{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-traps" value="(PE + AG)" readonly /></td>
@@ -314,8 +323,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-sneak" value='/em @{character_name} rolls Sneak skill [[1d100]], compared to [[@{sneak}]]' /></td>
             <td>Sneak</td>
-            <td><input name="attr_tagskill11" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_sneak" value="@{mod-sneak} + @{base-sneak} + 20*@{tagskill11}" disabled="true"/></td>
+            <td><input name="attr_tagskill12" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_sneak" value="@{mod-sneak} + @{base-sneak} + 20*@{tagskill12}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-sneak" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-sneak" value="@{agility} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-sneak" value="(AG + AG)" readonly /></td>
@@ -323,8 +332,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-steal" value='/em @{character_name} rolls Steal skill [[1d100]], compared to [[@{steal}]]' /></td>
             <td>Steal</td>
-            <td><input name="attr_tagskill12" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_steal" value="@{mod-steal} + @{base-steal} + 20*@{tagskill12}" disabled="true"/></td>
+            <td><input name="attr_tagskill13" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_steal" value="@{mod-steal} + @{base-steal} + 20*@{tagskill13}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-steal" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-steal" value="5 + @{agility} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-steal" value="5 + (AG + AG)" readonly /></td>
@@ -332,8 +341,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-lockpick" value='/em @{character_name} rolls Lockpick skill [[1d100]], compared to [[@{lockpick}]]' /></td>
             <td>Lockpick</td>
-            <td><input name="attr_tagskill13" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_lockpick" value="@{mod-lockpick} + @{base-lockpick} + 20*@{tagskill13}" disabled="true"/></td>
+            <td><input name="attr_tagskill14" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_lockpick" value="@{mod-lockpick} + @{base-lockpick} + 20*@{tagskill14}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-lockpick" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-lockpick" value="5 + @{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-lockpick" value="5 + (PE + AG)" readonly /></td>
@@ -341,8 +350,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-computer_science" value='/em @{character_name} rolls Computer Science skill [[1d100]], compared to [[@{computer_science}]]' /></td>
             <td>Computer Science</td>
-            <td><input name="attr_tagskill14" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_computer_science" value="@{mod-computer_science} + @{base-computer_science} + 20*@{tagskill14}" disabled="true"/></td>
+            <td><input name="attr_tagskill15" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_computer_science" value="@{mod-computer_science} + @{base-computer_science} + 20*@{tagskill15}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-computer_science" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-computer_science" value="@{perception} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-computer_science" value="(PE + IN)" readonly /></td>
@@ -350,8 +359,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-survival" value='/em @{character_name} rolls Survival skill [[1d100]], compared to [[@{survival}]]' /></td>
             <td>Survival</td>
-            <td><input name="attr_tagskill15" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_survival" value="@{mod-survival} + @{base-survival} + 20*@{tagskill15}" disabled="true"/></td>
+            <td><input name="attr_tagskill16" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_survival" value="@{mod-survival} + @{base-survival} + 20*@{tagskill16}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-survival" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-survival" value="5 + @{endurance} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-survival" value="5 + (EN + IN)" readonly /></td>
@@ -359,8 +368,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-wilderness_lore" value='/em @{character_name} rolls Wilderness Lore skill [[1d100]], compared to [[@{wilderness_lore}]]' /></td>
             <td>Wilderness Lore</td>
-            <td><input name="attr_tagskill16" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_wilderness_lore" value="@{mod-wilderness_lore} + @{base-wilderness_lore} + 20*@{tagskill16}" disabled="true"/></td>
+            <td><input name="attr_tagskill17" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_wilderness_lore" value="@{mod-wilderness_lore} + @{base-wilderness_lore} + 20*@{tagskill17}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-wilderness_lore" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-wilderness_lore" value="5 + @{perception} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-wilderness_lore" value="5 + (PE + IN)" readonly /></td>
@@ -368,8 +377,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-doctor" value='/em @{character_name} rolls Doctor skill [[1d100]], compared to [[@{doctor}]]' /></td>
             <td>Doctor</td>
-            <td><input name="attr_tagskill17" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_doctor" value="@{mod-doctor} + @{base-doctor} + 20*@{tagskill17}" disabled="true"/></td>
+            <td><input name="attr_tagskill18" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_doctor" value="@{mod-doctor} + @{base-doctor} + 20*@{tagskill18}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-doctor" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-doctor" value="@{perception} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-doctor" value="(PE + IN)" readonly /></td>
@@ -377,8 +386,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-nature_sciences" value='/em @{character_name} rolls Nature Sciences skill [[1d100]], compared to [[@{nature_sciences}]]' /></td>
             <td>Nature Sciences</td>
-            <td><input name="attr_tagskill18" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_nature_sciences" value="@{mod-nature_sciences} + @{base-nature_sciences} + 20*@{tagskill18}" disabled="true"/></td>
+            <td><input name="attr_tagskill19" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_nature_sciences" value="@{mod-nature_sciences} + @{base-nature_sciences} + 20*@{tagskill19}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-nature_sciences" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-nature_sciences" value="5 + @{intelligence} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-nature_sciences" value="5 + (IN + IN)" readonly /></td>
@@ -386,8 +395,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-animalism" value='/em @{character_name} rolls Animalism skill [[1d100]], compared to [[@{animalism}]]' /></td>
             <td>Animalism</td>
-            <td><input name="attr_tagskill19" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_animalism" value="@{mod-animalism} + @{base-animalism} + 20*@{tagskill19}" disabled="true"/></td>
+            <td><input name="attr_tagskill20" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_animalism" value="@{mod-animalism} + @{base-animalism} + 20*@{tagskill20}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-animalism" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-animalism" value="@{intelligence} + @{charisma} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-animalism" value="(IN) + (CH) + (AG)" readonly /></td>
@@ -395,8 +404,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-herbalism" value='/em @{character_name} rolls Herbalism skill [[1d100]], compared to [[@{herbalism}]]' /></td>
             <td>Herbalism</td>
-            <td><input name="attr_tagskill20" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_herbalism" value="@{mod-herbalism} + @{base-herbalism} + 20*@{tagskill20}" disabled="true"/></td>
+            <td><input name="attr_tagskill21" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_herbalism" value="@{mod-herbalism} + @{base-herbalism} + 20*@{tagskill21}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-herbalism" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-herbalism" value="@{intelligence} + @{agility} + @{perception}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-herbalism" value="(IN) + (AG) + (PE)" readonly /></td>
@@ -404,8 +413,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-repair" value='/em @{character_name} rolls Repair skill [[1d100]], compared to [[@{repair}]]' /></td>
             <td>Repair</td>
-            <td><input name="attr_tagskill21" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_repair" value="@{mod-repair} + @{base-repair} + 20*@{tagskill21}" disabled="true"/></td>
+            <td><input name="attr_tagskill22" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_repair" value="@{mod-repair} + @{base-repair} + 20*@{tagskill22}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-repair" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-repair" value="@{intelligence} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-repair" value="(IN + IN)" readonly /></td>
@@ -413,8 +422,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-robotics" value='/em @{character_name} rolls Robotics skill [[1d100]], compared to [[@{robotics}]]' /></td>
             <td>Robotics</td>
-            <td><input name="attr_tagskill22" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_robotics" value="@{mod-robotics} + @{base-robotics} + 20*@{tagskill22}" disabled="true"/></td>
+            <td><input name="attr_tagskill23" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_robotics" value="@{mod-robotics} + @{base-robotics} + 20*@{tagskill23}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-robotics" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-robotics" value="@{intelligence} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-robotics" value="(IN + IN)" readonly /></td>
@@ -422,8 +431,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-electronics" value='/em @{character_name} rolls Electronics skill [[1d100]], compared to [[@{electronics}]]' /></td>
             <td>Electronics</td>
-            <td><input name="attr_tagskill23" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_electronics" value="@{mod-electronics} + @{base-electronics} + 20*@{tagskill23}" disabled="true"/></td>
+            <td><input name="attr_tagskill24" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_electronics" value="@{mod-electronics} + @{base-electronics} + 20*@{tagskill24}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-electronics" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-electronics" value="@{perception} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-electronics" value="(PE + IN)" readonly /></td>
@@ -431,8 +440,8 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-weaponsmith" value='/em @{character_name} rolls Weaponsmith skill [[1d100]], compared to [[@{weaponsmith}]]' /></td>
             <td>Weaponsmith</td>
-            <td><input name="attr_tagskill24" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_weaponsmith" value="@{mod-weaponsmith} + @{base-weaponsmith} + 20*@{tagskill24}" disabled="true"/></td>
+            <td><input name="attr_tagskill25" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_weaponsmith" value="@{mod-weaponsmith} + @{base-weaponsmith} + 20*@{tagskill25}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-weaponsmith" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-weaponsmith" value="@{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-weaponsmith" value="(PE + AG)" readonly /></td>
@@ -440,20 +449,11 @@
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-armorsmith" value='/em @{character_name} rolls Armorsmith skill [[1d100]], compared to [[@{armorsmith}]]' /></td>
             <td>Armorsmith</td>
-            <td><input name="attr_tagskill25" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_armorsmith" value="@{mod-armorsmith} + @{base-armorsmith} + 20*@{tagskill25}" disabled="true"/></td>
+            <td><input name="attr_tagskill26" value="1" type="checkbox"></td>
+            <td><input type="number" class="sheet-number" name="attr_armorsmith" value="@{mod-armorsmith} + @{base-armorsmith} + 20*@{tagskill26}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-armorsmith" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-armorsmith" value="@{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-armorsmith" value="(PE + AG)" readonly /></td>
-        </tr>
-        <tr>
-            <td><button class="sheet-skill_button" type='roll' name="attr_roll-gambling" value='/em @{character_name} rolls Gambling skill [[1d100]], compared to [[@{gambling}]]' /></td>
-            <td>Gambling</td>
-            <td><input name="attr_tagskill26" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_gambling" value="@{mod-gambling} + @{base-gambling} + 20*@{tagskill26}" disabled="true"/></td>
-            <td><input type="number" class="sheet-number"name="attr_mod-gambling" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_base-gambling" value="5 + @{luck} + @{luck}" disabled="true" /></td>
-            <td><input type="text" class="sheet-number" name="attr_basetext-gambling" value="5 + (LK) + (LK)" readonly /></td>
         </tr>
         <tr>
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-barter" value='/em @{character_name} rolls Barter skill [[1d100]], compared to [[@{barter}]]' /></td>
@@ -531,7 +531,7 @@
                     <td></td>
                     <td><input type="number" class="sheet-number" name="attr_armor_class" value="@{mod-armor} + @{base-armor}" disabled="true"/></td>
                     <td><input type="number" class="sheet-number" name="attr_mod-armor" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_base-armor" value="@{agility}" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_base-armor" value="(@{agility_mod} + @{agility_base})" /></td>
                     <td>&nbsp;</td>
                     <td></td>
                 </tr>
@@ -635,8 +635,8 @@
                     <td><input type="number" class="sheet-number" name="attr_hit_points-max" value='@{hit_points-base} + @{hit_points-from_level} + @{hit_points-mod}' disabled="true"/></td>
                     <td><input type="number" class="sheet-number" name="attr_hit_points-mod" value='0' /></td>
                     <td><input type="number" class="sheet-number" name="attr_hit_points-from_level" value='(@{hit_points-per_level})*(@{level} - 1)' disabled="true" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_hit_points-per_level" value='(floor(@{endurance}/2) + 3)' disabled="true" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_hit_points-base" value='(15 + @{strength} + (@{endurance}*2))' disabled="true" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_hit_points-per_level" value='(floor((@{endurance_mod} + @{endurance_base})/2) + 3)' disabled="true" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_hit_points-base" value='(15 + (@{strength_mod} + @{strength_base}) + ((@{endurance_mod} + @{endurance_base})*2))' disabled="true" /></td>
                 </tr>
                 <tr>
                     <td></td>

--- a/Fallout 3.5/Fallout 3.5.html
+++ b/Fallout 3.5/Fallout 3.5.html
@@ -423,7 +423,7 @@
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-electronics" value='/em @{character_name} rolls Electronics skill [[1d100]], compared to [[@{electronics}]]' /></td>
             <td>Electronics</td>
             <td><input name="attr_tagskill23" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_electronics" value="@{mod-uelectronics} + @{base-electronics} + 20*@{tagskill23}" disabled="true"/></td>
+            <td><input type="number" class="sheet-number" name="attr_electronics" value="@{mod-electronics} + @{base-electronics} + 20*@{tagskill23}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-electronics" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-electronics" value="@{perception} + @{intelligence}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-electronics" value="(PE + IN)" readonly /></td>

--- a/Fallout 3.5/Fallout 3.5.html
+++ b/Fallout 3.5/Fallout 3.5.html
@@ -333,7 +333,7 @@
             <td><button class="sheet-skill_button" type='roll' name="attr_roll-lockpick" value='/em @{character_name} rolls Lockpick skill [[1d100]], compared to [[@{lockpick}]]' /></td>
             <td>Lockpick</td>
             <td><input name="attr_tagskill13" value="1" type="checkbox"></td>
-            <td><input type="number" class="sheet-number" name="attr_lockpick" value="@{mod-lockpick} + @{base-lockpick} + 20*@{tagskill3}" disabled="true"/></td>
+            <td><input type="number" class="sheet-number" name="attr_lockpick" value="@{mod-lockpick} + @{base-lockpick} + 20*@{tagskill13}" disabled="true"/></td>
             <td><input type="number" class="sheet-number"name="attr_mod-lockpick" value="0" /></td>
             <td><input type="number" class="sheet-number" name="attr_base-lockpick" value="5 + @{perception} + @{agility}" disabled="true" /></td>
             <td><input type="text" class="sheet-number" name="attr_basetext-lockpick" value="5 + (PE + AG)" readonly /></td>


### PR DESCRIPTION
Total point value of Electronics skill is not calculating due to small bug and tagskill number for Lockpick was wrong. Now, they have been fixed. Gambling skill moved to near top side in the skill tab. Changed formulas for secondaries and some in Combat tab have been changed due to not updating correctly when putting points in Primary Statistics. 