### PR TITLE
[5eOGL]Added Spell Attack Bonus Modifier.html

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -1644,7 +1644,7 @@
                 <span class="label" data-i18n="spell-save-dc-u">SPELL SAVE DC</span>
             </div>
             <div class="part">
-                <input type="text" name="attr_spell_attack_bonus" value="(@{spellcasting_ability}@{pb})" disabled="true">
+                <input type="text" name="attr_spell_attack_bonus" value="(@{spellcasting_ability}(@{pb}+@{spell_attack_bonus_mod}))" disabled="true">
                 <span class="label" data-i18n="spell-atk-bonus-u">SPELL ATTACK BONUS</span>
             </div>
         </div>
@@ -3423,6 +3423,10 @@
                 <div class="row">
                     <span data-i18n="spell_dc_mod:-u">SPELL SAVE DC MOD:</span>
                     <input type="text" class="num" name="attr_spell_dc_mod" placeholde="0" value="0">
+                </div>
+                <div class="row">
+                    <span data-i18n="spell_atk_bonus_mod:-u">SPELL ATTACK BONUS MOD:</span>
+                    <input type="text" class="num" name="attr_spell_attack_bonus_mod" placeholder="0" value="0">
                 </div>
                 <div class="row">
                     <input type="checkbox" name="attr_custom_ac_flag" value="1">


### PR DESCRIPTION
added a Spell Attack Bonus Modifier since there was one for the Spell Save DC but not the Spell Attack Bonus.

I don't know why that wasn't there already it was literally 5 lines and someone had make the same changes for the Spell Save DC earlier

I haven't done anything on GitHub before so I hope I did things correctly?