### PR TITLE
Fixing math on Focus Power test targets.

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -2358,9 +2358,9 @@
 	<div class="sheet-wrapper">
 		<h3>Focus Power Test</h3>
 			<div class="sheet-row">
-				<div class="sheet-item" style="width: 33%; "><button name="roll_Willpower" type="roll" value="/em channels their power [[1d100]] Target [[ @{Willpower} + @{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]."> <label>Willpower</label> </button></div>
-				<div class="sheet-item" style="width: 33%; "><button name="roll_Perception" type="roll" value="/em channels their power [[1d100]] Target [[ @{Perception} + @{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]."> <label>Perception</label> </button></div>
-				<div class="sheet-item" style="width: 33%;"><button name="roll_PsyniscienceCharacteristic" type="roll" value="/em channels their power [[1d100]] Target [[@{PsyniscienceCharacteristic} + (@{PsyRating} - ?{Psy Use?|1}) *10 + ?{Modifier|0}]]."> <label>Psyniscience</label> </button></div>
+				<div class="sheet-item" style="width: 33%; "><button name="roll_Willpower" type="roll" value="/em channels their power [[1d100]] Target [[ @{Willpower} + ((@{PsyRating} - ?{Psy Use?|1}) * 10) + ?{Modifier|0}]]."> <label>Willpower</label> </button></div>
+				<div class="sheet-item" style="width: 33%; "><button name="roll_Perception" type="roll" value="/em channels their power [[1d100]] Target [[ @{Perception} + ((@{PsyRating} - ?{Psy Use?|1}) * 10) + ?{Modifier|0}]]."> <label>Perception</label> </button></div>
+				<div class="sheet-item" style="width: 33%;"><button name="roll_PsyniscienceCharacteristic" type="roll" value="/em channels their power [[1d100]] Target [[@{PsyniscienceCharacteristic} + ((@{PsyRating} - ?{Psy Use?|1}) * 10) + ?{Modifier|0}]]."> <label>Psyniscience</label> </button></div>
 			</div>
 		<br>
 		<h3>Psychic Powers</h3>


### PR DESCRIPTION
Currently, the Dark Heresy second edition sheet does not add any modifier value given, nor does it properly calculate the effects of manifesting a psychic power at a rating that is different to the character's base Psy rating. This change aims to fix that.