### PR TITLE
[DnD_5e] Adding partial spell compendium support to D&D 5e Community sheet.

### DIFF
--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -12059,7 +12059,7 @@
 				</div>
 				<fieldset class="repeating_spellbookcantrip">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -12075,10 +12075,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Cantrip">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -12091,16 +12091,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -12140,16 +12140,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -12214,7 +12214,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -12253,7 +12253,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -12282,7 +12282,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -12294,7 +12294,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -12323,7 +12323,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -12367,7 +12367,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel1">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -12383,10 +12383,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 1">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -12399,16 +12399,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -12448,16 +12448,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -12522,7 +12522,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -12561,7 +12561,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -12590,7 +12590,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -12602,7 +12602,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -12631,7 +12631,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -12675,7 +12675,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel2">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -12691,10 +12691,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 2">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -12707,16 +12707,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -12756,16 +12756,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -12830,7 +12830,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -12869,7 +12869,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -12898,7 +12898,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -12910,7 +12910,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -12939,7 +12939,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -12983,7 +12983,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel3">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -12999,10 +12999,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 3">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -13015,16 +13015,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -13064,16 +13064,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -13138,7 +13138,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -13177,7 +13177,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -13206,7 +13206,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -13218,7 +13218,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -13247,7 +13247,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -13291,7 +13291,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel4">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -13307,10 +13307,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 4">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -13323,16 +13323,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -13372,16 +13372,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -13446,7 +13446,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -13485,7 +13485,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -13514,7 +13514,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -13526,7 +13526,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -13555,7 +13555,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -13599,7 +13599,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel5">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -13615,10 +13615,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 5">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -13631,16 +13631,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -13680,16 +13680,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -13754,7 +13754,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -13793,7 +13793,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -13822,7 +13822,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -13834,7 +13834,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -13863,7 +13863,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -13907,7 +13907,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel6">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -13923,10 +13923,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 6">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -13939,16 +13939,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -13988,16 +13988,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -14062,7 +14062,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -14101,7 +14101,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -14130,7 +14130,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -14142,7 +14142,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -14171,7 +14171,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -14215,7 +14215,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel7">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -14231,10 +14231,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 7">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -14247,16 +14247,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -14296,16 +14296,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -14370,7 +14370,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -14409,7 +14409,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -14438,7 +14438,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -14450,7 +14450,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -14479,7 +14479,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -14523,7 +14523,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel8">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -14539,10 +14539,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 8">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -14555,16 +14555,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -14604,16 +14604,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -14678,7 +14678,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -14717,7 +14717,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -14746,7 +14746,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -14758,7 +14758,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -14787,7 +14787,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">
@@ -14831,7 +14831,7 @@
 				</div>
 				<fieldset class="repeating_spellbooklevel9">
 					<!-- BEGIN spell row -->
-					<div class="sheet-margin-bottom sheet-padr sheet-padl">
+					<div class="sheet-margin-bottom sheet-padr sheet-padl compendium-drop-target">
 						<div class="sheet-row">
 							<div class="sheet-col-1-12 sheet-vert-bottom sheet-center sheet-small-label">Spell Level</div>
 							<div class="sheet-col-1-3 sheet-vert-bottom sheet-center sheet-small-label">Spell name</div>
@@ -14847,10 +14847,10 @@
 								<input type="hidden" name="attr_spellfriendlylevel" value="Level 9">
 							</div>
 							<div class="sheet-col-1-3 sheet-vert-middle">
-								<input type="text" class=" sheet-center" name="attr_spellname">
+								<input type="text" class=" sheet-center" name="attr_spellname" accept="Name">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<select name="attr_spellschool">
+								<select name="attr_spellschool" accept="School">
 									<option value="" selected="selected">n/a</option>
 									<option value="Abjuration">Abjuration</option>
 									<option value="Conjuration">Conjuration</option>
@@ -14863,16 +14863,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcasttime">
+								<input type="text" class="sheet-center" name="attr_spellcasttime" accept="Casting Time">
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellconcentration">
+								<select name="attr_spellconcentration" accept="Concentration">
 									<option value="" selected="selected">No</option>
 									<option value="(Concentration)">Yes</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-12 sheet-checkbox-row">
-								<select name="attr_spellritual">
+								<select name="attr_spellritual" accept="Ritual">
 									<option value="" selected="selected">No</option>
 									<option value="(Ritual)">Yes</option>
 								</select>
@@ -14912,16 +14912,16 @@
 								</select>
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spelltarget">
+								<input type="text" class="sheet-center" name="attr_spelltarget" accept="Target">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellrange">
+								<input type="text" class="sheet-center" name="attr_spellrange" accept="Range">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellduration">
+								<input type="text" class="sheet-center" name="attr_spellduration" accept="Duration">
 							</div>
 							<div class="sheet-col-1-8 sheet-vert-middle">
-								<input type="text" class="sheet-center" name="attr_spellcomponents">
+								<input type="text" class="sheet-center" name="attr_spellcomponents" accept="Components">
 							</div>
 							<div class="sheet-col-1-6 sheet-vert-middle sheet-center">
 								<button type="roll" class="sheet-roll" name="roll_SpellInfo" value="&{template:5eDefault} {{spell=1}} {{spellshowinfoblock=1}} {{spellshowdesc=1}} {{spellshowhigherlvl=1}} {{character_name=@{character_name}}} {{emote=looks at the instructions for a spell}} {{title=@{spellname}}} {{subheader=@{character_name}}} {{subheaderright=@{spellschool} @{spellfriendlylevel}}} {{subheader2=@{spellconcentration} @{spellritual}}}  {{spellcasttime=@{spellcasttime}}} {{spellduration=@{spellduration}}} {{spelltarget=@{spelltarget}}} {{spellrange=@{spellrange}}} {{spellgainedfrom=@{spellgainedfrom}}} {{spellcomponents=@{spellcomponents}}}  {{spelldescription=@{spelldescription}}} {{spellhigherlevel=@{spellhighersloteffect}}} @{classactionspellinfo}">Spell Info</button>
@@ -14986,7 +14986,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
-									<textarea class="sheet-medium-textarea" name="attr_spelldescription"></textarea>
+									<textarea class="sheet-medium-textarea" name="attr_spelldescription" accept="Content"></textarea>
 								</div>
 								<div class="sheet-col-1-2 sheet-small-label sheet-center">
 									<textarea name="attr_spellhighersloteffect" class="sheet-medium-textarea"></textarea>
@@ -15025,7 +15025,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-12">
-									<select name="attr_savestat">
+									<select name="attr_savestat" accept="Save">
 										<option value="STR">STR</option>
 										<option value="DEX">DEX</option>
 										<option value="CON">CON</option>
@@ -15054,7 +15054,7 @@
 									<input type="number" name="attr_customsavedc" value="0" min="0" step="1" title="Unless you have selected Custom in the previous field this should always be 0">
 								</div>
 								<div class="sheet-col-1-2">
-									<input type="text" class="sheet-center" name="attr_savesuccess">
+									<input type="text" class="sheet-center" name="attr_savesuccess" accept="Save Success">
 								</div>
 							</div>
 						</div>
@@ -15066,7 +15066,7 @@
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-col-1-3 sheet-offset-1-4 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0">
+									<input type="text" class="sheet-center" name="attr_spellhealamount" value="0" accept="Healing">
 								</div>
 								<div class="sheet-col-1-6 sheet-center">
 									<select name="attr_healstatbonus">
@@ -15095,7 +15095,7 @@
 									<input type="checkbox" name="attr_spellcancrit" value="{{spellcancrit=1}} {{spellcritdamage=Additional [[@{damage}]] damage}}" checked="checked" />
 								</div>
 								<div class="sheet-col-1-6 sheet-small-label sheet-center">
-									<input type="text" class="sheet-center" name="attr_damage" value="0">
+									<input type="text" class="sheet-center" name="attr_damage" value="0" accept="Damage">
 								</div>
 								<div class="sheet-col-1-6">
 									<select name="attr_damagestatbonus">


### PR DESCRIPTION
This adds partial spell compendium support to the community 5e sheet; I did not add the full range of fields, as some of them do not directly map between the compendium and the sheet.

Current known issues:
- Concentration / Ritual dropdowns can be set to 'Yes' from the compendium, but do not get unset if dropping a second spell onto the slot.
- Material components don't have a spot to live on the sheet
- Spell attack type (None/Melee/Range) does not have a spot on the sheet