### PR TITLE
[DSA4.1] Ranged Combat Fixes

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -156,13 +156,14 @@ input[type=number]::-webkit-outer-spin-button {
 
 .charsheet label {
     color: #000000;
-}
-
-.charsheet .sheet-activation-items label {
     font-size: 0.833em; /* Necessary to counter definition from app.css */
     font-weight: 400;
     margin: 0;
     padding: 0;
+}
+
+.charsheet label.sheet-lone-input-label {
+	display: inline;
 }
 
 /* Used to completely cover outer <label> area whenever the activation item

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -612,6 +612,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 
 /* Ranged combat related hiding and styling */
 .charsheet .sheet-hide-ranged-combat-calc:checked ~ table.sheet-ranged-combat-calc,
+.charsheet .sheet-hide-brightness:not(:checked) ~ table select.sheet-hide-wde-brightness,
+.charsheet .sheet-hide-brightness:checked ~ table select.sheet-hide-wds-brightness,
 .charsheet .sheet-hide-ranged-schussmitansage:checked ~ table div.sheet-hide-ranged-schussmitansage,
 .charsheet .sheet-hide-ranged-targeted-shot-twolegged:checked ~ table div.sheet-hide-ranged-targeted-shot-twolegged,
 .charsheet .sheet-hide-ranged-targeted-shot-fourlegged:checked ~ table div.sheet-hide-ranged-targeted-shot-fourlegged,

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -10597,7 +10597,7 @@
                             <input type="checkbox" name="attr_FKW1_Spez" value="2" style="width: 2em">
                         </td>
                         <td>
-                            <input type="checkbox" name="attr_FKW_Aktiv1" value="1">
+                            <input type="checkbox" name="attr_FKW_Aktiv1" value="1" checked>
                         </td>
                         <td>
                             <input type="text" name="attr_FKWname1" style="width: 12em;">
@@ -10637,34 +10637,34 @@
                             <input type="number" name="attr_FKWSchaden1_2" min="-5" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_RW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_RW1" min="0" value="10" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_RW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_RW2" min="0" value="20" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_RW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_RW3" min="0" value="30" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_RW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_RW4" min="0" value="40" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_RW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_RW5" min="0" value="50" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_TPRW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_TPRW1" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_TPRW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_TPRW2" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_TPRW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_TPRW3" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_TPRW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_TPRW4" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW1_TPRW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW1_TPRW5" value="0" style="width: 3.5em;">
                         </td>
                         <td>
                             <input type="number" name="attr_FKWGewicht1" min="0" value="0">
@@ -10715,34 +10715,34 @@
                             <input type="number" name="attr_FKWSchaden2_2" min="-5" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_RW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_RW1" min="0" value="10" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_RW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_RW2" min="0" value="20" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_RW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_RW3" min="0" value="30" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_RW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_RW4" min="0" value="40" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_RW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_RW5" min="0" value="50" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_TPRW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_TPRW1" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_TPRW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_TPRW2" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_TPRW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_TPRW3" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_TPRW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_TPRW4" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW2_TPRW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW2_TPRW5" value="0" style="width: 3.5em;">
                         </td>
                         <td>
                             <input type="number" name="attr_FKWGewicht2" min="0" value="0">
@@ -10793,34 +10793,34 @@
                             <input type="number" name="attr_FKWSchaden3_2" min="-5" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_RW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_RW1" min="0" value="10" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_RW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_RW2" min="0" value="20" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_RW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_RW3" min="0" value="30" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_RW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_RW4" min="0" value="40" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_RW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_RW5" min="0" value="50" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_TPRW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_TPRW1" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_TPRW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_TPRW2" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_TPRW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_TPRW3" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_TPRW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_TPRW4" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW3_TPRW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW3_TPRW5" value="0" style="width: 3.5em;">
                         </td>
                         <td>
                             <input type="number" name="attr_FKWGewicht3" min="0" value="0">
@@ -10871,34 +10871,34 @@
                             <input type="number" name="attr_FKWSchaden4_2" min="-5" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_RW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_RW1" min="0" value="10" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_RW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_RW2" min="0" value="20" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_RW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_RW3" min="0" value="30" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_RW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_RW4" min="0" value="40" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_RW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_RW5" min="0" value="50" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_TPRW1" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_TPRW1" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_TPRW2" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_TPRW2" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_TPRW3" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_TPRW3" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_TPRW4" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_TPRW4" value="0" style="width: 3.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKW4_TPRW5" style="width: 3.5em;">
+                            <input type="number" name="attr_FKW4_TPRW5" value="0" style="width: 3.5em;">
                         </td>
                         <td>
                             <input type="number" name="attr_FKWGewicht4" min="0" value="0">
@@ -11572,7 +11572,7 @@
                     <td>-</td>
                 </tr>
                 <tr>
-                    <td>Entfernung in Schritt: <input type="number" name="attr_fkr_entfernung_raw" min="0" max="9999"></td>
+                    <td>Entfernung in Schritt: <input type="number" name="attr_fkr_entfernung_raw" min="0" value="5" max="9999"></td>
                     <td><span name="attr_fkr_entfernung_final"></span></td>
                     <td>-</td>
                     <td><span name="attr_fkr_entfernung_final_tp"></span></td>
@@ -11649,7 +11649,7 @@
                             <option value="gezieltvierbeiner">Gezielter Schuss (Vierbeiner)</option>
                         </select>
                         <div class="sheet-hide-ranged-schussmitansage">
-                            Ansage: <input type="number" name="attr_fkr_schussmitansage_ansage_raw"></td>
+                            Ansage: <input type="number" name="attr_fkr_schussmitansage_ansage_raw" min="1" value="1"></td>
                         </div>
                         <div class="sheet-hide-ranged-targeted-shot-twolegged">
                             <select name="attr_fkr_gezielter_schuss_zweibeiner">
@@ -11675,7 +11675,7 @@
                                 <option value="verwundbar">verwundbare Stelle</option>
                             </select>
                             <div class="sheet-hide-ranged-targeted-shot-fourlegged-variable">
-                                Sinnesorgan/Schwanz: <input type="number" name="attr_fkr_gezielter_schuss_vierbeiner_variabel">
+                                Sinnesorgan/Schwanz: <input type="number" name="attr_fkr_gezielter_schuss_vierbeiner_variabel" value="0">
                             </div>
                         </div>
                     </td>
@@ -11758,10 +11758,10 @@
                         <input class="sheet-hide-ranged-fray-counts sheet-default-hide" type="checkbox" name="attr_fkr_kampfgetuemmel">
                         <div class="sheet-hide-ranged-fray-counts">
                             <div>
-                            Beteiligte in <span class="sheet-abbr" title="Distanzklasse">DK</span> <span class="sheet-abbr" title="Handgemenge">H</span> <input type="number" name="attr_fkr_kampfgetuemmel_beteiligte_H">
+                            Beteiligte in <span class="sheet-abbr" title="Distanzklasse">DK</span> <span class="sheet-abbr" title="Handgemenge">H</span> <input type="number" name="attr_fkr_kampfgetuemmel_beteiligte_H" min="0" value="0">
                             </div>
                             <div>
-                            Beteiligte in <span class="sheet-abbr" title="Distanzklasse">DK</span> <span class="sheet-abbr" title="Nahkampf">N</span> und <span class="sheet-abbr" title="Stangenwaffe">S</span> <input type="number" name="attr_fkr_kampfgetuemmel_beteiligte_NS">
+                            Beteiligte in <span class="sheet-abbr" title="Distanzklasse">DK</span> <span class="sheet-abbr" title="Nahkampf">N</span> und <span class="sheet-abbr" title="Stangenwaffe">S</span> <input type="number" name="attr_fkr_kampfgetuemmel_beteiligte_NS" min="0" value="2">
                             </div>
                         </div>
                     </td>
@@ -11770,10 +11770,10 @@
                     <td>-</td>
                 </tr>
                 <tr class="sheet-last">
-                    <td>Sonstige Erschwernis <input type="number" name="attr_fkr_sonstiges_raw">
+                    <td>Sonstige Erschwernis <input type="number" name="attr_fkr_sonstiges_raw" value="0">
                         <span class="sheet-abbr sheet-hide-ranged-warning-shortsighted" title="Meisterentscheid benötigt. Der Charakter verfügt über den Nachteil &bdquo;Kurzsichtig&ldquo; und soll auf ein Ziel in über 100 Schritt Entfernung feuern. Der Meister kann ab dieser Entfernung eine zusätzliche Erschwernis verhängen. Addieren Sie diese Erschwernis zur Erschwernis im nebenstehenden Feld.">!</span>
                         <br>
-                        Sonstige Ansage <input type="number" name="attr_fkr_sonstiges_ansage_raw"></td>
+                        Sonstige Ansage <input type="number" name="attr_fkr_sonstiges_ansage_raw" value="0"></td>
                     <td><span name="attr_fkr_sonstiges_final"></span></td>
                     <td>-</td>
                     <td>-</td>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12759,7 +12759,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-09-03"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-09-04"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11521,7 +11521,7 @@
                     <th><span class="sheet-abbr" title="Sämtliche Einstellungen inklusive Modifikatoren und Ansagen werden aus dem Fernkampfrechner übernommen.">Fernkampfangriff</span></th>
                 </tr>
                 <tr>
-                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="true"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[@{fkr_erschwernis_gesamt} - @{fkr_erschwernis_ansage_gesamt}]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - @{fkr_erschwernis_gesamt}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
+                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="true"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[(@{fkr_erschwernis_gesamt}) - (@{fkr_erschwernis_ansage_gesamt})]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_gesamt})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
                     </td>
                 </tr>
                 <tr>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11521,7 +11521,7 @@
                     <th><span class="sheet-abbr" title="Sämtliche Einstellungen inklusive Modifikatoren und Ansagen werden aus dem Fernkampfrechner übernommen.">Fernkampfangriff</span></th>
                 </tr>
                 <tr>
-                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="true"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[(@{fkr_erschwernis_gesamt}) - (@{fkr_erschwernis_ansage_gesamt})]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_gesamt})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
+                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="true"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[(@{fkr_erschwernis_gesamt}) - (@{fkr_erschwernis_ansage_gesamt})]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_gesamt})]]}} {{eff_wert_ohne_kampfgetuemmel=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_ohne_kampfgetuemmel})]]}} {{ZieleKampfgetuemmel=[[@{fkr_kampfgetuemmel_ziele}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
                     </td>
                 </tr>
                 <tr>
@@ -13846,8 +13846,31 @@
         </tr>
 {{#rollGreater() ansage 0}}
         <tr>
-            <td colspan="3" class="sheet-templates-result"><span class="sheet-abbr" title="Fernkampf">FK</span>-Angriff {{#rollLess() modansage 0}}{{modansage}}{{/rollLess() modansage 0}}{{#rollTotal() modansage 0}}&#177;{{modansage}}{{/rollTotal() modansage 0}}{{#rollGreater() modansage 0}}+{{modansage}}{{/rollGreater() modansage 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
+            <td colspan="3" class="sheet-templates-result">
+                <span class="sheet-abbr" title="Fernkampf">FK</span>-Angriff {{#rollLess() modansage 0}}{{modansage}}{{/rollLess() modansage 0}}{{#rollTotal() modansage 0}}&#177;{{modansage}}{{/rollTotal() modansage 0}}{{#rollGreater() modansage 0}}+{{modansage}}{{/rollGreater() modansage 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).
+            </td>
         </tr>
+{{#rollGreater() ZieleKampfgetuemmel 1}}
+        <tr>
+            <td colspan="3">
+                Schuss ins Kampfgetümmel trifft 
+                {{#^rollGreater() wurf eff_wert}}das beabsichtigte Ziel.{{/^rollGreater() wurf eff_wert}}
+                {{#^rollWasFumble() wurf}}
+                    {{#rollGreater() wurf eff_wert}}
+                        {{#^rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                            <span class="sheet-abbr" title="Ziel auswürfeln: Jedem Ziel eine Augenzahl zuweisen, dann auswürfeln. Beispiel mit fünf Beteiligten: Im Chat &bdquo;[[1d5]]&ldquo; schreiben und das Ergebnis ablesen.">zufällig einen der {{ZieleKampfgetuemmel}} Beteiligten.</span>
+                        {{/^rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                        {{#rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                            niemanden.
+                        {{/rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                    {{/rollGreater() wurf eff_wert}}
+                {{/^rollWasFumble() wurf}}
+                {{#rollWasFumble() wurf}}
+                    niemanden.
+                {{/rollWasFumble() wurf}}
+            </td>
+        </tr>
+{{/rollGreater() ZieleKampfgetuemmel 1}}
         <tr>
             <td><span class="sheet-abbr" title="Fernkampf">FK</span>-Wert: {{wert}}</td>
             <td><span class="sheet-abbr" title="Modifikator">Mod.</span>: {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}
@@ -13860,6 +13883,27 @@
         <tr>
             <td colspan="3" class="sheet-templates-result"><span class="sheet-abbr" title="Fernkampf">FK</span>-Angriff {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}{{#rollTotal() mod 0}}&#177;{{mod}}{{/rollTotal() mod 0}}{{#rollGreater() mod 0}}+{{mod}}{{/rollGreater() mod 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
         </tr>
+{{#rollGreater() ZieleKampfgetuemmel 1}}
+        <tr>
+            <td colspan="3">
+                Schuss ins Kampfgetümmel trifft 
+                {{#^rollGreater() wurf eff_wert}}das beabsichtigte Ziel.{{/^rollGreater() wurf eff_wert}}
+                {{#^rollWasFumble() wurf}}
+                    {{#rollGreater() wurf eff_wert}}
+                        {{#^rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                            <span class="sheet-abbr" title="Ziel auswürfeln: Jedem Ziel eine Augenzahl zuweisen, dann auswürfeln. Beispiel mit fünf Beteiligten: Im Chat &bdquo;[[1d5]]&ldquo; schreiben und das Ergebnis ablesen.">zufällig einen der {{ZieleKampfgetuemmel}} Beteiligten.</span>
+                        {{/^rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                        {{#rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                            niemanden.
+                        {{/rollGreater() wurf eff_wert_ohne_kampfgetuemmel}}
+                    {{/rollGreater() wurf eff_wert}}
+                {{/^rollWasFumble() wurf}}
+                {{#rollWasFumble() wurf}}
+                    niemanden.
+                {{/rollWasFumble() wurf}}
+            </td>
+        </tr>
+{{/rollGreater() ZieleKampfgetuemmel 1}}
         <tr>
             <td colspan="3"><span class="sheet-abbr" title="Fernkampf">FK</span>-Wert: {{wert}}</td>
         </tr>
@@ -14302,6 +14346,8 @@ function deactivateRCC() {
 		fkr_aktiv: "on",
 		fkr_erschwernis_gesamt: "?{Erleichterung (−) oder Erschwernis (+)|0} + ?{Ansage für Fernkampfangriff|0,0|1,1|2,2|3,3|4,4|5,5|6,6|7,7|8,8|9,9|10,10|11,11|12,12|13,13|14,14|15,15|16,16|17,17|18,18|19,19|20,20|21,21|22,22|23,23|24,24|25,25|26,26|27,27|28,28|29,29|30,30|31,31|32,32}",
 		fkr_erschwernis_ansage_gesamt: "?{Ansage für Fernkampfangriff|0,0|1,1|2,2|3,3|4,4|5,5|6,6|7,7|8,8|9,9|10,10|11,11|12,12|13,13|14,14|15,15|16,16|17,17|18,18|19,19|20,20|21,21|22,22|23,23|24,24|25,25|26,26|27,27|28,28|29,29|30,30|31,31|32,32}",
+		fkr_erschwernis_ohne_kampfgetuemmel: 0,
+		fkr_kampfgetuemmel_ziele: 0,
 		fk_tp_roll: "&{template:DSA-Kampf-Treffer} {{name=Fernkampf}} {{target=[[?{Tabelle für zufällige Trefferzone auswählen|Zweibeiner gegen unbeschwänzten Zweibeiner,0|Zweibeiner gegen beschwänzten Zweibeiner,1|Zweibeiner gegen Vierbeiner,3|Zweibeiner gegen Reiter,4|Reiter gegen Zweibeiner,2}]]}} {{zone=[[1d20]]}} {{damage=[[?{Anzahl W6 für Schadenswurf|1,1|2,2|3,3|4,4|5,5}d6 + ?{Bonus (+)/Malus (−) der Trefferpunkte|0}]]}}"
 	});
 }
@@ -15193,6 +15239,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 					// Kampfgetümmel
 					// Zielbewegung -> 0 (s. o.)
 					// pro Beteiligte auf DK H und DK NS erschwert
+					var zielekampfgetuemmel = 0;
 					if(FKR.getuemmel.aktiv != "0")
 					{
 						if(isNaN(parseInt(FKR.getuemmel.ziele_h)))
@@ -15233,6 +15280,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 							setAttrs({fkr_kampfgetuemmel_final: "!"});
 							return;
 						}
+						zielekampfgetuemmel = dk_ns + dk_h;
 						var mods = (2 * dk_ns) + (3 * dk_h);
 						mod_gesamt.getuemmel = mods;
 						setAttrs({fkr_kampfgetuemmel_final: prettifyMod(mods)});
@@ -15337,6 +15385,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 							fkr_erschwernis_gesamt: ergebnis.mod,
 							fkr_erschwernis_ansage_gesamt: ergebnis.ansage,
 							fkr_erschwernis_ohne_kampfgetuemmel: ergebnis.mod_ohne_getuemmel,
+							fkr_kampfgetuemmel_ziele: zielekampfgetuemmel,
 							fk_tp_roll: ergebnis.tp.roll,
 							ftp_w_aktiv: ergebnis.tp.w6,
 							ftp_bonus_aktiv: ergebnis.tp.mod,

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -10597,7 +10597,7 @@
                             <input type="checkbox" name="attr_FKW1_Spez" value="2" style="width: 2em">
                         </td>
                         <td>
-                            <input type="checkbox" name="attr_FKW_Aktiv1" value="1" checked>
+                            <input type="checkbox" name="attr_FKW_Aktiv1" value="1">
                         </td>
                         <td>
                             <input type="text" name="attr_FKWname1" style="width: 12em;">
@@ -11454,10 +11454,10 @@
                     </th>
                 </tr>
             </table>
-            <input type="checkbox" class="sheet-hide-ranged-weapon-1 sheet-default-hide" name="attr_FKW_Aktiv1" value="1" checked="true">
-            <input type="checkbox" class="sheet-hide-ranged-weapon-2 sheet-default-hide" name="attr_FKW_Aktiv2" value="1" checked="true">
-            <input type="checkbox" class="sheet-hide-ranged-weapon-3 sheet-default-hide" name="attr_FKW_Aktiv3" value="1" checked="true">
-            <input type="checkbox" class="sheet-hide-ranged-weapon-4 sheet-default-hide" name="attr_FKW_Aktiv4" value="1" checked="true">
+            <input type="checkbox" class="sheet-hide-ranged-weapon-1 sheet-default-hide" name="attr_FKW_Aktiv1" value="1">
+            <input type="checkbox" class="sheet-hide-ranged-weapon-2 sheet-default-hide" name="attr_FKW_Aktiv2" value="1">
+            <input type="checkbox" class="sheet-hide-ranged-weapon-3 sheet-default-hide" name="attr_FKW_Aktiv3" value="1">
+            <input type="checkbox" class="sheet-hide-ranged-weapon-4 sheet-default-hide" name="attr_FKW_Aktiv4" value="1">
 
             <table class="sheet-hideable-ranged-weapons">
                 <tr>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11752,7 +11752,7 @@
                 </tr>
                 <tr>
                     <td class="sheet-activation-items">
-                        <label>
+                        <label class="sheet-lone-input-label">
                           <input type="checkbox" name="attr_fkr_kampfgetuemmel"> Kampfgetümmel
                         </label>
                         <input class="sheet-hide-ranged-fray-counts sheet-default-hide" type="checkbox" name="attr_fkr_kampfgetuemmel">
@@ -11836,15 +11836,15 @@
                     <th colspan="4">Relevante Vor- und Nachteile (<span class="sheet-abbr" title="Soweit implementiert. Momentan ausschließlich auf den Kampf beschränkt.">?</span>)</th>
                 </tr>
                 <tr>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_vorteil_daemmerungssicht"> Dämmerungssicht</label></td>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_nachteil_einaeugig"> Einäugig</label></td>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_vorteil_entfernungssinn"> Entfernungssinn</label></td>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_nachteil_farbenblind"> Farbenblind</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_vorteil_daemmerungssicht"> Dämmerungssicht</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_nachteil_einaeugig"> Einäugig</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_vorteil_entfernungssinn"> Entfernungssinn</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_nachteil_farbenblind"> Farbenblind</label></td>
                 </tr>
                 <tr>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_nachteil_eingeschraenkter_sinn_sicht"> <span class="sheet-abbr" title="Synonym für &bdquo;Eingeschränkter Sinn (Sicht)&ldquo;">Kurzsichtig</span></label></td>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_nachteil_nachtblind"> Nachtblind</label></td>
-                    <td class="sheet-activation-items"><label><input type="checkbox" name="attr_vorteil_nachtsicht"> Nachtsicht</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_nachteil_eingeschraenkter_sinn_sicht"> <span class="sheet-abbr" title="Synonym für &bdquo;Eingeschränkter Sinn (Sicht)&ldquo;">Kurzsichtig</span></label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_nachteil_nachtblind"> Nachtblind</label></td>
+                    <td class="sheet-activation-items"><label class="sheet-lone-input-label"><input type="checkbox" name="attr_vorteil_nachtsicht"> Nachtsicht</label></td>
                     <td>&nbsp;</td>
                 </tr>
             </table>
@@ -11856,309 +11856,258 @@
                         <table>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_aufmerksamkeit" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_aufmerksamkeit" value="1"> Aufmerksamkeit</label>
                                 </td>
-                                <td>Aufmerksamkeit</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_ausfall">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_ausfall"> Ausfall</label>
                                 </td>
-                                <td>Ausfall</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_ausweichenI" value="3">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_ausweichenI" value="3"> Ausweichen I</label>
                                 </td>
-                                <td>Ausweichen I</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_ausweichenII" value="3">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_ausweichenII" value="3"> Ausweichen II</label>
                                 </td>
-                                <td>Ausweichen II</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_ausweicheniII" value="3">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_ausweicheniII" value="3"> Ausweichen III</label>
                                 </td>
-                                <td>Ausweichen III</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_befreiungsschlag">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_befreiungsschlag"> Befreiungsschlag</label>
                                 </td>
-                                <td>Befreiungsschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_beidhandigerkampfI" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_beidhandigerkampfI" value="1"> Beidhändiger Kampf I</label>
                                 </td>
-                                <td>Beidhändiger Kampf I</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_beidhandigerkampfII" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_beidhandigerkampfII" value="1"> Beidhändiger Kampf II</label>
                                 </td>
-                                <td>Beidhändiger Kampf II</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_binden">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_binden"> Binden</label>
                                 </td>
-                                <td>Binden</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_betaubungsschlag">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_betaubungsschlag"> Betäubungsschlag</label>
                                 </td>
-                                <td>Betäubungsschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_blindkampf" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_blindkampf" value="1"> Blindkampf</label>
                                 </td>
-                                <td>Blindkampf</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_defensiverkampfstil" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_defensiverkampfstil" value="1"> Defensiver Kampfstil</label>
                                 </td>
-                                <td>Defensiver Kampfstil</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_doppelangriff">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_doppelangriff"> Doppelangriff</label>
                                 </td>
-                                <td>Doppelangriff</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_entwaffnen">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_entwaffnen"> Entwaffnen</label>
                                 </td>
-                                <td>Entwaffnen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_festnageln">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_festnageln"> Festnageln</label>
                                 </td>
-                                <td>Festnageln</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_finte">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_finte"> Finte</label>
                                 </td>
-                                <td>Finte</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_formation" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_formation" value="1"> Formation</label>
                                 </td>
-                                <td>Formation</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_gegenhalten">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_gegenhalten"> Gegenhalten</label>
                                 </td>
-                                <td>Gegenhalten</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_gezielterstich">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_gezielterstich"> Gezielter Stich</label>
                                 </td>
-                                <td>Gezielter Stich</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_halbschwert" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_halbschwert" value="1"> Halbschwert</label>
                                 </td>
-                                <td>Halbschwert</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_hammerschlag">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_hammerschlag"> Hammerschlag</label>
                                 </td>
-                                <td>Hammerschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_improvisiertewaffen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_improvisiertewaffen" value="1"> Improvisierte Waffen</label>
                                 </td>
-                                <td>Improvisierte Waffen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_kampfimwasser" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_kampfimwasser" value="1"> Kampf im Wasser</label>
                                 </td>
-                                <td>Kampf im Wasser</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_kampfgespur" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_kampfgespur" value="1"> Kampfgespür</label>
                                 </td>
-                                <td>Kampfgespür</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_kampfreflexe" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_kampfreflexe" value="1"> Kampfreflexe</label>
                                 </td>
-                                <td>Kampfreflexe</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_klingensturm">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_klingensturm"> Klingensturm</label>
                                 </td>
-                                <td>Klingensturm</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_klingentanzer" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_klingentanzer" value="1"> Klingentänzer</label>
                                 </td>
-                                <td>Klingentänzer</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_klingenwand">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_klingenwand"> Klingenwand</label>
                                 </td>
-                                <td>Klingenwand</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_linkhand" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_linkhand" value="1"> Linkhand</label>
                                 </td>
-                                <td>Linkhand</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterlichesentwaffnen">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterlichesentwaffnen"> Meisterliches Entwaffnen</label>
                                 </td>
-                                <td>Meisterliches Entwaffnen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterparade">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterparade"> Meisterparade</label>
                                 </td>
-                                <td>Meisterparade</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_niederwerfen">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_niederwerfen"> Niederwerfen</label>
                                 </td>
-                                <td>Niederwerfen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_parierwaffenI">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_parierwaffenI"> Parierwaffen I</label>
                                 </td>
-                                <td>Parierwaffen I</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_parierwaffenII" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_parierwaffenII" value="1"> Parierwaffen II</label>
                                 </td>
-                                <td>Parierwaffen II</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_rustungsgewohnungI" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_rustungsgewohnungI" value="1"> Rüstungsgewöhnung I</label>
                                 </td>
-                                <td>Rüstungsgewöhnung I</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_rustungsgewonungII" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_rustungsgewonungII" value="1"> Rüstungsgewöhnung II</label>
                                 </td>
-                                <td>Rüstungsgewöhnung II</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_rustungsgewohnungIII" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_rustungsgewohnungIII" value="1"> Rüstungsgewöhnung III</label>
                                 </td>
-                                <td>Rüstungsgewöhnung III</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schildkampfI" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schildkampfI" value="1"> Schildkampf I</label>
                                 </td>
-                                <td>Schildkampf I</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schildkampfII" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schildkampfII" value="1"> Schildkampf II</label>
                                 </td>
-                                <td>Schildkampf II</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schildspalter">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schildspalter"> Schildspalter</label>
                                 </td>
-                                <td>Schildspalter</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schnellziehen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schnellziehen" value="1"> Schnellziehen</label>
                                 </td>
-                                <td>Schnellziehen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_spiessgespann" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_spiessgespann" value="1"> Spießgespann</label>
                                 </td>
-                                <td>Spießgespann</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_sturmangriff">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_sturmangriff"> Sturmangriff</label>
                                 </td>
-                                <td>Sturmangriff</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_todvonlinks">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_todvonlinks"> Tod von Links</label>
                                 </td>
-                                <td>Tod von Links</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_todesstoss">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_todesstoss"> Todesstoß</label>
                                 </td>
-                                <td>Todesstoß</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_umreissen">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_umreissen"> Umreißen</label>
                                 </td>
-                                <td>Umreißen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_unterwasserkampf" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_unterwasserkampf" value="1"> Unterwasserkampf</label>
                                 </td>
-                                <td>Unterwasserkampf</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_waffezerbrechen">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_waffezerbrechen"> Waffe zerbrechen</label>
                                 </td>
-                                <td>Waffe zerbrechen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_waffenmeister" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_waffenmeister" value="1"> Waffenmeister</label>
                                 </td>
-                                <td>Waffenmeister</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_windmuehle">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_windmuehle"> Windmühle</label>
                                 </td>
-                                <td>Windmühle</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_wuchtschlag">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_wuchtschlag"> Wuchtschlag</label>
                                 </td>
-                                <td>Wuchtschlag</td>
                             </tr>
                         </table>
                         </td>
@@ -12169,93 +12118,78 @@
                         <table>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_berittenerschutze" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_berittenerschutze" value="1"> Berittener Schütze</label>
                                 </td>
-                                <td>Berittener Schütze</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_eisenhagel" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_eisenhagel" value="1"> Eisenhagel</label>
                                 </td>
-                                <td>Eisenhagel</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterschutze_armbrust" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterschutze_armbrust" value="1"> Meisterschütze (Armbrust)</label>
                                 </td>
-                                <td>Meisterschütze (Armbrust)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterschutze_bogen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterschutze_bogen" value="1"> Meisterschütze (Bogen)</label>
                                 </td>
-                                <td>Meisterschütze (Bogen)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterschutze_wurfbeile" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterschutze_wurfbeile" value="1"> Meisterschütze (Wurfbeile)</label>
                                 </td>
-                                <td>Meisterschütze (Wurfbeile)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterschutze_wurfmesser" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterschutze_wurfmesser" value="1"> Meisterschütze (Wurfmesser)</label>
                                 </td>
-                                <td>Meisterschütze (Wurfmesser)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_meisterschutze_wurfspeere" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_meisterschutze_wurfspeere" value="1"> Meisterschütze (Wurfspeere)</label>
                                 </td>
-                                <td>Meisterschütze (Wurfspeere)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_scharfschutze_armbrust" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_scharfschutze_armbrust" value="1"> Scharfschütze (Armbrust)</label>
                                 </td>
-                                <td>Scharfschütze (Armbrust)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_scharfschutze_bogen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_scharfschutze_bogen" value="1"> Scharfschütze (Bogen)</label>
                                 </td>
-                                <td>Scharfschütze (Bogen)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_scharfschutze_wurfbeile" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_scharfschutze_wurfbeile" value="1"> Scharfschütze (Wurfbeile)</label>
                                 </td>
-                                <td>Scharfschütze (Wurfbeile)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_scharfschutze_wurfmesser" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_scharfschutze_wurfmesser" value="1"> Scharfschütze (Wurfmesser)</label>
                                 </td>
-                                <td>Scharfschütze (Wurfmesser)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_scharfschutze_wurfspeere" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_scharfschutze_wurfspeere" value="1"> Scharfschütze (Wurfspeere)</label>
                                 </td>
-                                <td>Scharfschütze (Wurfspeere)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schnellladenarmbrust" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schnellladenarmbrust" value="1"> Schnellladen (Armbrust)</label>
                                 </td>
-                                <td>Schnellladen (Armbrust)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schnellladenbogen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schnellladenbogen" value="1"> Schnellladen (Bogen)</label>
                                 </td>
-                                <td>Schnellladen (Bogen)</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schnellziehen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schnellziehen" value="1"> Schnellziehen</label>
                                 </td>
-                                <td>Schnellziehen</td>
                             </tr>
                         </table>
                     </td>
@@ -12266,39 +12200,33 @@
                         <table>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_bornlandisch" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_bornlandisch" value="1"> Bornländisch</label>
                                 </td>
-                                <td>Bornländisch</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_gladiatorenstil" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_gladiatorenstil" value="1"> Gladiatorenstil</label>
                                 </td>
-                                <td>Gladiatorenstil</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_hammerfaust" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_hammerfaust" value="1"> Hammerfaust</label>
                                 </td>
-                                <td>Hammerfaust</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_hruruzat" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_hruruzat" value="1"> Hruruzat</label>
                                 </td>
-                                <td>Hruruzat</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_mercenario" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_mercenario" value="1"> Mercenario</label>
                                 </td>
-                                <td>Mercenario</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_stil_unauerschule" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_stil_unauerschule" value="1"> Unauer Schule</label>
                                 </td>
-                                <td>Unauer Schule</td>
                             </tr>
                         </table>
                         <br>
@@ -12310,183 +12238,153 @@
                         <table>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_auspendeln" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_auspendeln" value="1"> Auspendeln</label>
                                 </td>
-                                <td>Auspendeln</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_beinarbeit" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_beinarbeit" value="1"> Beinarbeit</label>
                                 </td>
-                                <td>Beinarbeit</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_biss" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_biss" value="1"> Biss</label>
                                 </td>
-                                <td>Biss</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_block" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_block" value="1"> Block</label>
                                 </td>
-                                <td>Block</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_doppelschlag" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_doppelschlag" value="1"> Doppelschlag</label>
                                 </td>
-                                <td>Doppelschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_eisenarm" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_eisenarm" value="1"> Eisenarm</label>
                                 </td>
-                                <td>Eisenarm</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_fussfeger" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_fussfeger" value="1"> Fußfeger</label>
                                 </td>
-                                <td>Fußfeger</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_gerade" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_gerade" value="1"> Gerade</label>
                                 </td>
-                                <td>Gerade</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_griff" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_griff" value="1"> Griff</label>
                                 </td>
-                                <td>Griff</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_halten" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_halten" value="1"> Halten</label>
                                 </td>
-                                <td>Halten</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_handkante" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_handkante" value="1"> Handkante</label>
                                 </td>
-                                <td>Handkante</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_hohertritt" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_hohertritt" value="1"> Hoher Tritt</label>
                                 </td>
-                                <td>Hoher Tritt</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_klammer" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_klammer" value="1"> Klammer</label>
                                 </td>
-                                <td>Klammer</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_knaufschlag" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_knaufschlag" value="1"> Knaufschlag</label>
                                 </td>
-                                <td>Knaufschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_knie" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_knie" value="1"> Knie</label>
                                 </td>
-                                <td>Knie</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_kopfstoss" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_kopfstoss" value="1"> Kopfstoß</label>
                                 </td>
-                                <td>Kopfstoß</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_kreuzblock" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_kreuzblock" value="1"> Kreuzblock</label>
                                 </td>
-                                <td>Kreuzblock</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_niederringen" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_niederringen" value="1"> Niederingen</label>
                                 </td>
-                                <td>Niederingen</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schmetterschlag" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schmetterschlag" value="1"> Schmetterschlag</label>
                                 </td>
-                                <td>Schmetterschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schmutzigetricks" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schmutzigetricks" value="1"> Schmutzige Tricks</label>
                                 </td>
-                                <td>Schmutzige Tricks</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schwanzfeger" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schwanzfeger" value="1"> Schwanzfeger</label>
                                 </td>
-                                <td>Schwanzfeger</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schwanzschlag" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schwanzschlag" value="1"> Schwanzschlag</label>
                                 </td>
-                                <td>Schwanzschlag</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schwinger" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schwinger" value="1"> Schwinger</label>
                                 </td>
-                                <td>Schwinger</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_schwitzkasten" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_schwitzkasten" value="1"> Schwitzkasten</label>
                                 </td>
-                                <td>Schwitzkasten</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_sprung" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_sprung" value="1"> Sprung</label>
                                 </td>
-                                <td>Sprung</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_sprungtritt" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_sprungtritt" value="1"> Sprungtritt</label>
                                 </td>
-                                <td>Sprungtritt</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_tritt" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_tritt" value="1"> Tritt</label>
                                 </td>
-                                <td>Tritt</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_versteckteklinge" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_versteckteklinge" value="1"> Versteckte Klinge</label>
                                 </td>
-                                <td>Versteckte Klinge</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_wurgegriff" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_wurgegriff" value="1"> Würgegriff</label>
                                 </td>
-                                <td>Würgegriff</td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_sf_wurf" value="1">
+                                    <label class="sheet-lone-input-label"><input type="checkbox" name="attr_sf_wurf" value="1"> Wurf</label>
                                 </td>
-                                <td>Wurf</td>
                             </tr>
                         </table>
                     </td>
@@ -12820,13 +12718,21 @@
                 <option value="/w GM ">Nur zu Meister würfeln</option>
             </select>
             <br>
-            <input type="checkbox" class="sheet-versteckeMagie" name="attr_MagieTab"> Verstecke Magie
+            <label class="sheet-lone-input-label">
+                <input type="checkbox" class="sheet-versteckeMagie" name="attr_MagieTab"> Verstecke Magie
+            </label>
             <br>
-            <input type="checkbox" class="sheet-verstecke-dz-magie" name="attr_DZMagie">Verstecke Aktivierung von Sprüchen aus &bdquo;Dunkle Zeiten&ldquo;
+            <label class="sheet-lone-input-label">
+                <input type="checkbox" class="sheet-verstecke-dz-magie" name="attr_DZMagie"> Verstecke Aktivierung von Sprüchen aus &bdquo;Dunkle Zeiten&ldquo;
+            </label>
             <br>
-            <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab"> Verstecke Götterwirken
+            <label class="sheet-lone-input-label">
+               <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab"> Verstecke Götterwirken
+            </label>
             <br>
-            <input type="checkbox" name="attr_fkr_helligkeitssystem"> Fernkampfrechner: Dunkelheitsstufen aus Wege des Entdeckers (0 bis 16) statt aus Wege des Schwerts (0 bis 8) benutzen
+            <label class="sheet-lone-input-label">
+                <input type="checkbox" name="attr_fkr_helligkeitssystem"> Fernkampfrechner: Dunkelheitsstufen aus Wege des Entdeckers (0 bis 16) statt aus Wege des Schwerts (0 bis 8) benutzen
+            </label>
             <br>
         </div>
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11539,6 +11539,7 @@
             <input type="checkbox" class="sheet-hide-ranged-targeted-shot-fourlegged-variable sheet-default-hide" name="attr_fkr_schussart_gezielter_schuss_vierbeiner_variabel">
             <input type="checkbox" class="sheet-hide-ranged-warning-shortsighted sheet-default-hide" name="attr_fkr_warnung_kurzsichtig">
             <input class="sheet-hide-ranged-fray-counts sheet-default-hide" type="checkbox" name="attr_fkr_kampfgetuemmel">
+            <input class="sheet-hide-brightness sheet-default-hide" type="checkbox" name="attr_fkr_helligkeitssystem">
             <table class="sheet-ranged-combat-calc" align="left">
                 <tr>
                     <th>Einflussgröße</th>
@@ -11590,14 +11591,34 @@
                     <td>-</td>
                 </tr>
                 <tr>
-                    <td>
-                        <select name="attr_fkr_helligkeit_raw">
+                    <td class="sheet-activation-items">
+                        <select class="sheet-hide-wds-brightness" name="attr_fkr_helligkeit_raw">
                             <option value="nd">Helligkeit</option>
                             <option value="0">Tag</option>
                             <option value="2">Dämmerung</option>
                             <option value="4">Mond</option>
                             <option value="6">Sternenhimmel</option>
                             <option value="8">absolute Finsternis</option>
+                        </select>
+                        <select class="sheet-hide-wde-brightness" name="attr_fkr_helligkeit_raw">
+                            <option value="nd">Helligkeit</option>
+                            <option value="0">Tageslicht</option>
+                            <option value="1">mäßig bewölkt</option>
+                            <option value="2">stark bewölkt/beginnende Abenddämmerung</option>
+                            <option value="3">Abenddämmerung</option>
+                            <option value="4">endende Abenddämmerung</option>
+                            <option value="5">beginnende Nacht</option>
+                            <option value="6">Nacht (Vollmond)</option>
+                            <option value="7">Nacht (Dreiviertelmond)</option>
+                            <option value="8">Nacht (Halbmond)</option>
+                            <option value="9">Nacht (Viertelmond)</option>
+                            <option value="10">Nacht (sternenklar, Neumond)</option>
+                            <option value="11">Nacht (Sterne, mäßig bewölkt)</option>
+                            <option value="12">Nacht (Sterne, stark bewölkt)</option>
+                            <option value="13">Finsternis, leicht</option>
+                            <option value="14">Finsternis, mittel</option>
+                            <option value="15">Finsternis, stark</option>
+                            <option value="16">Finsternis, absolut</option>
                         </select>
                     </td>
                     <td><span name="attr_fkr_helligkeit_final"></span></td>
@@ -12804,6 +12825,8 @@
             <input type="checkbox" class="sheet-verstecke-dz-magie" name="attr_DZMagie">Verstecke Aktivierung von Sprüchen aus &bdquo;Dunkle Zeiten&ldquo;
             <br>
             <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab"> Verstecke Götterwirken
+            <br>
+            <input type="checkbox" name="attr_fkr_helligkeitssystem"> Fernkampfrechner: Dunkelheitsstufen aus Wege des Entdeckers (0 bis 16) statt aus Wege des Schwerts (0 bis 8) benutzen
             <br>
         </div>
 
@@ -14404,7 +14427,7 @@ on("change:vorteil_daemmerungssicht change:vorteil_nachtsicht",
 		});
 });
 
-on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 change:fkwname1 change:fkwname2 change:fkwname3 change:fkwname4 change:fkwtyp1 change:fkwtyp2 change:fkwtyp3 change:fkwtyp4 change:fkwladezeit1 change:fkwladezeit2 change:fkwladezeit3 change:fkwladezeit4 change:fkwschaden1_1 change:fkwschaden2_1 change:fkwschaden3_1 change:fkwschaden4_1 change:fkwschaden1_2 change:fkwschaden2_2 change:fkwschaden3_2 change:fkwschaden4_2 change:fkw1_rw1 change:fkw1_rw2 change:fkw1_rw3 change:fkw1_rw4 change:fkw1_rw5 change:fkw2_rw1 change:fkw2_rw2 change:fkw2_rw3 change:fkw2_rw4 change:fkw2_rw5 change:fkw3_rw1 change:fkw3_rw2 change:fkw3_rw3 change:fkw3_rw4 change:fkw3_rw5 change:fkw4_rw1 change:fkw4_rw2 change:fkw4_rw3 change:fkw4_rw4 change:fkw4_rw5 change:fkw1_tprw1 change:fkw1_tprw2 change:fkw1_tprw3 change:fkw1_tprw4 change:fkw1_tprw5 change:fkw2_tprw1 change:fkw2_tprw2 change:fkw2_tprw3 change:fkw2_tprw4 change:fkw2_tprw5 change:fkw3_tprw1 change:fkw3_tprw2 change:fkw3_tprw3 change:fkw3_tprw4 change:fkw3_tprw5 change:fkw4_tprw1 change:fkw4_tprw2 change:fkw4_tprw3 change:fkw4_tprw4 change:fkw4_tprw5 change:fkw_aktiv_schuetzentyp change:sf_scharfschutze_armbrust change:sf_meisterschutze_armbrust change:sf_scharfschutze_bogen change:sf_meisterschutze_bogen change:sf_scharfschutze_wurfbeile change:sf_meisterschutze_wurfbeile change:sf_scharfschutze_wurfmesser change:sf_meisterschutze_wurfmesser change:sf_scharfschutze_wurfspeere change:sf_meisterschutze_wurfspeere change:nachteil_einaeugig change:nachteil_farbenblind change:nachteil_eingeschraenkter_sinn_sicht change:nachteil_nachtblind change:vorteil_daemmerungssicht change:vorteil_entfernungssinn change:vorteil_nachtsicht change:fkr_zielgroesse_raw change:fkr_entfernung_raw change:fkr_wetterlage_raw change:fkr_helligkeit_raw change:fkr_deckung_raw change:fkr_schussart_raw change:fkr_schussmitansage_ansage_raw change:fkr_gezielter_schuss_zweibeiner change:fkr_gezielter_schuss_vierbeiner change:fkr_gezielter_schuss_vierbeiner_variabel change:fkr_anvisieren_raw change:fkr_schussnummer_raw change:fkr_steilschuss_raw change:fkr_ort_raw change:fkr_bewegung_raw change:fkr_kampfgetuemmel change:fkr_kampfgetuemmel_beteiligte_h change:fkr_kampfgetuemmel_beteiligte_ns change:fkr_sonstiges_raw change:fkr_sonstiges_ansage_raw",
+on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 change:fkwname1 change:fkwname2 change:fkwname3 change:fkwname4 change:fkwtyp1 change:fkwtyp2 change:fkwtyp3 change:fkwtyp4 change:fkwladezeit1 change:fkwladezeit2 change:fkwladezeit3 change:fkwladezeit4 change:fkwschaden1_1 change:fkwschaden2_1 change:fkwschaden3_1 change:fkwschaden4_1 change:fkwschaden1_2 change:fkwschaden2_2 change:fkwschaden3_2 change:fkwschaden4_2 change:fkw1_rw1 change:fkw1_rw2 change:fkw1_rw3 change:fkw1_rw4 change:fkw1_rw5 change:fkw2_rw1 change:fkw2_rw2 change:fkw2_rw3 change:fkw2_rw4 change:fkw2_rw5 change:fkw3_rw1 change:fkw3_rw2 change:fkw3_rw3 change:fkw3_rw4 change:fkw3_rw5 change:fkw4_rw1 change:fkw4_rw2 change:fkw4_rw3 change:fkw4_rw4 change:fkw4_rw5 change:fkw1_tprw1 change:fkw1_tprw2 change:fkw1_tprw3 change:fkw1_tprw4 change:fkw1_tprw5 change:fkw2_tprw1 change:fkw2_tprw2 change:fkw2_tprw3 change:fkw2_tprw4 change:fkw2_tprw5 change:fkw3_tprw1 change:fkw3_tprw2 change:fkw3_tprw3 change:fkw3_tprw4 change:fkw3_tprw5 change:fkw4_tprw1 change:fkw4_tprw2 change:fkw4_tprw3 change:fkw4_tprw4 change:fkw4_tprw5 change:fkw_aktiv_schuetzentyp change:sf_scharfschutze_armbrust change:sf_meisterschutze_armbrust change:sf_scharfschutze_bogen change:sf_meisterschutze_bogen change:sf_scharfschutze_wurfbeile change:sf_meisterschutze_wurfbeile change:sf_scharfschutze_wurfmesser change:sf_meisterschutze_wurfmesser change:sf_scharfschutze_wurfspeere change:sf_meisterschutze_wurfspeere change:nachteil_einaeugig change:nachteil_farbenblind change:nachteil_eingeschraenkter_sinn_sicht change:nachteil_nachtblind change:vorteil_daemmerungssicht change:vorteil_entfernungssinn change:vorteil_nachtsicht change:fkr_zielgroesse_raw change:fkr_entfernung_raw change:fkr_wetterlage_raw change:fkr_helligkeit_raw change:fkr_helligkeitssystem change:fkr_deckung_raw change:fkr_schussart_raw change:fkr_schussmitansage_ansage_raw change:fkr_gezielter_schuss_zweibeiner change:fkr_gezielter_schuss_vierbeiner change:fkr_gezielter_schuss_vierbeiner_variabel change:fkr_anvisieren_raw change:fkr_schussnummer_raw change:fkr_steilschuss_raw change:fkr_ort_raw change:fkr_bewegung_raw change:fkr_kampfgetuemmel change:fkr_kampfgetuemmel_beteiligte_h change:fkr_kampfgetuemmel_beteiligte_ns change:fkr_sonstiges_raw change:fkr_sonstiges_ansage_raw",
 	function() {
 		getAttrs(
 			[
@@ -14477,6 +14500,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 				'fkr_entfernung_raw',
 				'fkr_wetterlage_raw',
 				'fkr_helligkeit_raw',
+				'fkr_helligkeitssystem',
 				'fkr_deckung_raw',
 				'fkr_schussart_raw',
 				'fkr_schussmitansage_ansage_raw',
@@ -14495,6 +14519,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 				'fkr_sonstiges_ansage_raw'
 			],
 			function(v) {
+				console.log(JSON.stringify(v));
 				console.log('FKW_aktiv1: ', v.fkw_aktiv1, 
 					'; FKW_aktiv2: ', v.fkw_aktiv2, 
 					'; FKW_aktiv3: ', v.fkw_aktiv3, 
@@ -14536,6 +14561,7 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 					FKR.abstand = parseInt(v.fkr_entfernung_raw);
 					FKR.wetter = v.fkr_wetterlage_raw;
 					FKR.licht = v.fkr_helligkeit_raw;
+					FKR.lichtsys = v.fkr_helligkeitssystem;
 					FKR.deckung = v.fkr_deckung_raw;
 					FKR.schuss = {
 						art: v.fkr_schussart_raw,
@@ -14558,7 +14584,6 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 					};
 					FKR.misc = v.fkr_sonstiges_raw;
 					FKR.misc_ansage = v.fkr_sonstiges_ansage_raw;
-					console.log(JSON.stringify(FKR));
 
 					// Zeige FK-Rechner an
 					console.log('Genau eine aktive Fernkampfwaffe gewählt. Fernkampfrechneraktivierung im Gange ...');
@@ -14822,35 +14847,52 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 					}
 
 					// Helligkeit
-					// absolute Dunkelheit immer 8
+					// absolute Dunkelheit immer "finsternis"
+					
 					if(FKR.licht != "nd")
 					{
+						var finsternis = 8;
+						console.log("FKR.lichtsys: ", FKR.lichtsys);
+						if(FKR.lichtsys == "on") { finsternis = 16; }
+
 						if(FKR.DS == "0" && FKR.NS == "0")
 						{
 							mod_gesamt.licht = parseInt(FKR.licht);
 							setAttrs({fkr_helligkeit_final: prettifyMod(parseInt(FKR.licht))});
 						} else if(FKR.DS != "0" && FKR.NS == "0") {
-							var licht = parseInt(FKR.licht) / 2;
-							if(licht == 4) { licht = 8; }
+							var licht;
+							if(parseInt(FKR.licht) == finsternis)
+							{
+								licht = finsternis;
+							} else {
+								licht = Math.ceil(parseInt(FKR.licht) / 2);
+							}
 							mod_gesamt.licht = parseInt(licht);
 							setAttrs({fkr_helligkeit_final: prettifyMod(licht)});
 						} else if(
 						(FKR.DS != "0" && FKR.NS != "0")
 						|| (FKR.DS == "0" && FKR.NS != "0")) {
 							var licht;
-							if(FKR.licht == "8")
+							if(parseInt(FKR.licht) == finsternis)
 							{
-								licht = 8;
+								licht = finsternis;
 							} else {
-								licht = Math.max((parseInt(FKR.licht) / 2) - 5, 0);
+								if(FKR.lichtsys != "on")
+								{
+									// Mit WdS macht Erschwernisobergrenze keinen Sinn
+									licht = Math.max((parseInt(FKR.licht) / 2) - 5, 0);
+								} else if(FKR.lichtsys == "on") {
+									// Mit WdE macht die Erschwernisobergrenze von 5 Sinn
+									licht = Math.min(Math.ceil((parseInt(FKR.licht) / 2)), 5);
+								}
 							}
 							mod_gesamt.licht = parseInt(licht);
 							setAttrs({fkr_helligkeit_final: prettifyMod(licht)});
 						}
 						if(FKR.NB != "0")
 						{
-							var licht = Math.min(8, parseInt(FKR.licht) * 2);
-							mod_gesamt.licht = parseInt(licht);
+							var licht = Math.min(finsternis, parseInt(FKR.licht) * 2);
+							mod_gesamt.licht = licht;
 							setAttrs({fkr_helligkeit_final: prettifyMod(licht)});
 						}
 					} else {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12759,7 +12759,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-08-20"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-09-03"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11574,7 +11574,7 @@
                     <td>Entfernung in Schritt: <input type="number" name="attr_fkr_entfernung_raw" min="0" max="9999"></td>
                     <td><span name="attr_fkr_entfernung_final"></span></td>
                     <td>-</td>
-                    <td>-</td>
+                    <td><span name="attr_fkr_entfernung_final_tp"></span></td>
                 </tr>
                 <tr>
                     <td>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -14368,6 +14368,15 @@ function getTargetZoneName(targetZone) {
 	return zoneName;
 }
 
+function deactivateRCC() {
+	setAttrs({
+		fkr_aktiv: "on",
+		fkr_erschwernis_gesamt: "?{Erleichterung (−) oder Erschwernis (+)|0} + ?{Ansage für Fernkampfangriff|0,0|1,1|2,2|3,3|4,4|5,5|6,6|7,7|8,8|9,9|10,10|11,11|12,12|13,13|14,14|15,15|16,16|17,17|18,18|19,19|20,20|21,21|22,22|23,23|24,24|25,25|26,26|27,27|28,28|29,29|30,30|31,31|32,32}",
+		fkr_erschwernis_ansage_gesamt: "?{Ansage für Fernkampfangriff|0,0|1,1|2,2|3,3|4,4|5,5|6,6|7,7|8,8|9,9|10,10|11,11|12,12|13,13|14,14|15,15|16,16|17,17|18,18|19,19|20,20|21,21|22,22|23,23|24,24|25,25|26,26|27,27|28,28|29,29|30,30|31,31|32,32}",
+		fk_tp_roll: "&{template:DSA-Kampf-Treffer} {{name=Fernkampf}} {{target=[[?{Tabelle für zufällige Trefferzone auswählen|Zweibeiner gegen unbeschwänzten Zweibeiner,0|Zweibeiner gegen beschwänzten Zweibeiner,1|Zweibeiner gegen Vierbeiner,3|Zweibeiner gegen Reiter,4|Reiter gegen Zweibeiner,2}]]}} {{zone=[[1d20]]}} {{damage=[[?{Anzahl W6 für Schadenswurf|1,1|2,2|3,3|4,4|5,5}d6 + ?{Bonus (+)/Malus (−) der Trefferpunkte|0}]]}}"
+	});
+}
+
 on("change:nachteil_nachtblind",
 	function() {
 		getAttrs(
@@ -14395,7 +14404,7 @@ on("change:vorteil_daemmerungssicht change:vorteil_nachtsicht",
 		});
 });
 
-on("change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 change:fkwname1 change:fkwname2 change:fkwname3 change:fkwname4 change:fkwtyp1 change:fkwtyp2 change:fkwtyp3 change:fkwtyp4 change:fkwladezeit1 change:fkwladezeit2 change:fkwladezeit3 change:fkwladezeit4 change:fkwschaden1_1 change:fkwschaden2_1 change:fkwschaden3_1 change:fkwschaden4_1 change:fkwschaden1_2 change:fkwschaden2_2 change:fkwschaden3_2 change:fkwschaden4_2 change:fkw1_rw1 change:fkw1_rw2 change:fkw1_rw3 change:fkw1_rw4 change:fkw1_rw5 change:fkw2_rw1 change:fkw2_rw2 change:fkw2_rw3 change:fkw2_rw4 change:fkw2_rw5 change:fkw3_rw1 change:fkw3_rw2 change:fkw3_rw3 change:fkw3_rw4 change:fkw3_rw5 change:fkw4_rw1 change:fkw4_rw2 change:fkw4_rw3 change:fkw4_rw4 change:fkw4_rw5 change:fkw1_tprw1 change:fkw1_tprw2 change:fkw1_tprw3 change:fkw1_tprw4 change:fkw1_tprw5 change:fkw2_tprw1 change:fkw2_tprw2 change:fkw2_tprw3 change:fkw2_tprw4 change:fkw2_tprw5 change:fkw3_tprw1 change:fkw3_tprw2 change:fkw3_tprw3 change:fkw3_tprw4 change:fkw3_tprw5 change:fkw4_tprw1 change:fkw4_tprw2 change:fkw4_tprw3 change:fkw4_tprw4 change:fkw4_tprw5 change:fkw_aktiv_schuetzentyp change:sf_scharfschutze_armbrust change:sf_meisterschutze_armbrust change:sf_scharfschutze_bogen change:sf_meisterschutze_bogen change:sf_scharfschutze_wurfbeile change:sf_meisterschutze_wurfbeile change:sf_scharfschutze_wurfmesser change:sf_meisterschutze_wurfmesser change:sf_scharfschutze_wurfspeere change:sf_meisterschutze_wurfspeere change:nachteil_einaeugig change:nachteil_farbenblind change:nachteil_eingeschraenkter_sinn_sicht change:nachteil_nachtblind change:vorteil_daemmerungssicht change:vorteil_entfernungssinn change:vorteil_nachtsicht change:fkr_zielgroesse_raw change:fkr_entfernung_raw change:fkr_wetterlage_raw change:fkr_helligkeit_raw change:fkr_deckung_raw change:fkr_schussart_raw change:fkr_schussmitansage_ansage_raw change:fkr_gezielter_schuss_zweibeiner change:fkr_gezielter_schuss_vierbeiner change:fkr_gezielter_schuss_vierbeiner_variabel change:fkr_anvisieren_raw change:fkr_schussnummer_raw change:fkr_steilschuss_raw change:fkr_ort_raw change:fkr_bewegung_raw change:fkr_kampfgetuemmel change:fkr_kampfgetuemmel_beteiligte_h change:fkr_kampfgetuemmel_beteiligte_ns change:fkr_sonstiges_raw change:fkr_sonstiges_ansage_raw",
+on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 change:fkwname1 change:fkwname2 change:fkwname3 change:fkwname4 change:fkwtyp1 change:fkwtyp2 change:fkwtyp3 change:fkwtyp4 change:fkwladezeit1 change:fkwladezeit2 change:fkwladezeit3 change:fkwladezeit4 change:fkwschaden1_1 change:fkwschaden2_1 change:fkwschaden3_1 change:fkwschaden4_1 change:fkwschaden1_2 change:fkwschaden2_2 change:fkwschaden3_2 change:fkwschaden4_2 change:fkw1_rw1 change:fkw1_rw2 change:fkw1_rw3 change:fkw1_rw4 change:fkw1_rw5 change:fkw2_rw1 change:fkw2_rw2 change:fkw2_rw3 change:fkw2_rw4 change:fkw2_rw5 change:fkw3_rw1 change:fkw3_rw2 change:fkw3_rw3 change:fkw3_rw4 change:fkw3_rw5 change:fkw4_rw1 change:fkw4_rw2 change:fkw4_rw3 change:fkw4_rw4 change:fkw4_rw5 change:fkw1_tprw1 change:fkw1_tprw2 change:fkw1_tprw3 change:fkw1_tprw4 change:fkw1_tprw5 change:fkw2_tprw1 change:fkw2_tprw2 change:fkw2_tprw3 change:fkw2_tprw4 change:fkw2_tprw5 change:fkw3_tprw1 change:fkw3_tprw2 change:fkw3_tprw3 change:fkw3_tprw4 change:fkw3_tprw5 change:fkw4_tprw1 change:fkw4_tprw2 change:fkw4_tprw3 change:fkw4_tprw4 change:fkw4_tprw5 change:fkw_aktiv_schuetzentyp change:sf_scharfschutze_armbrust change:sf_meisterschutze_armbrust change:sf_scharfschutze_bogen change:sf_meisterschutze_bogen change:sf_scharfschutze_wurfbeile change:sf_meisterschutze_wurfbeile change:sf_scharfschutze_wurfmesser change:sf_meisterschutze_wurfmesser change:sf_scharfschutze_wurfspeere change:sf_meisterschutze_wurfspeere change:nachteil_einaeugig change:nachteil_farbenblind change:nachteil_eingeschraenkter_sinn_sicht change:nachteil_nachtblind change:vorteil_daemmerungssicht change:vorteil_entfernungssinn change:vorteil_nachtsicht change:fkr_zielgroesse_raw change:fkr_entfernung_raw change:fkr_wetterlage_raw change:fkr_helligkeit_raw change:fkr_deckung_raw change:fkr_schussart_raw change:fkr_schussmitansage_ansage_raw change:fkr_gezielter_schuss_zweibeiner change:fkr_gezielter_schuss_vierbeiner change:fkr_gezielter_schuss_vierbeiner_variabel change:fkr_anvisieren_raw change:fkr_schussnummer_raw change:fkr_steilschuss_raw change:fkr_ort_raw change:fkr_bewegung_raw change:fkr_kampfgetuemmel change:fkr_kampfgetuemmel_beteiligte_h change:fkr_kampfgetuemmel_beteiligte_ns change:fkr_sonstiges_raw change:fkr_sonstiges_ansage_raw",
 	function() {
 		getAttrs(
 			[
@@ -14495,8 +14504,7 @@ on("change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 chan
 				if(activeCount === 0)
 				{
 					console.log('Keine aktive Fernkampfwaffe gewählt. Fernkampfrechner deaktiviert.');
-					setAttrs({fkr_aktiv: "on"});
-
+					deactivateRCC();
 
 				} else if (activeCount === 1) {
 					// Hauptteil
@@ -15394,10 +15402,10 @@ on("change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fkw_aktiv4 chan
 
 				} else if (activeCount > 1) {
 					console.log('Mehr als eine aktive Fernkampfwaffe gewählt. Fernkampfrechner deaktiviert.');
-					setAttrs({fkr_aktiv: "on"});
+					deactivateRCC();
 				} else {
 					console.log('Dieser Fall sollte niemals eintreten. Weniger als keine oder mehr als vier aktive Fernkampfwaffen gewählt. Fernkampfrechner deaktiviert.');
-					setAttrs({fkr_aktiv: "on"});
+					deactivateRCC();
 				}
 			}
 		);

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -659,7 +659,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−5</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_armbrust">
                     <input type="number" class="sheet-talent-at" name="attr_AT_armbrust" disabled="true" value="@{FKBasis} + @{TaW_armbrust}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_armbrust" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_armbrust" min="-4" value="0">
                     <br>
                 </div>
@@ -670,7 +670,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">-</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_belagerungswaffen">
                     <input type="number" class="sheet-talent-at" name="attr_AT_belagerungswaffen" disabled="true" value="@{FKBasis} + @{TaW_belagerungswaffen}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_belagerungswaffen" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_belagerungswaffen" min="-4" value="0">
                     <br>
                 </div>
@@ -681,7 +681,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−5</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_blasrohr">
                     <input type="number" class="sheet-talent-at" name="attr_AT_blasrohr" disabled="true" value="@{FKBasis} + @{TaW_Blasrohr}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_blasrohr" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_blasrohr" min="-4" value="0">
                     <br>
                 </div>
@@ -692,7 +692,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−3</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_bogen">
                     <input type="number" class="sheet-talent-at" name="attr_AT_bogen" disabled="true" value="@{FKBasis} + @{TaW_Bogen}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_bogen" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_bogen" min="-4" value="0">
                     <br>
                 </div>
@@ -703,7 +703,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_diskus">
                     <input type="number" class="sheet-talent-at" name="attr_AT_diskus" disabled="true" value="@{FKBasis} + @{TaW_Diskus}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_diskus" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_diskus" min="-4" value="0">
                     <br>
                 </div>
@@ -791,7 +791,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−1</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_peitsche">
                     <input type="number" class="sheet-talent-at" name="attr_AT_peitsche" disabled="true" value="@{ATbasis} + @{TaW_peitsche}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_peitsche" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_peitsche" min="-4" value="0">
                     <br>
                 </div>
@@ -835,7 +835,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schleuder">
                     <input type="number" class="sheet-talent-at" name="attr_AT_schleuder" disabled="true" value="@{FKBasis} + @{TaW_schleuder}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_schleuder" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schleuder" min="-4" value="0">
                     <br>
                 </div>
@@ -879,7 +879,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfbeile">
                     <input type="number" class="sheet-talent-at" name="attr_AT_wurfbeile" disabled="true" value="@{FKBasis} + @{TaW_wurfbeile}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_wurfbeile" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfbeile" min="-4" value="0">
                     <br>
                 </div>
@@ -890,7 +890,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−3</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfmesser">
                     <input type="number" class="sheet-talent-at" name="attr_AT_wurfmesser" disabled="true" value="@{FKBasis} + @{TaW_wurfmesser}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_wurfmesser" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfmesser" min="-4" value="0">
                     <br>
                 </div>
@@ -901,7 +901,7 @@
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfspeere">
                     <input type="number" class="sheet-talent-at" name="attr_AT_wurfspeere" disabled="true" value="@{FKBasis} + @{TaW_wurfspeere}">
-                    <input type="number" class="sheet-talent-pa" name="attr_PA_wurfspeere" disabled="true">
+                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfspeere" min="-4" value="0">
                     <br>
                 </div>


### PR DESCRIPTION
* **Bug Fixes**: Roll buttons now work without active calculator (3d5e0ce), distance-dependent modifier now shown to the user (7fecfbe), ranged attack roll button roll no longer leads to false-positive fails with negative modifiers (c40ae4c), activation weirdness of the ranged combat calculator on new characters fixed (05274c6)
* **New Features**: Adapt roll template to take shots into the fray into account (d0bd416), add option to use a different brightness system (02a0f57
* **Convenience Issues**: Add default and minimum values to ranged combat equipment/calculator (fa27013)
* **Style Issues**: Limit label width to child width (d3a17d7)
* **New Attributes**: fkr_helligkeitssystem (02a0f57)
* **Removed Attributes**: PA_armbrust, PA_belagerungswaffen, PA_blasrohr, PA_bogen, PA_diskus, PA_peitsche, PA_schleuder, PA_wurfbeile, PA_wurfmesser, PA_wurfspeer (190aa8d; see commit message for details)