### PR TITLE
Urban Shadows - Updated for Dark Streets supplement playbooks

### DIFF
--- a/Urban_Shadows/sheet.html
+++ b/Urban_Shadows/sheet.html
@@ -18,10 +18,16 @@
 		<input type="checkbox" name="attr_class" class="sheet-class" value='The Veteran'/><label>The Veteran</label>
 		<input type="checkbox" name="attr_class" class="sheet-class" value='The Wizard'/><label>The Wizard</label>
 		<input type="checkbox" name="attr_class" class="sheet-class" value='The Wolf'/><label>The Wolf</label>
+		<input type="checkbox" name="attr_class" class="sheet-class" value='The Scholar' /><label>The Scholar</label>
+		<input type="checkbox" name="attr_class" class="sheet-class" value='The Revenant'/><label>The Revenant</label>
+		<input type="checkbox" name="attr_class" class="sheet-class" value='The Hallowed'/><label>The Hallowed</label>
+		<input type="checkbox" name="attr_class" class="sheet-class" value='The Vessel'/><label>The Vessel</label>
     </div>
     <div class="sheet-2colrow" style="padding-left: 20px;">
     	<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
     	<div class="sheet-col sheet-classcol" style="width: 120px;">
+
+        <strong>Base Playbooks</strong><br>
     		<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
 			<input type="checkbox" name="attr_class" class="sheet-class" value='The Aware' /><label style="width: 70%;">The Aware</label>
 			<input type="checkbox" name="attr_class" class="sheet-class" value='The Fae'/><label style="width: 70%;">The Fae</label>
@@ -31,11 +37,27 @@
 		</div>
 		<div class="sheet-col sheet-classcol" style="width: 120px;">
 			<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
-			<input type="checkbox" name="attr_class" class="sheet-class" value='The Tainted'/><label style="width: 70%;">The Tainted </label>
-			<input type="checkbox" name="attr_class" class="sheet-class" value='The Vamp'/><label style="width: 70%;">The Vamp </label>
-			<input type="checkbox" name="attr_class" class="sheet-class" value='The Veteran'/><label style="width: 70%;">The Veteran </label>
-			<input type="checkbox" name="attr_class" class="sheet-class" value='The Wizard'/><label style="width: 70%;">The Wizard </label>
-			<input type="checkbox" name="attr_class" class="sheet-class" value='The Wolf'/><label style="width: 70%;">The Wolf </label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Tainted'/><label style="width: 70%;">The Tainted</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Vamp'/><label style="width: 70%;">The Vamp</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Veteran'/><label style="width: 70%;">The Veteran</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Wizard'/><label style="width: 70%;">The Wizard</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Wolf'/><label style="width: 70%;">The Wolf</label>
+		</div>
+	</div>
+	<div class="sheet-2colrow" style="padding-left: 20px;">
+    	<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
+    	<div class="sheet-col sheet-classcol" style="width: 120px;">
+    	    <strong>Dark Streets</strong><br>
+    		<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Scholar' /><label style="width: 70%;">The Scholar</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Revenant'/><label style="width: 70%;">The Revenant</label>
+
+		</div>
+		<div class="sheet-col sheet-classcol" style="width: 120px;">
+			<input type='checkbox' name='attr_lock_class' class='sheet-lock' style="display: none;">
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Hallowed'/><label style="width: 70%;">The Hallowed</label>
+			<input type="checkbox" name="attr_class" class="sheet-class" value='The Vessel'/><label style="width: 70%;">The Vessel</label>
+
 		</div>
 	</div>
 
@@ -110,13 +132,17 @@
 					<input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
 					<input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
 					<input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
+					<input type="checkbox" name="attr_class" class="sheet-isscholar" value='The Scholar' style="display: none;"/>
+		            <input type="checkbox" name="attr_class" class="sheet-isrevenant" value='The Revenant'style="display: none;"/>
+	            	<input type="checkbox" name="attr_class" class="sheet-ishallowed" value='The Hallowed' style="display: none;"/>
+	            	<input type="checkbox" name="attr_class" class="sheet-isvessel" value='The Vessel' style="display: none;"/>
 					<!-- End Class Selected -->
 
 					<div class="sheet-aware">
 						<ul>
 							<b>Advances available at beginning of play:</b>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-6"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-7"/>+1 Heart (max blood+3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-7"/>+1 Heart (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-8"/>+1 Spirit (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-9"/>+1 Mind (max+3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_aware-improvement-10" />A new <b>Aware</b> move</label></li>
@@ -140,7 +166,7 @@
 						<ul>
 							<b>Advances available at beginning of play:</b>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-6"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-7"/>+1 Heart (max blood+3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-7"/>+1 Heart (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-8"/>+1 Spirit (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-9"/>+1 Mind (max+3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_fae-improvement-10" />A new <b>Fae</b> move</label></li>
@@ -164,7 +190,7 @@
 						<ul>
 							<b>Advances available at beginning of play:</b>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-6"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-7"/>+1 Heart (max blood+3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-7"/>+1 Heart (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-8"/>+1 Spirit (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-9" />A new <b>Hunter</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hunter-improvement-10" />A new <b>Hunter</b> move</label></li>
@@ -188,7 +214,7 @@
 						<ul>
 							<b>Advances available at beginning of play:</b>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-6"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-7"/>+1 Heart (max blood+3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-7"/>+1 Heart (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-8"/>+1 Spirit (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-9"/>+1 Mind (max+3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_oracle-improvement-10" />A new <b>Oracle</b> move</label></li>
@@ -211,9 +237,9 @@
 					<div class="sheet-spectre">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_blood_improve" value="1"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-8"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-9" />A new <b>spectre</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-10" />A new <b>spectre</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-11" />A move from another archetype</label></li>
@@ -235,16 +261,16 @@
 					<div class="sheet-tainted">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_heart_improve" value="1"/>+1 Heart (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-6"/>+1 Heart (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-8"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-9" />A new <b>Tainted</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-10" />A new <b>Tainted</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-11" />A move from another archetype</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-12" />A move from another archetype</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-13" />Change your <b>Faction</b></label></li>
 							<b>After 5 advances you may select:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spectre-improvement-14"/>+1 to any stat(max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-14"/>+1 to any stat(max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-15" />+1 to any Faction (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-16" />Erase a <b>Scar</b></label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_tainted-improvement-17" />Gain <b>Fiendish Underlings</b></label></li>
@@ -258,10 +284,10 @@
 					<div class="sheet-vamp">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_blood_improve" value="1"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_heart_improve" value="1"/>+1 Heart (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-7"/>+1 Heart (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-8"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-9"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-10" />A new <b>Vamp</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-11" />A new <b>Vamp</b></label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vamp-improvement-12" />A move from another archetype</label></li>
@@ -283,9 +309,9 @@
 					<div class="sheet-veteran">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_heart_improve" value="1"/>+1 Heart (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-6"/>+1 Heart (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-8"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-9" />A new <b>Veteran</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-10" />A new <b>Veteran</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_veteran-improvement-11" />Add 2 more features to your Workspace</label></li>
@@ -307,9 +333,9 @@
 					<div class="sheet-wizard" style="padding-left: 20px;">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_blood_improve" value="1"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-8"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-9" />Add 2 features to your Sanctum</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-10" />Take 3 more Spells</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wizard-improvement-11" />A move from another archetype</label></li>
@@ -330,9 +356,9 @@
 					<div class="sheet-wolf">
 						<ul>
 							<b>Advances available at beginning of play:</b>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_blood_improve" value="1"/>+1 Blood (max +3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_spirit_improve" value="1"/>+1 Spirit (max blood+3)</label></li>
-							<li><label class="sheet-improvement"><input type="checkbox" name="attr_mind_improve" value="1"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-8"/>+1 Mind (max +3)</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-9" />A new <b>Wolf</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-10" />A new <b>Wolf</b> move</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-11" />Add 2 qualities to your Transformation</label></li>
@@ -350,6 +376,99 @@
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-22" />Advance 3 basic moves</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-23" />Retire your character to safety</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_wolf-improvement-24" />Change to a new archetype</label></li>
+						</ul>
+					</div>
+					<div class="sheet-scholar">
+						<ul>
+							<b>Advances available at beginning of play:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-6"/>+1 Heart (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-8"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-9" />A new <b>Scholar</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-10" />A new <b>Scholar</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-11" />A move from another Archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-12" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-13" />Add two features to your arcane network</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-14" />Change your <b>Faction</b></label></li>
+							<b>After 5 advances you may select:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-15"/>+1 to any stat(max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-16" />+1 to any Faction (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-17" />Erase a <b>Scar</b></label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-18" />Take <b>Channeling</b> and two spells</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-19" />Erase a Corruption Advance</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-20" />Advance 3 basic moves</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-21" />Advance 3 basic moves</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-22" />Retire your character to safety</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_scholar-improvement-23" />Change to a new archetype</label></li>
+						</ul>
+					</div>
+					<div class="sheet-revenant">
+						<ul>
+							<b>Advances available at beginning of play:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-8"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-9" />Gain armor+1 ongoing</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-10" />A new <b>Revenant</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-11" />A new <b>Revenant</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-12" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-13" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-14" />Change your <b>Faction</b></label></li>
+							<b>After 5 advances you may select:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-15"/>+1 to any stat(max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-16" />+1 to any stat(max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-17" />+1 to any Faction (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-18" />Erase a <b>Scar</b></label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-19" />Erase a <b>Scar</b></label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-20" />Advance 3 basic moves</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-21" />Advance an underworld move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_revenant-improvement-22" />Advance an underworld move</label></li>
+						</ul>
+					</div>
+					<div class="sheet-hallowed">
+						<ul>
+							<b>Advances available at beginning of play:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-7"/>+1 Heart (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-8"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-9" />Add a feature to your flock</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-10" />Add a feature to your flock</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-11" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-12" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-13" />Erase a corruption advance</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-14" />Change your <b>Faction</b></label></li>
+							<b>After 5 advances you may select:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-15"/>+1 to any stat(max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-16" />+1 to any Faction (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-17" />Erase a <b>Scar</b></label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-18" />Erase a corruption advance</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-19" />Change to a new Archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-20" />Advance 3 basic moves</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-21" />Advance 3 basic moves</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_hallowed-improvement-22" />Take channeling and three Spells</label></li>
+						</ul>
+					</div>
+					<div class="sheet-vessel">
+						<ul>
+							<b>Advances available at beginning of play:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-6"/>+1 Blood (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-7"/>+1 Spirit (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-8"/>+1 Mind (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-9" />A new <b>Vessel</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-10" />A new <b>Vessel</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-11" />A new <b>Vessel</b> move</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-12" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-13" />A move from another archetype</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-14" />Change your <b>Faction</b></label></li>
+							<b>After 5 advances you may select:</b>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-15"/>+1 to any stat (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-16" />+1 to any stat (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-17" />+1 to any Faction (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-18" />+1 to any Faction (max +3)</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-19" />Erase a scar</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-20" />Erase a scar</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-21" />Join or lead a sphere of materia</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-improvement-22" />Advance 3 basic moves</label></li>
 						</ul>
 					</div>
 				</div>
@@ -374,6 +493,10 @@
 					<input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
 					<input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
 					<input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
+					<input type="checkbox" name="attr_class" class="sheet-isscholar" value='The Scholar' style="display: none;"/>
+		      <input type="checkbox" name="attr_class" class="sheet-isrevenant" value='The Revenant'style="display: none;"/>
+	        <input type="checkbox" name="attr_class" class="sheet-ishallowed" value='The Hallowed' style="display: none;"/>
+	        <input type="checkbox" name="attr_class" class="sheet-isvessel" value='The Vessel' style="display: none;"/>
 					<!-- End Class Selected -->
 
 					<div class="sheet-aware">
@@ -459,6 +582,41 @@
 							<li><b>End Move</b><br>When you die or retire your character, anyone in the scene you wish to protect escapes and reaches safety, no matter the odds.</li>
 						</ul>
 					</div>
+					<div class="sheet-scholar">
+						<ul>
+							<li><b>Scholar Corruption Move</b><br>When you exploit someone's ignorance of the arcane for personal gain, mark corruption.</li>
+							<li><b>Intimacy Move</b><br>When you share a moment of intimacy—physical or emotional—with another person, they get a Debt on you...and you have what they desire.
+							Ask them to name an item they have been seeking; that item has recently turned up in your arcane network.</li>
+							<li><b>End Move</b><br>When you die or retire your character, choose one character to inherit your collection of tomes and artifacts.
+							They gain the Private Collection move so long as they care for and protect these arcane holdings.</li>
+						</ul>
+					</div>
+					<div class="sheet-revenant">
+						<ul>
+							<li><b>Revenant Corruption Move</b><br>When you kill someone not marked by your caul, mark corruption</li>
+							<li><b>Intimacy Move</b><br>When you share a moment of intimacy—physical or emotional—with another person, ask them if you should be an agent of justice or vengeance. If they say
+                            justice, ask them how you could relieve the burdens they carry and take +1 ongoing to actions toward that end; if they say vengeance, mark corruption.</li>
+							<li><b>End Move</b><br>When you fill up on harm, your body ceases to function, but you do not die. Anyone who views your corpse with supernatural senses knows that you still
+                            live and how to bring you back, e.g., sprinkling graveyard dirt on your body, performing a lost ritual, etc. Your daemon may attempt to enlist someone else to facilitate your return.</li>
+						</ul>
+					</div>
+					<div class="sheet-hallowed">
+						<ul>
+							<li><b>Hallowed Corruption Move</b><br>When you violate the tenants of your faith (or through inaction allow them to be violated), mark corruption</li>
+							<li><b>Intimacy Move</b><br>When you share a moment of intimacy—physical or emotional—with another person, you choose whether or not their intimacy move triggers. If it doesn’t, tell them what mark or aspect of your faith keeps you distant from them.</li>
+							<li><b>End Move</b><br>When you die, you perform a powerful miracle of your faith. The innocent may rise, the wicked may fall, so on and so forth. You cannot prevent your own death.</li>
+						</ul>
+					</div>
+					<div class="sheet-vessel">
+						<ul>
+							<li><b>Vessel Redemption Move</b><br>When you resist serving your instincts to attend to your mortal relationships or responsibilities, mark redemption.</li>
+							<li><b>Intimacy Move</b><br>When you share a moment of intimacy—physical or emotional—with another person, ask them an invasive question about being human. If they answer the question honestly, mark redemption. If they deflect the inquiry or offer falsehoods, they must give you a Debt.</li>
+							<li><b>End Move</b><br>When you die, change playbooks, or retire your character, you leave something of your old body behind, containing a remnant of your instincts, as a permanent mark on the city.
+							Tell the MC which instinct became most central to your identity; the city will take that instinct into itself. Add the following option to let it out for all PCs:<br>
+                            »»Call upon the city to obey its instinct.</li>
+						</ul>
+					</div>
+
 				</div>
 
         	<label class="sheet-section-title">Factions</label>
@@ -557,34 +715,41 @@
 				<label class="sheet-harm sheet-section-title">A Member Of:</label>
 				<input type="text" name="attr_playerfaction"/>
 
-				<label class="sheet-harm sheet-section-title">Corruption</label>
-				<input type="checkbox" name="attr_corrupt1"/>
-				<input type="checkbox" name="attr_corrupt2"/>
-				<input type="checkbox" name="attr_corrupt3"/>
-				<input type="checkbox" name="attr_corrupt4"/>
-				<input type="checkbox" name="attr_corrupt5"/><br>
-				<ul>
-					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
-					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
-					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
-					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
-					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
-				</ul>
-				<label class="sheet-section-title">Corruption Moves</label>
+        <!-- Class Selected -->
+        <input type="checkbox" name="attr_class" class="sheet-isaware" value='The Aware' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isfae" value='The Fae' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-ishunter" value='The Hunter' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isoracle" value='The Oracle' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isspectre" value='The Spectre' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-istainted" value='The Tainted' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isvamp" value='The Vamp' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isscholar" value='The Scholar' style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-isrevenant" value='The Revenant'style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-ishallowed" value='The Hallowed' style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-isvessel" value='The Vessel' style="display: none;"/>
+        <!-- End Class Selected -->
 
-        		<!-- Class Selected -->
-				<input type="checkbox" name="attr_class" class="sheet-isaware" value='The Aware' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-isfae" value='The Fae' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-ishunter" value='The Hunter' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-isoracle" value='The Oracle' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-isspectre" value='The Spectre' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-istainted" value='The Tainted' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-isvamp" value='The Vamp' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
-				<input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
-				<!-- End Class Selected -->
+
+
+
 				<div class="sheet-aware">
+          <label class="sheet-harm sheet-section-title">Corruption</label>
+  				<input type="checkbox" name="attr_corrupt1"/>
+  				<input type="checkbox" name="attr_corrupt2"/>
+  				<input type="checkbox" name="attr_corrupt3"/>
+  				<input type="checkbox" name="attr_corrupt4"/>
+  				<input type="checkbox" name="attr_corrupt5"/><br>
+  				<ul>
+  					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+  					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+  					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+  					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+  					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+  				</ul>
+  				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>In Too Deep:</b>When a non-Mortal tries to <b><i>Lend You a Hand</i></b> or <b><i>Get in Your Way</i></b>, mark corruption to add or subtract 3 from their roll.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Eyes On The Door:</b>When in danger from the supernatural you can mark corruption to <b><i>Escape</i></b> as if you rolled a 12+.</label></li>
@@ -593,6 +758,20 @@
 						</ul>
 					</div>
 					<div class="sheet-fae">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Gach Cumhacht:</b>You gain the remaining faerie powers. When you use <b><i>Faerie Magic</i></b>, you may no longer choose to suffer harm.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Shrewd Negotiator:</b>When you roll a 10+ to <b><i>Refuse to Honor a Debt</i></b>, mark corruption to cancel the original Debt and claim a Debt from the person you refused.</label></li>
@@ -601,6 +780,20 @@
 						</ul>
 					</div>
 					<div class="sheet-hunter">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Divided I Stand:</b>When you turn down help and enter a dangerous situation alone, mark corruption and advance <b><i>Unleash</i></b> and <b><i>Keep Your Cool</i></b> for the scene.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Hard to Kill:</b>Choose a Faction. Mark corruption to gain armor +1 against that Faction until the end of the scene.</label></li>
@@ -609,6 +802,20 @@
 						</ul>
 					</div>
 					<div class="sheet-oracle">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Empath:</b>When you <b><i>Figure Someone Out, Skim the Surface,</i></b> or use <b><i>Psychometry</i></b>, mark corruption to ask any questions you'd like, not limited to the lists.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>I, All-Seeing:</b>Mark corruption and suffer 1-harm (ap) to have a vision about the situation at hand. Ask the MC a question; they will answer it honestly.</label></li>
@@ -621,6 +828,20 @@
 						</ul>
 					</div>
 					<div class="sheet-spectre">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Possession:</b>Mark corruption to enter the mind of a weak-minded person (MC's call) in your presence and control their movements and speech for a short time.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Telekinesis:</b>You can move and lift small objects at a distance by concentrating. Mark corruption to move an object up to the size of a car.</label></li>
@@ -629,6 +850,20 @@
 						</ul>
 					</div>
 					<div class="sheet-tainted">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Fringe Benefits:</b>Mark corruption to Drop the Name of your demonic patron as if you rolled a 10+. You don't have to have a Debt on your patron to use the move.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Just Below the Surface:</b>Mark corruption to assume your demon form without a roll and gain all the options listed.</label></li>
@@ -637,6 +872,20 @@
 						</ul>
 					</div>
 					<div class="sheet-vamp">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>True Hunter:</b>Mark corruption when pursuing a human NPC</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Adaptable Palate:</b>You can feed on any creature, not just humans. Feeding on something wildly different than a human will have unexpected side effects</label></li>
@@ -645,6 +894,20 @@
 						</ul>
 					</div>
 					<div class="sheet-veteran">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Back At It:</b>Take a standard move and a corruption move from another archetype. Whenever you use those moves, mark corruption.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Pack Rat:</b>You may mark corruption to reach into your kit and find just the thing you need to deal with your current situation.</label></li>
@@ -657,6 +920,20 @@
 						</ul>
 					</div>
 					<div class="sheet-wizard" style="padding-left: 20px;">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>The Dark Arts:</b>When you <b><i>Unleash</i></b> with magic or psychic energies, mark corruption to roll with Spirit instead of Blood</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Upon a Pale Horse:</b>Mark corruption and speak the true name of an NPC in the scene to inflict 3-harm (ap) on them.</label></li>
@@ -665,11 +942,142 @@
 						</ul>
 					</div>
 					<div class="sheet-wolf">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
 						<ul>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>One with the Beast:</b>Mark corruption to add 2 qualities to the Transformation until the end of the session.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Force of Nature:</b>You get +1 Blood (max +4). Whenever you roll with Blood and get a 12+, mark corruption.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption3"/><b>Sun and Moon:</b>Mark corruption to transform into your wolf form at will.</label></li>
 							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption4"/><b>Familiar Territory:</b>Mark corruption to know the source of the greatest danger to your territory, even if it has concealed itself with magic or misdirection.</label></li>
+						</ul>
+					</div>
+          <div class="sheet-wolf">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
+						<ul>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>One with the Beast:</b>Mark corruption to add 2 qualities to the Transformation until the end of the session.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Force of Nature:</b>You get +1 Blood (max +4). Whenever you roll with Blood and get a 12+, mark corruption.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption3"/><b>Sun and Moon:</b>Mark corruption to transform into your wolf form at will.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption4"/><b>Familiar Territory:</b>Mark corruption to know the source of the greatest danger to your territory, even if it has concealed itself with magic or misdirection.</label></li>
+						</ul>
+					</div>
+          <div class="sheet-scholar">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a Corruption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
+						<ul>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Occupational Hazards:</b>Mark corruption to <b>keep your cool</b> with Mind instead of Spirit when faced with arcance or supernatural threats.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>In the Bag:</b>Mark corruption after successfully <b>escaping a situation</b> to reveal that you pilfered an arcane object from the previous scene.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption3"/><b>Don't Trust Anyone:</b>When someone double-crosses you, mark corruption to reveal how you already planned for their sudden but inevitable betrayal. You immediately gain the upper hand in the situation.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption4"/><b>Interested Parties:</b>When you are outnumbered, outgunned, or surprised, mark corruption for a third party interested in your dealings to interrupt the proceedings. Their intrusion creates an opportunity for you, but you might be going from the frying pan into the fire.</label></li>
+						</ul>
+					</div>
+          <div class="sheet-revenant">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Strike out <b>escape a situation</b>; take <b>Against the Wall</b></label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Strike out <b>figure someone out</b>; take <b>Dig for Answers</b></label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Strike out <b>mislead, distract, or trick</b>; take <b>Haunt the Darkness</b></label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Retire your character. They may return as a Threat</label></li>
+    				</ul>
+					</div>
+          <div class="sheet-hallowed">
+            <label class="sheet-harm sheet-section-title">Corruption</label>
+    				<input type="checkbox" name="attr_corrupt1"/>
+    				<input type="checkbox" name="attr_corrupt2"/>
+    				<input type="checkbox" name="attr_corrupt3"/>
+    				<input type="checkbox" name="attr_corrupt4"/>
+    				<input type="checkbox" name="attr_corrupt5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance1"/>Take a corruption advance for your flock</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance2"/>Take a corruption advance for your flock</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance3"/>Take a corruption advance for your flock</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance4"/>Take a Corruption move from another archetype</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruptadvance5"/>Change playbooks to any Mortality playbook; your flock is now a Threat</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Corruption Moves</label>
+						<ul>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption1"/><b>Rites and Rituals:</b>Your flock, gathered and united, forms a powerful spiritual tool or weapon,
+                a sanctum (Urban Shadows, page 128) that allows you to perform magical rituals and create powerfully blessed objects.
+                When the GM tells you what you need to complete the ritual, you may ignore one of the requirements if you convince a member of your flock to give life or limb to the ceremony or mark corruption yourself.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption2"/><b>Augury:</b>Your flock, gathered and united, gives you insight into the ley lines and power centers of the city;
+                when you pray with them, you may investigate a place of power at any distance, provided you are willing to make an appropriate sacrifice to your faith or mark corruption.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption3"/><b>Infallible:</b>Your flock no longer questions your instructions or advice, following your will as best they can without violating the tenets of your faith.
+                When you call your flock to action, persuade one of its members, or mislead, distract, or trick them, treat a 7-9 as a 10+ result. Mark corruption to extend this effect to requests that violate the tenets of your faith.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_corruption4"/><b>Apocalypto:</b>Your flock is truly prepared for days of trial and tribulation: add +1 size, +1 armor, +1 harm, and +fanatical.
+                At the end of a session, mark corruption if you did not lead your flock in punishing unbelievers or heretics during the session.</label></li>
+						</ul>
+					</div>
+          <div class="sheet-vessel">
+            <label class="sheet-harm sheet-section-title">Redemption</label>
+            You don’t have a corruption track. Instead, you have the opportunity for redemption.
+            Each time your redemption track fills, mark a redemption advance. When your redemption track fills and you have no more redemption advances to mark, retire your character to safety or change to a Mortality Archetype.
+            If a move asks you to mark corruption, mark 1-harm (ap) instead.
+    				<input type="checkbox" name="attr_vessel-redemption1"/>
+    				<input type="checkbox" name="attr_vessel-redemption2"/>
+    				<input type="checkbox" name="attr_vessel-redemption3"/>
+    				<input type="checkbox" name="attr_vessel-redemption4"/>
+    				<input type="checkbox" name="attr_vessel-redemption5"/><br>
+    				<ul>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance1"/>Rewrite an instinct</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance2"/>Rewrite an instinct</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance3"/>Rewrite an instinct</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance4"/>Take a redemption move</label></li>
+    					<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance5"/>Take a redemption move</label></li>
+              <li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionadvance5"/>Take a redemption move</label></li>
+    				</ul>
+    				<label class="sheet-section-title">Redemption Moves</label>
+						<ul>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionmove1"/><b>Among the Sheep:</b>When you try to disappear in a crowd, roll with Blood. On a 10+, you vanish into the crowd without a trace; take +1 ongoing if you make use of your concealment.
+                On a 7-9, you are silent and invisible, but your deception is fragile and incomplete. On a miss, you’re clearly the wolf. Even the crowd knows it.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionmove2"/><b>Like Them:</b>When you try to figure out a member of Mortality, roll with Spirit instead of Mind.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionmove3"/><b>Absolution:</b>When you convince someone to be honest with you about their problems, roll with Spirit.
+                On a hit, you may take one Debt they owe (related to the problem) as your own if you promise to see it through. On a 10+, mark redemption when you honor the Debt.
+                On a miss, their problems confuse and perplex you; you owe them a Debt for trying to get mixed up in their business.</label></li>
+							<li><label class="sheet-improvement"><input type="checkbox" name="attr_vessel-redemptionmove4"/><b>Heartfelt:</b>Replace your existing intimacy move with the following:
+                When you share a moment of intimacy—physical or emotional—with another person, share one of your human experiences as you understand it.
+                If they reciprocate, mark redemption. If they refuse, they must give you a Debt.</b></label></li>
 						</ul>
 					</div>
 
@@ -693,18 +1101,7 @@
         	</div>
 
         	<div class="sheet-box">
-        	<!-- Class Selected -->
-			<input type="checkbox" name="attr_class" class="sheet-isaware" value='The Aware' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-isfae" value='The Fae' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-ishunter" value='The Hunter' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-isoracle" value='The Oracle' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-isspectre" value='The Spectre' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-istainted" value='The Tainted' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-isvamp" value='The Vamp' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
-			<input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
-			<!-- End Class Selected -->
+
 
         	<label class="sheet-other sheet-section-title">Other:</label>
 
@@ -728,6 +1125,10 @@
 				<input type="checkbox" name="attr_class" class="sheet-isveteran" value='The Veteran' style="display: none;" />
 				<input type="checkbox" name="attr_class" class="sheet-iswizard" value='The Wizard' style="display: none;" />
 				<input type="checkbox" name="attr_class" class="sheet-iswolf" value='The Wolf' style="display: none;" />
+        <input type="checkbox" name="attr_class" class="sheet-isscholar" value='The Scholar' style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-isrevenant" value='The Revenant'style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-ishallowed" value='The Hallowed' style="display: none;"/>
+        <input type="checkbox" name="attr_class" class="sheet-isvessel" value='The Vessel' style="display: none;"/>
 				<!-- End Class Selected -->
 
 				<div class="sheet-fae">
@@ -790,13 +1191,73 @@
 					<textarea name="attr_territory"></textarea>
 
 				</div>
-		</div>
-	</div>
-	</div>
+        <div class="sheet-scholar">
+          <b>Arcane Network Features and Members</b><textarea name="attr_arcanenetwork"></textarea>
+          When you <b>cash in a Debt</b> with a member of your arcane network to obtain a worthy and useful gift without cost, they must offer you three things. Pick the one you want, but the others will never be “free” again.<br>
+          When you <br>hit the streets</br> to consult your arcane network, you can roll with Mind instead of Mortality. Mark Mortality as normal. In addition, add this option to the 7-9 list:<br>
+          »»You owe them an object you haven’t yet acquired<br>
+          When you <br>refuse to honor a Debt</b> to someone to whom you’ve previously sold arcane objects, add this option to the 7-9 list:<br>
+          »»Promise to secure a valuable object for them<br>
+          <b>Your Private Collection</b>
+          What is your most prized possession? <textarea name="attr_prizedpossession"></textarea>
+          When you retreat to your private collection to research an occult occurrence, object, or individual, roll with Mind. On a 10+, pick 3. On a 7-9, pick 1.<br>
+          »»You discover a previously unknown weakness or vulnerability<br>
+          »»You discover a previously unknown resource or ally<br>
+          »»You don’t attract any supernatural attention to your research<br>
+          On a miss, you discover something terrible in your research that spells doom for you, your friends...or the city itself.
+        </div>
+        <div class="sheet-revenant">
+          <b>Your Caul</b><br>
+          On whom do you seek revenge?<textarea name="attr_caul"></textarea>
+          When you <b>punish one of them absolutely</b>—however you see fit—strike their
+          name from the list. Your daemon will tell you if the punishment is fitting; if it is,
+          advance. If it isn’t, you owe your daemon a Debt.<br>
+          When you ask your daemon to <b>add someone who has wronged you to
+          your caul</b>, roll with Spirit. On a hit, your daemon acquiesces to your request.
+          On a 10+, your daemon reveals how you might attack their vulnerabilities or
+          weaknesses. On a miss, that person is beyond your reach; take -1 ongoing
+          against them until you offer them forgiveness for the wrongs they have done
+          to you.
+          When you <b>cross out all the names in your caul</b>, your connection to the land
+          of the dead is severed. Your daemon returns to the spirit realm; you are no
+          longer able to avoid the land of the dead if you are killed. You can lay your
+          own soul to rest by returning your physical form to its final resting place.<br>
+          <b>Your Daemon</b><br>
+          Describe your daemon<textarea name="attr_daemon"></textarea>
+          When your <b>daemon stands with you in battle</b>, take armor+1. Your daemon will only follow you in the pursuit of your caul or to fulfill a Debt.
 
-	<textarea name="attr_charnotes" placeholder="Use this space for your notes, hold, and anything else!"></textarea>
+	       </div>
+         <div class="sheet-hallowed">
+           <b>Your Flock</b><br>
+           Describe your flock: the community, your meeting place, your rituals and traditions, their stats, your starting choices. <textarea name="attr_flock"></textarea><br>
+           Your flock is connected to you through a psychic link that offers you unparalleled access:
+           you can let it out to try to listen in on specific members’ thoughts; cash in Debts as if a member of your flock was right in front of you; call your flock to action at a distance;
+           or even mark corruption to take on the physical appearance of a member of your flock for a scene.<br>
+           At the start of each session, take one Debt against your flock as a whole, provided you were available to perform your religious duties;
+           you can cash the Debt in with any member of your flock, even other PCs.<br>
+           <b>Tenants of Your Faith</b><br>
+           List the tenants of your faith:<br>
+           <input type="text" name="attr_tenent1"/><br>
+           <input type="text" name="attr_tenent2"/><br>
+           Violating any tenet of your faith in the presence of your flock—or if they find out later that you violated one of the tenets—
+           immediately gives them a Debt over you. Any member of the flock can cash in the Debt with you, even if they weren’t the one who witnessed or discovered the violation.<br>
+        </div>
+
+         <div class="sheet-vessel">
+           <b>Materials</b><br>
+           What material makes up your component parts?<input type="text" name="attr_materials"><br>
+           Once per session, you can heal up to 2-harm by consuming a copious quantity of the materials of which you are made. Anyone who witnesses the consumption sees your true form.<br>
+           <b>Instincts</b><br>
+           List your instincts:<textarea name="attr_instincts"></textarea><br>
+           Resisting an opportunity to fulfill your instinct counts as keeping your cool.
+           If a redemption advance allows you to rewrite an instinct, cross it out and write a new instinct of your own choosing. The old one no longer bothers you.
+         </div>
+	</div>
 </div>
 
+</div>
+<textarea name="attr_charnotes" placeholder="Use this space for your notes, hold, and anything else!"></textarea>
+</div>
 <!-- ROLL TEMPLATES -->
 <rolltemplate class="sheet-rolltemplate-us">
     <table>

--- a/Urban_Shadows/sheet.json
+++ b/Urban_Shadows/sheet.json
@@ -2,8 +2,7 @@
 	"html": "sheet.html",
 	"css": "style.css",
 	"authors": "Changes for Urban Shadows made by Adam Brenner(@tuxtradamus), Original Apocalypse World sheet and most of the hard work done by Ryan Sigg (@ryansigg), Steve K.",
-   "roll20userid": "229266,13601,5047",
-   "preview": "preview.png",
-	"instructions": "Version: 1.1 - Cleaned up some divs, now updated with Dark Streets playbooks.
-	Select your class, then check 'Lock/Unlock Class'. Drama Moves, improvements, corruption, and special playbook features will appear, then simply fill everything out per the Character Creation in the Playbook. Please add feature requests or suggestions to the [issue tracker](https://github.com/tuxtradamus/roll20-character-sheets/issues)."
+	"roll20userid": "229266,13601,5047",
+	"preview": "preview.png",
+	"instructions": "Version: 1.1 - Cleaned up some divs, now updated with Dark Streets playbooks. Select your class, then check 'Lock/Unlock Class'. Drama Moves, improvements, corruption, and special playbook features will appear, then simply fill everything out per the Character Creation in the Playbook. Please add feature requests or suggestions to the [issue tracker](https://github.com/tuxtradamus/roll20-character-sheets/issues)."
 }

--- a/Urban_Shadows/sheet.json
+++ b/Urban_Shadows/sheet.json
@@ -4,5 +4,6 @@
 	"authors": "Changes for Urban Shadows made by Adam Brenner(@tuxtradamus), Original Apocalypse World sheet and most of the hard work done by Ryan Sigg (@ryansigg), Steve K.",
    "roll20userid": "229266,13601,5047",
    "preview": "preview.png",
-	"instructions": "Select your class, then check 'Lock/Unlock Class'. Drama Moves, improvements, corruption, and special playbook features will appear, then simply fill everything out per the Character Creation in the Playbook. Feature requests or suggestions, pls add them to the [issue tracker](https://github.com/tuxtradamus/roll20-character-sheets/issues)." 
+	"instructions": "Version: 1.1 - Cleaned up some divs, now updated with Dark Streets playbooks.
+	Select your class, then check 'Lock/Unlock Class'. Drama Moves, improvements, corruption, and special playbook features will appear, then simply fill everything out per the Character Creation in the Playbook. Please add feature requests or suggestions to the [issue tracker](https://github.com/tuxtradamus/roll20-character-sheets/issues)."
 }

--- a/Urban_Shadows/style.css
+++ b/Urban_Shadows/style.css
@@ -164,7 +164,11 @@ input[name="attr_movedesc"]{
 .sheet-vamp,
 .sheet-veteran,
 .sheet-wizard,
-.sheet-wolf, {
+.sheet-wolf,
+.sheet-scholar,
+.sheet-revenant,
+.sheet-hallowed,
+.sheet-vessel, {
 	display: none;
 }
 
@@ -207,7 +211,11 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
 .sheet-isvamp:checked ~ .sheet-vamp,
 .sheet-isveteran:checked ~ .sheet-veteran,
 .sheet-iswizard:checked ~ .sheet-wizard,
-.sheet-iswolf:checked ~ .sheet-wolf, {
+.sheet-iswolf:checked ~ .sheet-wolf,
+.sheet-isscholar:checked ~ .sheet-scholar,
+.sheet-isrevenant:checked ~ .sheet-revenant,
+.sheet-ishallowed:checked ~ .sheet-hallowed,
+.sheet-isvessel:checked ~ .sheet-vessel, {
 	display: block;
 }
 


### PR DESCRIPTION
A new supplement was released that introduced four new playbooks, that data has been added into the sheets.

I've swapped Corruption to load with the rest of the specific playbook information, as the new playbooks change around that mechanic so there are some specific versions now.

Moved notes section to stretch whole sheet instead of residing in the third column.