### PR TITLE
Partial DFA.html revert

### DIFF
--- a/DresdenFilesAccelerated/DFA.html
+++ b/DresdenFilesAccelerated/DFA.html
@@ -31,45 +31,45 @@
             <div class="sheet-text-header">APPROACHES</div>
             <div class="sheet-top">
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@flair}]]" name="roll_flair"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{flair}]]" name="roll_flair"></button>
                     <input type="number" class="sheet-number" name="attr_flair" title="@{flair}" placeholder="0" />
-                    <input type="text" placeholder="Flair" />
+                    <div class="sheet-text-other">Flair</div>
                 </div>
                 
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@focus}]]" name="roll_focus"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{focus}]]" name="roll_focus"></button>
                     <input type="number" class="sheet-number" name="attr_focus" title="@{focus}" placeholder="0" />
-                    <input type="text" placeholder="Focus" />
+                    <div class="sheet-text-other">Focus</div>
                 </div>
                 
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@force}]]" name="roll_force"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{force}]]" name="roll_force"></button>
                     <input type="number" class="sheet-number" name="attr_force" title="@{force}" placeholder="0" />
-                    <input type="text" placeholder="Force" />
+                    <div class="sheet-text-other">Force</div>
                 </div>
                 
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@guile}]]" name="roll_guile"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{guile}]]" name="roll_guile"></button>
                     <input type="number" class="sheet-number" name="attr_guile" title="@{guile}" placeholder="0" />
-                    <input type="text" placeholder="Guile" />
+                    <div class="sheet-text-other">Guile</div>
                 </div>
-                                
+                
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@haste}]]" name="roll_haste"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{haste}]]" name="roll_haste"></button>
                     <input type="number" class="sheet-number" name="attr_haste" title="@{haste}" placeholder="0" />
-                    <input type="text" placeholder="Haste" />
+                    <div class="sheet-text-other">Haste</div>
                 </div>
                 
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@intellect}]]" name="roll_intellect"></button>
+                    <button type="roll" class="sheet-button" value="[[4df + @{intellect}]]" name="roll_intellect"></button>
                     <input type="number" class="sheet-number" name="attr_intellect" title="@{intellect}" placeholder="0" />
-                    <input type="text" placeholder="Intellect" />
+                    <div class="sheet-text-other">Intellect</div>
                 </div>
                 
                 <div class="sheet-flexrow">
-                    <button type="roll" class="sheet-button" value="[[4df + @{@mantle-approach}]]" name="roll_mantle"></button>
-                    <input type="number" class="sheet-number" name="attr_mantle-approach" title="@{mantle-approach}" placeholder="0" />
-                    <input type="text" placeholder="Mantle" />
+                    <button type="roll" class="sheet-button" value="[[4df + @{mantle}]]" name="roll_mantle"></button>
+                    <input type="number" class="sheet-number" name="attr_mantle" title="@{mantle}" placeholder="0" />
+                    <div class="sheet-text-other">Mantle</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The change broke the roll buttons, but fixed the Fate Point calculations.

Rolling back the changes to the approaches.

Changed Mantle approach to fixed text because it never saved what was inside the text box. Also changed it to roll specifically for the mantle instead of Intellect as a fix from the first version.

I'm have no idea how to create flexible, saving text boxes for the approaches and still have them work, so this might be the next best option. Hopefully you (Ikidaore) or someone else can figure out a fix.