### PR TITLE
Werewolf 20 Updates

### DIFF
--- a/CWOD-W20/W20.css
+++ b/CWOD-W20/W20.css
@@ -14,8 +14,9 @@ div.sheet-core-content {
 	display: none;
 }
 .charsheet {
-    background: url('http://i.imgur.com/Gqhoqv5.jpg');
+    background: url('http://i.imgur.com/CWLfKIZ.jpg');
     background-size:100%;
+    background-repeat: repeat-y;
     width:840px;
 }
 
@@ -480,7 +481,7 @@ input.sheet-claw[type="checkbox"] + span::before {
 }
 
 input.sheet-claw[type="checkbox"]:checked + span::before {
-    background:url('http://pngimg.com/upload/scratches_PNG6175.png') no-repeat;
+    background:url('http://mongoosemachine.com/images/interface/claw-mark-mid-left.png') no-repeat;
     background-size:100%;
     content:"";
     width: 30px;

--- a/CWOD-W20/W20.html
+++ b/CWOD-W20/W20.html
@@ -701,8 +701,8 @@
     </div>
     <hr/>
     <!--Dice Pools-->
-    <h1>Dice Pools</h1>
     <div class="sheet-center">
+        <h1>Dice Pools</h1>
         <table class="sheet-table" style="width:820px">
             <tr>
                 <td style="width:60px">Roll</td>
@@ -714,7 +714,8 @@
                 <td style="width:60px">Difficulty</td>
                 <td style="width:80px">Query?</td>
                 <td style="width:80px">Specialization</td>
-            </tr>            <tr>
+            </tr>
+            <tr>
                 <td style="width:60px"><button type='roll' name='roll_DP1roll' value="@{DicePoolroll-1}"></button></td>
                 <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_DicePoolname-1" value=""/></td>
                 <td style="width:150px"><input type="text" class="sheet-dicepool" name="attr_Specname-1" value=""/></td>
@@ -1121,7 +1122,7 @@
                 </th>
             </tr>
         </table>
-        <hr>
+
         <fieldset class="repeating_dicepool">
             <table style="width:810px">
                 <tr>

--- a/CWOD-W20/W20.html
+++ b/CWOD-W20/W20.html
@@ -1122,7 +1122,7 @@
                 </th>
             </tr>
         </table>
-
+        <hr>
         <fieldset class="repeating_dicepool">
             <table style="width:810px">
                 <tr>
@@ -2164,7 +2164,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-1" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-1" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-1" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-1" value="@{weapon_Difficulty-1}" checked="checked" />
@@ -2178,7 +2178,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-1" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-1" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-1" value="0"/></th>>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-1" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-1} }} {{attr= Weapon @{weapon_Damage-1} }} {{skill= Stength @{weapon_StrengthDamage-1} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-1" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-1} }} {{attr= Weapon @{weapon_Damage-1} }} {{skill= Stength @{weapon_StrengthDamage-1} }}  {{mod= Extra ?{Attack Extra Successes|0} }} {{result= [[{(@{weapon_Damage-1} + @{weapon_StrengthDamage-1} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_2" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-2} }} {{attr= Attribute @{weapon_attribute-2} }} {{skill= Skill @{weapon_skill-2}}} {{mod= Weapon @{weapon_Modifier-2} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-2} + @{weapon_skill-2} + @{weapon_Modifier-2} + @{injury})d10}>@{weapon_Diff-2}f1]] }}"></button></th>
@@ -2211,7 +2211,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-2" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-2" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-2" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-2" value="@{weapon_Difficulty-2}" checked="checked" />
@@ -2225,7 +2225,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-2" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-2" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-2" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-2" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-2} }} {{attr= Weapon @{weapon_Damage-2} }} {{skill= Stength @{weapon_StrengthDamage-2} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-2" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-2} }} {{attr= Weapon @{weapon_Damage-2} }} {{skill= Stength @{weapon_StrengthDamage-2} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-2} + @{weapon_StrengthDamage-2} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_3" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-3} }} {{attr= Attribute @{weapon_attribute-3} }} {{skill= Skill @{weapon_skill-3}}} {{mod= Weapon @{weapon_Modifier-3} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-3} + @{weapon_skill-3} + @{weapon_Modifier-3} + @{injury})d10}>@{weapon_Diff-3}f1]] }}"></button></th>
@@ -2258,7 +2258,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-3" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-3" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-3" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-3" value="@{weapon_Difficulty-3}" checked="checked" />
@@ -2272,7 +2272,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-3" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-3" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-3" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-3" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-3} }} {{attr= Weapon @{weapon_Damage-3} }} {{skill= Stength @{weapon_StrengthDamage-3} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-3" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-3} }} {{attr= Weapon @{weapon_Damage-3} }} {{skill= Stength @{weapon_StrengthDamage-3} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-3} + @{weapon_StrengthDamage-3} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_4" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-4} }} {{attr= Attribute @{weapon_attribute-4} }} {{skill= Skill @{weapon_skill-4}}} {{mod= Weapon @{weapon_Modifier-4} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-4} + @{weapon_skill-4} + @{weapon_Modifier-4} + @{injury})d10}>@{weapon_Diff-4}f1]] }}"></button></th>
@@ -2305,7 +2305,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-4" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-4" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-4" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-4" value="@{weapon_Difficulty-4}" checked="checked" />
@@ -2319,7 +2319,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-4" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-4" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-4" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-4" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-4} }} {{attr= Weapon @{weapon_Damage-4} }} {{skill= Stength @{weapon_StrengthDamage-4} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-4" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-4} }} {{attr= Weapon @{weapon_Damage-4} }} {{skill= Stength @{weapon_StrengthDamage-4} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-4} + @{weapon_StrengthDamage-4} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_5" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-5} }} {{attr= Attribute @{weapon_attribute-5} }} {{skill= Skill @{weapon_skill-5}}} {{mod= Weapon @{weapon_Modifier-5} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-5} + @{weapon_skill-5} + @{weapon_Modifier-5} + @{injury})d10}>@{weapon_Diff-5}f1]] }}"></button></th>
@@ -2352,7 +2352,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-5" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-5" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-5" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-5" value="@{weapon_Difficulty-5}" checked="checked" />
@@ -2366,7 +2366,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-5" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-5" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-5" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-5" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-5} }} {{attr= Weapon @{weapon_Damage-5} }} {{skill= Stength @{weapon_StrengthDamage-5} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-5" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-5} }} {{attr= Weapon @{weapon_Damage-5} }} {{skill= Stength @{weapon_StrengthDamage-5} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-5} + @{weapon_StrengthDamage-5} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_6" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-6} }} {{attr= Attribute @{weapon_attribute-6} }} {{skill= Skill @{weapon_skill-6}}} {{mod= Weapon @{weapon_Modifier-6} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-6} + @{weapon_skill-6} + @{weapon_Modifier-6} + @{injury})d10}>@{weapon_Diff-6}f1]] }}"></button></th>
@@ -2399,7 +2399,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-6" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-6" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-6" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-6" value="@{weapon_Difficulty-6}" checked="checked" />
@@ -2413,7 +2413,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-6" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-6" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-6" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-6" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-6} }} {{attr= Weapon @{weapon_Damage-6} }} {{skill= Stength @{weapon_StrengthDamage-6} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-6" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-6} }} {{attr= Weapon @{weapon_Damage-6} }} {{skill= Stength @{weapon_StrengthDamage-6} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-6} + @{weapon_StrengthDamage-6} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
         <tr>
             <th><button type="roll" class="sheet-weaponroll" name="roll_weapon_7" value="&{template:wod} {{name= @{character_name} }} {{attack= @{weapon_name-7} }} {{attr= Attribute @{weapon_attribute-7} }} {{skill= Skill @{weapon_skill-7}}} {{mod= Weapon @{weapon_Modifier-7} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_attribute-7} + @{weapon_skill-7} + @{weapon_Modifier-7} + @{injury})d10}>@{weapon_Diff-7}f1]] }}"></button></th>
@@ -2446,7 +2446,7 @@
                     <option value="@{Other8}">Other8</option> 
                 </select></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Modifier-7" value="0"/></th>
-            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-7" value="0"/></th>
+            <th><input type="number" class="sheet-textbox" name="attr_weapon_Difficulty-7" value="6"/></th>
             <th>
                 <div class="sheet-Query">
                     <input type="radio" class="sheet-Query sheet-no" name="attr_weapon_Diff-7" value="@{weapon_Difficulty-7}" checked="checked" />
@@ -2460,7 +2460,7 @@
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Range-7" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Rate-7" value="0"/></th>
             <th><input type="number" class="sheet-textbox" name="attr_weapon_Clip-7" value="0"/></th>
-            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-7" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-7} }} {{attr= Weapon @{weapon_Damage-7} }} {{skill= Stength @{weapon_StrengthDamage-7} }}  {{mod= Extra ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7} + ?{Attack Successes|1} + @{injury})d10}>6}]] }}"></button></th>
+            <th><button type="roll" class="sheet-damageroll" name="roll_weapon_damage-7" value="&{template:wod} {{name= @{character_name} }} {{damage= @{weapon_name-7} }} {{attr= Weapon @{weapon_Damage-7} }} {{skill= Stength @{weapon_StrengthDamage-7} }}  {{mod= Extra ?{Attack Extra Successes|0} }}  {{result= [[{(@{weapon_Damage-7} + @{weapon_StrengthDamage-7} + ?{Attack Extra Successes|0})d10}>6}]] }}"></button></th>
         </tr>
     </table>
     <br>
@@ -2495,7 +2495,7 @@
                 <th>Strength +1</th>
                 <th><input type="number" class="sheet-textbox" name="attr_Bite_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_Bite_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-Bite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Bite }} {{attr= Bite [[1 + @{Bite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 1 + @{Bite_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Bite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+                <th><button type="roll" name="roll_damage-Bite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Bite }} {{attr= Bite [[1 + @{Bite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + 1 + @{Bite_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{Bite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_Hispobite" value="&{template:wod} {{name= @{character_name} }} {{attack= Hispo Bite }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{HispoBite_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{HispoBite_Mod-Attack} + @{injury})d10}>@{HispoBite_At_Difficulty}f1]] }}">HispoBite</button></th>
@@ -2513,7 +2513,7 @@
                 <th>Strength +2</th>
                 <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_HispoBite_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-HispoBite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Hispo Bite }} {{attr= HispoBite [[2 + @{HispoBite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 2 + @{HispoBite_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{HispoBite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+                <th><button type="roll" name="roll_damage-HispoBite" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Hispo Bite }} {{attr= HispoBite [[2 + @{HispoBite_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + 2 + @{HispoBite_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{HispoBite_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_body_tackle" value="&{template:wod} {{name= @{character_name} }} {{attack= Body Tackle }} {{attr= Dexterity @{Dexterity} }} {{mod= Modifier @{BodyTackle_Mod-Attack} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{BodyTackle_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{BodyTackle_Mod-Attack} + @{injury})d10}>@{BodyTackle_At_Difficulty}f1]] }}">Body Tackle</button></th>
@@ -2531,7 +2531,7 @@
                 <th>Special</th>
                 <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_BodyTackle_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-BodyTackle" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Body Tackle }} {{attr= Body Tackle [[@{BodyTackle_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + @{BodyTackle_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{BodyTackle_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+                <th><button type="roll" name="roll_damage-BodyTackle" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Body Tackle }} {{attr= Body Tackle [[@{BodyTackle_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + @{BodyTackle_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{BodyTackle_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_Claw" value="&{template:wod} {{name= @{character_name} }} {{attack= Claw }} {{attr= Dexterity @{Dexterity} }} {{mod= Modifier @{Claw_Mod-Attack} }} {{skill= Brawl @{Brawl}}} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Claw_Mod-Attack} + @{injury})d10}>@{Claw_At_Difficulty}f1]] }}">Claw</button></th>
@@ -2549,7 +2549,7 @@
                 <th>Strength +2</th>
                 <th><input type="number" class="sheet-textbox" name="attr_Claw_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_Claw_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-Claw" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Claw }} {{attr= Claw [[2 + @{Claw_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 2 + @{Claw_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Claw_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
+                <th><button type="roll" name="roll_damage-Claw" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Claw }} {{attr= Claw [[2 + @{Claw_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + 2 + @{Claw_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{Claw_Difficulty}]] }} {{type= Aggravated}}">Aggravated</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_Grapple" value="&{template:wod} {{name= @{character_name} }} {{attack= Grapple }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Modifier @{Grapple_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Grapple_Mod-Attack} + @{injury})d10}>@{Grapple_At_Difficulty}f1]] }}">Grapple</button></th>
@@ -2567,7 +2567,7 @@
                 <th>Strength</th>
                 <th><input type="number" class="sheet-textbox" name="attr_Grapple_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_Grapple_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-Grapple" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Grapple }} {{attr= Grapple [[@{Grapple_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + @{Grapple_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Grapple_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+                <th><button type="roll" name="roll_damage-Grapple" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Grapple }} {{attr= Grapple [[@{Grapple_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + @{Grapple_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{Grapple_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_Kick" value="&{template:wod} {{name= @{character_name} }} {{attack= Kick }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{Kick_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Kick_Mod-Attack} + @{injury})d10}>@{Kick_At_Difficulty}f1]] }}">Kick</button></th>
@@ -2585,7 +2585,7 @@
                 <th>Strength +1</th>
                 <th><input type="number" class="sheet-textbox" name="attr_Kick_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_Kick_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-Kick" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Kick }} {{attr= Kick [[1 + @{Kick_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} + 1 + @{Kick_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Kick_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+                <th><button type="roll" name="roll_damage-Kick" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Kick }} {{attr= Kick [[1 + @{Kick_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} + 1 + @{Kick_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{Kick_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
             </tr>
             <tr>
                 <th><button type="roll" class="sheet-adv" name="roll_Punch" value="&{template:wod} {{name= @{character_name} }} {{attack= Punch }} {{attr= Dexterity @{Dexterity} }} {{skill= Brawl @{Brawl}}} {{mod= Weapon @{Punch_Mod-Attack} }} {{wound= Wound @{injury} }} {{result= [[{(@{Dexterity} + @{Brawl} + @{Punch_Mod-Attack} + @{injury})d10}>@{Punch_At_Difficulty}f1]] }}">Punch</button></th>
@@ -2603,7 +2603,7 @@
                 <th>Strength</th>
                 <th><input type="number" class="sheet-textbox" name="attr_Punch_Mod-Damage" value="0"/></th>
                 <th><input type="number" class="sheet-textbox" name="attr_Punch_Difficulty" value="6"/></th>
-                <th><button type="roll" name="roll_damage-Punch" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Punch }} {{attr= Punch [[@{Punch_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Successes|1} }} {{wound= Wound @{injury} }} {{result= [[{(@{Strength} +  @{Punch_Mod-Damage} + ?{Attack Successes|1} + @{injury})d10}>@{Punch_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
+                <th><button type="roll" name="roll_damage-Punch" class="sheet-adv" value="&{template:wod} {{name= @{character_name} }} {{damage= Punch }} {{attr= Punch [[@{Punch_Mod-Damage}]] }} {{skill= Strength @{Strength} }} {{mod= Successes ?{Attack Extra Successes|0} }}  {{result= [[{(@{Strength} +  @{Punch_Mod-Damage} + ?{Attack Extra Successes|0})d10}>@{Punch_Difficulty}]] }} {{type= Bashing}}">Bashing</button></th>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
- Moved Dicepool header so it's centered.
- Standard difficulty is 6, so attack difficulty has been defaulted to 6. 
- When rolling damage, wound penalties should not be applied. These have been removed from damage calculations in combat.
- Only extra successes above those required to hit should be applied as extra dice of damage. Changed wording of query to reflect this. Change default extra die to 0, since this is the minimum extra dice that can be rolled as extra damage. 
- Updated broken image for check boxes. Now slash image will display for both conditions, but will distinguish between checked and unchecked with red behind image. 
- Background was using a Chronicles of Darkness image. Updated to use W20 specific background.