### PR TITLE
[DSA4.1] Fix Minor Break Factor Issues

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -10161,7 +10161,7 @@
                     <th colspan="2">AT/PA</th>
                     <th>DK</th>
                     <th>INI</th>
-                    <th colspan="2">BF aktuell/min</th>
+                    <th colspan="3">BF aktuell/min</th>
                 </tr>
                 <tr>
                     <td>
@@ -10251,10 +10251,12 @@
                     <td>
                         <input type="number" name="attr_INIModNKW1" min="-9" max="9" value="0" style="width: 2.5em;">
                     </td>
-                    <td nowrap>
-                        <input type="number" name="attr_BFStartNKW1" min="-99" value="0" style="width: 2.5em;"> / </td>
                     <td>
                         <input type="number" name="attr_BFAktuellNKW1" min="-99" value="0" style="width: 2.5em;">
+                    </td>
+                    <td>/</td>
+                    <td>
+                        <input type="number" name="attr_BFStartNKW1" min="-99" value="0" style="width: 2.5em;">
                     </td>
                 </tr>
                 <tr>
@@ -10345,10 +10347,12 @@
                     <td>
                         <input type="number" name="attr_INIModNKW2" min="-9" max="9" value="0" style="width: 2.5em;">
                     </td>
-                    <td nowrap>
-                        <input type="number" name="attr_BFStartNKW2" min="-99" value="0" style="width: 2.5em;"> / </td>
                     <td>
                         <input type="number" name="attr_BFAktuellNKW2" min="-99" value="0" style="width: 2.5em;">
+                    </td>
+                    <td>/</td>
+                    <td>
+                        <input type="number" name="attr_BFStartNKW2" min="-99" value="0" style="width: 2.5em;">
                     </td>
                 </tr>
                 <tr>
@@ -10439,10 +10443,12 @@
                     <td>
                         <input type="number" name="attr_INIModNKW3" min="-9" max="9" value="0" style="width: 2.5em;">
                     </td>
-                    <td nowrap>
-                        <input type="number" name="attr_BFStartNKW3" min="-99" value="0" style="width: 2.5em;"> / </td>
                     <td>
                         <input type="number" name="attr_BFAktuellNKW3" min="-99" value="0" style="width: 2.5em;">
+                    </td>
+                    <td>/</td>
+                    <td>
+                        <input type="number" name="attr_BFStartNKW3" min="-99" value="0" style="width: 2.5em;">
                     </td>
                 </tr>
                 <tr>
@@ -10533,10 +10539,12 @@
                     <td>
                         <input type="number" name="attr_INIModNKW4" min="-9" max="9" value="0" style="width: 2.5em;">
                     </td>
-                    <td nowrap>
-                        <input type="number" name="attr_BFStartNKW4" min="-99" value="0" style="width: 2.5em;"> / </td>
                     <td>
                         <input type="number" name="attr_BFAktuellNKW4" min="-99" value="0" style="width: 2.5em;">
+                    </td>
+                    <td>/</td>
+                    <td>
+                        <input type="number" name="attr_BFStartNKW4" min="-99" value="0" style="width: 2.5em;">
                     </td>
                 </tr>
             </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12537,7 +12537,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-06-19"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-07-17"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11000,7 +11000,7 @@
                     <td><input type="text" class="sheet-stat-immutable" name="attr_TPKK_NKW1" disabled="true" value="@{NKW1_SB}"></td>
                     <td><input type="text" class="sheet-distance-class sheet-stat-immutable" name="attr_DK_NKW1" disabled="true" value="@{ReichweiteNKW1}"></td>
                     <td><input type="text" class="sheet-stat-immutable" name="attr_INI_NKW1" disabled="true" value="@{INIModNKW1}"></td>
-                    <td><input type="number" name="attr_BF1_NKW1" value="@{BFStartNKW1}"></td>
+                    <td><input type="number" name="attr_BFAktuellNKW1" value="@{BFStartNKW1}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-2">
                     <td><input type="text" class="sheet-stat-immutable sheet-input-weapon-name" name="attr_name_NKW2" disabled="true" value="@{NKWname2}"></td>
@@ -11010,7 +11010,7 @@
                     <td><input type="text" class="sheet-stat-immutable" name="attr_TPKK_NKW2" disabled="true" value="@{NKW2_SB}"></td>
                     <td><input type="text" class="sheet-distance-class sheet-stat-immutable" name="attr_DK_NKW2" disabled="true" value="@{ReichweiteNKW2}"></td>
                     <td><input type="text" class="sheet-stat-immutable" name="attr_INI_NKW2" disabled="true" value="@{INIModNKW2}"></td>
-                    <td><input type="number" name="attr_BF1_NKW2" value="@{BFStartNKW2}"></td>
+                    <td><input type="number" name="attr_BFAktuellNKW2" value="@{BFStartNKW2}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-3">
                     <td><input type="text" class="sheet-stat-immutable sheet-input-weapon-name" name="attr_name_NKW3" disabled="true" value="@{NKWname3}"></td>
@@ -11020,7 +11020,7 @@
                     <td><input type="text" class="sheet-stat-immutable" name="attr_TPKK_NKW3" disabled="true" value="@{NKW3_SB}"></td>
                     <td><input type="text" class="sheet-distance-class sheet-stat-immutable" name="attr_DK_NKW3" disabled="true" value="@{ReichweiteNKW3}"></td>
                     <td><input type="text" class="sheet-stat-immutable" name="attr_INI_NKW3" disabled="true" value="@{INIModNKW3}"></td>
-                    <td><input type="number" name="attr_BF1_NKW3" value="@{BFStartNKW3}"></td>
+                    <td><input type="number" name="attr_BFAktuellNKW3" value="@{BFStartNKW3}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-4">
                     <td><input type="text" class="sheet-stat-immutable sheet-input-weapon-name" name="attr_name_NKW4" disabled="true" value="@{NKWname4}"></td>
@@ -11030,7 +11030,7 @@
                     <td><input type="text" class="sheet-stat-immutable" name="attr_TPKK_NKW4" disabled="true" value="@{NKW4_SB}"></td>
                     <td><input type="text" class="sheet-distance-class sheet-stat-immutable" name="attr_DK_NKW4" disabled="true" value="@{ReichweiteNKW4}"></td>
                     <td><input type="text" class="sheet-stat-immutable" name="attr_INI_NKW4" disabled="true" value="@{INIModNKW4}"></td>
-                    <td><input type="number" name="attr_BF1_NKW4" value="@{BFStartNKW4}"></td>
+                    <td><input type="number" name="attr_BFAktuellNKW4" value="@{BFStartNKW4}"></td>
                 </tr>
             </table>
 


### PR DESCRIPTION
* Minor bug fixes: Swap "current break factor" and "minimum break factor" to match attributes and UI (f56d28d); remove superfluous attributes introduced in my last PR (#2704) and use the pre-existing ones instead (2e50073)

The first commit will require people to manually swap the values in the UI (up to 4 x 2 fields).

The attributes in the second commit were added a month ago, but were merely duplicating already existing data. Know idea what I was thinking ;) The problem is (or: was) that both attributes were user-editable and not synchronized. Therefore, there might be inconsistencies in the sheets. The attributes in question do not change frequently. In my group with six players, the values remain constant for tens of sessions. Since there is no sensible way to decide which of the two values is the true one, nothing can be done about them with sheet workers. In order to prevent such issues in the future, I will keep an eye on all newly introduced attributes and check for possible duplication.

The first commit probably impacts way more people than the second.