### PR TITLE
Iron Kingdoms RPG - shield modifiers and derived stats

### DIFF
--- a/Iron Kingdoms RPG/IKPRG.html
+++ b/Iron Kingdoms RPG/IKPRG.html
@@ -8043,15 +8043,11 @@ All free strikes are resovled after the steamjack has finished it Trample and th
                 <table style="width:620px">
                     <tr>
                         <td><h5>Shield</h5></td>
-                        <td><h5>SPD Modifier</h5></td>
-                        <td><h5>DEF Modifier</h5></td>
-                        <td><h5>ARM Modifier</h5></td>
+                        <td colspan="3"></td>
                     </tr>
                     <tr>
                         <td><input type="text" class="sheet-input-center-aligned" name="attr_shield_name" value="" placeholder="Shield Name" /></td>
-                        <td><input type="number" class="sheet-input-center-aligned" name="attr_shield_speed_mod" value="0" /></td>
-                        <td><input type="number" class="sheet-input-center-aligned" name="attr_shield_def_mod" value="0" /></td>
-                        <td><input type="number" class="sheet-input-center-aligned" name="attr_shield_arm_mod" value="0" /></td>
+                        <td colspan="3"></td>
                     </tr>
                     <tr>
                         <td colspan="4"><textarea class="sheet-input-center-aligned" wrap="soft" type="text" value="" name="attr_shield_note" style="width:620px" placeholder="Shield" /></textarea></td>
@@ -9977,18 +9973,18 @@ on("change:speed change:prowess change:perception change:initiative_mod change:n
         });
     });
     //arm
-on("change:physique change:Ogrun_toggle change:Blighted_Ogrun_toggle change:worn_armor_arm change:hasshield change:shield_arm_mod change:otherarmor_arm_mod change:jack_arm change:npc_arm change:shield sheet:opened", function() {
-        getAttrs(["physique", "Ogrun_toggle", "Blighted_Ogrun_toggle", "worn_armor_arm", "hasshield", "shield_arm_mod", "otherarmor_arm_mod", "jack_arm", "npc_arm", "shield"], function(values) {
+on("change:physique change:Ogrun_toggle change:Blighted_Ogrun_toggle change:worn_armor_arm change:hasshield change:otherarmor_arm_mod change:jack_arm change:npc_arm change:shield sheet:opened", function() {
+        getAttrs(["physique", "Ogrun_toggle", "Blighted_Ogrun_toggle", "worn_armor_arm", "hasshield", "otherarmor_arm_mod", "jack_arm", "npc_arm", "shield"], function(values) {
             setAttrs({
-                arm: (+values.physique + +values.Ogrun_toggle + +values.Blighted_Ogrun_toggle + +values.worn_armor_arm + +values.shield_arm_mod + +values.otherarmor_arm_mod + +values.jack_arm + +values.npc_arm + (+values.shield * values.hasshield))
+                arm: (+values.physique + +values.Ogrun_toggle + +values.Blighted_Ogrun_toggle + +values.worn_armor_arm + +values.otherarmor_arm_mod + +values.jack_arm + +values.npc_arm + (+values.shield * values.hasshield))
             });
         });
     });
     //def
-on("change:speed change:agility change:perception change:worn_armor_def change:worn_armor_speed change:npc_def change:jack_def change:Gobber_toggle change:Bogrin_toggle change:Swamp_Gobber_toggle change:mounted change:Crippled_Intellect change:shield_def_mod change:otherarmor_def_mod change:riding sheet:opened", function() {
-        getAttrs(["speed", "agility", "perception", "worn_armor_def", "npc_def", "jack_def", "Gobber_toggle", "Bogrin_toggle", "Swamp_Gobber_toggle", "mounted","Crippled_Intellect", "shield_def_mod", "otherarmor_def_mod", "riding"], function(values) {
+on("change:speed change:agility change:perception change:worn_armor_def change:worn_armor_speed change:npc_def change:jack_def change:Gobber_toggle change:Bogrin_toggle change:Swamp_Gobber_toggle change:mounted change:Crippled_Intellect change:otherarmor_def_mod change:riding sheet:opened", function() {
+        getAttrs(["speed", "agility", "perception", "worn_armor_def", "npc_def", "jack_def", "Gobber_toggle", "Bogrin_toggle", "Swamp_Gobber_toggle", "mounted","Crippled_Intellect", "otherarmor_def_mod", "riding"], function(values) {
             setAttrs({
-                def: (+values.speed + +values.agility + +values.perception + +values.worn_armor_def + +values.npc_def + +values.jack_def + +values.Gobber_toggle + +values.Bogrin_toggle + +values.Swamp_Gobber_toggle + +values.Crippled_Intellect + +values.shield_def_mod + +values.otherarmor_def_mod + (+values.mounted * (+values.riding - 4)))
+                def: (+values.speed + +values.agility + +values.perception + +values.worn_armor_def + +values.npc_def + +values.jack_def + +values.Gobber_toggle + +values.Bogrin_toggle + +values.Swamp_Gobber_toggle + +values.Crippled_Intellect + +values.otherarmor_def_mod + (+values.mounted * (+values.riding - 4)))
             });
         });
     });


### PR DESCRIPTION
- Remove SPD, DEF, ARM modifiers from the Shield section since they
don't apply to shields (shields are weapons, not armor).
- Remove shield DEF and ARM modifiers from the derived stats
calculations.

@CoalPoweredPuppet FYI