### PR TITLE
Minor Edits and Fixes

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -166,21 +166,12 @@
                         <!-- <td><input type="number" name="attr_Effort" value="[[5*@{STR}]]" disabled="true" /></td>-->
 						<!--<td>Effort</td>-->
 					   	<td >
-							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Modifier|5}]] Effort Roll" >Effort</button>	
+							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|5}]] Effort Roll" >Effort</button>	
 						</td>
 						<td><p>Dmg. Bonus</p></td>
 						<td colspan="3">	
-							<select name="attr_Damage_Bonus" style="margin-bottom: 0px;height: 24px ; width: 75px">
-								  <option></option>
-								  <option>-1D6</option>
-								  <option>-1D4</option>
-								  <option>0</option>
-								  <option>1D4</option>
-								  <option>1D6</option>
-								  <option>2D6</option>
-								  <option>3D6</option>
-								  <option>4D6</option>
-							</select>	
+							<input type="text" name="attr_Damage_Bonus" style="margin-bottom: 0px;height: 24px ; width: 75px">
+
 					</tr>
 					
 					<tr>
@@ -191,7 +182,7 @@
 						<td class=".sheet-chkfiller"><td>
                         <td><p>CON</p></td>
                         <td><input type="number" name="attr_CON" /></td>
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Modifier|5}]] Stamina Roll" >Stamina</button></td>
+                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|5}]] Stamina Roll" >Stamina</button></td>
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank"><p >Siz SR</p></div>
@@ -233,7 +224,7 @@
                         <td><p>INT</p></td>
                         <td><input type="number" name="attr_INT" /></td>
                         <!--<td><input type="number" name="attr_Idea" value="[[5*@{INT}]]" disabled="true" /></td>-->
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Modifier|5}]] Idea Roll" >Idea</button></td>
+                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|5}]] Idea Roll" >Idea</button></td>
 						<td><p>MOV</p></td><td><input type="number" name="attr_mov" /></td>		
 						<td></td>
 						<td></td>						
@@ -244,29 +235,29 @@
 					    <td><p>POW</p></td>
                         <td><input class="sheet-plain" type="number" name="attr_POW" /></td>
                         <!--<td><input type="number" name="attr_Luck" value="[[5*@{POW}]]" disabled="true" /></td>-->
-                        <td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Modifier|5}]] Luck Roll" >&nbsp;Luck</button></td>
+                        <td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|5}]] Luck Roll" >&nbsp;Luck</button></td>
 						<td><p>Hit Pts.</p></td>
-						<td><input type="number" name="attr_max_hp" />
+						<td><input type="number" name="attr_cur_hp" />
 						<td>/</td>
-						<td><input type="number" name="attr_cur_hp" /></td>									
+						<td><input type="number" name="attr_max_hp" /></td>									
 					</tr>
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
                         <td><p>DEX</p></td>
                         <td><input type="number" name="attr_DEX" /></td>	
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Modifier|5}]] Agility Roll" >Agility</button></td>
-						<td><p>Magic Pts.</p></td>
-						<td><input type="number" name="attr_max_mp" />
+                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|5}]] Agility Roll" >Agility</button></td>
+						<td><p>Power Pts.</p></td>
+						<td><input type="number" name="attr_cur_mp" />
 						<td>/</td>
-						<td><input type="number" name="attr_cur_mp" /></td>
+						<td><input type="number" name="attr_max_mp" /></td>
 					</tr>
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
                         <td><p>APP</p></td>
                         <td><input type="number" name="attr_APP" /></td>
-                        <td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Modifier|5}]] Charisma Roll" >Charisma</button></td>
+                        <td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Mulitplier|5}]] Charisma Roll" >Charisma</button></td>
 							
 							<div class="sheet-hpbl">
 								<td>
@@ -274,7 +265,7 @@
 								<div class="sheet-hpbl"><p>Ftg. Pts.</div></p></td>
 								<td>
 									<input type="checkbox" class="sheet-showhbpl" name="attr_showhpbl" checked="checked" style="display: none">
-									<div class="sheet-hpbl"><input  type="number" name="attr_max_ftgp" /></div>
+									<div class="sheet-hpbl"><input  type="number" name="attr_cur_ftgp" /></div>
 								</td>
 								<td>
 									<input type="checkbox" class="sheet-showhbpl" name="attr_showhpbl" checked="checked" style="display: none">
@@ -282,7 +273,7 @@
 								</td>
 								<td>
 									<input type="checkbox" class="sheet-showhbpl" name="attr_showhpbl" checked="checked" style="display: none">
-									<div class="sheet-hpbl"><input type="number" name="attr_cur_ftgp" /></div>
+									<div class="sheet-hpbl"><input type="number" name="attr_max_ftgp" /></div>
 								</td>
 							</div>
 						
@@ -302,7 +293,7 @@
                         <td >
 							<input type="checkbox" class="sheet-showedufld" name="attr_showedufld" checked="checked" style="display: none">
 							<div class="sheet-edufld">
-							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{EDU}*?{Modifier|5}]] Know Roll">Know</button>
+							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{EDU}*?{Multiplier|5}]] Know Roll">Know</button>
 							</div>
 						</td>
 						
@@ -310,9 +301,9 @@
 							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<@{cur_san}"><p>SAN</p></button>
 						</td>
 						<!--<td><p>SAN Pts.</p></td>-->
-						<td><input type="number" name="attr_max_san" /></td>
-						<td>/</td>
 						<td><input type="number" name="attr_cur_san" /></td>
+						<td>/</td>
+						<td><input type="number" name="attr_max_san" /></td>
 										
 										
 					</tr>					
@@ -591,7 +582,7 @@
                             <td>37<br><input type="radio" value="37" name="attr_HP" /></td>
                         </tr>
                     </table>
-                </div>
+                </div>c
             </div>
         </div>
     </div>
@@ -612,7 +603,7 @@
 						<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
 						<td class="sheet-skillname">Appraise (15%)</td>
 						<td><input type="number" name="attr_Appraise"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}+?{Mods|0})/5)+1]]}}         {{success=[[@{Appraise}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Appraise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
 						<!--<td><button type="roll" value="/roll 1d100<@{Appraise}" /></td>-->
 					</tr>
 					<tr>
@@ -627,29 +618,30 @@
 						<!--<input  type="text" name="attr_artSkillname" class="sheet-skillname" />-->
 						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
 						<td><input type="number" name="attr_artScore" /></td>
-					   <td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}+?{Mods|0})/5)+1]]}}          {{success=[[@{artScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+					   <td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@ceil({artScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
 					   </tr>
 					</table>
 				</fieldset>	
-				<table style="width: 100%">		
+				<table style="width: 100%">
+					</tr>
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
 						<td class="sheet-skillname">Bargain (05%)</td>
 						<td><input type="number" name="attr_Bargain"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[@{Bargain}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Bargain}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Climb"  /></td>
 						<td class="sheet-skillname">Climb (40%)</td>
 						<td><input type="number" name="attr_Climb"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}+?{Mods|0})/5)+1]]}}       {{success=[[@{Climb}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+						<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Climb}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Command"  /></td>
 						<td class="sheet-skillname">Command (05)</td>
 						<td><input type="number" name="attr_Command"  /></td>
 						<!--<td><button type="roll" value="/roll 1d100<@{Command}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}+?{Mods|0})/5)+1]]}}  {{success=[[@{Command}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{success=[[ceil(@{Command}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
 					</tr>
 					<tr>
 						<td class="sheet-chkfiller"></td>
@@ -661,7 +653,7 @@
 						<td><input type="checkbox" name="attr_craftSuccess"  /></td>
 						<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
 						<td><input type="number" name="attr_craftScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{craftScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{craftScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
 					</table>	
 				</fieldset>
 				<table style="width: 100%">
@@ -669,7 +661,7 @@
 						<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
 						<td class="sheet-skillname">Demolition (01%)</td>
 						<td><input type="number" name="attr_Demolition"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}+?{Mods|0})/5)+1]]}}         {{success=[[@{Demolition}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Demolition}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
 						<!--<td><button type="roll" value="/roll 1d100<@{Demolition}" /></td>-->					
 					</tr>
 					<tr>
@@ -677,13 +669,13 @@
 						<td class="sheet-skillname">Disguise (01)</td>
 						<td><input type="number" name="attr_Disguise"  /></td>
 						<!--<td><button type="roll" value="/roll 1d100<@{Disguise}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}+?{Mods|0})/5)+1]]}}    {{success=[[@{Disguise}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}    {{success=[[ceil(@{Disguise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
 						<td class="sheet-skillname">Dodge (DEX x02%)</td>
 						<td><input type="number" name="attr_Dodge"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Dodge}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
 						<!--<td><button type="roll" value="/roll 1d100<@{Dodge}" /></td>-->
 					</tr>				
 					<tr>
@@ -695,7 +687,7 @@
 					 <input type="checkbox" name="attr_DriveSucess"  />
 					 <input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_DriveScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{DriveScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{DriveScore}*?{Multipler|1})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{Drive Skill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					
 				</fieldset>	
 				<table style="width: 100%">	
 					<tr>
@@ -703,28 +695,35 @@
 						<td class="sheet-skillname">Etiquette (05)</td>
 						<td><input type="number" name="attr_Etiquette"  /></td>
 						<!--<td><button type="roll" value="/roll 1d100<@{Etiquette}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+?{Mods|0})/5)+1]]}}         {{success=[[@{Etiquette}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Etiquette}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
 					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
+						<td class="sheet-skillname">Fast Talk (05%)</td>
+						<td><input type="number" name="attr_FastTalk" /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FastTalk}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
+						<!--<td><button type="roll" value="/roll 1d100<@{FastTalk}" /></td>-->
+					</tr>					
 					<tr>
 						<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
 						<td class="sheet-skillname">Fine Manipulation (05%)</td>
 						<td><input type="number" name="attr_FineManipulation" /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{FineManipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FineManipulation}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
 						<!--<td><button type="roll" value="/roll 1d100<@{FineManipulation}" /></td>-->
 					</tr>
 
                 <tr>
                     <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-                    <td class="sheet-skillname">First Aid (30%) or INT x1</td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
                     <td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}+?{Mods|0})/5)+1]]}}       {{success=[[@{FirstAid}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{FirstAid}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
                     <!--<td><button type="roll" value="/roll 1d100<@{FirstAid}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
                     <td class="sheet-skillname">Gaming (INT+POW)</td>
                     <td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}+?{Mods|0})/5)+1]]}}        {{success=[[@{Gaming}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Gaming}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
                 </tr>		
 
 				<tr>
@@ -737,21 +736,21 @@
 						 <input type="checkbox" name="attr_hMachineSuccess"  />
 						 <input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
 						 <input type="number" name="attr_hMachineScore" />
-						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{hMachineScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{hMachineScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
 				</fieldset>					
 				<table style="width: 100%">		
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Hide"  /></td>
 						<td class="sheet-skillname">Hide (10%)</td>
 						<td><input type="number" name="attr_Hide"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}+?{Mods|0})/5)+1]]}}          {{success=[[@{Hide}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{Hide}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
 						<!--<td><button type="roll" value="/roll 1d100<@{Spot-Hide}" /></td>-->
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Insight"  /></td>
 						<td class="sheet-skillname">Insight (05%)</td>
 						<td><input type="number" name="attr_Insight"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}+?{Mods|0})/5)+1]]}}        {{success=[[@{Insight}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Insight}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
 						<!--<td><button type="roll" value="/roll 1d100<@{Insight}" /></td>-->
 					</tr>
 				</table>
@@ -766,7 +765,7 @@
 				<td><input type="checkbox" name="attr_Success-Jump"  /></td>
 				<td class="sheet-skillname">Jump (25%)</td>
 				<td><input type="number" name="attr_Jump"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}+?{Mods|0})/5)+1]]}}        {{success=[[@{Jump}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Jump}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
 				<!--<td><button type="roll" value="/roll 1d100<@{Jump}" /></td>-->
 			</tr>
 
@@ -779,7 +778,7 @@
 					 <input type="checkbox" name="attr_KnowSucess"  />
 					 <input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
 					 <input type="number" name="attr_KnowScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{KnowScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{KnowScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
 
 			</fieldset>	
 			<table style="width: 100%">					
@@ -788,7 +787,7 @@
 					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
 					<td><input type="number" name="attr_ownLang"  /></td>
 					<!--<td><button type="roll" value="/roll 1d100<@{ownLang}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}+?{Mods|0})/5)+1]]}}        {{success=[[@{ownLang}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{ownLang}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
 				</tr>			
 			</table>
 			<fieldset class='repeating_Langskills'>
@@ -796,7 +795,7 @@
 					 <input type="checkbox" name="attr_LangSuccess"  />
 					 <input type="text" name="attr_LangSkillname" class="sheet-skillname" />
 					 <input type="number" name="attr_LangScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{LangScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{LangScore}*?{Multipler|1}+?{Mods|0})]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
 				</tr>		
 			</fieldset>
 			<table style="width: 100%">								
@@ -804,7 +803,7 @@
 					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
 					<td class="sheet-skillname">Listen (25%)</td>
 					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}+?{Mods|0})/5)+1]]}}   {{success=[[@{Listen}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/5)+1]]}}   {{success=[[ceil(@{Listen}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
 				 </tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -815,37 +814,49 @@
 					 <input type="checkbox" name="attr_LitSucess"  />
 					 <input type="text" name="attr_LitSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_LitScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{LitScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{LitScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{LitScore}" />-->
 			</fieldset>				
 			<table style="width: 100%;">	
 					<tr>
+						<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+						<td class="sheet-skillname">Martial Arts (01%)</td>
+						<td><input type="number" name="attr_MartialArts"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{MartialArts}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>																																																							
+						<!--<td><button type="roll" value="/roll 1d100<@{MartialArts}" /></td>-->
+					</tr>
+					<tr>
 						<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
 						<td class="sheet-skillname">Medicine (05%)</td>
 						<td><input type="number" name="attr_Medicine"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}+?{Mods|0})/5)+1]]}}        {{success=[[@{Medicine}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Medicine}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
 						<!--<td><button type="roll" value="/roll 1d100<@{Medicine}" /></td>-->
 					</tr>
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
 					<td class="sheet-skillname">Navigate (10%)</td>
 					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}+?{Mods|0})/5)+1]]}}        {{success=[[@{Navigate}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Navigate}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
 					<!--<td><button type="roll" value="/roll 1d100<@{Navigate}" /></td>-->
 				</tr>			
 				<tr>
-					<td><input type="checkbox" name="attr_Success-Perform"  /></td>
-					<td class="sheet-skillname">Perform (05%)</td>
-					<td><input type="number" name="attr_Perform"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{Perform}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}+?{Mods|0})/5)+1]]}}        {{success=[[@{Perform}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>																									
-				</tr>				
+					<td class="sheet-chkfiller"></td>
+					<td>Perform (05%):</td>
+				</tr>								
+			</table>
+			<fieldset class='repeating_PerformSkills'>
+					 <input type="checkbox" name="attr_Success-Perform"  />
+					 <input type="text" name="attr_PerformSkill" class="sheet-skillname"/>
+					 <input type="number" name="attr_Perform" />
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Perform}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+			</fieldset>	
+				<table style="width: 100%;">	
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
 					<td class="sheet-skillname">Persuade (15%)</td>
 					<td><input type="number" name="attr_Persuade"  /></td>
 					<!--<td><button type="roll" value="/roll 1d100<@{Persuade}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+?{Mods|0})/5)+1]]}}       {{success=[[@{Persuade}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Persuade}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -856,13 +867,27 @@
 					 <input type="checkbox" name="attr_PilotSucess"  />
 					 <input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_PilotScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{PilotScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{PilotScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
 				<table style="width: 100%;">				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
+					<td class="sheet-skillname">Projection(DEX x02%)</td>
+					<td><input type="number" name="attr_Projection"  /></td>
+					<!--<td><button type="roll" value="/roll 1d100<@{Projection}" /></td>-->
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Projection}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																														
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+					<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
+					<td><input type="number" name="attr_Psychotherapy"  /></td>
+					<!--<td><button type="roll" value="/roll 1d100<@{Psychotherapy}" /></td>-->
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																														
+				</tr>								
 						<tr>
 							<td class="sheet-chkfiller"></td>
 							<td class="sheet-skillname">Repair (15%)</td>
-						</tr>	
+						</tr>
 				</table>
 				<fieldset class='repeating_repairSkills'>
 					 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
@@ -871,11 +896,18 @@
 						 <input type="checkbox" name="attr_repairSuccess"  />
 						 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
 						 <input type="number" name="attr_repairScore" />
-						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{repairScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{repairScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
 						 <!--<button type="roll" value="/roll 1d100<@{repairScore" />-->
 
 				</fieldset>				
 				<table style="width: 100%;">				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Research"  /></td>
+					<td class="sheet-skillname">Research (25%)</td>
+					<td><input type="number" name="attr_Research"  /></td>
+					<!--<td><button type="roll" value="/roll 1d100<@{Research}" /></td>-->
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Research}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
+				</tr>						
 					<tr>
 						<td class="sheet-chkfiller"></td>
 						<td>Ride(Varies):</td>
@@ -888,7 +920,7 @@
 							 <input type="checkbox" name="attr_RideSucess"  />
 							 <input type="text" name="attr_RideSkill" class="sheet-skillname"/>
 							 <input type="number" name="attr_RideScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{RideScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{RideScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
 
 				</fieldset>				 
@@ -902,7 +934,7 @@
 						 <input type="checkbox" name="attr_ScienceSucess"  />
 						 <input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
 						 <input type="number" name="attr_ScienceScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{ScienceScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ScienceScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
 				</fieldset>	
 			
         </div><!-- col 2 close --> 
@@ -914,21 +946,21 @@
 				<td><input type="checkbox" name="attr_Success-Sense"  /></td>
 				<td class="sheet-skillname">Sense (10%)</td>
 				<td><input type="number" name="attr_Sense"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}+?{Mods|0})/5)+1]]}}        {{success=[[@{Sense}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Sense}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
 				<!--<td><button type="roll" value="/roll 1d100<@{Sense}" /></td>-->
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
 				<td class="sheet-skillname">Sleight of Hand (05%)</td>
 				<td><input type="number" name="attr_SleightofHandScore"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{SleightofHandScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
 
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Spot"  /></td>
 				<td class="sheet-skillname">Spot (25%)</td>
 				<td><input type="number" name="attr_Spot"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}+?{Mods|0})/5)+1]]}}        {{success=[[@{Spot}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Spot}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
 				<!--<td><button type="roll" value="/roll 1d100<@{Spot}" /></td>-->
 			</tr>				
 			<tr>
@@ -936,27 +968,27 @@
 				<td class="sheet-skillname">Status (05%)</td>
 				<td><input type="number" name="attr_Status"  /></td>
 				<!--<td><button type="roll" value="/roll 1d100<@{Status}" /></td>-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}+?{Mods|0})/5)+1]]}}        {{success=[[@{Status}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Status}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
 				<td class="sheet-skillname">Stealth (10%)</td>
 				<td><input type="number" name="attr_Stealth"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}+?{Mods|0})/5)+1]]}}     {{success=[[@{Stealth}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/5)+1]]}}     {{success=[[ceil(@{Stealth}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
 				<!--<td><button type="roll" value="/roll 1d100<@{Stealth}" /></td>-->
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
 				<td class="sheet-skillname">Strategy (01%)</td>
 				<td><input type="number" name="attr_Strategy"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}+?{Mods|0})/5)+1]]}}        {{success=[[@{Strategy}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Strategy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
 				<!--<td><button type="roll" value="/roll 1d100<@{Strategy}" /></td>-->
 			</tr>		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Swim"  /></td>
 				<td class="sheet-skillname">Swim (25%)</td>
 				<td><input type="number" name="attr_Swim"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}+?{Mods|0})/5)+1]]}}        {{success=[[@{Swim}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Swim}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
 				<!--<td><button type="roll" value="/roll 1d100<@{Swim}" /></td>-->
 			</tr>	
 			<tr>
@@ -964,7 +996,7 @@
 				<td class="sheet-skillname">Teach (10%)</td>
 				<td><input type="number" name="attr_Teach"  /></td>
 				<!--<td><button type="roll" value="/roll 1d100<@{Teach}" /></td>-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}*?{Multipler|1}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
 			</tr>	
 
 					<tr>
@@ -976,21 +1008,21 @@
 					 <input type="checkbox" name="attr_TechSucess"  />
 					 <input type="text" name="attr_TechSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_TechScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{TechScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{TechScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Throw"  /></td>
 				<td class="sheet-skillname">Throw (25%)</td>
 				<td><input type="number" name="attr_throw"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}+?{Mods|0})/5)+1]]}}        {{success=[[@{throw}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{throw}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
 				<!--<td><button type="roll" value="/roll 1d100<@{Throw}" /></td>-->
 			</tr>			
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Track "  /></td>
 				<td class="sheet-skillname">Track (10%)</td>
 				<td><input type="number" name="attr_Track"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}+?{Mods|0})/5)+1]]}}        {{success=[[@{Track}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Track}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
 				<!--<td><button type="roll" value="/roll 1d100<@{Track}" /></td>-->
 			</tr>					
 			</table>		
@@ -1005,7 +1037,7 @@
 					 <input type="checkbox" name="attr_OtherSucess"  />
 					 <input type="text" name="attr_OtherSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_OtherScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{OtherScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/></td>
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{OtherScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/></td>
 			</fieldset>	
 			<br />
 				<table style="width: 100%;">					
@@ -1028,7 +1060,7 @@
 							 <input type="checkbox" name="attr_meleeSucess"  />
 							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
 							 <input type="number" name="attr_meleeScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{meleeScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{meleeScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
 				</fieldset>				
 
 				<table style="width: 100%;">
@@ -1037,16 +1069,32 @@
 					<td>Ranged (Manip.)</td>
 				</tr>	
 				</table>
-				<fieldset class='repeating_meleeSkills'>
+				<fieldset class='repeating_rangedSkills'>
 						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
 
 
 							 <input type="checkbox" name="attr_rangedSucess"  />
 							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
 							 <input type="number" name="attr_rangedScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{rangedScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{rangedScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
+				</fieldset>
+				
+				<table style="width: 100%;">
+				<tr>
+					<td class="sheet-chkfiller"></td>
+                    <td>Artillery (Manip.)</td>
+				</tr>	
+				</table>
+				<fieldset class='repeating_artillerySkills'>
+						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
 
+
+							 <input type="checkbox" name="attr_ArtillerySucess"  />
+							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_ArtilleryScore" />
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
 				</fieldset>				
 				<br />					
             <br>
@@ -1055,8 +1103,6 @@
 </p>
 </div>
 <!--End of alabetical skills>
-
-
 <!-- ********************************************************************************************************************* -->
 <!-- Start of skills by category-->
 <input type="checkbox" class="sheet-toggle-categories" name="attr_toggle-categories"  checked="checked" style="display: none">
@@ -1078,7 +1124,7 @@
                     <!-- <td><button type="roll" value="/roll 1d100<@{Bargain}" /></td> -->
 					<!--<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Bargain}}}{{success=[[@{Bargain}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td>-->
 					<!-- <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{special=[[ floor((@{Bargain}+@{Communication})/5)]]}}  {{crit=[[ floor((@{Bargain}+@{Communication})/20)]]}} {{success=[[@{Bargain}+@{Communication}]]}} {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> -->	 
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{success=[[@{Bargain}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Bargain}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{success=[[ceil((@{Bargain}+@{Communication})*?{Multipler|1})+?{Mods|0}]]}} {{fumble=[[ceil((95+((@{Bargain}+@{Communication})*?{Multipler|1})+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
 					<!-- {{crit=[[ floor((@{Bargain}+@{Communication})/20)]]}}  -->
 					
 					
@@ -1088,28 +1134,28 @@
                     <td class="sheet-skillname">Command (05)</td>
                     <td><input type="number" name="attr_Command"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Command}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}+?{Mods|0})/5)+1]]}}  {{success=[[@{Command}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}+@{Communication}+?{Mods|0})/5)+1]]}}  {{success=[[@{Command}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Disguise"  /></td>
                     <td class="sheet-skillname">Disguise (01)</td>
                     <td><input type="number" name="attr_Disguise"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Disguise}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}+?{Mods|0})/5)+1]]}}    {{success=[[@{Disguise}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}+@{Communication}+?{Mods|0})/5)+1]]}}    {{success=[[@{Disguise}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
                     <td class="sheet-skillname">Etiquette (05)</td>
                     <td><input type="number" name="attr_Etiquette"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Etiquette}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+?{Mods|0})/5)+1]]}}         {{success=[[@{Etiquette}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{Etiquette}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-ownLang"  /></td>
                     <td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
                     <td><input type="number" name="attr_ownLang"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{ownLang}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}+?{Mods|0})/5)+1]]}}        {{success=[[@{ownLang}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{ownLang}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
                 </tr>
 		    </table>
 			
@@ -1117,7 +1163,7 @@
 					 <input type="checkbox" name="attr_LangSuccess"  />
 					 <input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" />
 					 <input type="number" name="attr_LangScore" /></td>
-				 	 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{LangScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
+				 	 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{LangScore}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
 			</fieldset>
 			</table>			
 			<table style="width:100%;">	
@@ -1126,37 +1172,35 @@
                     <td class="sheet-skillname">Perform (05%)</td>
                     <td><input type="number" name="attr_Perform"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Perform}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}+?{Mods|0})/5)+1]]}}        {{success=[[@{Perform}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>																									
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{Perform}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>																									
                 </tr>				
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Persuade"  /></td>
                     <td class="sheet-skillname">Persuade (15%)</td>
                     <td><input type="number" name="attr_Persuade"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Persuade}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+?{Mods|0})/5)+1]]}}       {{success=[[@{Persuade}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/5)+1]]}}       {{success=[[@{Persuade}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Status"  /></td>
                     <td class="sheet-skillname">Status (05%)</td>
                     <td><input type="number" name="attr_Status"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Status}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}+?{Mods|0})/5)+1]]}}        {{success=[[@{Status}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{Status}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Teach"  /></td>
                     <td class="sheet-skillname">Teach (10%)</td>
                     <td><input type="number" name="attr_Teach"  /></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Teach}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}+@{Communication}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
                 </tr>				
 				
 				
 				
 		  </table>	
-
 		<fieldset class='repeating_commskills'>
 			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
 			<table style="width: 100%;">	
 			<tr>
 				 <td><input type="checkbox" name="attr_ComSuccess"  /></td>
@@ -1164,13 +1208,11 @@
 				 <td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td> 
 				 <td><input type="number" name="attr_ComScore" /></td>
 				 <!--<button type="roll" value="/roll 1d100<@{ComScore}" />-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ComScore}}} {{fumble=[[ceil(95+(@{ComScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ComScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ComScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{ComScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ComScore}}} {{fumble=[[ceil(95+(@{ComScore}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ComScore}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ComScore}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{ComScore}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
 			</tr>		
 			</table>			
 		</fieldset>
-
 <!--		<br />-->	
-
 			<table style="width: 100%;">
 				<tr>
 					<!-- <td style="width="20px"></td> -->
@@ -1193,7 +1235,7 @@
 				<!--<input  type="text" name="attr_artSkillname" class="sheet-skillname" />-->
 				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
 				<td><input type="number" name="attr_artScore" /></td>
-			   <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}+?{Mods|0})/5)+1]]}}          {{success=[[@{artScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+			   <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}          {{success=[[@{artScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
 			   </tr>
 			</table>
 		</fieldset>			
@@ -1212,7 +1254,7 @@
 				 <input type="checkbox" name="attr_craftSuccess"  />
 				 <input type="text" name="attr_craftSkillname" class="sheet-skillname"/>
 				 <input type="number" name="attr_craftScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{craftScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{craftScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
 				 <!--<button type="roll" value="/roll 1d100<@{craftScore}" />-->
 
 		</fieldset>				
@@ -1223,14 +1265,14 @@
                     <td><input type="checkbox" name="attr_Success-Demolition"  /></td>
                     <td class="sheet-skillname">Demolition (01%)</td>
                     <td><input type="number" name="attr_Demolition"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}+?{Mods|0})/5)+1]]}}         {{success=[[@{Demolition}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{Demolition}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
                     <!--<td><button type="roll" value="/roll 1d100<@{Demolition}" /></td>-->					
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
                     <td class="sheet-skillname">Fine Manipulation (05%)</td>
                     <td><input type="number" name="attr_FineManipulation" /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{FineManipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{FineManipulation}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{FineManipulation}" /></td>-->
                 </tr>
 			</table>
@@ -1249,7 +1291,7 @@
 				 <input type="checkbox" name="attr_hMachineSuccess"  />
 				 <input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
 				 <input type="number" name="attr_hMachineScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{hMachineScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{hMachineScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
 				 <!--<button type="roll" value="/roll 1d100<@{hMachineScore}" />-->
 
 		</fieldset>				
@@ -1268,7 +1310,7 @@
 				 <input type="checkbox" name="attr_repairSuccess"  />
 				 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
 				 <input type="number" name="attr_repairScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{repairScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
+				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{repairScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
 				 <!--<button type="roll" value="/roll 1d100<@{repairScore" />-->
 
 		</fieldset>				
@@ -1280,7 +1322,7 @@
                     <td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
                     <td class="sheet-skillname">Sleight of Hand (05%)</td>
                     <td><input type="number" name="attr_SleightofHandScore"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{SleightofHandScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{SleightofHandScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
 					<!--<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Demolition}}}{{success=[[@{Demolition}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																								-->
                     <!--<td><button type="roll" value="/roll 1d100<@{SleightofHandScore}" /></td>-->
                 </tr>
@@ -1298,7 +1340,7 @@
 				 <td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
 				 <td><input type="number" name="attr_manipScore" /></td>
 				 <!--<button type="roll" value="/roll 1d100<@{ComScore}" />-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{manipScore}}} {{fumble=[[ceil(95+(@{manipScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{manipScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{manipScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{manipScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{manipSkillname}}}"/></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{manipScore}}} {{fumble=[[ceil(95+(@{manipScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{manipScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{manipScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{manipScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{manipSkillname}}}"/></td>
 			</tr>		
 			</table>			
 		</fieldset>			
@@ -1316,23 +1358,30 @@
                     <td><input type="checkbox" name="attr_Success-Appraise"  /></td>
                     <td class="sheet-skillname">Appraise (15%)</td>
                     <td><input type="number" name="attr_Appraise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}+?{Mods|0})/5)+1]]}}         {{success=[[@{Appraise}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{Appraise}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
                     <!--<td><button type="roll" value="/roll 1d100<@{Appraise}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-                    <td class="sheet-skillname">First Aid (30%) or INT x1</td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
                     <td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}+?{Mods|0})/5)+1]]}}       {{success=[[@{FirstAid}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}+@{Mental}+?{Mods|0})/5)+1]]}}       {{success=[[@{FirstAid}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
                     <!--<td><button type="roll" value="/roll 1d100<@{FirstAid}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
                     <td class="sheet-skillname">Gaming (INT+POW)</td>
                     <td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}+?{Mods|0})/5)+1]]}}        {{success=[[@{Gaming}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Gaming}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
                     <!--<td><button type="roll" value="/roll 1d100<@{Gaming}" /></td>-->
                 </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+                    <td class="sheet-skillname">Psychotherapy (00 or 01)</td>
+                    <td><input type="number" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Psychotherapy}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																																																		
+                    <!--<td><button type="roll" value="/roll 1d100<@{Psychotherapy}" /></td>-->
+                </tr>                
 				
 			</table>	
 			
@@ -1344,17 +1393,13 @@
 			</table>
 			<fieldset class='repeating_repairSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_KnowSucess"  />
 					 <input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
 					 <input type="number" name="attr_KnowScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{KnowScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}+@{Mental}?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}+@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{KnowScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
 					 <!--<button type="roll" value="/roll 1d100<@{KnowScore}" />-->
-
 			</fieldset>				
 <!--		<br />	-->
-
 			<table style="width: 100%;">				
 					<tr>
 						<td class="sheet-chkfiller"></td>
@@ -1363,14 +1408,11 @@
 			</table>
 			<fieldset class='repeating_LitSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_LitSucess"  />
 					 <input type="text" name="attr_LitSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_LitScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{LitScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{LitScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{LitScore}" />-->
-
 			</fieldset>				
 <!--		<br />	-->
 			
@@ -1381,7 +1423,7 @@
                     <td><input type="checkbox" name="attr_Success-Medicine"  /></td>
                     <td class="sheet-skillname">Medicine (05%)</td>
                     <td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}+?{Mods|0})/5)+1]]}}        {{success=[[@{Medicine}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Medicine}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
                     <!--<td><button type="roll" value="/roll 1d100<@{Medicine}" /></td>-->
                 </tr>
 			</table>
@@ -1394,14 +1436,11 @@
 			</table>
 			<fieldset class='repeating_ScienceSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_ScienceSucess"  />
 					 <input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_ScienceScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{ScienceScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}+@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{ScienceScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{ScienceScore}" />-->
-
 			</fieldset>				
 <!--		<br />	-->
 			
@@ -1410,7 +1449,7 @@
                     <td><input type="checkbox" name="attr_Success-Strategy"  /></td>
                     <td class="sheet-skillname">Strategy (01%)</td>
                     <td><input type="number" name="attr_Strategy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}+?{Mods|0})/5)+1]]}}        {{success=[[@{Strategy}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Strategy}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
                     <!--<td><button type="roll" value="/roll 1d100<@{Strategy}" /></td>-->
                 </tr>
 			</table>	
@@ -1423,17 +1462,12 @@
 			</table>
 			<fieldset class='repeating_TechSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_TechSucess"  />
 					 <input type="text" name="attr_TechSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_TechScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{TechScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{TechScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
-
 			</fieldset>	
-
-
 			
 <!--		<br />	-->
 				
@@ -1447,42 +1481,49 @@
                     <td><input type="checkbox" name="attr_Success-Insight"  /></td>
                     <td class="sheet-skillname">Insight (05%)</td>
                     <td><input type="number" name="attr_Insight"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}+?{Mods|0})/5)+1]]}}        {{success=[[@{Insight}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Insight}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
                     <!--<td><button type="roll" value="/roll 1d100<@{Insight}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Listen"  /></td>
                     <td class="sheet-skillname">Listen (25%)</td>
                     <td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}+?{Mods|0})/5)+1]]}}   {{success=[[@{Listen}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}+@{Perception}+?{Mods|0})/5)+1]]}}   {{success=[[@{Listen}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
                     <!--<td><button type="roll" value="/roll 1d100<@{Listen}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Navigate"  /></td>
                     <td class="sheet-skillname">Navigate (10%)</td>
                     <td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}+?{Mods|0})/5)+1]]}}        {{success=[[@{Navigate}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Navigate}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
                     <!--<td><button type="roll" value="/roll 1d100<@{Navigate}" /></td>-->
                 </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Research"  /></td>
+                    <td class="sheet-skillname">Research (25%)</td>
+                    <td><input type="number" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Research}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																																																																																
+                    <!--<td><button type="roll" value="/roll 1d100<@{Research}" /></td>-->
+                </tr>                
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Sense"  /></td>
                     <td class="sheet-skillname">Sense (10%)</td>
                     <td><input type="number" name="attr_Sense"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}+?{Mods|0})/5)+1]]}}        {{success=[[@{Sense}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Sense}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
                     <!--<td><button type="roll" value="/roll 1d100<@{Sense}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Spot"  /></td>
                     <td class="sheet-skillname">Spot (25%)</td>
                     <td><input type="number" name="attr_Spot"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}+?{Mods|0})/5)+1]]}}        {{success=[[@{Spot}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Spot}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
                     <!--<td><button type="roll" value="/roll 1d100<@{Spot}" /></td>-->
                 </tr>				
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Track "  /></td>
                     <td class="sheet-skillname">Track (10%)</td>
                     <td><input type="number" name="attr_Track"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}+?{Mods|0})/5)+1]]}}        {{success=[[@{Track}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Track}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
                     <!--<td><button type="roll" value="/roll 1d100<@{Track}" /></td>-->
                 </tr>					
 				
@@ -1495,7 +1536,7 @@
 					 <input type="checkbox" name="attr_PercepSucess"  />
 					 <input type="text" name="attr_PercepSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_PercepScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
 
 			</fieldset>	
@@ -1511,9 +1552,7 @@
                     <td><input type="checkbox" name="attr_Success-Climb"  /></td>
                     <td class="sheet-skillname">Climb (40%)</td>
                     <td><input type="number" name="attr_Climb"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}+?{Mods|0})/5)+1]]}}       {{success=[[@{Climb}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-
-
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}+@{Physical}+?{Mods|0})/5)+1]]}}       {{success=[[@{Climb}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
                     <!--<td><button type="roll" value="/roll 1d100<@{Climb}" /></td>-->
                 </tr>
 					
@@ -1522,7 +1561,7 @@
                     <td><input type="checkbox" name="attr_Success-Dodge"  /></td>
                     <td class="sheet-skillname">Dodge (DEX x02%)</td>
                     <td><input type="number" name="attr_Dodge"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
                     <!--<td><button type="roll" value="/roll 1d100<@{Dodge}" /></td>-->
                 </tr>
 		</table>		
@@ -1535,14 +1574,11 @@
 			</table>
 			<fieldset class='repeating_DriveSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_DriveSucess"  />
 					 <input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_DriveScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{DriveScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{DriveScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{DriveScore}" />-->
-
 			</fieldset>				
 <!--		<br />	-->
 		
@@ -1554,24 +1590,23 @@
                     <td><input type="checkbox" name="attr_Success-Fly"  /></td>
                     <td class="sheet-skillname">Fly (Varies)</td>
                     <td><input type="number" name="attr_Fly"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Fly}}}{{success=[[@{Fly}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fly}}"/></td>																																																																																																									
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Fly}}} {{fumble=[[ceil(95+(@{Fly}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Fly}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Fly}+@{Physical}+?{Mods|0})/5)+1]]}}          {{success=[[@{Fly}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fly}}"/></td>																																																																																																									
                     
                 </tr>-->
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Hide"  /></td>
                     <td class="sheet-skillname">Hide (10%)</td>
                     <td><input type="number" name="attr_Hide"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}+?{Mods|0})/5)+1]]}}          {{success=[[@{Hide}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}+@{Physical}+?{Mods|0})/5)+1]]}}          {{success=[[@{Hide}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
                     <!--<td><button type="roll" value="/roll 1d100<@{Spot-Hide}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Jump"  /></td>
                     <td class="sheet-skillname">Jump (25%)</td>
                     <td><input type="number" name="attr_Jump"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}+?{Mods|0})/5)+1]]}}        {{success=[[@{Jump}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Jump}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
                     <!--<td><button type="roll" value="/roll 1d100<@{Jump}" /></td>-->
                 </tr>
-				
 		</table>		
 		
 			<table style="width: 100%;">				
@@ -1582,20 +1617,22 @@
 			</table>
 			<fieldset class='repeating_PilotSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_PilotSucess"  />
 					 <input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_PilotScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{PilotScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}+@{Physical}+?{Mods|0})/5)+1]]}}         {{success=[[@{PilotScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{PilotScore}" />-->
-
 			</fieldset>				
+		<table style="width: 100%;">
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Projection"  /></td>
+                    <td class="sheet-skillname">Projection (DEX x02%)</td>
+                    <td><input type="number" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Projection}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																																																																																																																																							
+                    <!--<td><button type="roll" value="/roll 1d100<@{Projection}" /></td>-->
+                </tr>			
+		</table>		
 <!--		<br />	-->
-		
-		
-
-		
 		<table style="width: 100%;">				
 			<tr>
 				<td class="sheet-chkfiller"></td>
@@ -1604,14 +1641,11 @@
 		</table>
 		<fieldset class='repeating_RideSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_RideSucess"  />
 					 <input type="text" name="attr_RideSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_RideScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{RideScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{RideScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
-
 		</fieldset>				
 <!--		<br />	-->
 		<table style="width: 100%;">		
@@ -1619,42 +1653,42 @@
                     <td><input type="checkbox" name="attr_Success-Stealth"  /></td>
                     <td class="sheet-skillname">Stealth (10%)</td>
                     <td><input type="number" name="attr_Stealth"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}+?{Mods|0})/5)+1]]}}     {{success=[[@{Stealth}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}+@{Physical}+?{Mods|0})/5)+1]]}}     {{success=[[@{Stealth}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
                     <!--<td><button type="roll" value="/roll 1d100<@{Stealth}" /></td>-->
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Swim"  /></td>
                     <td class="sheet-skillname">Swim (25%)</td>
                     <td><input type="number" name="attr_Swim"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}+?{Mods|0})/5)+1]]}}        {{success=[[@{Swim}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Swim}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
                     <!--<td><button type="roll" value="/roll 1d100<@{Swim}" /></td>-->
                 </tr>	
                 <tr>
                     <td><input type="checkbox" name="attr_Success-Throw"  /></td>
                     <td class="sheet-skillname">Throw (25%)</td>
                     <td><input type="number" name="attr_throw"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}+?{Mods|0})/5)+1]]}}        {{success=[[@{throw}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{throw}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
                     <!--<td><button type="roll" value="/roll 1d100<@{Throw}" /></td>-->
                 </tr>	
 								
 			
 		</table>
-
 		<fieldset class='repeating_PhysicalSkills'>
 				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 					 <input type="checkbox" name="attr_PhysicalSucess"  />
 					 <input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/>
 					 <input type="number" name="attr_PhysicalScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PhysicalScore}}} {{fumble=[[ceil(95+(@{PhysicalScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PhysicalScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PhysicalScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{PhysicalScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PhysicalScore}}} {{fumble=[[ceil(95+(@{PhysicalScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PhysicalScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PhysicalScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{PhysicalScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
-
 		</fieldset>	
 		
 			
 		<table style="width: 100%;">					
-			
+				<tr>
+					<td style="width="20px"></td>
+					<td><b class="sheet-cat_header">Combat</b></td>
+					<td><input type="number" name="attr_Combat"  /></td>
+				</tr>				
                 <tr>
                     <td style="width: 20px;"></td>
                     <td><strong>Combat</strong></td>
@@ -1664,39 +1698,59 @@
 				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Melee (Physical)</td>
+					<td>Melee</td>
 				</tr>	
 				
 		</table>	
-
 				<fieldset class='repeating_meleeSkills'>
 							 <input type="checkbox" name="attr_meleeSucess"  />
 							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
 							 <input type="number" name="attr_meleeScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}+?{Mods|0})/5)+1]]}}        {{success=[[@{meleeScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}+@{Combat}+?{Mods|0})/5)+1]]}}        {{success=[[@{meleeScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
 				</fieldset>				
-
-				
+		<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Ranged (Manip.)</td>
+					<td>Ranged</td>
 				</tr	>	
-		
-				<fieldset class='repeating_meleeSkills'>
+				
+		</table>			
+				<fieldset class='repeating_rangedSkills'>
 						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
 							 <input type="checkbox" name="attr_rangedSucess"  />
 							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
 							 <input type="number" name="attr_rangedScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}+?{Mods|0})/5)+1]]}}         {{success=[[@{rangedScore}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
-
-				</fieldset>				
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}+@{Combat}+?{Mods|0})/5)+1]]}}         {{success=[[@{rangedScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+							 <!--<button type="roll" value="/roll 1d100<@{rangedScore}" />-->
+				</fieldset>
+		<table style="width: 100%;">					
+				<tr>
+				
+					<td class="sheet-chkfiller"></td> 
+					<td>Artillery</td>
+				</tr>	
+				
+		</table>	
+				<fieldset class='repeating_artillerySkills'>
+						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
+							 <input type="checkbox" name="attr_ArtillerySucess"  />
+							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_ArtilleryScore" />
+							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}+@{Combat}+?{Mods|0})/5)+1]]}}         {{success=[[@{ArtilleryScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+							 <!--<button type="roll" value="/roll 1d100<@{ArtilleryScore}" />-->
+				</fieldset>					
+		<table style="width: 100%;">	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+                    <td class="sheet-skillname">Martial Arts (1%)</td>
+                    <td><input type="number" name="attr_MartialArts"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}+@{Combat}+?{Mods|0})/5)+1]]}}        {{success=[[@{MartialArts}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=MartialArts}}"/></td>																																																																																																																																							
+                    <!--<td><button type="roll" value="/roll 1d100<@{MartialArts}" /></td>-->
+                </tr>					
+		</table>				
 				<br />					
 			<table style="width: 100%;">			
             </table>
-
             <br>
             <!--<fieldset class="repeating_Skills">
                <input type="checkbox" name="attr_Success"  />
@@ -1709,13 +1763,7 @@
 </p>
 </div>
 <!--End of Skills by category-->
-
-
-
 <hr />
-
-
-
 <div class='sheet-2colrow'>
 	    <div class='sheet-col sheet-big-col'>
 			
@@ -1741,12 +1789,10 @@
 						<th></th>
 					</thead>
 					<tbody>
-
 					<tr>
 						<td><input type="checkbox" name="attr_Success-Fist-Punch" /></td>
-						<td style="width: 122px;"><p style="width: 111px; margin-bottom: 0px">Brawl (50%)</p></td>
+						<td style="width: 122px;"><p style="width: 111px; margin-bottom: 0px">Brawl (25%)</p></td>
 						
-
 						<td >
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank">					
@@ -1777,7 +1823,7 @@
 						<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
 						<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
 						<!--//<td><button type="roll" value="/roll 1d100<@{Fist-Punch}" /></td>-->
-						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[@{Brawl}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Brawl}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
+						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
 					</tr>
 					
 					<tr>
@@ -1789,7 +1835,6 @@
 									<input style="width:35px" type="number" name="attr_Grapple_sr" />
 								</div>
 							</td>
-
 						<td>
 							<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_length">
 								<option value="">S</option>
@@ -1813,13 +1858,12 @@
 						<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
 						<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
 						<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
-						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[@{Brawl}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Grapple}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
+						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
 					</tr>
 					
 				</tbody>
 			</table>
 			                               
-
 	                                                        
 		<input type="checkbox" class="sheet-check-melee-toggle" name="attr_showstrike-rank" style="display: none" />
 		<fieldset class="repeating_melee">
@@ -1849,7 +1893,7 @@
 					<td><input style="width:62px" type="text" name="attr_Damagex"  /></td>
 					<td><input style="width:36px; margin-right:3px" type="number" name="attr_Attacks-Round" /></td>
 					<td><input  style="width:40px" type="text" name="attr_HP" /></td>
-					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[@{Score}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Score}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
+					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
 				</tr>
 			</table>
 		</fieldset>
@@ -1866,7 +1910,7 @@
 					<th style="" >Shots<br>in Gun</th>
 					<th style="" >Mal.</th>
 					<th style="">HP</th>
-					<th>Type</th>	
+					<th>Damage<br>Bonus?</td></th>	
 				</thead>
 				<tbody>
 					<tr>
@@ -1874,18 +1918,18 @@
 						<td><input type="number" name="attr_Score1" style="width: 50px" /></td>
 						<td><input type="text" name="attr_Damage1" style="width: 46px" /></td>
 						<td><input type="number" name="attr_Range1"style="width: 47px "/></td>
-						<td><input type="number" name="attr_Shots-per-Round1" style="width: 40px" /></td>
+						<td><input type="text" name="attr_Shots-per-Round1" style="width: 40px" /></td>
 						<td><input type="number" name="attr_Shots-in-Gun1" style="width: 50px" /></td>
 						<td><input type="number" name="attr_Malfunc-Num1" style="width: 40px"/></td>
 						<td><input type="number" name="attr_HP" style="width: 40px" /></td>
 						<!--<td><button type="roll" value="/roll 1d100" /></td>-->
 						<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type1">
-							<option selected="selected" value="0">S</option>
-							<option value="0.5">M</option>
+							<option selected="selected" value="0">No</option>
+							<option value="0.5">Yes</option>
 						</select>
 						</td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+ceil(@{Damage_Bonus})*@{weapon_type1})]]}} {{success=[[@{Score1}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{Score1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
 					</tr>				
 				</tbody>
 			</table>
@@ -1896,17 +1940,17 @@
 						<td><input type="number" name="attr_Score" style="width: 50px" /></td>
 						<td><input type="text" name="attr_Damage" style="width: 46px" /></td>
 						<td><input type="number" name="attr_Range"style="width: 47px "/></td>
-						<td><input type="number" name="attr_Shots-per-Round" style="width: 40px" /></td>
+						<td><input type="text" name="attr_Shots-per-Round" style="width: 40px" /></td>
 						<td><input type="number" name="attr_Shots-in-Gun" style="width: 50px" /></td>
 						<td><input type="number" name="attr_Malfunc-Num" style="width: 40px"/></td>
 						<td><input type="number" name="attr_HP" style="width: 40px" /></td>
 						<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type">
-							<option selected="selected" value="0">S</option>
-							<option value="0.5">M</option>
+							<option selected="selected" value="0">No</option>
+							<option value="0.5">Yes</option>
 						</select>						
 						</td>
-						<td><button type="roll" value="/roll 1d100" /></td>
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
 					</tr>
 				</table>
 			</fieldset>
@@ -1934,7 +1978,7 @@
 					<tr>
 						<!--<td class="sheet-loc-text">01-04</td>
 						<td class="sheet-loc-text">01-03</td>-->
-						<td class="sheet-loc-text">Right Leg</td>
+						<td><input type="text" name="attr_armor-name" class="sheet-armor-name"/></td>
 						<td><input type="text" name="attr_r_leg_armor_name" class="sheet-armor-name"/></td>
 						<td><input type="number" name="attr_r_Leg_ap" /></td>
 						<td><input type="number" name="attr_r_leg_max_hp" /></td>
@@ -2006,44 +2050,50 @@
 							<td><input type="number" name="attr_app"  /></td>
 							<td><input type="number" name="attr_mhp"/></td>
 							<td><input type="number" name="attr_chp" /></td>
-
 						</tr>
 					</table>
 				</fieldset>
 				</div>
-				
-
 				<input type="checkbox" class="sheet-showmjrwnd" name="attr_showmjrwnd"  style="display: none">
 				<div class="sheet-mjrwnd">
 					<h3 style="text-align: center; color: #FFF; background-color: #000;">Armor, Shield</h3>
 					<table style="width: 100%">
-						<tr>	
-							<td></td>
-							<td style="text-align:center"><button type="roll" value="Helm on Armor deflects [[@{helm_on_deflect}]] pts" /></td>
-							<td style="text-align:center"><button type="roll" value="/roll 1d100<[[@{helm_on_affect}]] Helm on Skill effect" /></td>	
-							<td style="text-align:center"><button type="roll" value="Helm off Armor deflects [[@{helm_on_deflect}]] pts" /></td>
-							<td style="text-align:center"><button type="roll" value="/roll 1d100<[[@{helm_off_affect}]] Helm off Skill Affect" /></td>
-							<td></td>
-							<td></td>
-							<td></td>		
-						</tr>
-	
-						<tr class="sheet-header-text">
-						<th><br />Armor Type</th><th colspan="2">Helment on<br />Dmg Deflect/%Affect</th><th Colspan="2">Helment off<br />Dmg Deflect/%Affect</th>
-						<th>Nom.<br /></th><th>Round's to<br />Put On</th>
-						</tr>
-
+					
+	<tr><!-- <th>
+						<button name="roll_melee-location"  type="roll" value="/me rolls melee hit location [[1d20]]"   class="btn ui-draggable">
+							  <div class="sheet-button_header">Melee</div>
+						</button>
+					  </th>
+					  <th>Missle</th>-->
+				<thead>
+					    
+	<tr>				     			
+					  <th>Armor</th><th>AV</th><th>Skill <br />Penalty</th><th>Energy <br />Points</th></tr>
+				</thead>					
+				<tbody>			
+<tr>
+						<!--<td class="sheet-loc-text">01-04</td>
+						<td class="sheet-loc-text">01-03</td>-->
+						<td><input style="width:125px" type="text" name="attr_armor_name" /></td>
+						<td ><input style="width:60px" type="text" name="attr_armor_value" /></td>
+						<td><input type="number" name="attr_armor_skill_penalty" /></td>
+						<td><input type="number" name="attr_armor_energy_points" /></td>
+						<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value}]] pts" /></td>
+					</tr>
+				</tbody>
+				</table>
+				<fieldset class="repeating_ armors">
+					<table>
 						<tr>
-							<td><input value="" style="width: 55px";" type="text" name="attr_armor_worn" /></td>
-							<td><input value="0" style="width: 39px";" type="text" name="attr_helm_on_deflect" /></td>
-							<td><input value="0" style="width: 42px";" type="number" name="attr_helm_on_affect" /></td>
-							<td><input value="0" style="width: 39px";" type="text" name="attr_helm_off_deflect" /></td>
-							<td><input value="0" style="width: 42px";" type="number" name="attr_helm_off_affect" /></td>							
-							<td><input style="width: 55px";" type="text" name="attr_burden" /></td>
-							<td><input style="width: 42px";" type="text" name="attr_rnds_to_put" /></td>
-							
+						<td><input style="width:125px" type="text" name="attr_armor_name1" /></td>
+						<td ><input style="width:60px" type="text" name="attr_armor_value1" /></td>
+						<td><input type="number" name="attr_armor_skill_penalty1" /></td>
+						<td><input type="number" name="attr_armor_energy_points1" /></td>
+						<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value1}]] pts" /></td>
 						</tr>
 					</table>
+				</fieldset>
+					
 					<div style="width: 100%;font-size:0.8em">
 						<div style="display: inline">
 							<input type="checkbox" name="attr_shield_success" />
@@ -2070,6 +2120,37 @@
 							HP<input type="number" name="attr_shield_hp" />
 						</div>
 					</div>
+
+				<fieldset class="repeating_ shields">
+					<table>
+					<div style="width: 100%;font-size:0.8em">
+						<div style="display: inline">
+							<input type="checkbox" name="attr_shield_success" />
+							<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
+							<input type="number" name="attr_shield_skill" />
+							%&nbsp;
+						</div>
+						<div style="display:inline; float:right">
+							Attack Damage
+							<input style="width: 55px" type="text" name="attr_shield_damage" />
+						</div>
+					</div>
+					<div style="font-size:0.8em">
+						<div style="display:inline">
+							<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
+							<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
+							<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
+							<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
+						
+							Base Chance
+							<input type="number" name="attr_shield_base_chance" />
+						</div>
+						<div style="display: inline; float: right">
+							HP<input type="number" name="attr_shield_hp" />
+						</div>
+					</div>
+					</table>
+				</fieldset>
 					
 				</div >				
 				<div  style=" color: #FFF; background-color: #000;width: 100%" >
@@ -2149,11 +2230,11 @@
 <input type="checkbox" class="sheet-toggle-magic1" name="attr_toggle-magic1"  style="display: none">
 <div class="sheet-skills-magic1" />
  <p>
-			<h3 class="sheet-section-header">Magic / Powers
-			<div style="float:right">Magic Pts.
-				<input class="sheet-section-header" type="number" name="attr_max_mp" />
-				/
+			<h3 class="sheet-section-header">Powers
+			<div style="float:right">Power Pts.
 				<input class="sheet-section-header" type="number" name="attr_cur_mp" />
+				/
+				<input class="sheet-section-header" type="number" name="attr_max_mp" />
 			<div> 
 			</h3>
 
@@ -2164,7 +2245,7 @@
 		
 				<table style="width: 100%">
 					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Spell</th>
+						<th style="width: 111px; text-align: left">Power</th>
 						<th style="width: 50px" >Skill</th>
 						<th style="width: 60px" >Range</th>
 						<th style="width: 60px" >Duration</th>
@@ -2199,7 +2280,7 @@
 		
 				<table style="width: 100%">
 					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Spell</th>
+						<th style="width: 111px; text-align: left">Power</th>
 						<th style="width: 50px" >Skill</th>
 						<th style="width: 60px" >Range</th>
 						<th style="width: 60px" >Duration</th>
@@ -2234,7 +2315,7 @@
 		
 				<table style="width: 100%">
 					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Spell</th>
+						<th style="width: 111px; text-align: left">Power</th>
 						<th style="width: 50px" >Skill</th>
 						<th style="width: 60px" >Range</th>
 						<th style="width: 60px" >Duration</th>
@@ -2535,11 +2616,11 @@
 		{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
 		{{#rollBetween() roll 41 50}}<td class="template_value">Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
 		{{#rollBetween() roll 51 60}}<td class="template_value">Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
-		{{#rollBetween() roll 61 65}}<td class="template_value">Lose 1D10 points of weapon’s hit points.</td>{{/rollBetween() roll 61 65}}
+		{{#rollBetween() roll 61 65}}<td class="template_value">Lose 1D10 points of weaponÂ’s hit points.</td>{{/rollBetween() roll 61 65}}
 		{{#rollBetween() roll 66 75}}<td class="template_value">Vision obscured, lose 30% on all appropriate skills for 1D3 combat rounds.</td>{{/rollBetween() roll 66 75}}
 		{{#rollBetween() roll 76 85}}<td class="template_value">Hit nearest ally for normal damage, or Drop the weapon being used if no ally nearby.</td>{{/rollBetween() roll 76 85}}
 		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for special damage, or Throw weapon 1D10 meters away, if no ally nearby.</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 98}}<td class="template_value">Hit nearest ally for critical damage, or Lose 1D10 points of weapon’s hit points, if no ally nearby.</td>{{/rollBetween() roll 91 98}}
+		{{#rollBetween() roll 91 98}}<td class="template_value">Hit nearest ally for critical damage, or Lose 1D10 points of weaponÂ’s hit points, if no ally nearby.</td>{{/rollBetween() roll 91 98}}
 		{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
 		{{#rollTotal() roll 00}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 00}}
 	{{/rollTotal() table 0}}
@@ -2549,7 +2630,7 @@
 		{{#rollBetween() roll 21 40}}<td>Fall down.</td>{{/rollBetween() roll 21 40}}		
 		{{#rollBetween() roll 41 50}}<td>Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
 		{{#rollBetween() roll 51 60}}<td>Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
-		{{#rollBetween() roll 61 75}}<td>Lose 1D10 points of weapon’s hit points.</td>{{/rollBetween() roll 61 75}}
+		{{#rollBetween() roll 61 75}}<td>Lose 1D10 points of weaponÂ’s hit points.</td>{{/rollBetween() roll 61 75}}
 		{{#rollBetween() roll 76 85}}<td>Wide open; foe automatically hits with normal hit.</td>{{/rollBetween() roll 76 85}}
 		{{#rollBetween() roll 86 90}}<td>Wide open; foe automatically hits with special hit.</td>{{/rollBetween() roll 86 90}}
 		{{#rollBetween() roll 91 93}}<td>Wide open; foe automatically hits with critical hit</td>{{/rollBetween() roll 91 93}}
@@ -2562,11 +2643,11 @@
 		{{#rollBetween() roll 16 25}}<td class="template_value">Lose the next 1D3 combat rounds or other activity.</td>{{/rollBetween() roll 16 25}}		
 		{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
 		{{#rollBetween() roll 41 55}}<td class="template_value">Vision obscured; lose 30% on all appropriate skills for 1D3 combat rounds</td>{{/rollBetween() roll 41 55}}
-		{{#rollBetween() roll 56 65}}<td class="template_value">Drop weapon; which slides or bounces 1D6–1 meters away.</td>{{/rollBetween() roll 56 65}}
-		{{#rollBetween() roll 66 80}}<td class="template_value">Do 1D6 damage to weapon’s hit points or break if the weapon has no hit points.</td>{{/rollBetween() roll 66 80}}
+		{{#rollBetween() roll 56 65}}<td class="template_value">Drop weapon; which slides or bounces 1D6Â–1 meters away.</td>{{/rollBetween() roll 56 65}}
+		{{#rollBetween() roll 66 80}}<td class="template_value">Do 1D6 damage to weaponÂ’s hit points or break if the weapon has no hit points.</td>{{/rollBetween() roll 66 80}}
 		{{#rollBetween() roll 81 85}}<td class="template_value">Break weapon.</td>{{/rollBetween() roll 81 85}}
-		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Drop weapon; which slides or bounces 1D6–1 meters away. if no ally nearby.</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 95}}<td class="template_value">Hit nearest ally for special damage, orDo 1D6 damage to weapon’s hit points or break if the weapon has no hit points, if no ally nearby.</td>{{/rollBetween() roll 91 95}}
+		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Drop weapon; which slides or bounces 1D6Â–1 meters away. if no ally nearby.</td>{{/rollBetween() roll 86 90}}
+		{{#rollBetween() roll 91 95}}<td class="template_value">Hit nearest ally for special damage, orDo 1D6 damage to weaponÂ’s hit points or break if the weapon has no hit points, if no ally nearby.</td>{{/rollBetween() roll 91 95}}
 		{{#rollBetween() roll 96 98}}<td class="template_value">Hit nearest ally for critical damage, or Break weapon, if no ally nearby</td>{{/rollBetween() roll 96 98}}
 		{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
 		{{#rollTotal() roll 100}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 100}}
@@ -2599,17 +2680,17 @@
 		</tr>
 		<tr>
 			{{#rollBetween() roll 1 10}} <td class="template_value"> Severed leg tendons cause limping; fused ankle bones cause limping; back muscles or spinal nerve damage bend the torso to the left or right; a shattered knee cannot bend; or make up a new wound effect. Lose 1D3 DEX. The maximum MOV is now reduced by the same 1D3 result. Your character is still able to fight. {{/rollBetween() roll 1 10}} </td>
-			{{#rollBetween() roll 11 20}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your character’s appearance; or make up a new wound effect. Lose 1D3 APP. The visible and unappealing deformity cannot be disguised. Your character is still able to fight. {{/rollBetween() roll 11 20}} </td>
+			{{#rollBetween() roll 11 20}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characterÂ’s appearance; or make up a new wound effect. Lose 1D3 APP. The visible and unappealing deformity cannot be disguised. Your character is still able to fight. {{/rollBetween() roll 11 20}} </td>
 			{{#rollBetween() roll 21 30}} <td class="template_value"> Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D3 STR; this loss may change what weapons can be used. Your character is still able to fight with a weapon, but not a shield. {{/rollBetween() roll 21 30}} </td>
 			{{#rollBetween() roll 31 40}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D3 CON; maximum MOV is now reduced by the same 1D3, and hit points may be lowered. Your character is still able to fight. {{/rollBetween() roll 31 40}} </td>
-			{{#rollBetween() roll 41 50}} <td class="template_value"> Concussion damages hearing and limits Listen and Insight to maximums of 65 percent; injury to the head thereafter require Luck rolls each time to use any Mental skills; blows or cuts which affect depth perception leave missile weapon skill ratings at a maximum of 65%; multiple wounds to the face and neck limit the skills of any Communication skills to 65% maximum; or make up a new wound effect. Lose 1D3 INT; this loss may affect your character’s ability to use any powers. Your character is still able to fight. {{/rollBetween() roll 41 50}} </td>
-			{{#rollBetween() roll 51 60}} <td class="template_value"> Refer to 01–10 for what happened, which now expands to the loss of one or both arms or legs. Lose 1D6 DEX and reduce maximum MOV by that same amount. Your character is unable to fight.  {{/rollBetween() roll 51 60}} </td>
-			{{#rollBetween() roll 61 70}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your character’s appearance; or make up a new wound effect. . Lose 1D6 APP; it creates one or more visible deformities that cannot be disguised Your character is still able to fight. {{/rollBetween() roll 61 70}} </td>
+			{{#rollBetween() roll 41 50}} <td class="template_value"> Concussion damages hearing and limits Listen and Insight to maximums of 65 percent; injury to the head thereafter require Luck rolls each time to use any Mental skills; blows or cuts which affect depth perception leave missile weapon skill ratings at a maximum of 65%; multiple wounds to the face and neck limit the skills of any Communication skills to 65% maximum; or make up a new wound effect. Lose 1D3 INT; this loss may affect your characterÂ’s ability to use any powers. Your character is still able to fight. {{/rollBetween() roll 41 50}} </td>
+			{{#rollBetween() roll 51 60}} <td class="template_value"> Refer to 01Â–10 for what happened, which now expands to the loss of one or both arms or legs. Lose 1D6 DEX and reduce maximum MOV by that same amount. Your character is unable to fight.  {{/rollBetween() roll 51 60}} </td>
+			{{#rollBetween() roll 61 70}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characterÂ’s appearance; or make up a new wound effect. . Lose 1D6 APP; it creates one or more visible deformities that cannot be disguised Your character is still able to fight. {{/rollBetween() roll 61 70}} </td>
 			{{#rollBetween() roll 71 80}} <td class="template_value">  Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D6 STR; change hit points and damage bonus. Your character is still able to fight. {{/rollBetween() roll 71 80}} </td>
 			{{#rollBetween() roll 81 90}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D6 CON; may affect hit points, damage bonus, and reduces MOV by that number of units equal to the 1D6 result rolled.Your character is unable to fight. {{/rollBetween() roll 81 90}} </td>
 			{{#rollBetween() roll 91 92}} <td class="template_value"> Bad facial and vocal-cord injuries. Lose 1D6 APP; lower the Charisma roll respectively. Your character is still able to fight. {{/rollBetween() roll 91 92}} </td>
 			{{#rollBetween() roll 93 94}} <td class="template_value"> Broken bones and severed ganglia. Lose 1D6 DEX; from now on your character can only use one-handed melee weapons. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll 93 94}} </td>
-			{{#rollBetween() roll95 96}} <td class="template_value"> Nerve damage to left or right arm (roll 1D6; a result of 1–3 is the left arm, 4–6 is the right arm). Lose 1D6 DEX; hereafter your character can only wield weapons or equipment in his or her undamaged arm. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll95 96}} </td>
+			{{#rollBetween() roll95 96}} <td class="template_value"> Nerve damage to left or right arm (roll 1D6; a result of 1Â–3 is the left arm, 4Â–6 is the right arm). Lose 1D6 DEX; hereafter your character can only wield weapons or equipment in his or her undamaged arm. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll95 96}} </td>
 			{{#rollBetween() roll 97 98}} <td class="template_value"> Nerve damage to both arms. Lose 1D6 DEX; though the legs are fine, neither arms nor hands can wield anything. Your character is unable to fight, unless using his or her legs or head butts. {{/rollBetween() roll 97 98}} </td>
 			{{#rollTotal() roll 99}} <td class="template_value"> Your character is mutilated with vicious wounds. Lose 1D3 points each from APP, DEX, and CON, and describe the results. Your character is unable to fight. {{/rollTotal() roll 99}} </td>
 			</tr>
@@ -2638,4 +2719,3 @@ on("change:is_config", function() {
 
 });
 </script>
-


### PR DESCRIPTION
Minor Edits and Fixes on Existing Basic_Roleplaying Character Sheet
•	You now input your damage bonus instead of choosing one from a drop-down list.
•	Changed Modifier to Multiplier in the Attribute rolls
•	Changed Magic Pts to Power Pts in Characteristic Box
•	Flipped Max HP, Max MP, Max Fati. Max San with Cur HP, Cur MP, Cur Fati, Cur San respectively.
•	Fliped Max MP and Cur MP in the powers section.
•	Fixed the extra Ranged Weapons section so that it uses the roll template
•	Changed Ranged Weapon Type to Damage Bonus? (Y/N)
•	Fixed Ranged Damage Bonus so that the modified Bonus is rounded up. Instead of the allowing fractions.
•	Fixed the Persuade skill, the special success section was using the Etiquette skill instead of the persuade skill.
•	Added Artillery (Various), Fast Talk (05%), Martial Arts (01%), Projection (DEX x02%), Psychotherapy (00% or 01%), Research (25%) in alphabetical skills
•	Fixed the problem with the combat skills where deleting one deletes all the others by changing repeating_meleeskill to repeating_rangeskil and repeating_artilleryskill
•	Change SR/Attks to a text box to allow fractions
•	Aligned the combat skills in the Skills by Category
•	Add Artillery (Various), Fast Talk (05%), Martial Arts (01%), Projection (DEX x02%), Psychotherapy (00% or 01%), Research (25%) in categorical skills
•	Change Magic Pts to Power Pts in Magic/Powers Section
•	Modify First Aid (30%) or INT x1 to First Aid (30% or INT x01%), Brawl (50%) to Brawl (25%)
•	Add a Multiplier Modifier for every Skill Roll in Alphabetic Skills.
•	Add Multiplier Modifier for Combat Skill Rolls.
•	Fixed the grapple skill since it used the brawling skill.
•	Change Perform from a single skill to a repeating skill in alphabetical skills.
•	Fixed the fly in skills by category, added fumbles, critical and special success.
•	Skills by Category now adds the category bonus automatically.
•	Made Combat a skill category under the skills by category tag
•	Changed the general armor section to make it easier to read and be more like the character sheet. Added an energy charge counter for energy shields and other magical defenses.
•	Fixed the Repair Skill’s Fumble on the Categorical Skills List
•	Add (Stat) section for Skill Categories
•	Have the Skill Categories sections receive a bonus based on stats.
•	Add a Multiplier Modifier for every Skill Roll in Categorical Skills