### PR TITLE
Fixed rules errors in to make the sheet playable

### DIFF
--- a/Marvel Heroic Roleplaying/mhrpg.html
+++ b/Marvel Heroic Roleplaying/mhrpg.html
@@ -5,67 +5,74 @@
 <input type="text" name="attr_dis3"/></form>
 <p>&nbsp;</p>
 <h1>Affiliations:</h1>
-<strong>Solo</strong>
-<select name="attr_solo" class="affiliation">                
-          <option value="d6">d6</option>
-          <option value="d8">d8</option>
-          <option value="d10">d10</option>
-          </select>
-          <strong>Buddy</strong>
-<select name="attr_buddy" class="affiliation">                
-          <option value="d6">d6</option>
-          <option value="d8">d8</option>
-          <option value="d10">d10</option>
-          </select>
-<strong>Team</strong>
-<select name="attr_team" class="affiliation">                
-          <option value="d6">d6</option>
-          <option value="d8">d8</option>
-          <option value="d10">d10</option>
-          </select><br />
+    <strong>Solo</strong>
+        <input type="text" name="attr_solo" class="affiliation"/>
+    <strong>Buddy</strong>
+        <input type="text" name="attr_buddy" class="affiliation"/>
+    <strong>Team</strong>
+        <input type="text"  name="attr_team" class="affiliation"/>
+        <br />
 <h1>Stress:</h1><br />
-Physical <select name="attr_pstress" class="stress">                
+Physical <select name="attr_pstress" class="stress">
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="Out">Out</option>
           </select>
 Mental <select name="attr_mstress" class="stress">                
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="d12">d12</option>
+          <option value="Out">Out</option>
           </select>
 Emotional <select name="attr_estress" class="stress">                
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="d12">d12</option>
+          <option value="Out">Out</option>
           </select><br />
 <h1>Trauma:</h1><br />
-Physical <select name="attr_ptrauma" class="trauma">                
+Physical <select name="attr_ptrauma" class="trauma">
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="d12">d12</option>
+          <option value="Dead">Dead</option>
           </select>
-Mental <select name="attr_mtrauma" class="trauma">                
+Mental <select name="attr_mtrauma" class="trauma">
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="d12">d12</option>
+          <option value="Dead">Dead</option>
           </select>
-Emotional <select name="attr_etrauma" class="trauma">                
+Emotional <select name="attr_etrauma" class="trauma">
           <option value="0">0</option>
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
+          <option value="d12">d12</option>
+          <option value="Dead">Dead</option>
           </select><br />
 <h1>Power Sets:</h1>
 <form><input type="text" name="attr_ps1" placeholder="Power Set 1" /></form>
 <fieldset class="repeating_pow1">            
      <input type="text" name="attr_power1" placeholder="Power Name"/>
      <select name="attr_p1" class="pow1">                
+          <option value="d4">d4</option>
           <option value="d6">d6</option>
           <option value="d8">d8</option>
           <option value="d10">d10</option>
@@ -98,71 +105,17 @@ Emotional <select name="attr_etrauma" class="trauma">
      <input type="text" name="attr_limit2"/>
 </fieldset>
 <h1>Specialties:</h1>
-<p>Acrobatics <select name="attr_acrobatics" class="specialty">                
+<p>
+<fieldset class="repeating_spec1">
+    <select name="attr_spec1" class="specialty">                
+          <option value="d4">Amateur d4</option>
           <option value="d6">Rookie d6</option>
           <option value="d8">Expert d8</option>
           <option value="d10">Master d10</option>
-          </select> <br />
-  Business <select name="attr_business" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Combat <select name="attr_combat" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Cosmic <select name="attr_cosmic" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Covert <select name="attr_covert" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Crime <select name="attr_crime" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Medical<select name="attr_medical" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Menace <select name="attr_menace" class="specialty">                
-          <option value="d6">Apprentice d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Mystic <select name="attr_mystic" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Psych <select name="attr_psych" class="specialty">                
-          <option value="d6">Apprentice d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Science <select name="attr_science" class="specialty">                
-          <option value="d6">Apprentice d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Tech <select name="attr_tech" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br />
-  Vehicle <select name="attr_vehicle" class="specialty">                
-          <option value="d6">Rookie d6</option>
-          <option value="d8">Expert d8</option>
-          <option value="d10">Master d10</option>
-          </select> <br /></p>
+              <option value="d10">Grandmaster d12</option>
+          </select>
+    </fieldset>
+</p>
 <h1>Milestones:</h1>
 <form><input type="text" name="attr_milestone1" placeholder="Milestone Name" /></form><br />
 1 XP: <form><input type="text" name="attr_trigger11" /></form><br />


### PR DESCRIPTION
Changed distinctions to a Form, so now it is possible to use NPC distinctions (d4) and mob/large scale thread distinctions (multiple dice).
Fixed the dice range for both trauma and stress (it should go from d4 to d12 for each option, plus 0 and Dead/Out).
Changed Specialties to Repeating fields, as Marvel Heroic characters have very few of those. Also, fixed the range from d4 to d12, to include the Grandmaster level introduced in the Annihilation core book.