### PR TITLE
Exalted 3e sheet v2.1 updates

### DIFF
--- a/Exalted 3/Ex3-Sheet.css
+++ b/Exalted 3/Ex3-Sheet.css
@@ -2,15 +2,25 @@
     position: absolute;
     left: 0;
     padding: 0 0 0 10px !important;
+    height: calc(100% - 70px);
+    width: calc(100% - 12px);
+}
+
+.sheet-content {
+    height: 100%;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: row;
+    flex-direction: column;
 }
 
 .sheet-body {
     display: block;
-    height: 565px;
-    padding: 5px 0 5px 1px;
+    padding: 5px 0 5px 0;
     overflow-x: visible;
     overflow-y: scroll;
     position: relative;
+    flex: 1 1 auto;
 }
 
 .sheet-body::-webkit-scrollbar {
@@ -28,7 +38,8 @@
 .sheet-footer {
     padding-top: 3px;
     text-align: right;
-    background: url(http://i.imgur.com/R0FTYGB.jpg) no-repeat;
+    background: url(http://i.imgur.com/R0FTYGB.jpg) white no-repeat;
+    flex: 0 0 auto;
 }
 
 .sheet-footer button[type=roll] {
@@ -111,7 +122,10 @@ fieldset.sheet-table-body + .repcontainer { display: table-row-group; }
     width: 100%;
 }
 
-.sheet-flexbox-inline > label > span { white-space: nowrap; }
+.sheet-flexbox-inline > label > span {
+    white-space: nowrap;
+    font-size: 89%;
+}
  
 .sheet-flexbox-h input[type=text],
 .sheet-flexbox-h input[type=number],
@@ -241,6 +255,10 @@ input[type=number]::-webkit-outer-spin-button {
     margin: 0;
 }
 
+input[type=number] {
+    -moz-appearance: textfield;
+}
+
 .sheet-motes span { display: inline-block; }
 
 .sheet-motes span:last-child {
@@ -348,6 +366,7 @@ input[type=checkbox].sheet-unnamed-toggle + span::before {
     text-align: center;
     line-height: 100%;
     font-size: 18px;
+    overflow: hidden;
 }
 
 .sheet-layer7,

--- a/Exalted 3/Ex3-Sheet.html
+++ b/Exalted 3/Ex3-Sheet.html
@@ -464,2141 +464,2143 @@
 // Contact:  https://app.roll20.net/users/104025/the-aaron
 // Minified with http://jscompress.com/
 function initTAS() {
-TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug",title:"DEBUG",color:{bgLabel:"#7732A2",label:"#F2EF40",bgText:"#FFFEB7",text:"#7732A2"}},error:{key:"error",title:"Error",color:{bgLabel:"#C11713",label:"white",bgText:"#C11713",text:"white"}},warn:{key:"warn",title:"Warning",color:{bgLabel:"#F29140",label:"white",bgText:"#FFD8B7",text:"black"}},info:{key:"info",title:"Info",color:{bgLabel:"#413FA9",label:"white",bgText:"#B3B2EB",text:"black"}},notice:{key:"notice",title:"Notice",color:{bgLabel:"#33C133",label:"white",bgText:"#ADF1AD",text:"black"}},log:{key:"log",title:"Log",color:{bgLabel:"#f2f240",label:"black",bgText:"#ffff90",text:"black"}},callstack:{key:"TAS",title:"function",color:{bgLabel:"#413FA9",label:"white",bgText:"#B3B2EB",text:"black"}},callstack_async:{key:"TAS",title:"ASYNC CALL",color:{bgLabel:"#413FA9",label:"white",bgText:"#413FA9",text:"white"}},TAS:{key:"TAS",title:"TAS",color:{bgLabel:"grey",label:"black;background:linear-gradient(#304352,#d7d2cc,#d7d2cc,#d7d2cc,#304352)",bgText:"grey",text:"black;background:linear-gradient(#304352,#d7d2cc,#d7d2cc,#d7d2cc,#304352)"}}},o={debugMode:!1,logging:{log:!0,notice:!0,info:!0,warn:!0,error:!0,debug:!1}},r=[],c={},a=function(e){switch(typeof e){case"string":return"string";case"boolean":return"boolean";case"number":return _.isNaN(e)?"NaN":e.toString().match(/\./)?"decimal":"integer";case"function":return"function: "+(e.name?e.name+"()":"(anonymous)");case"object":return _.isArray(e)?"array":_.isArguments(e)?"arguments":_.isNull(e)?"null":"object";default:return typeof e}},i=function(e,n,t){_.each(t,function(t){var o=a(t);switch(o){case"string":e(t);break;case"undefined":case"null":case"NaN":e("["+o+"]");break;case"number":case"not a number":case"integer":case"decimal":case"boolean":e("["+o+"]: "+t);break;default:e("["+o+"]:========================================="),n(t),e("=========================================================")}})},u=function(e){var n,t=e.key,r=e.title||"TAS",c=e.color&&e.color.bgLabel||"blue",a=e.color&&e.color.label||"white",u=e.color&&e.color.bgText||"blue",l=e.color&&e.color.text||"white";return n=function(e){console.log("%c "+r+": %c "+e+" ","background-color: "+c+";color: "+a+"; font-weight:bold;","background-color: "+u+";color: "+l+";")},function(){("TAS"===t||o.logging[t])&&i(n,function(e){console.log(e)},_.toArray(arguments))}},l=u(t.debug),f=u(t.error),g=u(t.warn),b=u(t.info),s=u(t.notice),d=u(t.log),p=u(t.TAS),h=u(t.callstack),m=u(t.callstack_async),y=function(e,n){var t=_.findIndex(r,function(t){return _.difference(t.stack,e).length===_.difference(e,t.stack).length&&0===_.difference(t.stack,e).length&&t.label===n});return-1===t&&(t=r.length,r.push({stack:e,label:n})),t},k=function(e){var n=_.defaults(e,o);n.logging=_.defaults(e&&e.logging||{},o.logging),o=n},x=function(){o.logging.debug=!0,o.debugMode=!0},A=function(){var e=new Error("dummy"),n=_.map(_.rest(e.stack.replace(/^[^\(]+?[\n$]/gm,"").replace(/^\s+at\s+/gm,"").replace(/^Object.<anonymous>\s*\(/gm,"{anonymous}()@").split("\n")),function(e){return e.replace(/\s+.*$/,"")});return n},w=function(e){var n,t;_.find(e,function(e){return(n=e.match(/TAS_CALLSTACK_(\d+)/))?(t=r[n[1]],m("===================="+(t.label?"> "+t.label+" <":"")+"===================="),w(t.stack),!0):(h(e),!1)})},F=function(){var e;o.debugMode&&(e=A(),e.shift(),p("==============================> CALLSTACK <=============================="),w(e),p("========================================================================="))},S=function(e,n,t){var r;return"function"==typeof e&&(t=n,n=e,e=void 0),o.debugMode?(r=A(),r.shift(),function(e,n,t,o){var r=y(t,o);return new Function("cb","ctx","TASlog","return function TAS_CALLSTACK_"+r+"(){TASlog('Entering: '+(cb.name||'(anonymous function)'));cb.apply(ctx||{},arguments);TASlog('Exiting: '+(cb.name||'(anonymous function)'));};")(e,n,p)}(n,t,r,e)):function(e,n){return function(){e.apply(n||{},arguments)}}(n,t)},T=function(e,n){c[e]=n},v=function(){setAttrs(c),c={}},L=function(e,n){return _.chain(e).reduce(function(n,t){return"string"==typeof t?n.push(t):(_.isArray(e)||_.isArguments(e))&&(n=L(t,n)),n},_.isArray(n)&&n||[]).uniq().value()},j=function(e,n){Object.defineProperty(e,"id",{value:n,writeable:!1,enumerable:!1})},C=function(e,n,t,o){!function(){var r=_.contains(["S","F","I","D"],n)?"_"+n:n,c=o||n,a=t;_.each(["S","I","F"],function(n){_.has(e,n)||Object.defineProperty(e,n,{value:{},enumerable:!1,readonly:!0})}),_.has(e,"D")||Object.defineProperty(e,"D",{value:_.reduce(_.range(10),function(e,n){return Object.defineProperty(e,n,{value:{},enumerable:!0,readonly:!0}),e},{}),enumerable:!1,readonly:!0}),Object.defineProperty(e,r,{enumerable:!0,set:function(e){e!==a&&(a=e,T(c,e))},get:function(){return a}}),Object.defineProperty(e.S,r,{enumerable:!0,set:function(e){var n=e.toString();n!==a&&(a=n,T(c,n))},get:function(){return a.toString()}}),Object.defineProperty(e.I,r,{enumerable:!0,set:function(e){var n=parseInt(e,10)||0;n!==a&&(a=n,T(c,n))},get:function(){return parseInt(a,10)||0}}),Object.defineProperty(e.F,r,{enumerable:!0,set:function(e){var n=parseFloat(e)||0;n!==a&&(a=n,T(c,n))},get:function(){return parseFloat(a)||0}}),_.each(_.range(10),function(n){Object.defineProperty(e.D[n],r,{enumerable:!0,set:function(e){var t=(parseFloat(e)||0).toFixed(n);t!==a&&(a=t,T(c,t))},get:function(){return(parseFloat(a)||0).toFixed(n)}})})}()},O=function(e){return function(e){var n=e,t=[],o=[],r=[],c=[],a=function(){return t=L(arguments,t),this},i=function(){return o=L(arguments,o),this},u=function(e,n,t,o){return r.push({type:"reduce",func:e&&_.isFunction(e)&&e||_.noop,memo:_.isUndefined(n)&&0||n,"final":t&&_.isFunction(t)&&t||_.noop,context:o||{}}),this},l=function(e,n,t){return r.push({type:"map",func:e&&_.isFunction(e)&&e||_.noop,"final":n&&_.isFunction(n)&&n||_.noop,context:t||{}}),this},f=function(e,n,t){return r.push({type:"each",func:e&&_.isFunction(e)&&e||_.noop,"final":n&&_.isFunction(n)&&n||_.noop,context:t||{}}),this},g=function(e,n){return r.push({type:"tap","final":e&&_.isFunction(e)&&e||_.noop,context:n||{}}),this},b=function(e,n){return c.push({callback:e&&_.isFunction(e)&&e||_.noop,context:n||{}}),this},s=function(e,a){var i={},u={},l=[],f=[];b(e,a),getSectionIDs("repeating_"+n,function(e){l=e,f=_.reduce(l,function(e,t){return e.concat(_.map(o,function(e){return"repeating_"+n+"_"+t+"_"+e}))},[]),getAttrs(_.uniq(t.concat(f)),function(e){_.each(t,function(n){e.hasOwnProperty(n)&&C(u,n,e[n])}),i=_.reduce(l,function(t,r){var c={};return j(c,r),_.each(o,function(t){var o="repeating_"+n+"_"+r+"_"+t;C(c,t,e[o],o)}),t[r]=c,t},{}),_.each(r,function(e){var n;switch(e.type){case"tap":_.bind(e["final"],e.context,i,u)();break;case"each":_.each(i,function(n){_.bind(e.func,e.context,n,u,n.id,i)()}),_.bind(e["final"],e.context,i,u)();break;case"map":n=_.map(i,function(n){return _.bind(e.func,e.context,n,u,n.id,i)()}),_.bind(e["final"],e.context,n,i,u)();break;case"reduce":n=e.memo,_.each(i,function(t){n=_.bind(e.func,e.context,n,t,u,t.id,i)()}),_.bind(e["final"],e.context,n,i,u)()}}),v(),_.each(c,function(e){_.bind(e.callback,e.context)()})})})};return{attrs:a,attr:a,column:i,columns:i,field:i,fields:i,reduce:u,inject:u,foldl:u,map:l,collect:l,each:f,forEach:f,tap:g,"do":g,after:b,last:b,done:b,execute:s,go:s,run:s}}(e)},D=function(e,n,t){O(e).attr(t).field(n).reduce(function(e,t){return e+t.F[n]},0,function(e,n,o){o.S[t]=e}).execute()};return console.log("%c?.¸¸.?*´¨`*?.¸¸.?*´¨`*?.¸  The Aaron Sheet  v"+e+"  ¸.?*´¨`*?.¸¸.?*´¨`*?.¸¸.?","background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;"),console.log("%c?.¸¸.?*´¨`*?.¸¸.?*´¨`*?.¸  Last update: "+new Date(1e3*n)+"  ¸.?*´¨`*?.¸¸.?*´¨`*?.¸¸.?","background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;"),{repeatingSimpleSum:D,repeating:O,config:k,callback:S,callstack:F,debugMode:x,_fn:S,debug:l,error:f,warn:g,info:b,notice:s,log:d}}();
+TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug",title:"DEBUG",color:{bgLabel:"#7732A2",label:"#F2EF40",bgText:"#FFFEB7",text:"#7732A2"}},error:{key:"error",title:"Error",color:{bgLabel:"#C11713",label:"white",bgText:"#C11713",text:"white"}},warn:{key:"warn",title:"Warning",color:{bgLabel:"#F29140",label:"white",bgText:"#FFD8B7",text:"black"}},info:{key:"info",title:"Info",color:{bgLabel:"#413FA9",label:"white",bgText:"#B3B2EB",text:"black"}},notice:{key:"notice",title:"Notice",color:{bgLabel:"#33C133",label:"white",bgText:"#ADF1AD",text:"black"}},log:{key:"log",title:"Log",color:{bgLabel:"#f2f240",label:"black",bgText:"#ffff90",text:"black"}},callstack:{key:"TAS",title:"function",color:{bgLabel:"#413FA9",label:"white",bgText:"#B3B2EB",text:"black"}},callstack_async:{key:"TAS",title:"ASYNC CALL",color:{bgLabel:"#413FA9",label:"white",bgText:"#413FA9",text:"white"}},TAS:{key:"TAS",title:"TAS",color:{bgLabel:"grey",label:"black;background:linear-gradient(#304352,#d7d2cc,#d7d2cc,#d7d2cc,#304352)",bgText:"grey",text:"black;background:linear-gradient(#304352,#d7d2cc,#d7d2cc,#d7d2cc,#304352)"}}},o={debugMode:!1,logging:{log:!0,notice:!0,info:!0,warn:!0,error:!0,debug:!1}},r=[],c={},a=function(e){switch(typeof e){case"string":return"string";case"boolean":return"boolean";case"number":return _.isNaN(e)?"NaN":e.toString().match(/\./)?"decimal":"integer";case"function":return"function: "+(e.name?e.name+"()":"(anonymous)");case"object":return _.isArray(e)?"array":_.isArguments(e)?"arguments":_.isNull(e)?"null":"object";default:return typeof e}},i=function(e,n,t){_.each(t,function(t){var o=a(t);switch(o){case"string":e(t);break;case"undefined":case"null":case"NaN":e("["+o+"]");break;case"number":case"not a number":case"integer":case"decimal":case"boolean":e("["+o+"]: "+t);break;default:e("["+o+"]:========================================="),n(t),e("=========================================================")}})},u=function(e){var n,t=e.key,r=e.title||"TAS",c=e.color&&e.color.bgLabel||"blue",a=e.color&&e.color.label||"white",u=e.color&&e.color.bgText||"blue",l=e.color&&e.color.text||"white";return n=function(e){console.log("%c "+r+": %c "+e+" ","background-color: "+c+";color: "+a+"; font-weight:bold;","background-color: "+u+";color: "+l+";")},function(){("TAS"===t||o.logging[t])&&i(n,function(e){console.log(e)},_.toArray(arguments))}},l=u(t.debug),f=u(t.error),g=u(t.warn),b=u(t.info),s=u(t.notice),d=u(t.log),p=u(t.TAS),h=u(t.callstack),m=u(t.callstack_async),y=function(e,n){var t=_.findIndex(r,function(t){return _.difference(t.stack,e).length===_.difference(e,t.stack).length&&0===_.difference(t.stack,e).length&&t.label===n});return-1===t&&(t=r.length,r.push({stack:e,label:n})),t},k=function(e){var n=_.defaults(e,o);n.logging=_.defaults(e&&e.logging||{},o.logging),o=n},x=function(){o.logging.debug=!0,o.debugMode=!0},A=function(){var e=new Error("dummy"),n=_.map(_.rest(e.stack.replace(/^[^\(]+?[\n$]/gm,"").replace(/^\s+at\s+/gm,"").replace(/^Object.<anonymous>\s*\(/gm,"{anonymous}()@").split("\n")),function(e){return e.replace(/\s+.*$/,"")});return n},w=function(e){var n,t;_.find(e,function(e){return(n=e.match(/TAS_CALLSTACK_(\d+)/))?(t=r[n[1]],m("===================="+(t.label?"> "+t.label+" <":"")+"===================="),w(t.stack),!0):(h(e),!1)})},F=function(){var e;o.debugMode&&(e=A(),e.shift(),p("==============================> CALLSTACK <=============================="),w(e),p("========================================================================="))},S=function(e,n,t){var r;return"function"==typeof e&&(t=n,n=e,e=void 0),o.debugMode?(r=A(),r.shift(),function(e,n,t,o){var r=y(t,o);return new Function("cb","ctx","TASlog","return function TAS_CALLSTACK_"+r+"(){TASlog('Entering: '+(cb.name||'(anonymous function)'));cb.apply(ctx||{},arguments);TASlog('Exiting: '+(cb.name||'(anonymous function)'));};")(e,n,p)}(n,t,r,e)):function(e,n){return function(){e.apply(n||{},arguments)}}(n,t)},T=function(e,n){c[e]=n},v=function(){setAttrs(c),c={}},L=function(e,n){return _.chain(e).reduce(function(n,t){return"string"==typeof t?n.push(t):(_.isArray(e)||_.isArguments(e))&&(n=L(t,n)),n},_.isArray(n)&&n||[]).uniq().value()},j=function(e,n){Object.defineProperty(e,"id",{value:n,writeable:!1,enumerable:!1})},C=function(e,n,t,o){!function(){var r=_.contains(["S","F","I","D"],n)?"_"+n:n,c=o||n,a=t;_.each(["S","I","F"],function(n){_.has(e,n)||Object.defineProperty(e,n,{value:{},enumerable:!1,readonly:!0})}),_.has(e,"D")||Object.defineProperty(e,"D",{value:_.reduce(_.range(10),function(e,n){return Object.defineProperty(e,n,{value:{},enumerable:!0,readonly:!0}),e},{}),enumerable:!1,readonly:!0}),Object.defineProperty(e,r,{enumerable:!0,set:function(e){e!==a&&(a=e,T(c,e))},get:function(){return a}}),Object.defineProperty(e.S,r,{enumerable:!0,set:function(e){var n=e.toString();n!==a&&(a=n,T(c,n))},get:function(){return a.toString()}}),Object.defineProperty(e.I,r,{enumerable:!0,set:function(e){var n=parseInt(e,10)||0;n!==a&&(a=n,T(c,n))},get:function(){return parseInt(a,10)||0}}),Object.defineProperty(e.F,r,{enumerable:!0,set:function(e){var n=parseFloat(e)||0;n!==a&&(a=n,T(c,n))},get:function(){return parseFloat(a)||0}}),_.each(_.range(10),function(n){Object.defineProperty(e.D[n],r,{enumerable:!0,set:function(e){var t=(parseFloat(e)||0).toFixed(n);t!==a&&(a=t,T(c,t))},get:function(){return(parseFloat(a)||0).toFixed(n)}})})}()},O=function(e){return function(e){var n=e,t=[],o=[],r=[],c=[],a=function(){return t=L(arguments,t),this},i=function(){return o=L(arguments,o),this},u=function(e,n,t,o){return r.push({type:"reduce",func:e&&_.isFunction(e)&&e||_.noop,memo:_.isUndefined(n)&&0||n,"final":t&&_.isFunction(t)&&t||_.noop,context:o||{}}),this},l=function(e,n,t){return r.push({type:"map",func:e&&_.isFunction(e)&&e||_.noop,"final":n&&_.isFunction(n)&&n||_.noop,context:t||{}}),this},f=function(e,n,t){return r.push({type:"each",func:e&&_.isFunction(e)&&e||_.noop,"final":n&&_.isFunction(n)&&n||_.noop,context:t||{}}),this},g=function(e,n){return r.push({type:"tap","final":e&&_.isFunction(e)&&e||_.noop,context:n||{}}),this},b=function(e,n){return c.push({callback:e&&_.isFunction(e)&&e||_.noop,context:n||{}}),this},s=function(e,a){var i={},u={},l=[],f=[];b(e,a),getSectionIDs("repeating_"+n,function(e){l=e,f=_.reduce(l,function(e,t){return e.concat(_.map(o,function(e){return"repeating_"+n+"_"+t+"_"+e}))},[]),getAttrs(_.uniq(t.concat(f)),function(e){_.each(t,function(n){e.hasOwnProperty(n)&&C(u,n,e[n])}),i=_.reduce(l,function(t,r){var c={};return j(c,r),_.each(o,function(t){var o="repeating_"+n+"_"+r+"_"+t;C(c,t,e[o],o)}),t[r]=c,t},{}),_.each(r,function(e){var n;switch(e.type){case"tap":_.bind(e["final"],e.context,i,u)();break;case"each":_.each(i,function(n){_.bind(e.func,e.context,n,u,n.id,i)()}),_.bind(e["final"],e.context,i,u)();break;case"map":n=_.map(i,function(n){return _.bind(e.func,e.context,n,u,n.id,i)()}),_.bind(e["final"],e.context,n,i,u)();break;case"reduce":n=e.memo,_.each(i,function(t){n=_.bind(e.func,e.context,n,t,u,t.id,i)()}),_.bind(e["final"],e.context,n,i,u)()}}),v(),_.each(c,function(e){_.bind(e.callback,e.context)()})})})};return{attrs:a,attr:a,column:i,columns:i,field:i,fields:i,reduce:u,inject:u,foldl:u,map:l,collect:l,each:f,forEach:f,tap:g,"do":g,after:b,last:b,done:b,execute:s,go:s,run:s}}(e)},D=function(e,n,t){O(e).attr(t).field(n).reduce(function(e,t){return e+t.F[n]},0,function(e,n,o){o.S[t]=e}).execute()};return console.log("%c?.??.?*??`*?.??.?*??`*?.?  The Aaron Sheet  v"+e+"  ?.?*??`*?.??.?*??`*?.??.?","background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;"),console.log("%c?.??.?*??`*?.??.?*??`*?.?  Last update: "+new Date(1e3*n)+"  ?.?*??`*?.??.?*??`*?.??.?","background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;"),{repeatingSimpleSum:D,repeating:O,config:k,callback:S,callstack:F,debugMode:x,_fn:S,debug:l,error:f,warn:g,info:b,notice:s,log:d}}();
 }
 </script>
-<div class="sheet-body">
-    <div class="sheet-3colrow">
-        <div class="sheet-col">
-            <img src="http://i.imgur.com/JqdPTxp.png">
-        </div>
-        <div class="sheet-col">
-            <div class="sheet-flexbox-h">
-                <label><span data-i18n="name">Name</span>: <input type="text" name="attr_character_name" placeholder="Karal Fire Orchid"></label>
+<div class="sheet-content">
+    <div class="sheet-body">
+        <div class="sheet-3colrow">
+            <div class="sheet-col">
+                <img src="http://i.imgur.com/JqdPTxp.png">
             </div>
-            <div class="sheet-flexbox-h">
-                <label><span data-i18n="player">Player</span>: <input type="text" name="attr_player-name" placeholder="John Smith"></label>
-            </div>
-            <div class="sheet-flexbox-h">
-                <label>
-                    <span data-i18n="caste/aspect">Caste/Aspect</span>:
-                    <select name="attr_caste">
-                        <option value=""></option>
-                        <optgroup data-i18n-label="solar-exalted" label="Solar Exalted">
-                            <option data-i18n="dawn" value="Dawn">Dawn</option>
-                            <option data-i18n="zenith" value="Zenith">Zenith</option>
-                            <option data-i18n="twilight" value="Twilight">Twilight</option>
-                            <option data-i18n="night" value="Night">Night</option>
-                            <option data-i18n="eclipse" value="Eclipse">Eclipse</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="abyssal-exalted" label="Abyssal Exalted">
-                            <option data-i18n="dusk" value="Dusk">Dusk</option>
-                            <option data-i18n="midnight" value="Midnight">Midnight</option>
-                            <option data-i18n="daybreak" value="Daybreak">Daybreak</option>
-                            <option data-i18n="day" value="Day">Day</option>
-                            <option data-i18n="moonshadow" value="Moonshadow">Moonshadow</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="terrestrial-exalted" label="Terrestrial Exalted">
-                            <option data-i18n="air" value="Air">Air</option>
-                            <option data-i18n="earth" value="Earth">Earth</option>
-                            <option data-i18n="fire" value="Fire">Fire</option>
-                            <option data-i18n="water" value="Water">Water</option>
-                            <option data-i18n="wood" value="Wood">Wood</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="lunar-exalted" label="Lunar Exalted">
-                            <option data-i18n="full-moon" value="Full Moon">Full Moon</option>
-                            <option data-i18n="changing-moon" value="Changing Moon">Changing Moon</option>
-                            <option data-i18n="no-moon" value="No Moon">No Moon</option>
-                            <option data-i18n="casteless" value="Casteless">Casteless</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="sidereal-exalted" label="Sidereal Exalted">
-                            <option data-i18n="journeys" value="Journeys">Journeys</option>
-                            <option data-i18n="serenity" value="Serenity">Serenity</option>
-                            <option data-i18n="battles" value="Battles">Battles</option>
-                            <option data-i18n="secrets" value="Secrets">Secrets</option>
-                            <option data-i18n="endings" value="Endings">Endings</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="liminal-exalted" label="Liminal Exalted">
-                            <option data-i18n="blood" value="Blood">Blood</option>
-                            <option data-i18n="breath" value="Breath">Breath</option>
-                            <option data-i18n="flesh" value="Flesh">Flesh</option>
-                            <option data-i18n="marrow" value="Marrow">Marrow</option>
-                            <option data-i18n="soil" value="Soil">Soil</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="exigent-exalted" label="Exigent Exalted">
-                            <option data-i18n="exigent" value="Exigent">Exigent</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="infernal-exalted" label="Infernal Exalted">
-                            <option data-i18n="slayer" value="Slayer">Slayer</option>
-                            <option data-i18n="malefactor" value="Malefactor">Malefactor</option>
-                            <option data-i18n="defiler" value="Defiler">Defiler</option>
-                            <option data-i18n="scourge" value="Scourge">Scourge</option>
-                            <option data-i18n="fiend" value="Fiend">Fiend</option>
-                            <option data-i18n="custom" value="Custom">Custom</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="alchemical-exalted" label="Alchemical Exalted">
-                            <option data-i18n="orichalcum" value="Orichalcum">Orichalcum</option>
-                            <option data-i18n="soulsteel" value="Soulsteel">Soulsteel</option>
-                            <option data-i18n="moonsilver" value="Moonsilver">Moonsilver</option>
-                            <option data-i18n="starmetal" value="Starmetal">Starmetal</option>
-                            <option data-i18n="jade" value="Jade">Jade</option>
-                        </optgroup>
-                    </select>
-                </label>
-            </div><!-- /sheet-flexbox-h -->
-        </div><!-- /sheet-col name, player, caste -->
-        <div class="sheet-col">
-            <div class="sheet-flexbox-h">
-                <label><span data-i18n="concept">Concept</span>: <input type="text" name="attr_concept" data-i18n-placeholder="concept-place" placeholder="Inspirational Teacher"></label>
-            </div>
-            <div class="sheet-flexbox-h">
-                <label><span data-i18n="anima">Anima</span>: <input type="text" name="attr_anima" data-i18n-placeholder="anima-place" placeholder="Orchid of golden fire"></label>
-            </div>
-            <div class="sheet-flexbox-h">
-                <label>
-                    <span data-i18n="supernal-trait">Supernal Trait</span>:
-                    <select name="attr_supattr">
-                        <option value=""></option>
-                        <optgroup data-i18n-label="abilities" label="Abilities">
-                            <option data-i18n="archery" value="Archery">Archery</option>
-                            <option data-i18n="athletics" value="Athletics">Athletics</option>
-                            <option data-i18n="awareness" value="Awareness">Awareness</option>
-                            <option data-i18n="brawl" value="Brawl">Brawl</option>
-                            <option data-i18n="bureaucracy" value="Bureaucracy">Bureaucracy</option>
-                            <option data-i18n="craft" value="Craft">Craft</option>
-                            <option data-i18n="dodge" value="Dodge">Dodge</option>
-                            <option data-i18n="integrity" value="Integrity">Integrity</option>
-                            <option data-i18n="investigation" value="Investigation">Investigation</option>
-                            <option data-i18n="larceny" value="Larceny">Larceny</option>
-                            <option data-i18n="linguistics" value="Linguistics">Linguistics</option>
-                            <option data-i18n="lore" value="Lore">Lore</option>
-                            <option data-i18n="martial-arts" value="Martial Arts">Martial Arts</option>
-                            <option data-i18n="medicine" value="Medicine">Medicine</option>
-                            <option data-i18n="melee" value="Melee">Melee</option>
-                            <option data-i18n="occult" value="Occult">Occult</option>
-                            <option data-i18n="performance" value="Performance">Performance</option>
-                            <option data-i18n="presence" value="Presence">Presence</option>
-                            <option data-i18n="resistance" value="Resistance">Resistance</option>
-                            <option data-i18n="ride" value="Ride">Ride</option>
-                            <option data-i18n="sail" value="Sail">Sail</option>
-                            <option data-i18n="socialize" value="Socialize">Socialize</option>
-                            <option data-i18n="stealth" value="Stealth">Stealth</option>
-                            <option data-i18n="survival" value="Survival">Survival</option>
-                            <option data-i18n="thrown" value="Thrown">Thrown</option>
-                            <option data-i18n="war" value="War">War</option>
-                            <option data-i18n="custom" value="Custom">Custom</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="attributes" label="Attributes">
-                            <option data-i18n="strength" value="Strength">Strength</option>
-                            <option data-i18n="dexterity" value="Dexterity">Dexterity</option>
-                            <option data-i18n="stamina" value="Stamina">Stamina</option>
-                            <option data-i18n="charisma" value="Charisma">Charisma</option>
-                            <option data-i18n="manipulation" value="Manipulation">Manipulation</option>
-                            <option data-i18n="appearance" value="Appearance">Appearance</option>
-                            <option data-i18n="perception" value="Perception">Perception</option>
-                            <option data-i18n="intelligence" value="Intelligence">Intelligence</option>
-                            <option data-i18n="wits" value="Wits">Wits</option>
-                        </optgroup>
-                    </select>
-                </label>
-            </div><!-- /sheet-flexbox-h -->
-        </div><!-- /sheet-col concept, animal, supernal -->
-    </div><!-- /sheet-3colrow bio -->
-    
-    <h1><span data-i18n="attributes">Attributes</span></h1>
-    <div class="sheet-3colrow">
-        <div class="sheet-col">
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_strengthfav" value="1"><span></span>
-                    <span data-i18n="strength">Strength</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_strength" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_strength" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_strength" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_strength" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_strength" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_strength" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_strength" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_strength" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_strength" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_strength" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_strength" value="10"><span></span>
+            <div class="sheet-col">
+                <div class="sheet-flexbox-h">
+                    <label><span data-i18n="name">Name</span>: <input type="text" name="attr_character_name" placeholder="Karal Fire Orchid"></label>
                 </div>
-            </div><!-- /sheet-trait strength -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_dexterityfav" value="1"><span></span>
-                    <span data-i18n="dexterity">Dexterity</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_dexterity" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_dexterity" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_dexterity" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_dexterity" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_dexterity" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_dexterity" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_dexterity" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_dexterity" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_dexterity" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_dexterity" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_dexterity" value="10"><span></span>
+                <div class="sheet-flexbox-h">
+                    <label><span data-i18n="player">Player</span>: <input type="text" name="attr_player-name" placeholder="John Smith"></label>
                 </div>
-            </div><!-- /sheet-trait dexterity -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_staminafav" value="1"><span></span>
-                    <span data-i18n="stamina">Stamina</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_stamina" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_stamina" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_stamina" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_stamina" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_stamina" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_stamina" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_stamina" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_stamina" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_stamina" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_stamina" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_stamina" value="10"><span></span>
+                <div class="sheet-flexbox-h">
+                    <label>
+                        <span data-i18n="caste/aspect">Caste/Aspect</span>:
+                        <select name="attr_caste">
+                            <option value=""></option>
+                            <optgroup data-i18n-label="solar-exalted" label="Solar Exalted">
+                                <option data-i18n="dawn" value="Dawn">Dawn</option>
+                                <option data-i18n="zenith" value="Zenith">Zenith</option>
+                                <option data-i18n="twilight" value="Twilight">Twilight</option>
+                                <option data-i18n="night" value="Night">Night</option>
+                                <option data-i18n="eclipse" value="Eclipse">Eclipse</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="abyssal-exalted" label="Abyssal Exalted">
+                                <option data-i18n="dusk" value="Dusk">Dusk</option>
+                                <option data-i18n="midnight" value="Midnight">Midnight</option>
+                                <option data-i18n="daybreak" value="Daybreak">Daybreak</option>
+                                <option data-i18n="day" value="Day">Day</option>
+                                <option data-i18n="moonshadow" value="Moonshadow">Moonshadow</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="terrestrial-exalted" label="Terrestrial Exalted">
+                                <option data-i18n="air" value="Air">Air</option>
+                                <option data-i18n="earth" value="Earth">Earth</option>
+                                <option data-i18n="fire" value="Fire">Fire</option>
+                                <option data-i18n="water" value="Water">Water</option>
+                                <option data-i18n="wood" value="Wood">Wood</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="lunar-exalted" label="Lunar Exalted">
+                                <option data-i18n="full-moon" value="Full Moon">Full Moon</option>
+                                <option data-i18n="changing-moon" value="Changing Moon">Changing Moon</option>
+                                <option data-i18n="no-moon" value="No Moon">No Moon</option>
+                                <option data-i18n="casteless" value="Casteless">Casteless</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="sidereal-exalted" label="Sidereal Exalted">
+                                <option data-i18n="journeys" value="Journeys">Journeys</option>
+                                <option data-i18n="serenity" value="Serenity">Serenity</option>
+                                <option data-i18n="battles" value="Battles">Battles</option>
+                                <option data-i18n="secrets" value="Secrets">Secrets</option>
+                                <option data-i18n="endings" value="Endings">Endings</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="liminal-exalted" label="Liminal Exalted">
+                                <option data-i18n="blood" value="Blood">Blood</option>
+                                <option data-i18n="breath" value="Breath">Breath</option>
+                                <option data-i18n="flesh" value="Flesh">Flesh</option>
+                                <option data-i18n="marrow" value="Marrow">Marrow</option>
+                                <option data-i18n="soil" value="Soil">Soil</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="exigent-exalted" label="Exigent Exalted">
+                                <option data-i18n="exigent" value="Exigent">Exigent</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="infernal-exalted" label="Infernal Exalted">
+                                <option data-i18n="slayer" value="Slayer">Slayer</option>
+                                <option data-i18n="malefactor" value="Malefactor">Malefactor</option>
+                                <option data-i18n="defiler" value="Defiler">Defiler</option>
+                                <option data-i18n="scourge" value="Scourge">Scourge</option>
+                                <option data-i18n="fiend" value="Fiend">Fiend</option>
+                                <option data-i18n="custom" value="Custom">Custom</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="alchemical-exalted" label="Alchemical Exalted">
+                                <option data-i18n="orichalcum" value="Orichalcum">Orichalcum</option>
+                                <option data-i18n="soulsteel" value="Soulsteel">Soulsteel</option>
+                                <option data-i18n="moonsilver" value="Moonsilver">Moonsilver</option>
+                                <option data-i18n="starmetal" value="Starmetal">Starmetal</option>
+                                <option data-i18n="jade" value="Jade">Jade</option>
+                            </optgroup>
+                        </select>
+                    </label>
+                </div><!-- /sheet-flexbox-h -->
+            </div><!-- /sheet-col name, player, caste -->
+            <div class="sheet-col">
+                <div class="sheet-flexbox-h">
+                    <label><span data-i18n="concept">Concept</span>: <input type="text" name="attr_concept" data-i18n-placeholder="concept-place" placeholder="Inspirational Teacher"></label>
                 </div>
-            </div><!-- /sheet-trait stamina-->
-        </div><!-- /sheet-col physical -->
-        <div class="sheet-col">
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_charismafav" value="1"><span></span>
-                    <span data-i18n="charisma">Charisma</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_charisma" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_charisma" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_charisma" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_charisma" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_charisma" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_charisma" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_charisma" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_charisma" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_charisma" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_charisma" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_charisma" value="10"><span></span>
+                <div class="sheet-flexbox-h">
+                    <label><span data-i18n="anima">Anima</span>: <input type="text" name="attr_anima" data-i18n-placeholder="anima-place" placeholder="Orchid of golden fire"></label>
                 </div>
-            </div><!-- /sheet-trait charisma -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_manipulationfav" value="1"><span></span>
-                    <span data-i18n="manipulation">Manipulation</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_manipulation" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_manipulation" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_manipulation" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_manipulation" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_manipulation" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_manipulation" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_manipulation" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_manipulation" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_manipulation" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_manipulation" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_manipulation" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait manipulation -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_apperancefav" value="1"><span></span>
-                    <span data-i18n="appearance">Appearance</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_appearance" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_appearance" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_appearance" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_appearance" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_appearance" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_appearance" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_appearance" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_appearance" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_appearance" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_appearance" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_appearance" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait appearance -->
-        </div><!-- /sheet-col social -->
-        <div class="sheet-col">
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_perceptionfav" value="1"><span></span>
-                    <span data-i18n="perception">Perception</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_perception" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_perception" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_perception" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_perception" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_perception" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_perception" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_perception" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_perception" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_perception" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_perception" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_perception" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait perception -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_intelligencefav" value="1"><span></span>
-                    <span data-i18n="intelligence">Intelligence</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_intelligence" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_intelligence" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_intelligence" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_intelligence" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_intelligence" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_intelligence" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_intelligence" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_intelligence" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_intelligence" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_intelligence" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_intelligence" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait intelligence -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_witsfav" value="1"><span></span>
-                    <span data-i18n="wits">Wits</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_wits" value="0"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_wits" value="1" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_wits" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_wits" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_wits" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_wits" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_wits" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_wits" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_wits" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_wits" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_wits" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait wits -->
-        </div><!-- /sheet-col mental -->
-    </div><!-- /sheet-3colrow attributes -->
-    
-    <div class="sheet-3colrow">
-        <div class="sheet-col">
-            <h1><span data-i18n="abilities">Abilities</span></h1>
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_archeryfav" value="1"><span></span>
-                    <span data-i18n="archery">Archery</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_archery" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_archery" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_archery" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_archery" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_archery" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_archery" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_archery" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_archery" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_archery" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_archery" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_archery" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait archery -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_athleticsfav" value="1"><span></span>
-                    <span data-i18n="athletics">Athletics</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_athletics" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_athletics" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_athletics" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_athletics" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_athletics" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_athletics" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_athletics" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_athletics" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_athletics" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_athletics" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_athletics" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait athletics-->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_awarenessfav" value="1"><span></span>
-                    <span data-i18n="awareness">Awareness</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_awareness" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_awareness" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_awareness" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_awareness" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_awareness" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_awareness" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_awareness" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_awareness" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_awareness" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_awareness" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_awareness" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait awareness -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_brawlfav" value="1"><span></span>
-                    <span data-i18n="brawl">Brawl</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_brawl" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_brawl" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_brawl" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_brawl" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_brawl" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_brawl" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_brawl" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_brawl" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_brawl" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_brawl" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_brawl" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait brawl -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_bureaucracyfav" value="1"><span></span>
-                    <span data-i18n="bureaucracy">Bureaucracy</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_bureaucracy" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_bureaucracy" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_bureaucracy" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_bureaucracy" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_bureaucracy" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_bureaucracy" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_bureaucracy" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_bureaucracy" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_bureaucracy" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_bureaucracy" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_bureaucracy" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait bureaucracy -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_craftfav" value="1"><span></span>
-                    <span data-i18n="craft">Craft</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="checkbox" class="sheet-unnamed-toggle"><span data-i18n-title="show-crafts" title="Show crafts" class="sheet-layer7"></span>
-                    <div class="sheet-layer6">
-                        <div class="sheet-trait">
-                            <label data-i18n="armoring">Armoring</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-armoring" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-armoring" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-armoring" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-armoring" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-armoring" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-armoring" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-armoring" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-armoring" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-armoring" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-armoring" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-armoring" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait armoring -->
-                        <div class="sheet-trait">
-                            <label data-i18n="artifact">Artifact</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-artifact" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-artifact" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-artifact" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-artifact" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-artifact" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-artifact" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-artifact" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-artifact" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-artifact" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-artifact" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-artifact" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait artifact -->
-                        <div class="sheet-trait">
-                            <label data-i18n="cooking">Cooking</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-cooking" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-cooking" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-cooking" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-cooking" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-cooking" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-cooking" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-cooking" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-cooking" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-cooking" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-cooking" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-cooking" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait cooking -->
-                        <div class="sheet-trait">
-                            <label data-i18n="first-age-artifice">First Age Artifice</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-artifice" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-artifice" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-artifice" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-artifice" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-artifice" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-artifice" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-artifice" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-artifice" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-artifice" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-artifice" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-artifice" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait artifice -->
-                        <div class="sheet-trait">
-                            <label data-i18n="gemcutting">Gemcutting</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-gemcutting" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-gemcutting" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-gemcutting" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-gemcutting" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-gemcutting" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-gemcutting" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-gemcutting" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-gemcutting" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-gemcutting" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-gemcutting" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-gemcutting" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait gemcutting -->
-                        <div class="sheet-trait">
-                            <label data-i18n="geomancy">Geomancy</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-geomancy" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-geomancy" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-geomancy" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-geomancy" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-geomancy" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-geomancy" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-geomancy" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-geomancy" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-geomancy" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-geomancy" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-geomancy" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait geomancy -->
-                        <div class="sheet-trait">
-                            <label data-i18n="jewelry">Jewelry</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-jewelry" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-jewelry" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-jewelry" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-jewelry" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-jewelry" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-jewelry" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-jewelry" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-jewelry" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-jewelry" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-jewelry" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-jewelry" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait jewelry -->
-                        <div class="sheet-trait">
-                            <label data-i18n="tailoring">Tailoring</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-tailoring" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-tailoring" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-tailoring" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-tailoring" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-tailoring" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-tailoring" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-tailoring" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-tailoring" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-tailoring" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-tailoring" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-tailoring" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait tailoring -->
-                        <div class="sheet-trait">
-                            <label data-i18n-"weapon-forging">Weapon Forging</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_craft-forging" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_craft-forging" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_craft-forging" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_craft-forging" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_craft-forging" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_craft-forging" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_craft-forging" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_craft-forging" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_craft-forging" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_craft-forging" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_craft-forging" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait forging -->
-                        <fieldset class="repeating_crafts">
-                            <div class="sheet-trait">
-                                <input type="text" name="attr_repcraftsname" data-i18n-placeholder="craft-place" placeholder="Fate">
-                                <div class="sheet-dots">
-                                    <input type="radio" class="sheet-dots0" name="attr_repcrafts" value="0" checked="checked"><span></span>
-                                    <input type="radio" class="sheet-dots1" name="attr_repcrafts" value="1"><span></span>
-                                    <input type="radio" class="sheet-dots2" name="attr_repcrafts" value="2"><span></span>
-                                    <input type="radio" class="sheet-dots3" name="attr_repcrafts" value="3"><span></span>
-                                    <input type="radio" class="sheet-dots4" name="attr_repcrafts" value="4"><span></span>
-                                    <input type="radio" class="sheet-dots5" name="attr_repcrafts" value="5"><span></span>
-                                    <input type="radio" class="sheet-dots6" name="attr_repcrafts" value="6"><span></span>
-                                    <input type="radio" class="sheet-dots7" name="attr_repcrafts" value="7"><span></span>
-                                    <input type="radio" class="sheet-dots8" name="attr_repcrafts" value="8"><span></span>
-                                    <input type="radio" class="sheet-dots9" name="attr_repcrafts" value="9"><span></span>
-                                    <input type="radio" class="sheet-dots10" name="attr_repcrafts" value="10"><span></span>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                </div>
-            </div><!-- /sheet-trait craft -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_dodgefav" value="1"><span></span>
-                    <span data-i18n="dodge">Dodge</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_dodge" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_dodge" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_dodge" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_dodge" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_dodge" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_dodge" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_dodge" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_dodge" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_dodge" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_dodge" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_dodge" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait dodge -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_integrityfav" value="1"><span></span>
-                    <span data-i18n="integrity">Integrity</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_integrity" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_integrity" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_integrity" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_integrity" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_integrity" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_integrity" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_integrity" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_integrity" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_integrity" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_integrity" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_integrity" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait integrity -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_investigationfav" value="1"><span></span>
-                    <span data-i18n="investigation">Investigation</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_investigation" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_investigation" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_investigation" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_investigation" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_investigation" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_investigation" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_investigation" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_investigation" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_investigation" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_investigation" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_investigation" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait investigation -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_larcenyfav" value="1"><span></span>
-                    <span data-i18n="larceny">Larceny</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_larceny" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_larceny" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_larceny" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_larceny" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_larceny" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_larceny" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_larceny" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_larceny" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_larceny" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_larceny" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_larceny" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait larceny -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_linguisticsfav" value="1"><span></span>
-                    <span data-i18n="linguistics">Linguistics</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_linguistics" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_linguistics" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_linguistics" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_linguistics" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_linguistics" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_linguistics" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_linguistics" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_linguistics" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_linguistics" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_linguistics" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_linguistics" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait linguistics -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_lorefav" value="1"><span></span>
-                    <span data-i18n="lore">Lore</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_lore" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_lore" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_lore" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_lore" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_lore" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_lore" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_lore" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_lore" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_lore" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_lore" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_lore" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait lore -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_martialartsfav" value="1"><span></span>
-                    <span data-i18n="martial-arts">Martial Arts</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="checkbox" class="sheet-unnamed-toggle"><span data-i18n-title="show-styles" title="Show styles" class="sheet-layer5"></span>
-                    <div class="sheet-layer4">
-                        <div class="sheet-trait">
-                            <label data-i18n="snake-style">Snake Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-snake" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-snake" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-snake" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-snake" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-snake" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-snake" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-snake" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-snake" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-snake" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-snake" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-snake" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait snake -->
-                        <div class="sheet-trait">
-                            <label data-i18n="tiger-style">Tiger Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-tiger" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-tiger" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-tiger" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-tiger" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-tiger" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-tiger" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-tiger" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-tiger" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-tiger" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-tiger" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-tiger" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait tiger -->
-                        <div class="sheet-trait">
-                            <label data-i18n="single-point-shining-into-the-void-style">Single Point Shining Into the Void Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-void" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-void" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-void" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-void" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-void" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-void" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-void" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-void" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-void" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-void" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-void" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait shining void -->
-                        <div class="sheet-trait">
-                            <label data-i18n="white-reaper-style">White Reaper Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-reaper" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-reaper" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-reaper" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-reaper" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-reaper" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-reaper" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-reaper" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-reaper" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-reaper" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-reaper" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-reaper" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait white reaper -->
-                        <div class="sheet-trait">
-                            <label data-i18n="ebon-shaodw-style">Ebon Shadow Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-ebon" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-ebon" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-ebon" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-ebon" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-ebon" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-ebon" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-ebon" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-ebon" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-ebon" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-ebon" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-ebon" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait ebon shadow -->
-                        <div class="sheet-trait">
-                            <label data-i18n="crane-style">Crane Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-crane" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-crane" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-crane" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-crane" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-crane" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-crane" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-crane" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-crane" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-crane" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-crane" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-crane" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait crane -->
-                        <div class="sheet-trait">
-                            <label data-i18n="silver-voiced-nightingale-style">Silver-Voiced Nightingale Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-nightingale" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-nightingale" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-nightingale" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-nightingale" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-nightingale" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-nightingale" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-nightingale" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-nightingale" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-nightingale" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-nightingale" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-nightingale" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait nightingale -->
-                        <div class="sheet-trait">
-                            <label data-i18n="righteous-devil-style">Righteous Devil Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-devil" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-devil" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-devil" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-devil" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-devil" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-devil" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-devil" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-devil" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-devil" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-devil" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-devil" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait righteous devil -->
-                        <div class="sheet-trait">
-                            <label data-i18n="black-claw-style">Black Claw Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-claw" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-claw" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-claw" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-claw" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-claw" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-claw" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-claw" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-claw" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-claw" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-claw" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-claw" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait black claw -->
-                        <div class="sheet-trait">
-                            <label data-i18n="dreaming-pearl-courtesan-style">Dreaming Pearl Courtesan Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-pearl" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-pearl" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-pearl" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-pearl" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-pearl" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-pearl" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-pearl" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-pearl" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-pearl" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-pearl" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-pearl" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait pearl courtesan -->
-                        <div class="sheet-trait">
-                            <label data-i18n="steel-devil-style">Steel Devil Style</label>
-                            <div class="sheet-dots">
-                                <input type="radio" class="sheet-dots0" name="attr_ma-steel" value="0" checked="checked"><span></span>
-                                <input type="radio" class="sheet-dots1" name="attr_ma-steel" value="1"><span></span>
-                                <input type="radio" class="sheet-dots2" name="attr_ma-steel" value="2"><span></span>
-                                <input type="radio" class="sheet-dots3" name="attr_ma-steel" value="3"><span></span>
-                                <input type="radio" class="sheet-dots4" name="attr_ma-steel" value="4"><span></span>
-                                <input type="radio" class="sheet-dots5" name="attr_ma-steel" value="5"><span></span>
-                                <input type="radio" class="sheet-dots6" name="attr_ma-steel" value="6"><span></span>
-                                <input type="radio" class="sheet-dots7" name="attr_ma-steel" value="7"><span></span>
-                                <input type="radio" class="sheet-dots8" name="attr_ma-steel" value="8"><span></span>
-                                <input type="radio" class="sheet-dots9" name="attr_ma-steel" value="9"><span></span>
-                                <input type="radio" class="sheet-dots10" name="attr_ma-steel" value="10"><span></span>
-                            </div>
-                        </div><!-- /sheet-trait steel devil -->
-                        <fieldset class="repeating_martialarts">
-                            <div class="sheet-trait">
-                                <input type="text" name="attr_repmartialartsname" data-i18n-placeholder="martial-arts-place" placeholder="Celestial Monkey Style">
-                                <div class="sheet-dots">
-                                    <input type="radio" class="sheet-dots0" name="attr_repmartialarts" value="0" checked="checked"><span></span>
-                                    <input type="radio" class="sheet-dots1" name="attr_repmartialarts" value="1"><span></span>
-                                    <input type="radio" class="sheet-dots2" name="attr_repmartialarts" value="2"><span></span>
-                                    <input type="radio" class="sheet-dots3" name="attr_repmartialarts" value="3"><span></span>
-                                    <input type="radio" class="sheet-dots4" name="attr_repmartialarts" value="4"><span></span>
-                                    <input type="radio" class="sheet-dots5" name="attr_repmartialarts" value="5"><span></span>
-                                    <input type="radio" class="sheet-dots6" name="attr_repmartialarts" value="6"><span></span>
-                                    <input type="radio" class="sheet-dots7" name="attr_repmartialarts" value="7"><span></span>
-                                    <input type="radio" class="sheet-dots8" name="attr_repmartialarts" value="8"><span></span>
-                                    <input type="radio" class="sheet-dots9" name="attr_repmartialarts" value="9"><span></span>
-                                    <input type="radio" class="sheet-dots10" name="attr_repmartialarts" value="10"><span></span>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                </div>
-            </div><!-- /sheet-trait martial arts -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_medicinefav" value="1"><span></span>
-                    <span data-i18n="medicine">Medicine</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_medicine" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_medicine" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_medicine" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_medicine" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_medicine" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_medicine" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_medicine" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_medicine" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_medicine" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_medicine" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_medicine" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait medicine -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_meleefav" value="1"><span></span>
-                    <span data-i18n="melee">Melee</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_melee" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_melee" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_melee" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_melee" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_melee" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_melee" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_melee" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_melee" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_melee" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_melee" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_melee" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait melee -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_occultfav" value="1"><span></span>
-                    <span data-i18n="occult">Occult</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_occult" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_occult" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_occult" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_occult" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_occult" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_occult" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_occult" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_occult" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_occult" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_occult" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_occult" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait occult -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_performancefav" value="1"><span></span>
-                    <span data-i18n="performance">Performance</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_performance" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_performance" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_performance" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_performance" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_performance" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_performance" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_performance" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_performance" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_performance" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_performance" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_performance" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait performance -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_presencefav" value="1"><span></span>
-                    <span data-i18n="presence">Presence</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_presence" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_presence" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_presence" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_presence" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_presence" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_presence" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_presence" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_presence" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_presence" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_presence" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_presence" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait presence -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_resistancefav" value="1"><span></span>
-                    <span data-i18n="resistance">Resistance</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_resistance" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_resistance" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_resistance" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_resistance" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_resistance" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_resistance" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_resistance" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_resistance" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_resistance" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_resistance" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_resistance" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait resistance -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_ridefav" value="1"><span></span>
-                    <span data-i18n="ride">Ride</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_ride" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_ride" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_ride" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_ride" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_ride" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_ride" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_ride" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_ride" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_ride" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_ride" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_ride" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait ride -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_sailfav" value="1"><span></span>
-                    <span data-i18n="sail">Sail</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_sail" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_sail" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_sail" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_sail" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_sail" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_sail" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_sail" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_sail" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_sail" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_sail" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_sail" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait sail -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_socializefav" value="1"><span></span>
-                    <span data-i18n="socialize">Socialize</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_socialize" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_socialize" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_socialize" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_socialize" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_socialize" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_socialize" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_socialize" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_socialize" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_socialize" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_socialize" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_socialize" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait socialize -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_stealthfav" value="1"><span></span>
-                    <span data-i18n="stealth">Stealth</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_stealth" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_stealth" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_stealth" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_stealth" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_stealth" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_stealth" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_stealth" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_stealth" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_stealth" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_stealth" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_stealth" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait stealth -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_survivalfav" value="1"><span></span>
-                    <span data-i18n="survival">Survival</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_survival" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_survival" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_survival" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_survival" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_survival" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_survival" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_survival" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_survival" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_survival" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_survival" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_survival" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait survival -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_thrownfav" value="1"><span></span>
-                    <span data-i18n="thrown">Thrown</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_thrown" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_thrown" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_thrown" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_thrown" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_thrown" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_thrown" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_thrown" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_thrown" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_thrown" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_thrown" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_thrown" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait thrown -->
-            <div class="sheet-trait">
-                <label>
-                    <input type="checkbox" name="attr_warfav" value="1"><span></span>
-                    <span data-i18n="war">War</span>
-                </label>
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_war" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_war" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_war" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_war" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_war" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_war" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_war" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_war" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_war" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_war" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_war" value="10"><span></span>
-                </div>
-            </div><!-- /sheet-trait war -->
-            <fieldset class="repeating_abilities">
+                <div class="sheet-flexbox-h">
+                    <label>
+                        <span data-i18n="supernal-trait">Supernal Trait</span>:
+                        <select name="attr_supattr">
+                            <option value=""></option>
+                            <optgroup data-i18n-label="abilities" label="Abilities">
+                                <option data-i18n="archery" value="Archery">Archery</option>
+                                <option data-i18n="athletics" value="Athletics">Athletics</option>
+                                <option data-i18n="awareness" value="Awareness">Awareness</option>
+                                <option data-i18n="brawl" value="Brawl">Brawl</option>
+                                <option data-i18n="bureaucracy" value="Bureaucracy">Bureaucracy</option>
+                                <option data-i18n="craft" value="Craft">Craft</option>
+                                <option data-i18n="dodge" value="Dodge">Dodge</option>
+                                <option data-i18n="integrity" value="Integrity">Integrity</option>
+                                <option data-i18n="investigation" value="Investigation">Investigation</option>
+                                <option data-i18n="larceny" value="Larceny">Larceny</option>
+                                <option data-i18n="linguistics" value="Linguistics">Linguistics</option>
+                                <option data-i18n="lore" value="Lore">Lore</option>
+                                <option data-i18n="martial-arts" value="Martial Arts">Martial Arts</option>
+                                <option data-i18n="medicine" value="Medicine">Medicine</option>
+                                <option data-i18n="melee" value="Melee">Melee</option>
+                                <option data-i18n="occult" value="Occult">Occult</option>
+                                <option data-i18n="performance" value="Performance">Performance</option>
+                                <option data-i18n="presence" value="Presence">Presence</option>
+                                <option data-i18n="resistance" value="Resistance">Resistance</option>
+                                <option data-i18n="ride" value="Ride">Ride</option>
+                                <option data-i18n="sail" value="Sail">Sail</option>
+                                <option data-i18n="socialize" value="Socialize">Socialize</option>
+                                <option data-i18n="stealth" value="Stealth">Stealth</option>
+                                <option data-i18n="survival" value="Survival">Survival</option>
+                                <option data-i18n="thrown" value="Thrown">Thrown</option>
+                                <option data-i18n="war" value="War">War</option>
+                                <option data-i18n="custom" value="Custom">Custom</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="attributes" label="Attributes">
+                                <option data-i18n="strength" value="Strength">Strength</option>
+                                <option data-i18n="dexterity" value="Dexterity">Dexterity</option>
+                                <option data-i18n="stamina" value="Stamina">Stamina</option>
+                                <option data-i18n="charisma" value="Charisma">Charisma</option>
+                                <option data-i18n="manipulation" value="Manipulation">Manipulation</option>
+                                <option data-i18n="appearance" value="Appearance">Appearance</option>
+                                <option data-i18n="perception" value="Perception">Perception</option>
+                                <option data-i18n="intelligence" value="Intelligence">Intelligence</option>
+                                <option data-i18n="wits" value="Wits">Wits</option>
+                            </optgroup>
+                        </select>
+                    </label>
+                </div><!-- /sheet-flexbox-h -->
+            </div><!-- /sheet-col concept, animal, supernal -->
+        </div><!-- /sheet-3colrow bio -->
+        
+        <h1><span data-i18n="attributes">Attributes</span></h1>
+        <div class="sheet-3colrow">
+            <div class="sheet-col">
                 <div class="sheet-trait">
-                    <input type="checkbox" name="attr_repabilityfav" value="1"><span></span>
-                    <input type="text" name="attr_repabilityname" data-i18n-placeholder="ability-place" placeholder="Astrology">
+                    <label>
+                        <input type="checkbox" name="attr_strengthfav" value="1"><span></span>
+                        <span data-i18n="strength">Strength</span>
+                    </label>
                     <div class="sheet-dots">
-                        <input type="radio" class="sheet-dots0" name="attr_repability" value="0" checked="checked"><span></span>
-                        <input type="radio" class="sheet-dots1" name="attr_repability" value="1"><span></span>
-                        <input type="radio" class="sheet-dots2" name="attr_repability" value="2"><span></span>
-                        <input type="radio" class="sheet-dots3" name="attr_repability" value="3"><span></span>
-                        <input type="radio" class="sheet-dots4" name="attr_repability" value="4"><span></span>
-                        <input type="radio" class="sheet-dots5" name="attr_repability" value="5"><span></span>
-                        <input type="radio" class="sheet-dots6" name="attr_repability" value="6"><span></span>
-                        <input type="radio" class="sheet-dots7" name="attr_repability" value="7"><span></span>
-                        <input type="radio" class="sheet-dots8" name="attr_repability" value="8"><span></span>
-                        <input type="radio" class="sheet-dots9" name="attr_repability" value="9"><span></span>
-                        <input type="radio" class="sheet-dots10" name="attr_repability" value="10"><span></span>
+                        <input type="radio" class="sheet-dots0" name="attr_strength" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_strength" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_strength" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_strength" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_strength" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_strength" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_strength" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_strength" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_strength" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_strength" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_strength" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait strength -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_dexterityfav" value="1"><span></span>
+                        <span data-i18n="dexterity">Dexterity</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_dexterity" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_dexterity" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_dexterity" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_dexterity" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_dexterity" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_dexterity" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_dexterity" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_dexterity" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_dexterity" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_dexterity" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_dexterity" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait dexterity -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_staminafav" value="1"><span></span>
+                        <span data-i18n="stamina">Stamina</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_stamina" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_stamina" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_stamina" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_stamina" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_stamina" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_stamina" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_stamina" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_stamina" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_stamina" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_stamina" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_stamina" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait stamina-->
+            </div><!-- /sheet-col physical -->
+            <div class="sheet-col">
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_charismafav" value="1"><span></span>
+                        <span data-i18n="charisma">Charisma</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_charisma" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_charisma" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_charisma" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_charisma" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_charisma" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_charisma" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_charisma" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_charisma" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_charisma" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_charisma" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_charisma" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait charisma -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_manipulationfav" value="1"><span></span>
+                        <span data-i18n="manipulation">Manipulation</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_manipulation" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_manipulation" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_manipulation" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_manipulation" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_manipulation" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_manipulation" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_manipulation" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_manipulation" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_manipulation" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_manipulation" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_manipulation" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait manipulation -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_apperancefav" value="1"><span></span>
+                        <span data-i18n="appearance">Appearance</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_appearance" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_appearance" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_appearance" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_appearance" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_appearance" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_appearance" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_appearance" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_appearance" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_appearance" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_appearance" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_appearance" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait appearance -->
+            </div><!-- /sheet-col social -->
+            <div class="sheet-col">
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_perceptionfav" value="1"><span></span>
+                        <span data-i18n="perception">Perception</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_perception" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_perception" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_perception" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_perception" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_perception" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_perception" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_perception" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_perception" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_perception" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_perception" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_perception" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait perception -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_intelligencefav" value="1"><span></span>
+                        <span data-i18n="intelligence">Intelligence</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_intelligence" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_intelligence" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_intelligence" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_intelligence" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_intelligence" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_intelligence" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_intelligence" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_intelligence" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_intelligence" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_intelligence" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_intelligence" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait intelligence -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_witsfav" value="1"><span></span>
+                        <span data-i18n="wits">Wits</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_wits" value="0"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_wits" value="1" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_wits" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_wits" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_wits" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_wits" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_wits" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_wits" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_wits" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_wits" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_wits" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait wits -->
+            </div><!-- /sheet-col mental -->
+        </div><!-- /sheet-3colrow attributes -->
+        
+        <div class="sheet-3colrow">
+            <div class="sheet-col">
+                <h1><span data-i18n="abilities">Abilities</span></h1>
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_archeryfav" value="1"><span></span>
+                        <span data-i18n="archery">Archery</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_archery" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_archery" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_archery" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_archery" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_archery" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_archery" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_archery" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_archery" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_archery" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_archery" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_archery" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait archery -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_athleticsfav" value="1"><span></span>
+                        <span data-i18n="athletics">Athletics</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_athletics" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_athletics" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_athletics" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_athletics" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_athletics" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_athletics" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_athletics" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_athletics" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_athletics" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_athletics" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_athletics" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait athletics-->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_awarenessfav" value="1"><span></span>
+                        <span data-i18n="awareness">Awareness</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_awareness" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_awareness" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_awareness" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_awareness" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_awareness" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_awareness" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_awareness" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_awareness" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_awareness" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_awareness" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_awareness" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait awareness -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_brawlfav" value="1"><span></span>
+                        <span data-i18n="brawl">Brawl</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_brawl" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_brawl" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_brawl" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_brawl" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_brawl" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_brawl" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_brawl" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_brawl" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_brawl" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_brawl" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_brawl" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait brawl -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_bureaucracyfav" value="1"><span></span>
+                        <span data-i18n="bureaucracy">Bureaucracy</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_bureaucracy" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_bureaucracy" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_bureaucracy" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_bureaucracy" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_bureaucracy" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_bureaucracy" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_bureaucracy" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_bureaucracy" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_bureaucracy" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_bureaucracy" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_bureaucracy" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait bureaucracy -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_craftfav" value="1"><span></span>
+                        <span data-i18n="craft">Craft</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="checkbox" class="sheet-unnamed-toggle"><span data-i18n-title="show-crafts" title="Show crafts" class="sheet-layer7"></span>
+                        <div class="sheet-layer6">
+                            <div class="sheet-trait">
+                                <label data-i18n="armoring">Armoring</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-armoring" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-armoring" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-armoring" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-armoring" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-armoring" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-armoring" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-armoring" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-armoring" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-armoring" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-armoring" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-armoring" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait armoring -->
+                            <div class="sheet-trait">
+                                <label data-i18n="artifact">Artifact</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-artifact" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-artifact" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-artifact" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-artifact" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-artifact" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-artifact" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-artifact" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-artifact" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-artifact" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-artifact" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-artifact" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait artifact -->
+                            <div class="sheet-trait">
+                                <label data-i18n="cooking">Cooking</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-cooking" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-cooking" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-cooking" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-cooking" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-cooking" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-cooking" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-cooking" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-cooking" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-cooking" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-cooking" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-cooking" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait cooking -->
+                            <div class="sheet-trait">
+                                <label data-i18n="first-age-artifice">First Age Artifice</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-artifice" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-artifice" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-artifice" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-artifice" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-artifice" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-artifice" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-artifice" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-artifice" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-artifice" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-artifice" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-artifice" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait artifice -->
+                            <div class="sheet-trait">
+                                <label data-i18n="gemcutting">Gemcutting</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-gemcutting" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-gemcutting" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-gemcutting" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-gemcutting" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-gemcutting" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-gemcutting" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-gemcutting" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-gemcutting" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-gemcutting" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-gemcutting" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-gemcutting" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait gemcutting -->
+                            <div class="sheet-trait">
+                                <label data-i18n="geomancy">Geomancy</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-geomancy" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-geomancy" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-geomancy" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-geomancy" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-geomancy" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-geomancy" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-geomancy" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-geomancy" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-geomancy" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-geomancy" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-geomancy" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait geomancy -->
+                            <div class="sheet-trait">
+                                <label data-i18n="jewelry">Jewelry</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-jewelry" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-jewelry" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-jewelry" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-jewelry" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-jewelry" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-jewelry" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-jewelry" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-jewelry" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-jewelry" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-jewelry" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-jewelry" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait jewelry -->
+                            <div class="sheet-trait">
+                                <label data-i18n="tailoring">Tailoring</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-tailoring" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-tailoring" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-tailoring" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-tailoring" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-tailoring" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-tailoring" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-tailoring" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-tailoring" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-tailoring" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-tailoring" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-tailoring" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait tailoring -->
+                            <div class="sheet-trait">
+                                <label data-i18n-"weapon-forging">Weapon Forging</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_craft-forging" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_craft-forging" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_craft-forging" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_craft-forging" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_craft-forging" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_craft-forging" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_craft-forging" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_craft-forging" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_craft-forging" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_craft-forging" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_craft-forging" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait forging -->
+                            <fieldset class="repeating_crafts">
+                                <div class="sheet-trait">
+                                    <input type="text" name="attr_repcraftsname" data-i18n-placeholder="craft-place" placeholder="Fate">
+                                    <div class="sheet-dots">
+                                        <input type="radio" class="sheet-dots0" name="attr_repcrafts" value="0" checked="checked"><span></span>
+                                        <input type="radio" class="sheet-dots1" name="attr_repcrafts" value="1"><span></span>
+                                        <input type="radio" class="sheet-dots2" name="attr_repcrafts" value="2"><span></span>
+                                        <input type="radio" class="sheet-dots3" name="attr_repcrafts" value="3"><span></span>
+                                        <input type="radio" class="sheet-dots4" name="attr_repcrafts" value="4"><span></span>
+                                        <input type="radio" class="sheet-dots5" name="attr_repcrafts" value="5"><span></span>
+                                        <input type="radio" class="sheet-dots6" name="attr_repcrafts" value="6"><span></span>
+                                        <input type="radio" class="sheet-dots7" name="attr_repcrafts" value="7"><span></span>
+                                        <input type="radio" class="sheet-dots8" name="attr_repcrafts" value="8"><span></span>
+                                        <input type="radio" class="sheet-dots9" name="attr_repcrafts" value="9"><span></span>
+                                        <input type="radio" class="sheet-dots10" name="attr_repcrafts" value="10"><span></span>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    </div>
+                </div><!-- /sheet-trait craft -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_dodgefav" value="1"><span></span>
+                        <span data-i18n="dodge">Dodge</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_dodge" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_dodge" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_dodge" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_dodge" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_dodge" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_dodge" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_dodge" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_dodge" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_dodge" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_dodge" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_dodge" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait dodge -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_integrityfav" value="1"><span></span>
+                        <span data-i18n="integrity">Integrity</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_integrity" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_integrity" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_integrity" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_integrity" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_integrity" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_integrity" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_integrity" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_integrity" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_integrity" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_integrity" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_integrity" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait integrity -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_investigationfav" value="1"><span></span>
+                        <span data-i18n="investigation">Investigation</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_investigation" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_investigation" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_investigation" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_investigation" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_investigation" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_investigation" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_investigation" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_investigation" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_investigation" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_investigation" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_investigation" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait investigation -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_larcenyfav" value="1"><span></span>
+                        <span data-i18n="larceny">Larceny</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_larceny" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_larceny" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_larceny" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_larceny" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_larceny" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_larceny" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_larceny" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_larceny" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_larceny" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_larceny" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_larceny" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait larceny -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_linguisticsfav" value="1"><span></span>
+                        <span data-i18n="linguistics">Linguistics</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_linguistics" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_linguistics" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_linguistics" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_linguistics" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_linguistics" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_linguistics" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_linguistics" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_linguistics" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_linguistics" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_linguistics" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_linguistics" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait linguistics -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_lorefav" value="1"><span></span>
+                        <span data-i18n="lore">Lore</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_lore" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_lore" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_lore" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_lore" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_lore" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_lore" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_lore" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_lore" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_lore" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_lore" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_lore" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait lore -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_martialartsfav" value="1"><span></span>
+                        <span data-i18n="martial-arts">Martial Arts</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="checkbox" class="sheet-unnamed-toggle"><span data-i18n-title="show-styles" title="Show styles" class="sheet-layer5"></span>
+                        <div class="sheet-layer4">
+                            <div class="sheet-trait">
+                                <label data-i18n="snake-style">Snake Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-snake" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-snake" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-snake" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-snake" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-snake" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-snake" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-snake" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-snake" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-snake" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-snake" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-snake" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait snake -->
+                            <div class="sheet-trait">
+                                <label data-i18n="tiger-style">Tiger Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-tiger" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-tiger" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-tiger" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-tiger" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-tiger" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-tiger" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-tiger" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-tiger" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-tiger" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-tiger" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-tiger" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait tiger -->
+                            <div class="sheet-trait">
+                                <label data-i18n="single-point-shining-into-the-void-style">Single Point Shining Into the Void Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-void" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-void" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-void" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-void" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-void" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-void" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-void" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-void" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-void" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-void" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-void" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait shining void -->
+                            <div class="sheet-trait">
+                                <label data-i18n="white-reaper-style">White Reaper Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-reaper" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-reaper" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-reaper" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-reaper" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-reaper" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-reaper" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-reaper" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-reaper" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-reaper" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-reaper" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-reaper" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait white reaper -->
+                            <div class="sheet-trait">
+                                <label data-i18n="ebon-shaodw-style">Ebon Shadow Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-ebon" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-ebon" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-ebon" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-ebon" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-ebon" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-ebon" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-ebon" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-ebon" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-ebon" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-ebon" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-ebon" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait ebon shadow -->
+                            <div class="sheet-trait">
+                                <label data-i18n="crane-style">Crane Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-crane" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-crane" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-crane" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-crane" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-crane" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-crane" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-crane" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-crane" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-crane" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-crane" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-crane" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait crane -->
+                            <div class="sheet-trait">
+                                <label data-i18n="silver-voiced-nightingale-style">Silver-Voiced Nightingale Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-nightingale" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-nightingale" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-nightingale" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-nightingale" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-nightingale" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-nightingale" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-nightingale" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-nightingale" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-nightingale" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-nightingale" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-nightingale" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait nightingale -->
+                            <div class="sheet-trait">
+                                <label data-i18n="righteous-devil-style">Righteous Devil Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-devil" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-devil" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-devil" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-devil" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-devil" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-devil" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-devil" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-devil" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-devil" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-devil" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-devil" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait righteous devil -->
+                            <div class="sheet-trait">
+                                <label data-i18n="black-claw-style">Black Claw Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-claw" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-claw" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-claw" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-claw" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-claw" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-claw" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-claw" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-claw" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-claw" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-claw" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-claw" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait black claw -->
+                            <div class="sheet-trait">
+                                <label data-i18n="dreaming-pearl-courtesan-style">Dreaming Pearl Courtesan Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-pearl" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-pearl" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-pearl" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-pearl" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-pearl" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-pearl" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-pearl" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-pearl" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-pearl" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-pearl" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-pearl" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait pearl courtesan -->
+                            <div class="sheet-trait">
+                                <label data-i18n="steel-devil-style">Steel Devil Style</label>
+                                <div class="sheet-dots">
+                                    <input type="radio" class="sheet-dots0" name="attr_ma-steel" value="0" checked="checked"><span></span>
+                                    <input type="radio" class="sheet-dots1" name="attr_ma-steel" value="1"><span></span>
+                                    <input type="radio" class="sheet-dots2" name="attr_ma-steel" value="2"><span></span>
+                                    <input type="radio" class="sheet-dots3" name="attr_ma-steel" value="3"><span></span>
+                                    <input type="radio" class="sheet-dots4" name="attr_ma-steel" value="4"><span></span>
+                                    <input type="radio" class="sheet-dots5" name="attr_ma-steel" value="5"><span></span>
+                                    <input type="radio" class="sheet-dots6" name="attr_ma-steel" value="6"><span></span>
+                                    <input type="radio" class="sheet-dots7" name="attr_ma-steel" value="7"><span></span>
+                                    <input type="radio" class="sheet-dots8" name="attr_ma-steel" value="8"><span></span>
+                                    <input type="radio" class="sheet-dots9" name="attr_ma-steel" value="9"><span></span>
+                                    <input type="radio" class="sheet-dots10" name="attr_ma-steel" value="10"><span></span>
+                                </div>
+                            </div><!-- /sheet-trait steel devil -->
+                            <fieldset class="repeating_martialarts">
+                                <div class="sheet-trait">
+                                    <input type="text" name="attr_repmartialartsname" data-i18n-placeholder="martial-arts-place" placeholder="Celestial Monkey Style">
+                                    <div class="sheet-dots">
+                                        <input type="radio" class="sheet-dots0" name="attr_repmartialarts" value="0" checked="checked"><span></span>
+                                        <input type="radio" class="sheet-dots1" name="attr_repmartialarts" value="1"><span></span>
+                                        <input type="radio" class="sheet-dots2" name="attr_repmartialarts" value="2"><span></span>
+                                        <input type="radio" class="sheet-dots3" name="attr_repmartialarts" value="3"><span></span>
+                                        <input type="radio" class="sheet-dots4" name="attr_repmartialarts" value="4"><span></span>
+                                        <input type="radio" class="sheet-dots5" name="attr_repmartialarts" value="5"><span></span>
+                                        <input type="radio" class="sheet-dots6" name="attr_repmartialarts" value="6"><span></span>
+                                        <input type="radio" class="sheet-dots7" name="attr_repmartialarts" value="7"><span></span>
+                                        <input type="radio" class="sheet-dots8" name="attr_repmartialarts" value="8"><span></span>
+                                        <input type="radio" class="sheet-dots9" name="attr_repmartialarts" value="9"><span></span>
+                                        <input type="radio" class="sheet-dots10" name="attr_repmartialarts" value="10"><span></span>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                    </div>
+                </div><!-- /sheet-trait martial arts -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_medicinefav" value="1"><span></span>
+                        <span data-i18n="medicine">Medicine</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_medicine" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_medicine" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_medicine" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_medicine" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_medicine" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_medicine" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_medicine" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_medicine" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_medicine" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_medicine" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_medicine" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait medicine -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_meleefav" value="1"><span></span>
+                        <span data-i18n="melee">Melee</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_melee" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_melee" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_melee" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_melee" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_melee" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_melee" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_melee" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_melee" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_melee" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_melee" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_melee" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait melee -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_occultfav" value="1"><span></span>
+                        <span data-i18n="occult">Occult</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_occult" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_occult" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_occult" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_occult" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_occult" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_occult" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_occult" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_occult" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_occult" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_occult" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_occult" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait occult -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_performancefav" value="1"><span></span>
+                        <span data-i18n="performance">Performance</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_performance" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_performance" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_performance" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_performance" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_performance" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_performance" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_performance" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_performance" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_performance" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_performance" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_performance" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait performance -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_presencefav" value="1"><span></span>
+                        <span data-i18n="presence">Presence</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_presence" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_presence" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_presence" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_presence" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_presence" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_presence" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_presence" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_presence" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_presence" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_presence" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_presence" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait presence -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_resistancefav" value="1"><span></span>
+                        <span data-i18n="resistance">Resistance</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_resistance" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_resistance" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_resistance" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_resistance" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_resistance" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_resistance" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_resistance" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_resistance" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_resistance" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_resistance" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_resistance" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait resistance -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_ridefav" value="1"><span></span>
+                        <span data-i18n="ride">Ride</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_ride" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_ride" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_ride" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_ride" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_ride" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_ride" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_ride" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_ride" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_ride" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_ride" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_ride" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait ride -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_sailfav" value="1"><span></span>
+                        <span data-i18n="sail">Sail</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_sail" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_sail" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_sail" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_sail" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_sail" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_sail" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_sail" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_sail" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_sail" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_sail" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_sail" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait sail -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_socializefav" value="1"><span></span>
+                        <span data-i18n="socialize">Socialize</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_socialize" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_socialize" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_socialize" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_socialize" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_socialize" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_socialize" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_socialize" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_socialize" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_socialize" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_socialize" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_socialize" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait socialize -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_stealthfav" value="1"><span></span>
+                        <span data-i18n="stealth">Stealth</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_stealth" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_stealth" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_stealth" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_stealth" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_stealth" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_stealth" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_stealth" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_stealth" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_stealth" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_stealth" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_stealth" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait stealth -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_survivalfav" value="1"><span></span>
+                        <span data-i18n="survival">Survival</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_survival" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_survival" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_survival" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_survival" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_survival" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_survival" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_survival" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_survival" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_survival" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_survival" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_survival" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait survival -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_thrownfav" value="1"><span></span>
+                        <span data-i18n="thrown">Thrown</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_thrown" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_thrown" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_thrown" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_thrown" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_thrown" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_thrown" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_thrown" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_thrown" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_thrown" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_thrown" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_thrown" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait thrown -->
+                <div class="sheet-trait">
+                    <label>
+                        <input type="checkbox" name="attr_warfav" value="1"><span></span>
+                        <span data-i18n="war">War</span>
+                    </label>
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_war" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_war" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_war" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_war" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_war" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_war" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_war" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_war" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_war" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_war" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_war" value="10"><span></span>
+                    </div>
+                </div><!-- /sheet-trait war -->
+                <fieldset class="repeating_abilities">
+                    <div class="sheet-trait">
+                        <input type="checkbox" name="attr_repabilityfav" value="1"><span></span>
+                        <input type="text" name="attr_repabilityname" data-i18n-placeholder="ability-place" placeholder="Astrology">
+                        <div class="sheet-dots">
+                            <input type="radio" class="sheet-dots0" name="attr_repability" value="0" checked="checked"><span></span>
+                            <input type="radio" class="sheet-dots1" name="attr_repability" value="1"><span></span>
+                            <input type="radio" class="sheet-dots2" name="attr_repability" value="2"><span></span>
+                            <input type="radio" class="sheet-dots3" name="attr_repability" value="3"><span></span>
+                            <input type="radio" class="sheet-dots4" name="attr_repability" value="4"><span></span>
+                            <input type="radio" class="sheet-dots5" name="attr_repability" value="5"><span></span>
+                            <input type="radio" class="sheet-dots6" name="attr_repability" value="6"><span></span>
+                            <input type="radio" class="sheet-dots7" name="attr_repability" value="7"><span></span>
+                            <input type="radio" class="sheet-dots8" name="attr_repability" value="8"><span></span>
+                            <input type="radio" class="sheet-dots9" name="attr_repability" value="9"><span></span>
+                            <input type="radio" class="sheet-dots10" name="attr_repability" value="10"><span></span>
+                        </div>
+                    </div>
+                </fieldset>
+                
+                <h1><span data-i18n="specialties">Specialties</span></h1>
+                <fieldset class="repeating_specialty">
+                    <div class="sheet-flexbox-h sheet-flexbox0">
+                        <input type="text" name="attr_repspecialty" style="margin-top:3px" data-i18n-placeholder="specialty-place" placeholder="Pirate Tactics">
+                        <select name="attr_repspecialtyability">
+                            <option value=""></option>
+                            <optgroup data-i18n-label="abilities" label="Abilities">
+                                <option data-i18n="archery" value="Archery">Archery</option>
+                                <option data-i18n="athletics" value="Athletics">Athletics</option>
+                                <option data-i18n="awareness" value="Awareness">Awareness</option>
+                                <option data-i18n="brawl" value="Brawl">Brawl</option>
+                                <option data-i18n="bureaucracy" value="Bureaucracy">Bureaucracy</option>
+                                <option data-i18n="craft" value="Craft">Craft</option>
+                                <option data-i18n="dodge" value="Dodge">Dodge</option>
+                                <option data-i18n="integrity" value="Integrity">Integrity</option>
+                                <option data-i18n="investigation" value="Investigation">Investigation</option>
+                                <option data-i18n="larceny" value="Larceny">Larceny</option>
+                                <option data-i18n="linguistics" value="Linguistics">Linguistics</option>
+                                <option data-i18n="lore" value="Lore">Lore</option>
+                                <option data-i18n="martial-arts" value="Martial Arts">Martial Arts</option>
+                                <option data-i18n="medicine" value="Medicine">Medicine</option>
+                                <option data-i18n="melee" value="Melee">Melee</option>
+                                <option data-i18n="occult" value="Occult">Occult</option>
+                                <option data-i18n="performance" value="Performance">Performance</option>
+                                <option data-i18n="presence" value="Presence">Presence</option>
+                                <option data-i18n="resistance" value="Resistance">Resistance</option>
+                                <option data-i18n="ride" value="Ride">Ride</option>
+                                <option data-i18n="sail" value="Sail">Sail</option>
+                                <option data-i18n="socialize" value="Socialize">Socialize</option>
+                                <option data-i18n="stealth" value="Stealth">Stealth</option>
+                                <option data-i18n="survival" value="Survival">Survival</option>
+                                <option data-i18n="thrown" value="Thrown">Thrown</option>
+                                <option data-i18n="war" value="War">War</option>
+                                <option data-i18n="custom" value="Custom">Custom</option>
+                            </optgroup>
+                            <optgroup data-i18n-label="attributes" label="Attributes">
+                                <option data-i18n="strength" value="Strength">Strength</option>
+                                <option data-i18n="dexterity" value="Dexterity">Dexterity</option>
+                                <option data-i18n="stamina" value="Stamina">Stamina</option>
+                                <option data-i18n="charisma" value="Charisma">Charisma</option>
+                                <option data-i18n="manipulation" value="Manipulation">Manipulation</option>
+                                <option data-i18n="appearance" value="Appearance">Appearance</option>
+                                <option data-i18n="perception" value="Perception">Perception</option>
+                                <option data-i18n="intelligence" value="Intelligence">Intelligence</option>
+                                <option data-i18n="wits" value="Wits">Wits</option>
+                            </optgroup>
+                        </select>
+                    </div>
+                </fieldset>
+            </div><!-- /sheet-col abilities -->
+            <div class="sheet-2col">
+                <h1><span data-i18n="merits">Merits</span></h1>
+                <fieldset class="repeating_merits">
+                    <input type="text" name="attr_repmerits-name" data-i18n-placeholder="merits-place" placeholder="Artifact">
+                    <div class="sheet-dots">
+                        <input type="radio" class="sheet-dots0" name="attr_repmerits" value="0" checked="checked"><span></span>
+                        <input type="radio" class="sheet-dots1" name="attr_repmerits" value="1"><span></span>
+                        <input type="radio" class="sheet-dots2" name="attr_repmerits" value="2"><span></span>
+                        <input type="radio" class="sheet-dots3" name="attr_repmerits" value="3"><span></span>
+                        <input type="radio" class="sheet-dots4" name="attr_repmerits" value="4"><span></span>
+                        <input type="radio" class="sheet-dots5" name="attr_repmerits" value="5"><span></span>
+                        <input type="radio" class="sheet-dots6" name="attr_repmerits" value="6"><span></span>
+                        <input type="radio" class="sheet-dots7" name="attr_repmerits" value="7"><span></span>
+                        <input type="radio" class="sheet-dots8" name="attr_repmerits" value="8"><span></span>
+                        <input type="radio" class="sheet-dots9" name="attr_repmerits" value="9"><span></span>
+                        <input type="radio" class="sheet-dots10" name="attr_repmerits" value="10"><span></span>
+                    </div>
+                </fieldset>
+                <div class="sheet-2colrow">
+                    <div class="sheet-col">
+                        <h1><span data-i18n="willpower">Willpower</span></h1>
+                        <div style="padding-left:6px">
+                            <div class="sheet-dots-full">
+                                <input type="radio" class="sheet-dots0" name="attr_willpower" value="0"><span></span>
+                                <input type="radio" class="sheet-dots1" name="attr_willpower" value="1"><span></span>
+                                <input type="radio" class="sheet-dots2" name="attr_willpower" value="2"><span></span>
+                                <input type="radio" class="sheet-dots3" name="attr_willpower" value="3"><span></span>
+                                <input type="radio" class="sheet-dots4" name="attr_willpower" value="4"><span></span>
+                                <input type="radio" class="sheet-dots5" name="attr_willpower" value="5" checked="checked"><span></span>
+                                <input type="radio" class="sheet-dots6" name="attr_willpower" value="6"><span></span>
+                                <input type="radio" class="sheet-dots7" name="attr_willpower" value="7"><span></span>
+                                <input type="radio" class="sheet-dots8" name="attr_willpower" value="8"><span></span>
+                                <input type="radio" class="sheet-dots9" name="attr_willpower" value="9"><span></span>
+                                <input type="radio" class="sheet-dots10" name="attr_willpower" value="10"><span></span>
+                            </div>
+                        </div>
+                        <div class="sheet-temp-will">
+                            <input type="checkbox" name="attr_willpower-spent1" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent2" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent3" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent4" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent5" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent6" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent7" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent8" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent9" value="1"><span></span>
+                            <input type="checkbox" name="attr_willpower-spent10" value="1"><span></span>
+                        </div>
+                        <h1><span data-i18n="essence">Essence</span></h1>
+                        <div style="padding-left:6px">
+                            <div class="sheet-dots-full">
+                                <input type="radio" class="sheet-dots0" name="attr_essence" value="0"><span></span>
+                                <input type="radio" class="sheet-dots1" name="attr_essence" value="1" checked="checked"><span></span>
+                                <input type="radio" class="sheet-dots2" name="attr_essence" value="2"><span></span>
+                                <input type="radio" class="sheet-dots3" name="attr_essence" value="3"><span></span>
+                                <input type="radio" class="sheet-dots4" name="attr_essence" value="4"><span></span>
+                                <input type="radio" class="sheet-dots5" name="attr_essence" value="5"><span></span>
+                                <input type="radio" class="sheet-dots6" name="attr_essence" value="6"><span></span>
+                                <input type="radio" class="sheet-dots7" name="attr_essence" value="7"><span></span>
+                                <input type="radio" class="sheet-dots8" name="attr_essence" value="8"><span></span>
+                                <input type="radio" class="sheet-dots9" name="attr_essence" value="9"><span></span>
+                                <input type="radio" class="sheet-dots10" name="attr_essence" value="10"><span></span>
+                            </div>
+                        </div>
+                        <div class="sheet-motes">
+                            <span data-i18n="personal">Personal</span>
+                            <span>
+                                <input type="number" name="attr_personal-essence"> |
+                                <input type="number" name="attr_personal-essence_max" value="@{essence} * 3 + 10" disabled="disabled">
+                            </span>
+                        </div>
+                        <div class="sheet-motes">
+                            <span data-i18n="peripheral">Peripheral</span>
+                            <span>
+                                <input type="number" name="attr_peripheral-essence"> |
+                                <input type="number" name="attr_peripheral-essence_max" value="@{essence} * 7 + 26" disabled="disabled">
+                            </span>
+                        </div>
+                        <div class="sheet-motes">
+                            <span data-i18n="committed">Committed</span>
+                            <span><input type="number" name="attr_committedesstotal"></span>
+                        </div>
+                    </div><!-- /sheet-col willpower/essence -->
+                    <div class="sheet-col">
+                        <h1><span data-i18n="limit-break">Limit Break</span></h1>
+                        <div style="padding-left:6px;margin:9px 0 9px 0">
+                            <div class="sheet-dots-full">
+                                <input type="radio" class="sheet-dots0" name="attr_limit" value="0" checked="checked"><span></span>
+                                <input type="radio" class="sheet-dots1" name="attr_limit" value="1"><span></span>
+                                <input type="radio" class="sheet-dots2" name="attr_limit" value="2"><span></span>
+                                <input type="radio" class="sheet-dots3" name="attr_limit" value="3"><span></span>
+                                <input type="radio" class="sheet-dots4" name="attr_limit" value="4"><span></span>
+                                <input type="radio" class="sheet-dots5" name="attr_limit" value="5"><span></span>
+                                <input type="radio" class="sheet-dots6" name="attr_limit" value="6"><span></span>
+                                <input type="radio" class="sheet-dots7" name="attr_limit" value="7"><span></span>
+                                <input type="radio" class="sheet-dots8" name="attr_limit" value="8"><span></span>
+                                <input type="radio" class="sheet-dots9" name="attr_limit" value="9"><span></span>
+                                <input type="radio" class="sheet-dots10" name="attr_limit" value="10"><span></span>
+                            </div>
+                        </div>
+                        <h1><span data-i18n="limit-trigger">Limit Trigger</span></h1>
+                        <textarea name="attr_limittrigger" class="sheet-6rows" data-i18n-placeholder="limit-trigger-place"
+                            placeholder="Karal is insulted, belittled, or deliberately frustrated by another character."></textarea>
+                    </div><!-- /sheet-col limit -->
+                </div><!-- /sheet-2colrow -->
+                <h1><span data-i18n="experience-and-crafting">Experience & Crafting</span></h1>
+                <div class="sheet-flexbox-h sheet-flexbox-inline">
+                    <label>
+                        <span data-i18n="current-experience-points">Current XP:</span>
+                        <input type="number" name="attr_xp">
+                    </label>
+                    <label>
+                        <span data-i18n="total-experience-points">Total XP:</span>
+                        <input type="number" name="attr_xp_max">
+                    </label>
+                    <label>
+                        <span data-i18n="current-solar-experience-points">Current SXP:</span>
+                        <input type="number" name="attr_sxp">
+                    </label>
+                    <label>
+                        <span data-i18n="total-solar-experience-points">Total SXP:</span>
+                        <input type="number" name="attr_sxp_max">
+                    </label>
+                </div><!-- /sheet-flexbox-h experience -->
+                <div class="sheet-2colrow">
+                    <div class="sheet-col sheet-flexbox-h">
+                        <label>
+                            <span data-i18n="silver-experience-points">Silver XP</span>:
+                            <input type="number" name="attr_silver-xp">
+                        </label>
+                        <label>
+                            <span data-i18n="gold-experience-points">Gold XP</span>:
+                            <input type="number" name="attr_gold-xp">
+                        </label>
+                        <label>
+                            <span data-i18n="white-experience-points">White XP</span>:
+                            <input type="number" name="attr_white-xp">
+                        </label>
+                    </div><!-- /sheet-col crafting xp -->
+                    <div class="sheet-crafting-projects sheet-col">
+                        <div class="sheet-flexbox-h sheet-flexbox0">
+                            <input type="text" name="attr_major-project1-name" data-i18n-placeholder="project-place" placeholder="Longsword">
+                            <select disabled="disabled"><option data-i18n="major">Major</option></select>
+                        </div>
+                        <div class="sheet-flexbox-h sheet-flexbox0">
+                            <input type="text" name="attr_major-project2-name" data-i18n-placeholder="project-place" placeholder="Longsword">
+                            <select disabled="disabled"><option data-i18n="major">Major</option></select>
+                        </div>
+                        <div class="sheet-flexbox-h sheet-flexbox0">
+                            <input type="text" name="attr_major-project3-name" data-i18n-placeholder="project-place" placeholder="Longsword">
+                            <select disabled="disabled"><option data-i18n="major">Major</option></select>
+                        </div>
+                        <fieldset class="repeating_crafting-projects">
+                            <div class="sheet-flexbox-h sheet-flexbox0">
+                                <input type="text" name="attr_project-name" data-i18n-placeholder="project-place" placeholder="Longsword">
+                                <select name="attr_project-type">
+                                    <option value=""></option>
+                                    <option data-i18n="major" value="Major">Major</option>
+                                    <option data-i18n="superior" value="Superior">Superior</option>
+                                    <option data-i18n="legendary" value="Legendary">Legendary</option>
+                                </select>
+                            </div>
+                        </fieldset>
+                    </div><!-- /sheet-col crafting projects -->
+                </div><!-- /sheet-2colrow -->
+                <h1><span data-i18n="weapons-and-gear">Weapons & Gear</span></h1>
+                <div class="sheet-table">
+                    <div class="sheet-table-header">
+                        <div class="sheet-table-row">
+                            <div data-i18n="weapon" class="sheet-table-cell">Weapon</div>
+                            <div data-i18n="accuracy" class="sheet-table-cell">Accuracy</div>
+                            <div data-i18n="damage" class="sheet-table-cell">Damage</div>
+                            <div data-i18n="defense" class="sheet-table-cell">Defense</div>
+                            <div data-i18n-title="overwhelming" class="sheet-table-cell" title="Overwhelming"><span data-i18n="overwhelming-abbreviation" class="sheet-dotted">Over.</span></div>
+                            <div data-i18n="attunement" class="sheet-table-cell">Attune</div>
+                            <div data-i18n="tags" class="sheet-table-cell">Tags</div>
+                        </div>
+                    </div>
+                    <fieldset class="repeating_weapon sheet-table-body">
+                        <div class="sheet-table-cell"><input type="text" name="attr_repweaponname" data-i18n-placeholder="weapon-place" placeholder="Khatar"></div>
+                        <div class="sheet-table-cell"><input type="number" name="attr_repweaponacc" value="0"></div>
+                        <div class="sheet-table-cell"><input type="number" name="attr_repweapondam" value="7"></div>
+                        <div class="sheet-table-cell"><input type="number" name="attr_repweapondef" value="0"></div>
+                        <div class="sheet-table-cell"><input type="number" name="attr_repweaponov" value="1"></div>
+                        <div class="sheet-table-cell"><input type="number" name="attr_repweaponatt" value="0"></div>
+                        <div class="sheet-table-cell"><input type="text" name="attr_repweapontags" data-i18n-placeholder="weapon-tags-place" placeholder="Lethal, Brawl, Piercing"></div>
+                    </fieldset>
+                </div><!-- /sheet-table weapons-->
+                
+                <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="miscellaneous-items">Miscellaneous Items</strong></div>
+                <fieldset class="repeating_gear">
+                    <input type="text" name="attr_repgear" style="width:100%" data-i18n-placeholder="miscellaneous-items-place" placeholder="Fancy scarf">
+                </fieldset>
+                
+                <h1><span data-i18n="armor">Armor</span></h1>
+                <div class="sheet-table">
+                    <div class="sheet-table-header">
+                        <div class="sheet-table-row">
+                            <div data-i18n="armor" class="sheet-table-cell">Armor</div>
+                            <div data-i18n="soak" class="sheet-table-cell">Soak</div>
+                            <div data-i18n="hardness" class="sheet-table-cell">Hardness</div>
+                            <div data-i18n="mobility-penalty" class="sheet-table-cell">Mobility</div>
+                            <div data-i18n="attunement" class="sheet-table-cell">Attune</div>
+                            <div data-i18n="tags" class="sheet-table-cell">Tags</div>
+                        </div>
+                    </div>
+                    <div class="sheet-table-body">
+                        <div class="sheet-table-row">
+                            <div class="sheet-table-cell"><input type="text" name="attr_armor-name" data-i18n-placeholder="armor-place" placeholder="Chain Shirt"></div>
+                            <div class="sheet-table-cell"><input type="number" name="attr_armorsoak" value="5"></div>
+                            <div class="sheet-table-cell"><input type="number" name="attr_hardness" value="4"></div>
+                            <div class="sheet-table-cell"><input type="number" name="attr_armor-mobility" value="0"></div>
+                            <div class="sheet-table-cell"><input type="number" name="attr_armor-attune" value="4"></div>
+                            <div class="sheet-table-cell"><input type="text" name="attr_armor-tags" data-i18n-placeholder="armor-tags-place" placeholder="Concealable"></div>
+                        </div>
+                    </div>
+                </div><!-- /sheet-table armor -->
+            </div><!-- /sheet-2col -->
+        </div><!-- /sheet-3colrow -->
+        
+        <h1><span data-i18n="health-and-defense">Health & Defense</span></h1>
+        <div class="sheet-table sheet-txt-lg sheet-center-table sheet-80pct">
+            <div class="sheet-table-body">
+                <div class="sheet-table-row">
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="natural-soak">Natural Soak</span>:</div>
+                    <div class="sheet-table-cell">
+                        <span name="attr_stamina" style="margin-left:3px;margin-right:3px;vertical-align:-2px"></span>+<input type="number" value="0" name="attr_naturalsoak" style="width:28px">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="armored-soak">Armored Soak</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="number" readonly="readonly" name="attr_armorsoak">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><strong><span data-i18n="total-soak">Total Soak</span>:</strong></div>
+                    <div class="sheet-table-cell">
+                        <input type="number" value="@{stamina}+@{naturalsoak}+@{armorsoak}" disabled="disabled" name="attr_totalsoak">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="hardness">Hardness</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="number" readonly="readonly" name="attr_hardness">
                     </div>
                 </div>
-            </fieldset>
-            
-            <h1><span data-i18n="specialties">Specialties</span></h1>
-            <fieldset class="repeating_specialty">
-                <div class="sheet-flexbox-h sheet-flexbox0">
-                    <input type="text" name="attr_repspecialty" style="margin-top:3px" data-i18n-placeholder="specialty-place" placeholder="Pirate Tactics">
-                    <select name="attr_repspecialtyability">
+                <div class="sheet-table-row">
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="parry">Parry</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="number" value="0" readonly="readonly" name="attr_parry">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="evasion">Evasion</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="hidden" value="(ceil((@{dexterity} + @{dodge}) / 2) - abs(@{armor-mobility}) - abs(@{wound-penalty}))" disabled="disabled" name="attr_evasion-base">
+                        <input type="number" value="(@{evasion-base} + abs(@{evasion-base})) / 2" disabled="disabled" name="attr_evasion">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="resolve">Resolve</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="hidden" value="(@{wits} + @{integrity})" disabled="disabled" name="attr_resolve-root">
+                        <input type="hidden" value="(@{resolve-root} + 1)" disabled="disabled" name="attr_resolve-root-s">
+                        <input type="hidden" value="(ceil(@{resolve-root} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_resolve-base">
+                        <input type="hidden" value="(ceil(@{resolve-root-s} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_resolve-base-s">
+                        <input type="number" value="(@{resolve-base} + abs(@{resolve-base})) / 2" disabled="disabled" style="width:27px;margin-right:2px" data-i18n-title="resolve-without-specialty" title="Resolve without specialty" name="attr_resolve"><input type="number" value="(@{resolve-base-s} + abs(@{resolve-base-s})) / 2" disabled="disabled" style="width:27px" data-i18n-title="resolve-with-specialty" title="Resolve with specialty" name="attr_resolve-specialty">
+                    </div>
+                    <div class="sheet-table-cell sheet-text-right"><span data-i18n="guile">Guile</span>:</div>
+                    <div class="sheet-table-cell">
+                        <input type="hidden" value="(@{manipulation} + @{socialize})" disabled="disabled" name="attr_guile-root">
+                        <input type="hidden" value="(@{guile-root} + 1)" disabled="disabled" name="attr_guile-root-s">
+                        <input type="hidden" value="(ceil(@{guile-root} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_guile-base">
+                        <input type="hidden" value="(ceil(@{guile-root-s} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_guile-base-s">
+                        <input type="number" value="(@{guile-base} + abs(@{guile-base})) / 2" disabled="disabled" style="width:27px;margin-right:2px" data-i18n-title="guile-without-specialty" title="Guile without specialty" name="attr_guile"><input type="number" value="(@{guile-base-s} + abs(@{guile-base-s})) / 2" disabled="disabled" style="width:27px" data-i18n-title="guile-with-specialty" title="Guile with specialty" name="attr_guile-specialty">
+                    </div>
+                </div>
+            </div>
+        </div><!-- /sheet-table defenses -->
+        <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="health-levels">Health Levels</strong></div>
+        <div class="sheet-health-track">
+            <input type="hidden" name="attr_wound-penalty" value="0">
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl1-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl1-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl1-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl1-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl1-penalty">
+                    <option value=""></option>
+                    <option value="0" selected="selected">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option>
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl2-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl2-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl2-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl2-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl2-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1" selected="selected">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl3-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl3-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl3-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl3-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl3-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1" selected="selected">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl4-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl4-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl4-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl4-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl4-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2" selected="selected">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl5-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl5-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl5-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl5-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl5-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2" selected="selected">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl6-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl6-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl6-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl6-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl6-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4" selected="selected">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl7-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl7-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl7-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl7-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl7-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I" selected="selected">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl8-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl8-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl8-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl8-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl8-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl9-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl9-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl9-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl9-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl9-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl10-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl10-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl10-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl10-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl10-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl11-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl11-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl11-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl11-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl11-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl12-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl12-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl12-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl12-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl12-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl13-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl13-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl13-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl13-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl13-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl14-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl14-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl14-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl14-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl14-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl15-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl15-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl15-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl15-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl15-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl16-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl16-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl16-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl16-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl16-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl17-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl17-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl17-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl17-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl17-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl18-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl18-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl18-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl18-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl18-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl19-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl19-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl19-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl19-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl19-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl20-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl20-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl20-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl20-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl20-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl21-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl21-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl21-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl21-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl21-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl22-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl22-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl22-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl22-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl22-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl23-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl23-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl23-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl23-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl23-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl24-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl24-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl24-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl24-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl24-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl25-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl25-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl25-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl25-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl25-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl26-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl26-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl26-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl26-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl26-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl27-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl27-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl27-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl27-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl27-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl28-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl28-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl28-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl28-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl28-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl29-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl29-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl29-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl29-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl29-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl30-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl30-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl30-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl30-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl30-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl31-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl31-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl31-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl31-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl31-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+            <div class="sheet-health-level">
+                <div class="sheet-damage-box">
+                    <input type="radio" name="attr_hl32-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
+                    <input type="radio" name="attr_hl32-damage" value="bashing" class="sheet-dots1"><span></span>
+                    <input type="radio" name="attr_hl32-damage" value="lethal" class="sheet-dots2"><span></span>
+                    <input type="radio" name="attr_hl32-damage" value="aggravated" class="sheet-dots3"><span></span>
+                </div>
+                <select class="sheet-wound-penalty" name="attr_hl32-penalty">
+                    <option value=""></option>
+                    <option value="0">-0</option>
+                    <option value="-1">-1</option>
+                    <option value="-2">-2</option> 
+                    <option value="-3">-3</option>
+                    <option value="-4">-4</option>
+                    <option data-i18n="incapacitated" value="I">Incapacitated</option>
+                </select>
+            </div>
+        </div><!-- /sheet-health-track -->
+        
+        <h1><span data-i18n="intimacies">Intimacies</span></h1>
+        <input type="hidden" value="0" name="attr_init-intimacies">
+        <div class="sheet-table">
+            <div class="sheet-table-header">
+                <div class="sheet-table-row">
+                    <div data-i18n="intimacy" class="sheet-table-cell">Intimacy</div>
+                    <div data-i18n="intensity" class="sheet-table-cell">Intensity</div>
+                </div>
+            </div>
+            <fieldset class="repeating_intimacies sheet-table-body">
+                <div class="sheet-table-cell"><input type="text" name="attr_intimacyrepeatingname" data-i18n-placeholder="intimacy-place" placeholder="Winter Plum (Grief)"></div>
+                <div class="sheet-table-cell">
+                    <select name="attr_intimacyrepeatingtype">
                         <option value=""></option>
-                        <optgroup data-i18n-label="abilities" label="Abilities">
-                            <option data-i18n="archery" value="Archery">Archery</option>
-                            <option data-i18n="athletics" value="Athletics">Athletics</option>
-                            <option data-i18n="awareness" value="Awareness">Awareness</option>
-                            <option data-i18n="brawl" value="Brawl">Brawl</option>
-                            <option data-i18n="bureaucracy" value="Bureaucracy">Bureaucracy</option>
-                            <option data-i18n="craft" value="Craft">Craft</option>
-                            <option data-i18n="dodge" value="Dodge">Dodge</option>
-                            <option data-i18n="integrity" value="Integrity">Integrity</option>
-                            <option data-i18n="investigation" value="Investigation">Investigation</option>
-                            <option data-i18n="larceny" value="Larceny">Larceny</option>
-                            <option data-i18n="linguistics" value="Linguistics">Linguistics</option>
-                            <option data-i18n="lore" value="Lore">Lore</option>
-                            <option data-i18n="martial-arts" value="Martial Arts">Martial Arts</option>
-                            <option data-i18n="medicine" value="Medicine">Medicine</option>
-                            <option data-i18n="melee" value="Melee">Melee</option>
-                            <option data-i18n="occult" value="Occult">Occult</option>
-                            <option data-i18n="performance" value="Performance">Performance</option>
-                            <option data-i18n="presence" value="Presence">Presence</option>
-                            <option data-i18n="resistance" value="Resistance">Resistance</option>
-                            <option data-i18n="ride" value="Ride">Ride</option>
-                            <option data-i18n="sail" value="Sail">Sail</option>
-                            <option data-i18n="socialize" value="Socialize">Socialize</option>
-                            <option data-i18n="stealth" value="Stealth">Stealth</option>
-                            <option data-i18n="survival" value="Survival">Survival</option>
-                            <option data-i18n="thrown" value="Thrown">Thrown</option>
-                            <option data-i18n="war" value="War">War</option>
-                            <option data-i18n="custom" value="Custom">Custom</option>
-                        </optgroup>
-                        <optgroup data-i18n-label="attributes" label="Attributes">
-                            <option data-i18n="strength" value="Strength">Strength</option>
-                            <option data-i18n="dexterity" value="Dexterity">Dexterity</option>
-                            <option data-i18n="stamina" value="Stamina">Stamina</option>
-                            <option data-i18n="charisma" value="Charisma">Charisma</option>
-                            <option data-i18n="manipulation" value="Manipulation">Manipulation</option>
-                            <option data-i18n="appearance" value="Appearance">Appearance</option>
-                            <option data-i18n="perception" value="Perception">Perception</option>
-                            <option data-i18n="intelligence" value="Intelligence">Intelligence</option>
-                            <option data-i18n="wits" value="Wits">Wits</option>
-                        </optgroup>
+                        <option data-i18n="minor" value="Minor">Minor</option>
+                        <option data-i18n="major" value="Major">Major</option>
+                        <option data-i18n="defining" value="Defining">Defining</option>
                     </select>
                 </div>
             </fieldset>
-        </div><!-- /sheet-col abilities -->
-        <div class="sheet-2col">
-            <h1><span data-i18n="merits">Merits</span></h1>
-            <fieldset class="repeating_merits">
-                <input type="text" name="attr_repmerits-name" data-i18n-placeholder="merits-place" placeholder="Artifact">
-                <div class="sheet-dots">
-                    <input type="radio" class="sheet-dots0" name="attr_repmerits" value="0" checked="checked"><span></span>
-                    <input type="radio" class="sheet-dots1" name="attr_repmerits" value="1"><span></span>
-                    <input type="radio" class="sheet-dots2" name="attr_repmerits" value="2"><span></span>
-                    <input type="radio" class="sheet-dots3" name="attr_repmerits" value="3"><span></span>
-                    <input type="radio" class="sheet-dots4" name="attr_repmerits" value="4"><span></span>
-                    <input type="radio" class="sheet-dots5" name="attr_repmerits" value="5"><span></span>
-                    <input type="radio" class="sheet-dots6" name="attr_repmerits" value="6"><span></span>
-                    <input type="radio" class="sheet-dots7" name="attr_repmerits" value="7"><span></span>
-                    <input type="radio" class="sheet-dots8" name="attr_repmerits" value="8"><span></span>
-                    <input type="radio" class="sheet-dots9" name="attr_repmerits" value="9"><span></span>
-                    <input type="radio" class="sheet-dots10" name="attr_repmerits" value="10"><span></span>
+        </div><!-- /sheet-table intimacies -->
+        
+        <h1><span data-i18n="charms-and-evocations">Charms & Evocations</span></h1>
+        <div class="sheet-table">
+            <div class="sheet-table-header">
+                <div class="sheet-table-row">
+                    <div data-i18n="name" class="sheet-table-cell">Name</div>
+                    <div data-i18n="type" class="sheet-table-cell">Type</div>
+                    <div data-i18n="duration" class="sheet-table-cell">Duration</div>
+                    <div data-i18n="cost" class="sheet-table-cell">Cost</div>
+                    <div data-i18n="book" class="sheet-table-cell">Book</div>
+                    <div data-i18n="page-number" class="sheet-table-cell">Page #</div>
+                    <div data-i18n="effect" class="sheet-table-cell">Effect</div>
                 </div>
+            </div>
+            <fieldset class="repeating_charms sheet-table-body">
+                <div class="sheet-table-cell"><input type="text" name="attr_charm-name" style="width:100%" data-i18n-placeholder="charm-place" placeholder="Excellent Solar Larceny"></div>
+                <div class="sheet-table-cell">
+                    <select name="attr_charm-type" style="width:109px">
+                        <option value=""></option>
+                        <option data-i18n="simple" value="Simple">Simple</option>
+                        <option data-i18n="supplemental" value="Supplemental">Supplemental</option>
+                        <option data-i18n="reflexive" value="Reflexive">Reflexive</option>
+                        <option data-i18n="premanent" value="Permanent">Permanent</option>
+                    </select>
+                </div>
+                <div class="sheet-table-cell"><input type="text" name="attr_charm-duration" data-i18n-placeholder="charm-duration-place" placeholder="Instant"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_charm-cost" data-i18n-placeholder="charm-cost-place" placeholder="1m/die"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_charm-book" data-i18n-placeholder="book-place" placeholder="Core"></div>
+                <div class="sheet-table-cell"><input type="number" name="attr_charm-page" data-i18n-placeholder="charm-page-number-place" placeholder="255"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_charm-effect" style="width:100%" data-i18n="charm-effect-place" placeholder="Add dice to a Larceny roll"></div>
             </fieldset>
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <h1><span data-i18n="willpower">Willpower</span></h1>
-                    <div style="padding-left:6px">
-                        <div class="sheet-dots-full">
-                            <input type="radio" class="sheet-dots0" name="attr_willpower" value="0"><span></span>
-                            <input type="radio" class="sheet-dots1" name="attr_willpower" value="1"><span></span>
-                            <input type="radio" class="sheet-dots2" name="attr_willpower" value="2"><span></span>
-                            <input type="radio" class="sheet-dots3" name="attr_willpower" value="3"><span></span>
-                            <input type="radio" class="sheet-dots4" name="attr_willpower" value="4"><span></span>
-                            <input type="radio" class="sheet-dots5" name="attr_willpower" value="5" checked="checked"><span></span>
-                            <input type="radio" class="sheet-dots6" name="attr_willpower" value="6"><span></span>
-                            <input type="radio" class="sheet-dots7" name="attr_willpower" value="7"><span></span>
-                            <input type="radio" class="sheet-dots8" name="attr_willpower" value="8"><span></span>
-                            <input type="radio" class="sheet-dots9" name="attr_willpower" value="9"><span></span>
-                            <input type="radio" class="sheet-dots10" name="attr_willpower" value="10"><span></span>
-                        </div>
-                    </div>
-                    <div class="sheet-temp-will">
-                        <input type="checkbox" name="attr_willpower-spent1" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent2" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent3" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent4" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent5" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent6" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent7" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent8" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent9" value="1"><span></span>
-                        <input type="checkbox" name="attr_willpower-spent10" value="1"><span></span>
-                    </div>
-                    <h1><span data-i18n="essence">Essence</span></h1>
-                    <div style="padding-left:6px">
-                        <div class="sheet-dots-full">
-                            <input type="radio" class="sheet-dots0" name="attr_essence" value="0"><span></span>
-                            <input type="radio" class="sheet-dots1" name="attr_essence" value="1" checked="checked"><span></span>
-                            <input type="radio" class="sheet-dots2" name="attr_essence" value="2"><span></span>
-                            <input type="radio" class="sheet-dots3" name="attr_essence" value="3"><span></span>
-                            <input type="radio" class="sheet-dots4" name="attr_essence" value="4"><span></span>
-                            <input type="radio" class="sheet-dots5" name="attr_essence" value="5"><span></span>
-                            <input type="radio" class="sheet-dots6" name="attr_essence" value="6"><span></span>
-                            <input type="radio" class="sheet-dots7" name="attr_essence" value="7"><span></span>
-                            <input type="radio" class="sheet-dots8" name="attr_essence" value="8"><span></span>
-                            <input type="radio" class="sheet-dots9" name="attr_essence" value="9"><span></span>
-                            <input type="radio" class="sheet-dots10" name="attr_essence" value="10"><span></span>
-                        </div>
-                    </div>
-                    <div class="sheet-motes">
-                        <span data-i18n="personal">Personal</span>
-                        <span>
-                            <input type="number" name="attr_personal-essence"> |
-                            <input type="number" name="attr_personal-essence_max" value="@{essence} * 3 + 10" disabled="disabled">
-                        </span>
-                    </div>
-                    <div class="sheet-motes">
-                        <span data-i18n="peripheral">Peripheral</span>
-                        <span>
-                            <input type="number" name="attr_peripheral-essence"> |
-                            <input type="number" name="attr_peripheral-essence_max" value="@{essence} * 7 + 26" disabled="disabled">
-                        </span>
-                    </div>
-                    <div class="sheet-motes">
-                        <span data-i18n="committed">Committed</span>
-                        <span><input type="number" name="attr_committedesstotal"></span>
-                    </div>
-                </div><!-- /sheet-col willpower/essence -->
-                <div class="sheet-col">
-                    <h1><span data-i18n="limit-break">Limit Break</span></h1>
-                    <div style="padding-left:6px;margin:9px 0 9px 0">
-                        <div class="sheet-dots-full">
-                            <input type="radio" class="sheet-dots0" name="attr_limit" value="0" checked="checked"><span></span>
-                            <input type="radio" class="sheet-dots1" name="attr_limit" value="1"><span></span>
-                            <input type="radio" class="sheet-dots2" name="attr_limit" value="2"><span></span>
-                            <input type="radio" class="sheet-dots3" name="attr_limit" value="3"><span></span>
-                            <input type="radio" class="sheet-dots4" name="attr_limit" value="4"><span></span>
-                            <input type="radio" class="sheet-dots5" name="attr_limit" value="5"><span></span>
-                            <input type="radio" class="sheet-dots6" name="attr_limit" value="6"><span></span>
-                            <input type="radio" class="sheet-dots7" name="attr_limit" value="7"><span></span>
-                            <input type="radio" class="sheet-dots8" name="attr_limit" value="8"><span></span>
-                            <input type="radio" class="sheet-dots9" name="attr_limit" value="9"><span></span>
-                            <input type="radio" class="sheet-dots10" name="attr_limit" value="10"><span></span>
-                        </div>
-                    </div>
-                    <h1><span data-i18n="limit-trigger">Limit Trigger</span></h1>
-                    <textarea name="attr_limittrigger" class="sheet-6rows" data-i18n-placeholder="limit-trigger-place"
-                        placeholder="Karal is insulted, belittled, or deliberately frustrated by another character."></textarea>
-                </div><!-- /sheet-col limit -->
-            </div><!-- /sheet-2colrow -->
-            <h1><span data-i18n="experience-and-crafting">Experience & Crafting</span></h1>
-            <div class="sheet-flexbox-h sheet-flexbox-inline">
-                <label>
-                    <span data-i18n="current-experience-points">Current XP:</span>
-                    <input type="number" name="attr_xp">
-                </label>
-                <label>
-                    <span data-i18n="total-experience-points">Total XP:</span>
-                    <input type="number" name="attr_xp_max">
-                </label>
-                <label>
-                    <span data-i18n="current-solar-experience-points">Current SXP:</span>
-                    <input type="number" name="attr_sxp">
-                </label>
-                <label>
-                    <span data-i18n="total-solar-experience-points">Total SXP:</span>
-                    <input type="number" name="attr_sxp_max">
-                </label>
-            </div><!-- /sheet-flexbox-h experience -->
-            <div class="sheet-2colrow">
-                <div class="sheet-col sheet-flexbox-h">
-                    <label>
-                        <span data-i18n="silver-experience-points">Silver XP</span>:
-                        <input type="number" name="attr_silver-xp">
-                    </label>
-                    <label>
-                        <span data-i18n="gold-experience-points">Gold XP</span>:
-                        <input type="number" name="attr_gold-xp">
-                    </label>
-                    <label>
-                        <span data-i18n="white-experience-points">White XP</span>:
-                        <input type="number" name="attr_white-xp">
-                    </label>
-                </div><!-- /sheet-col crafting xp -->
-                <div class="sheet-crafting-projects sheet-col">
-                    <div class="sheet-flexbox-h sheet-flexbox0">
-                        <input type="text" name="attr_major-project1-name" data-i18n-placeholder="project-place" placeholder="Longsword">
-                        <select disabled="disabled"><option data-i18n="major">Major</option></select>
-                    </div>
-                    <div class="sheet-flexbox-h sheet-flexbox0">
-                        <input type="text" name="attr_major-project2-name" data-i18n-placeholder="project-place" placeholder="Longsword">
-                        <select disabled="disabled"><option data-i18n="major">Major</option></select>
-                    </div>
-                    <div class="sheet-flexbox-h sheet-flexbox0">
-                        <input type="text" name="attr_major-project3-name" data-i18n-placeholder="project-place" placeholder="Longsword">
-                        <select disabled="disabled"><option data-i18n="major">Major</option></select>
-                    </div>
-                    <fieldset class="repeating_crafting-projects">
-                        <div class="sheet-flexbox-h sheet-flexbox0">
-                            <input type="text" name="attr_project-name" data-i18n-placeholder="project-place" placeholder="Longsword">
-                            <select name="attr_project-type">
-                                <option value=""></option>
-                                <option data-i18n="major" value="Major">Major</option>
-                                <option data-i18n="superior" value="Superior">Superior</option>
-                                <option data-i18n="legendary" value="Legendary">Legendary</option>
-                            </select>
-                        </div>
-                    </fieldset>
-                </div><!-- /sheet-col crafting projects -->
-            </div><!-- /sheet-2colrow -->
-            <h1><span data-i18n="weapons-and-gear">Weapons & Gear</span></h1>
-            <div class="sheet-table">
-                <div class="sheet-table-header">
-                    <div class="sheet-table-row">
-                        <div data-i18n="weapon" class="sheet-table-cell">Weapon</div>
-                        <div data-i18n="accuracy" class="sheet-table-cell">Accuracy</div>
-                        <div data-i18n="damage" class="sheet-table-cell">Damage</div>
-                        <div data-i18n="defense" class="sheet-table-cell">Defense</div>
-                        <div data-i18n-title="overwhelming" class="sheet-table-cell" title="Overwhelming"><span data-i18n="overwhelming-abbreviation" class="sheet-dotted">Over.</span></div>
-                        <div data-i18n="attunement" class="sheet-table-cell">Attune</div>
-                        <div data-i18n="tags" class="sheet-table-cell">Tags</div>
-                    </div>
+        </div><!-- /sheet-table charms -->
+        
+        <h1><span data-i18n="sorceries">Sorceries</span></h1>
+        <div class="sheet-table">
+            <div class="sheet-table-header">
+                <div class="sheet-table-row">
+                    <div data-i18n="name" class="sheet-table-cell">Name</div>
+                    <div data-i18n="circle" class="sheet-table-cell">Circle</div>
+                    <div data-i18n-title="control-spell" class="sheet-table-cell" title="Control Spell"><span data-i18n="control-spell-abbreviation" class="sheet-dotted">C.</span></div>
+                    <div data-i18n="duration" class="sheet-table-cell">Duration</div>
+                    <div data-i18n="cost" class="sheet-table-cell">Cost</div>
+                    <div data-i18n="book" class="sheet-table-cell">Book</div>
+                    <div data-i18n="page-number" class="sheet-table-cell">Page #</div>
+                    <div data-i18n="effect" class="sheet-table-cell">Effect</div>
                 </div>
-                <fieldset class="repeating_weapon sheet-table-body">
-                    <div class="sheet-table-cell"><input type="text" name="attr_repweaponname" data-i18n-placeholder="weapon-place" placeholder="Khatar"></div>
-                    <div class="sheet-table-cell"><input type="number" name="attr_repweaponacc" value="0"></div>
-                    <div class="sheet-table-cell"><input type="number" name="attr_repweapondam" value="7"></div>
-                    <div class="sheet-table-cell"><input type="number" name="attr_repweapondef" value="0"></div>
-                    <div class="sheet-table-cell"><input type="number" name="attr_repweaponov" value="1"></div>
-                    <div class="sheet-table-cell"><input type="number" name="attr_repweaponatt" value="0"></div>
-                    <div class="sheet-table-cell"><input type="text" name="attr_repweapontags" data-i18n-placeholder="weapon-tags-place" placeholder="Lethal, Brawl, Piercing"></div>
-                </fieldset>
-            </div><!-- /sheet-table weapons-->
-            
-            <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="miscellaneous-items">Miscellaneous Items</strong></div>
-            <fieldset class="repeating_gear">
-                <input type="text" name="attr_repgear" style="width:100%" data-i18n-placeholder="miscellaneous-items-place" placeholder="Fancy scarf">
+            </div>
+            <fieldset class="repeating_spells sheet-table-body">
+                <div class="sheet-table-cell"><input type="text" name="attr_repspell-name" style="width:100%" data-i18n-placeholder="spell-place" placeholder="Cirrus Skiff"></div>
+                <div class="sheet-table-cell">
+                    <select name="attr_repspell-circle" style="width:86px">
+                        <option value=""></option>
+                        <option data-i18n="terrestrial" value="Terrestrial">Terrestrial</option>
+                        <option data-i18n="celestial" value="Celestial">Celestial</option>
+                        <option data-i18n="solar" value="Solar">Solar</option>
+                    </select>
+                </div>
+                <div class="sheet-table-cell sheet-text-center"><input type="checkbox" name="attr_repspell-control" value="1"><span></span></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_repspell-dur" style="width:90px" data-i18n-placeholder="spell-duration-place" placeholder="Until ended"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_repspell-cost" data-i18n-placeholder="spell-cost-place" placeholder="15m, 1wp"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_spell-book" data-i18n-placeholder="book-place" placeholder="Core"></div>
+                <div class="sheet-table-cell"><input type="number" name="attr_spell-page" data-i18n-placeholder="spell-page-place" placeholder="471"></div>
+                <div class="sheet-table-cell"><input type="text" name="attr_repspell-effect" style="width:100%" data-i18n-placeholder="spell-effect-place" placeholder="Call a small cloud to ride on"></div>
             </fieldset>
-            
-            <h1><span data-i18n="armor">Armor</span></h1>
-            <div class="sheet-table">
-                <div class="sheet-table-header">
-                    <div class="sheet-table-row">
-                        <div data-i18n="armor" class="sheet-table-cell">Armor</div>
-                        <div data-i18n="soak" class="sheet-table-cell">Soak</div>
-                        <div data-i18n="hardness" class="sheet-table-cell">Hardness</div>
-                        <div data-i18n="mobility-penalty" class="sheet-table-cell">Mobility</div>
-                        <div data-i18n="attunement" class="sheet-table-cell">Attune</div>
-                        <div data-i18n="tags" class="sheet-table-cell">Tags</div>
-                    </div>
-                </div>
-                <div class="sheet-table-body">
-                    <div class="sheet-table-row">
-                        <div class="sheet-table-cell"><input type="text" name="attr_armor-name" data-i18n-placeholder="armor-place" placeholder="Chain Shirt"></div>
-                        <div class="sheet-table-cell"><input type="number" name="attr_armorsoak" value="5"></div>
-                        <div class="sheet-table-cell"><input type="number" name="attr_hardness" value="4"></div>
-                        <div class="sheet-table-cell"><input type="number" name="attr_armor-mobility" value="0"></div>
-                        <div class="sheet-table-cell"><input type="number" name="attr_armor-attune" value="4"></div>
-                        <div class="sheet-table-cell"><input type="text" name="attr_armor-tags" data-i18n-placeholder="armor-tags-place" placeholder="Concealable"></div>
-                    </div>
-                </div>
-            </div><!-- /sheet-table armor -->
-        </div><!-- /sheet-2col -->
-    </div><!-- /sheet-3colrow -->
-    
-    <h1><span data-i18n="health-and-defense">Health & Defense</span></h1>
-    <div class="sheet-table sheet-txt-lg sheet-center-table sheet-80pct">
-        <div class="sheet-table-body">
-            <div class="sheet-table-row">
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="natural-soak">Natural Soak</span>:</div>
-                <div class="sheet-table-cell">
-                    <span name="attr_stamina" style="margin-left:3px;margin-right:3px;vertical-align:-2px"></span>+<input type="number" value="0" name="attr_naturalsoak" style="width:28px">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="armored-soak">Armored Soak</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="number" readonly="readonly" name="attr_armorsoak">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><strong><span data-i18n="total-soak">Total Soak</span>:</strong></div>
-                <div class="sheet-table-cell">
-                    <input type="number" value="@{stamina}+@{naturalsoak}+@{armorsoak}" disabled="disabled" name="attr_totalsoak">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="hardness">Hardness</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="number" readonly="readonly" name="attr_hardness">
-                </div>
-            </div>
-            <div class="sheet-table-row">
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="parry">Parry</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="number" value="0" readonly="readonly" name="attr_parry">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="evasion">Evasion</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="hidden" value="(ceil((@{dexterity} + @{dodge}) / 2) - abs(@{armor-mobility}) - abs(@{wound-penalty}))" disabled="disabled" name="attr_evasion-base">
-                    <input type="number" value="(@{evasion-base} + abs(@{evasion-base})) / 2" disabled="disabled" name="attr_evasion">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="resolve">Resolve</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="hidden" value="(@{wits} + @{integrity})" disabled="disabled" name="attr_resolve-root">
-                    <input type="hidden" value="(@{resolve-root} + 1)" disabled="disabled" name="attr_resolve-root-s">
-                    <input type="hidden" value="(ceil(@{resolve-root} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_resolve-base">
-                    <input type="hidden" value="(ceil(@{resolve-root-s} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_resolve-base-s">
-                    <input type="number" value="(@{resolve-base} + abs(@{resolve-base})) / 2" disabled="disabled" style="width:27px;margin-right:2px" data-i18n-title="resolve-without-specialty" title="Resolve without specialty" name="attr_resolve"><input type="number" value="(@{resolve-base-s} + abs(@{resolve-base-s})) / 2" disabled="disabled" style="width:27px" data-i18n-title="resolve-with-specialty" title="Resolve with specialty" name="attr_resolve-specialty">
-                </div>
-                <div class="sheet-table-cell sheet-text-right"><span data-i18n="guile">Guile</span>:</div>
-                <div class="sheet-table-cell">
-                    <input type="hidden" value="(@{manipulation} + @{socialize})" disabled="disabled" name="attr_guile-root">
-                    <input type="hidden" value="(@{guile-root} + 1)" disabled="disabled" name="attr_guile-root-s">
-                    <input type="hidden" value="(ceil(@{guile-root} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_guile-base">
-                    <input type="hidden" value="(ceil(@{guile-root-s} / 2) - abs(@{wound-penalty}))" disabled="disabled" name="attr_guile-base-s">
-                    <input type="number" value="(@{guile-base} + abs(@{guile-base})) / 2" disabled="disabled" style="width:27px;margin-right:2px" data-i18n-title="guile-without-specialty" title="Guile without specialty" name="attr_guile"><input type="number" value="(@{guile-base-s} + abs(@{guile-base-s})) / 2" disabled="disabled" style="width:27px" data-i18n-title="guile-with-specialty" title="Guile with specialty" name="attr_guile-specialty">
-                </div>
-            </div>
-        </div>
-    </div><!-- /sheet-table defenses -->
-    <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="health-levels">Health Levels</strong></div>
-    <div class="sheet-health-track">
-        <input type="hidden" name="attr_wound-penalty" value="0">
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl1-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl1-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl1-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl1-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl1-penalty">
-                <option value=""></option>
-                <option value="0" selected="selected">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option>
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl2-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl2-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl2-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl2-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl2-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1" selected="selected">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl3-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl3-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl3-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl3-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl3-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1" selected="selected">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl4-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl4-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl4-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl4-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl4-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2" selected="selected">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl5-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl5-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl5-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl5-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl5-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2" selected="selected">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl6-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl6-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl6-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl6-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl6-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4" selected="selected">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl7-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl7-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl7-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl7-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl7-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I" selected="selected">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl8-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl8-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl8-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl8-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl8-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl9-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl9-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl9-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl9-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl9-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl10-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl10-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl10-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl10-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl10-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl11-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl11-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl11-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl11-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl11-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl12-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl12-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl12-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl12-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl12-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl13-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl13-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl13-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl13-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl13-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl14-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl14-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl14-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl14-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl14-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl15-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl15-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl15-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl15-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl15-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl16-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl16-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl16-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl16-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl16-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl17-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl17-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl17-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl17-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl17-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl18-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl18-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl18-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl18-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl18-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl19-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl19-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl19-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl19-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl19-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl20-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl20-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl20-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl20-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl20-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl21-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl21-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl21-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl21-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl21-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl22-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl22-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl22-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl22-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl22-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl23-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl23-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl23-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl23-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl23-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl24-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl24-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl24-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl24-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl24-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl25-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl25-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl25-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl25-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl25-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl26-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl26-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl26-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl26-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl26-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl27-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl27-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl27-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl27-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl27-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl28-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl28-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl28-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl28-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl28-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl29-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl29-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl29-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl29-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl29-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl30-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl30-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl30-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl30-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl30-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl31-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl31-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl31-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl31-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl31-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-        <div class="sheet-health-level">
-            <div class="sheet-damage-box">
-                <input type="radio" name="attr_hl32-damage" value="healthy" class="sheet-dots0" checked="checked"><span></span>
-                <input type="radio" name="attr_hl32-damage" value="bashing" class="sheet-dots1"><span></span>
-                <input type="radio" name="attr_hl32-damage" value="lethal" class="sheet-dots2"><span></span>
-                <input type="radio" name="attr_hl32-damage" value="aggravated" class="sheet-dots3"><span></span>
-            </div>
-            <select class="sheet-wound-penalty" name="attr_hl32-penalty">
-                <option value=""></option>
-                <option value="0">-0</option>
-                <option value="-1">-1</option>
-                <option value="-2">-2</option> 
-                <option value="-3">-3</option>
-                <option value="-4">-4</option>
-                <option data-i18n="incapacitated" value="I">Incapacitated</option>
-            </select>
-        </div>
-    </div><!-- /sheet-health-track -->
-    
-    <h1><span data-i18n="intimacies">Intimacies</span></h1>
-    <input type="hidden" value="0" name="attr_init-intimacies">
-    <div class="sheet-table">
-        <div class="sheet-table-header">
-            <div class="sheet-table-row">
-                <div data-i18n="intimacy" class="sheet-table-cell">Intimacy</div>
-                <div data-i18n="intensity" class="sheet-table-cell">Intensity</div>
-            </div>
-        </div>
-        <fieldset class="repeating_intimacies sheet-table-body">
-            <div class="sheet-table-cell"><input type="text" name="attr_intimacyrepeatingname" data-i18n-placeholder="intimacy-place" placeholder="Winter Plum (Grief)"></div>
-            <div class="sheet-table-cell">
-                <select name="attr_intimacyrepeatingtype">
-                    <option value=""></option>
-                    <option data-i18n="minor" value="Minor">Minor</option>
-                    <option data-i18n="major" value="Major">Major</option>
-                    <option data-i18n="defining" value="Defining">Defining</option>
-                </select>
-            </div>
-        </fieldset>
-    </div><!-- /sheet-table intimacies -->
-    
-    <h1><span data-i18n="charms-and-evocations">Charms & Evocations</span></h1>
-    <div class="sheet-table">
-        <div class="sheet-table-header">
-            <div class="sheet-table-row">
-                <div data-i18n="name" class="sheet-table-cell">Name</div>
-                <div data-i18n="type" class="sheet-table-cell">Type</div>
-                <div data-i18n="duration" class="sheet-table-cell">Duration</div>
-                <div data-i18n="cost" class="sheet-table-cell">Cost</div>
-                <div data-i18n="book" class="sheet-table-cell">Book</div>
-                <div data-i18n="page-number" class="sheet-table-cell">Page #</div>
-                <div data-i18n="effect" class="sheet-table-cell">Effect</div>
-            </div>
-        </div>
-        <fieldset class="repeating_charms sheet-table-body">
-            <div class="sheet-table-cell"><input type="text" name="attr_charm-name" style="width:100%" data-i18n-placeholder="charm-place" placeholder="Excellent Solar Larceny"></div>
-            <div class="sheet-table-cell">
-                <select name="attr_charm-type" style="width:109px">
-                    <option value=""></option>
-                    <option data-i18n="simple" value="Simple">Simple</option>
-                    <option data-i18n="supplemental" value="Supplemental">Supplemental</option>
-                    <option data-i18n="reflexive" value="Reflexive">Reflexive</option>
-                    <option data-i18n="premanent" value="Permanent">Permanent</option>
-                </select>
-            </div>
-            <div class="sheet-table-cell"><input type="text" name="attr_charm-duration" data-i18n-placeholder="charm-duration-place" placeholder="Instant"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_charm-cost" data-i18n-placeholder="charm-cost-place" placeholder="1m/die"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_charm-book" data-i18n-placeholder="book-place" placeholder="Core"></div>
-            <div class="sheet-table-cell"><input type="number" name="attr_charm-page" data-i18n-placeholder="charm-page-number-place" placeholder="255"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_charm-effect" style="width:100%" data-i18n="charm-effect-place" placeholder="Add dice to a Larceny roll"></div>
-        </fieldset>
-    </div><!-- /sheet-table charms -->
-    
-    <h1><span data-i18n="sorceries">Sorceries</span></h1>
-    <div class="sheet-table">
-        <div class="sheet-table-header">
-            <div class="sheet-table-row">
-                <div data-i18n="name" class="sheet-table-cell">Name</div>
-                <div data-i18n="circle" class="sheet-table-cell">Circle</div>
-                <div data-i18n-title="control-spell" class="sheet-table-cell" title="Control Spell"><span data-i18n="control-spell-abbreviation" class="sheet-dotted">C.</span></div>
-                <div data-i18n="duration" class="sheet-table-cell">Duration</div>
-                <div data-i18n="cost" class="sheet-table-cell">Cost</div>
-                <div data-i18n="book" class="sheet-table-cell">Book</div>
-                <div data-i18n="page-number" class="sheet-table-cell">Page #</div>
-                <div data-i18n="effect" class="sheet-table-cell">Effect</div>
-            </div>
-        </div>
-        <fieldset class="repeating_spells sheet-table-body">
-            <div class="sheet-table-cell"><input type="text" name="attr_repspell-name" style="width:100%" data-i18n-placeholder="spell-place" placeholder="Cirrus Skiff"></div>
-            <div class="sheet-table-cell">
-                <select name="attr_repspell-circle" style="width:86px">
-                    <option value=""></option>
-                    <option data-i18n="terrestrial" value="Terrestrial">Terrestrial</option>
-                    <option data-i18n="celestial" value="Celestial">Celestial</option>
-                    <option data-i18n="solar" value="Solar">Solar</option>
-                </select>
-            </div>
-            <div class="sheet-table-cell sheet-text-center"><input type="checkbox" name="attr_repspell-control" value="1"><span></span></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_repspell-dur" style="width:90px" data-i18n-placeholder="spell-duration-place" placeholder="Until ended"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_repspell-cost" data-i18n-placeholder="spell-cost-place" placeholder="15m, 1wp"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_spell-book" data-i18n-placeholder="book-place" placeholder="Core"></div>
-            <div class="sheet-table-cell"><input type="number" name="attr_spell-page" data-i18n-placeholder="spell-page-place" placeholder="471"></div>
-            <div class="sheet-table-cell"><input type="text" name="attr_repspell-effect" style="width:100%" data-i18n-placeholder="spell-effect-place" placeholder="Call a small cloud to ride on"></div>
-        </fieldset>
-    </div><!-- /sheet-table sorceries -->
-</div><!-- /sheet-body -->
-<div class="sheet-footer">
-    <button type="roll" value="/w &quot;@{character_name}&quot; &{template:default} {{name=Ex3 Character Sheet}} {{Version:=2.0}} {{Wiki Article:=[Click for info](https://wiki.roll20.net/Ex3 Character Sheet)}}"><span data-i18n="version">Version</span> 2.0 &ndash; <span data-i18n="more-information">More Information</span></button>
-</div>
+        </div><!-- /sheet-table sorceries -->
+    </div><!-- /sheet-body -->
+    <div class="sheet-footer">
+        <button type="roll" value="/w &quot;@{character_name}&quot; &{template:default} {{name=Ex3 Character Sheet}} {{Version:=2.0}} {{Wiki Article:=[Click for info](https://wiki.roll20.net/Ex3 Character Sheet)}}"><span data-i18n="version">Version</span> 2.0 &ndash; <span data-i18n="more-information">More Information</span></button>
+    </div>
+</div><!-- /sheet-content -->


### PR DESCRIPTION
Prevent overflow for crafting/MA

With teh Cimiez font, the "Show Crafts"/"Show Stlyes" text are wholly
contained within their buttons. If Cimiez is not loaded, the text
overflows onto the next ability.

Prevent horizontal scrolling without Cimiez

xp/sxp line was causing horizontalscrolling with the default character
sheet window size when Cimiez wasn't available.

Fixed issues with resizing charsheet dialog

Fixed horizontal scroll issue w/o Cimiez font

Removed spinners from FFX number inputs