### PR TITLE
Updating Planet Mercenary Sheet fields to support fireteam damage

### DIFF
--- a/Planet_Mercenary/Planet_Mercenary.html
+++ b/Planet_Mercenary/Planet_Mercenary.html
@@ -476,10 +476,10 @@
 			</div>
 			<div class="sheet-table-row">
 				<span class="sheet-table-cell-label">Combat</span>
-				<span class="sheet-table-cell"><input type="number" name="attr_fireteam_Combat_1" class="sheet-fireteamInput"/></span>
-				<span class="sheet-table-cell"><input type="number" name="attr_fireteam_Combat_2" class="sheet-fireteamInput"/></span>
-				<span class="sheet-table-cell"><input type="number" name="attr_fireteam_Combat_3" class="sheet-fireteamInput"/></span>
-				<span class="sheet-table-cell"><input type="number" name="attr_fireteam_Combat_total" class="sheet-fireteamInput"/></span>
+				<span class="sheet-table-cell"><input type="text" name="attr_fireteam_Combat_1" class="sheet-fireteamInput"/></span>
+				<span class="sheet-table-cell"><input type="text" name="attr_fireteam_Combat_2" class="sheet-fireteamInput"/></span>
+				<span class="sheet-table-cell"><input type="text" name="attr_fireteam_Combat_3" class="sheet-fireteamInput"/></span>
+				<span class="sheet-table-cell"><input type="text" name="attr_fireteam_Combat_total" class="sheet-fireteamInput"/></span>
 			</div>
 		</div>
 		<span>Team Qualities</span>
@@ -560,7 +560,7 @@
 			</div>
 		</div>
 	</div>
-	<div class="sheet-credit">Sheet created by Zargon based on the Planet Mercenary official sheet. Last updated 4/14/2017. v1.0</div>
+	<div class="sheet-credit">Sheet created by Zargon based on the Planet Mercenary official sheet. Last updated 7/7/2017. v1.1</div>
 </div>
 
 <div style="display: none;">


### PR DESCRIPTION
Updated Planet Mercenary sheet Fireteam Combat fields to be of the text type instead of number
based on Errata.