### PR TITLE
Fixing the styling of Rogue Trader ship sheet

### DIFF
--- a/Rogue_Trader/RogueTrader.html
+++ b/Rogue_Trader/RogueTrader.html
@@ -747,231 +747,232 @@
 <!-- Shipsheet begin -->
 <div class="sheet-switch-npc">
     <div class="sheet-wrapper">
-        <div class="sheet-2colrow">
-            <!-- left col -->
-            <div class="sheet-col">
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-little"><label>Name</label></div>
-                    <div class="sheet-item sheet-small"><input type="text" name="attr_shipname" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-little"><label>Class</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_type" /></div>
-                    <div class="sheet-item sheet-little"><label>Hull</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_hull" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-little"><label>Speed</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_speed" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-little"><label>Manoeuvrability</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_steering" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-little"><label>Detection</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_detection" /></div>
-                </div>
-                <h3>Essential Components</h3>
-
-                <input type="text" name="attr_fixbasicelement" />
-                <fieldset class="repeating_basicelement">
-                    <input type="text" name="attr_repbasicelement" />
-                </fieldset>
-
-                <h3>Supplemental Components</h3>
-
-                <input type="text" name="attr_fixannexelement" />
-                <fieldset class="repeating_annexelement">
-                    <input type="text" name="attr_repannexelement" />
-                </fieldset>
-
-                <h3>Complications/Past History</h3>
-
-                <input type="text" name="attr_fixsingularitypasthistory" />
-                <fieldset class="repeating_singularitypasthistory">
-                    <input type="text" name="attr_repsingularitypasthistory" />
-                </fieldset>
-
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-med"><label>Turret Rating</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_turret" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-small"><label>Shields</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_shield" /></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item sheet-small"><label>Armour</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_armor" /></div>
-                </div>
-                <div class="sheet-col sheet-skills">
-                    <hr>
-
-                    <table>
-                        <tr>
-                            <th>Hull Integrity</th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_totalhull" /></div>
-                            </th>
-                            <th></th>
-                            <th></th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_actualhull" /></div>
-                            </th>
-                        </tr>
-                        <tr>
-                            <th></th>
-                            <th>Total</th>
-                            <th></th>
-                            <th></th>
-                            <th>Current</th>
-                        </tr>
-                        <tr> </tr>
-                        <tr>
-                            <th>Space Available</th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_availablespace" /></div>
-                            </th>
-                            <th></th>
-                            <th>Power Available</th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_availableenergy" /></div>
-                            </th>
-                        </tr>
-                        <tr>
-                            <th>Space Used</th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_usedspace" /></div>
-                            </th>
-                            <th></th>
-                            <th>Power Used</th>
-                            <th>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_usedenergy" /></div>
-                            </th>
-                        </tr>
-                        <tr></tr>
-                    </table>
-                    <table>
-                        <tr>
-                            <th>Weapon Capacity</th>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_dorsal" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><label>Dorsal</label></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_prow" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><label>Prow</label></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_keel" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><label>Keel</label></div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th></th>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_port" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><label>Port</label></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_starboard" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><label>Starboard</label></div>
-                            </td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                    </table>
-                </div>
-
-                <table>
-                    <tr>
-                        <th> </th>
-                        <th>Weapons</th>
-                        <th> </th>
-                        <th> </th>
-                        <th> </th>
-                        <th> </th>
-                        <th>Location</th>
-                    </tr>
-                    <tr>
-                        <th></th>
-                        <th></th>
-                        <th>
-                            <div class="sheet-item sheet-small"><label>Strength</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-small"><label>Crit Rating</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Damage</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Range</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Dorsal</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Prow</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Keel</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Port</label></div>
-                        </th>
-                        <th>
-                            <div class="sheet-item sheet-little"><label>Starboard</label></div>
-                        </th>
-                    </tr>
-                    <tr>
-                        <fieldset class="repeating_shipweapon">
-                            <td>
-                                <div class="sheet-item sheet-med">
-                                    <select name="attr_shipweaponstyle1" class="charaselect">
-                                <option ><div class="sheet-item sheet-small">Macrobattery</div></option>
-                                <option ><div class="sheet-item sheet-small">Lance</div></option>
-                                </select>
-                                </div>
-                            </td>
-
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_shipweapon1" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_shipweaponstrenght" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_shipweaponcritical" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_shipweapondamage" /></div>
-                            </td>
-                            <td>
-                                <div class="sheet-item sheet-small"><input type="text" name="attr_shipweaponrange" /></div>
-                            </td>
-                            <td><input type="checkbox" name="attr_Weapondorsal1" /></td>
-                            <td><input type="checkbox" name="attr_Weaponprow1" /></td>
-                            <td><input type="checkbox" name="attr_Weaponkeel1" /></td>
-                            <td><input type="checkbox" name="attr_Weaponport1" /></td>
-                            <td><input type="checkbox" name="attr_Weaponstarbord1" /></td>
-                        </fieldset>
-
-                    </tr>
-
-                </table>
-            </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Name</label></div>
+            <div class="sheet-item sheet-small"><input type="text" name="attr_shipname" /></div>
         </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Class</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_type" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Hull</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_hull" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Speed</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_speed" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Manoeuvrability</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_steering" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Detection</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_detection" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Turret Rating</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_turret" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Shields</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_shield" /></div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-item sheet-small"><label>Armour</label></div>
+            <div class="sheet-item sheet-little"><input type="text" name="attr_armor" /></div>
+        </div>
+        <h3>Essential Components</h3>
+
+        <input type="text" name="attr_fixbasicelement" />
+        <fieldset class="repeating_basicelement">
+            <input type="text" name="attr_repbasicelement" />
+        </fieldset>
+
+        <h3>Supplemental Components</h3>
+
+        <input type="text" name="attr_fixannexelement" />
+        <fieldset class="repeating_annexelement">
+            <input type="text" name="attr_repannexelement" />
+        </fieldset>
+
+        <h3>Complications/Past History</h3>
+
+        <input type="text" name="attr_fixsingularitypasthistory" />
+        <fieldset class="repeating_singularitypasthistory">
+            <input type="text" name="attr_repsingularitypasthistory" />
+        </fieldset>
+
+        <div class="sheet-col sheet-skills">
+            <hr>
+
+            <table>
+                <tr>
+                    <th>Hull Integrity</th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_totalhull" /></div>
+                    </th>
+                    <th></th>
+                    <th></th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_actualhull" /></div>
+                    </th>
+                </tr>
+                <tr>
+                    <th></th>
+                    <th>Total</th>
+                    <th></th>
+                    <th></th>
+                    <th>Current</th>
+                </tr>
+                <tr> </tr>
+                <tr>
+                    <th>Space Available</th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_availablespace" /></div>
+                    </th>
+                    <th></th>
+                    <th>Power Available</th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_availableenergy" /></div>
+                    </th>
+                </tr>
+                <tr>
+                    <th>Space Used</th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_usedspace" /></div>
+                    </th>
+                    <th></th>
+                    <th>Power Used</th>
+                    <th>
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_usedenergy" /></div>
+                    </th>
+                </tr>
+                <tr></tr>
+            </table>
+            <table class="sheet-ship-weaponcap">
+                <tr>
+                    <th>Weapon Capacity</th>
+                    <td>
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_dorsal" /></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-med"><label>Dorsal</label></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_prow" /></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-med"><label>Prow</label></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_keel" /></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-med"><label>Keel</label></div>
+                    </td>
+                </tr>
+                <tr>
+                    <th></th>
+                    <td>
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_port" /></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-med"><label>Port</label></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_starboard" /></div>
+                    </td>
+                    <td>
+                        <div class="sheet-item sheet-med"><label>Starboard</label></div>
+                    </td>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </table>
+        </div>
+
+        <table class="sheet-ship-weapons">
+            <tr>
+                <th> </th>
+                <th>Weapons</th>
+                <th> </th>
+                <th> </th>
+                <th> </th>
+                <th> </th>
+                <th>Location</th>
+            </tr>
+            <tr>
+                <th class="sheet-ship-weapon-type">
+                    <div class="sheet-item sheet-small"><label>Type</label></div>
+                </th>
+                <th class="sheet-ship-weapon-name">
+                    <div class="sheet-item sheet-small"><label>Name</label></div>
+                </th>
+                <th class="sheet-ship-weapon-strength">
+                    <div class="sheet-item sheet-small"><label>Strength</label></div>
+                </th>
+                <th class="sheet-ship-weapon-critical">
+                    <div class="sheet-item sheet-small"><label>Crit Rating</label></div>
+                </th>
+                <th class="sheet-ship-weapon-damage">
+                    <div class="sheet-item sheet-little"><label>Damage</label></div>
+                </th>
+                <th class="sheet-ship-weapon-range">
+                    <div class="sheet-item sheet-little"><label>Range</label></div>
+                </th>
+                <th class="sheet-ship-weapon-mount">
+                    <div class="sheet-item sheet-little"><label>Dorsal</label></div>
+                </th>
+                <th class="sheet-ship-weapon-mount">
+                    <div class="sheet-item sheet-little"><label>Prow</label></div>
+                </th>
+                <th class="sheet-ship-weapon-mount">
+                    <div class="sheet-item sheet-little"><label>Keel</label></div>
+                </th>
+                <th class="sheet-ship-weapon-mount">
+                    <div class="sheet-item sheet-little"><label>Port</label></div>
+                </th>
+                <th class="sheet-ship-weapon-mount">
+                    <div class="sheet-item sheet-little"><label>Starboard</label></div>
+                </th>
+            </tr>
+            <tr>
+                <fieldset class="repeating_shipweapon">
+                    <td class="sheet-ship-weapon-type">
+                        <div class="sheet-item sheet-huge">
+                            <select name="attr_shipweaponstyle1" class="charaselect">
+                        <option ><div class="sheet-item sheet-small">Macrobattery</div></option>
+                        <option ><div class="sheet-item sheet-small">Lance</div></option>
+                        </select>
+                        </div>
+                    </td>
+
+                    <td class="sheet-ship-weapon-name">
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_shipweapon1" /></div>
+                    </td>
+                    <td class="sheet-ship-weapon-strength">
+                        <div class="sheet-item sheet-med"><input type="text" name="attr_shipweaponstrenght" /></div>
+                    </td>
+                    <td class="sheet-ship-weapon-critical">
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_shipweaponcritical" /></div>
+                    </td>
+                    <td class="sheet-ship-weapon-damage">
+                        <div class="sheet-item sheet-huge"><input type="text" name="attr_shipweapondamage" /></div>
+                    </td>
+                    <td class="sheet-ship-weapon-range">
+                        <div class="sheet-item sheet-small"><input type="text" name="attr_shipweaponrange" /></div>
+                    </td>
+                    <td class="sheet-ship-weapon-mount"><input type="checkbox" name="attr_Weapondorsal1" /></td>
+                    <td class="sheet-ship-weapon-mount"><input type="checkbox" name="attr_Weaponprow1" /></td>
+                    <td class="sheet-ship-weapon-mount"><input type="checkbox" name="attr_Weaponkeel1" /></td>
+                    <td class="sheet-ship-weapon-mount"><input type="checkbox" name="attr_Weaponport1" /></td>
+                    <td class="sheet-ship-weapon-mount"><input type="checkbox" name="attr_Weaponstarbord1" /></td>
+                </fieldset>
+
+            </tr>
+
+        </table>
     </div>
 </div>

--- a/Rogue_Trader/RogueTrader.html
+++ b/Rogue_Trader/RogueTrader.html
@@ -752,7 +752,7 @@
             <div class="sheet-col">
                 <div class="sheet-row">
                     <div class="sheet-item sheet-little"><label>Name</label></div>
-                    <div class="sheet-item sheet-little"><input type="text" name="attr_shipname" /></div>
+                    <div class="sheet-item sheet-small"><input type="text" name="attr_shipname" /></div>
                 </div>
                 <div class="sheet-row">
                     <div class="sheet-item sheet-little"><label>Class</label></div>
@@ -792,12 +792,9 @@
                 <fieldset class="repeating_singularitypasthistory">
                     <input type="text" name="attr_repsingularitypasthistory" />
                 </fieldset>
-            </div>
-            <!-- right col -->
 
-            <div class="sheet-col">
                 <div class="sheet-row">
-                    <div class="sheet-item sheet-small"><label>Turret Rating</label></div>
+                    <div class="sheet-item sheet-med"><label>Turret Rating</label></div>
                     <div class="sheet-item sheet-little"><input type="text" name="attr_turret" /></div>
                 </div>
                 <div class="sheet-row">
@@ -815,12 +812,12 @@
                         <tr>
                             <th>Hull Integrity</th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_totalhull" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_totalhull" /></div>
                             </th>
                             <th></th>
                             <th></th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_actualhull" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_actualhull" /></div>
                             </th>
                         </tr>
                         <tr>
@@ -834,23 +831,23 @@
                         <tr>
                             <th>Space Available</th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_availablespace" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_availablespace" /></div>
                             </th>
                             <th></th>
                             <th>Power Available</th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_availableenergy" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_availableenergy" /></div>
                             </th>
                         </tr>
                         <tr>
                             <th>Space Used</th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_usedspace" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_usedspace" /></div>
                             </th>
                             <th></th>
                             <th>Power Used</th>
                             <th>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_usedenergy" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_usedenergy" /></div>
                             </th>
                         </tr>
                         <tr></tr>
@@ -859,37 +856,37 @@
                         <tr>
                             <th>Weapon Capacity</th>
                             <td>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_dorsal" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_dorsal" /></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><label>Dorsal</label></div>
+                                <div class="sheet-item sheet-small"><label>Dorsal</label></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_prow" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_prow" /></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><label>Prow</label></div>
+                                <div class="sheet-item sheet-small"><label>Prow</label></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_keel" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_keel" /></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><label>Keel</label></div>
+                                <div class="sheet-item sheet-small"><label>Keel</label></div>
                             </td>
                         </tr>
                         <tr>
                             <th></th>
                             <td>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_port" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_port" /></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><label>Port</label></div>
+                                <div class="sheet-item sheet-small"><label>Port</label></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><input type="text" name="attr_starboard" /></div>
+                                <div class="sheet-item sheet-small"><input type="text" name="attr_starboard" /></div>
                             </td>
                             <td>
-                                <div class="sheet-item sheet-little"><label>Starboard</label></div>
+                                <div class="sheet-item sheet-small"><label>Starboard</label></div>
                             </td>
                             <td></td>
                             <td></td>

--- a/Rogue_Trader/RogueTraderStyle.css
+++ b/Rogue_Trader/RogueTraderStyle.css
@@ -22,6 +22,41 @@
     border-spacing: 0;
 }
 
+/*Special styling to make the weapon list work*/
+.sheet-ship-weapons th{
+	text-align: left;
+}
+.charsheet .sheet-wrapper .sheet-ship-weapon-type div {
+    min-width: 110px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-name div {
+    min-width: 100px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-strength div {
+    min-width: 10px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-critical div {
+    min-width: 74px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-damage div {
+    min-width: 60px
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-range div {
+    min-width: 50px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weapon-mount div {
+    min-width: 40px;
+}
+
+.charsheet .sheet-wrapper .sheet-ship-weaponcap div {
+    min-width: 80px;
+}
 .charsheet .sheet-wrapper input::-webkit-outer-spin-button,
 .charsheet .sheet-wrapper input::-webkit-inner-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
The old ship sheets in Rogue Trader were almost unusable. You could add names and components, but the weapon fields were just tiny and impossible to put info into/read. I moved the fields around a bit and added some CSS to make the fields for the weapons wide enough to read. Particularly, the ship sheet is now one column to make enough room for the tables. The code isn't pretty, but it works.

Since I do not have a Pro subscription I have not been able to test this as a custom sheet, but I have replaced the current sheet HTML and CSS with this using Inspect Element to design it. None of the changes should affect any functionality, but I can't test all of it without the editor.