### PR TITLE
Repeating Background Image for Talent and Spell Pages

### DIFF
--- a/Shadow of the Demon Lord/style.scss
+++ b/Shadow of the Demon Lord/style.scss
@@ -517,7 +517,7 @@ $circle_lg : 67px;
 		}		
 	}
 	.sheet-maindiv2 {
-		background: url('http://s20.postimg.org/p61pnke1p/sheet_final_bkg.jpg') no-repeat center center transparent;
+		background: url('http://s20.postimg.org/p61pnke1p/sheet_final_bkg.jpg') repeat-y center center transparent;
 		background-size: cover;
 		
 		.sheet-row-1 {
@@ -530,7 +530,7 @@ $circle_lg : 67px;
 		}
 	}
 	.sheet-maindiv3 {
-		background: url('http://s20.postimg.org/p61pnke1p/sheet_final_bkg.jpg') no-repeat center center transparent;
+		background: url('http://s20.postimg.org/p61pnke1p/sheet_final_bkg.jpg') repeat-y center center transparent;
 		background-size: cover;
 		
 		.sheet-row-1 {


### PR DESCRIPTION
Currently, when the Talent and Spell pages contain a large number of entries (Most Level 3+ Characters will have enough Talents/Spells to cause this issue), the background doesn't repeat and it simply goes to plain white. Which not only looks bad, but also makes entries that are on the edge of the background hard to read.

My proposed change is to simply have the backgrounds on those two pages repeat when they end, making the sheets look nicer and more uniform, and removing any legibility issues the current sheet may cause.