### PR TITLE
[DSA4.1] Default Stat Visibility, Evasion Checks, Exhaustion & Overstrain, Stat Check Roll Templates

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1235,7 +1235,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .sheet-rolltemplate-DSA-Nahkampf-AT table.sheet-templates-succ-crc,
 .sheet-rolltemplate-DSA-Nahkampf-PA table.sheet-templates-succ-crc,
 .sheet-rolltemplate-DSA-Kampf-Ausweichen table.sheet-templates-succ-crc,
-.sheet-rolltemplate-DSA-Fernkampf-AT table.sheet-templates-succ-crc {
+.sheet-rolltemplate-DSA-Fernkampf-AT table.sheet-templates-succ-crc,
+.sheet-rolltemplate-DSA-Eigenschaft table.sheet-templates-succ-crc {
 	background-color: #e8cdf2;
 	border-color: #ab97b3;
 }
@@ -1297,7 +1298,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .sheet-rolltemplate-DSA-Kampf-Ausweichen table.sheet-templates-fail-crc,
 .sheet-rolltemplate-DSA-Fernkampf-AT table.sheet-templates-fail-crc,
 .sheet-rolltemplate-DSA-Nahkampf-Patzer table.sheet-templates-fail-crc,
-.sheet-rolltemplate-DSA-Fernkampf-Patzer table.sheet-templates-fail-crc {
+.sheet-rolltemplate-DSA-Fernkampf-Patzer table.sheet-templates-fail-crc,
+.sheet-rolltemplate-DSA-Eigenschaft table.sheet-templates-fail-crc {
 	background-color: #f2cdcd;
 	border-color: #b39797;
 }

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -657,7 +657,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 }
 
 .charsheet .sheet-talent-default-eigenschaft {
-	font-weight: bold;
+    background-color: #bf9e60;
+    color: #ffffff;
 }
 
 .charsheet .sheet-talent-stf {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -534,6 +534,11 @@ The solution: convert the <input>s to type="text" and make them look like normal
     border-color: #806940;
     color: #000000;
 }
+.charsheet .sheet-verstecke-erschoepfung:checked ~ table tr.sheet-hideable-exhaustion,
+.charsheet .sheet-verstecke-ueberanstrengung:checked ~ table tr.sheet-hideable-overstrain {
+    display: none;
+}
+
 .charsheet .sheet-versteckeMagie:checked + input.sheet-tab5,
 .charsheet .sheet-versteckeMagie:checked ~ span.sheet-tab5,
 .charsheet .sheet-versteckeMagie:checked + div.sheet-section-Magie {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -1018,7 +1018,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Akrobatik" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Akrobatik}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_akrobatik}]]}} {{stat1=[[@{Eigenschaft1akrobatik}]]}} {{stat2=[[@{Eigenschaft2akrobatik}]]}} {{stat3=[[@{Eigenschaft3akrobatik}]]}} {{Talent=[[ { [[{0d1 + @{TaW_akrobatik} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft1akrobatik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft2akrobatik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft3akrobatik}, 0d1}kh1, 0d1 + @{TaW_akrobatik}}dh1]]}}"> <span>Akrobatik</span></button></div>
                     <select name="attr_Eigenschaft1akrobatik" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1034,7 +1034,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1047,7 +1047,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Akrobatik" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Akrobatik}} {{ebe=[[@{BE_TaW} * 2]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[@{BE_TaW} * 2]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_akrobatik}]]}} {{stat1=[[@{Eigenschaft1akrobatik}]]}} {{stat2=[[@{Eigenschaft2akrobatik}]]}} {{stat3=[[@{Eigenschaft3akrobatik}]]}} {{Talent=[[ { [[{0d1 + @{TaW_akrobatik} - [[@{BE_TaW} * 2]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft1akrobatik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft2akrobatik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_akrobatik}, 0d1}kh1]] - @{Eigenschaft3akrobatik}, 0d1}kh1, 0d1 + @{TaW_akrobatik}}dh1]]}}"> <span>BEx2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_akrobatik">
@@ -1065,7 +1065,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1077,7 +1077,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3athletik" class="sheet-talent-eigenschaft">
@@ -1089,7 +1089,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Athletik" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Athletik}} {{ebe=[[@{BE_TaW} * 2]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[@{BE_TaW} * 2]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_athletik}]]}} {{stat1=[[@{Eigenschaft1athletik}]]}} {{stat2=[[@{Eigenschaft2athletik}]]}} {{stat3=[[@{Eigenschaft3athletik}]]}} {{Talent=[[ { [[{0d1 + @{TaW_athletik} - [[@{BE_TaW} * 2]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_athletik}, 0d1}kh1]] - @{Eigenschaft1athletik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_athletik}, 0d1}kh1]] - @{Eigenschaft2athletik}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_athletik}, 0d1}kh1]] - @{Eigenschaft3athletik}, 0d1}kh1, 0d1 + @{TaW_athletik}}dh1]]}}"> <span>BEx2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_athletik">
@@ -1102,7 +1102,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Fliegen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Fliegen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_fliegen}]]}} {{stat1=[[@{Eigenschaft1fliegen}]]}} {{stat2=[[@{Eigenschaft2fliegen}]]}} {{stat3=[[@{Eigenschaft3fliegen}]]}} {{Talent=[[ { [[{0d1 + @{TaW_fliegen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fliegen}, 0d1}kh1]] - @{Eigenschaft1fliegen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fliegen}, 0d1}kh1]] - @{Eigenschaft2fliegen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fliegen}, 0d1}kh1]] - @{Eigenschaft3fliegen}, 0d1}kh1, 0d1 + @{TaW_fliegen}}dh1]]}}"> <span>Fliegen</span></button></div>
                     <select name="attr_Eigenschaft1fliegen" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1115,7 +1115,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1129,7 +1129,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1144,7 +1144,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Gaukeleien" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Gaukeleien}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_gaukeleien}]]}} {{stat1=[[@{Eigenschaft1gaukeleien}]]}} {{stat2=[[@{Eigenschaft2gaukeleien}]]}} {{stat3=[[@{Eigenschaft3gaukeleien}]]}} {{Talent=[[ { [[{0d1 + @{TaW_gaukeleien} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_gaukeleien}, 0d1}kh1]] - @{Eigenschaft1gaukeleien}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_gaukeleien}, 0d1}kh1]] - @{Eigenschaft2gaukeleien}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_gaukeleien}, 0d1}kh1]] - @{Eigenschaft3gaukeleien}, 0d1}kh1, 0d1 + @{TaW_gaukeleien}}dh1]]}}"> <span>Gaukeleien</span></button></div>
                     <select name="attr_Eigenschaft1gaukeleien" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1158,7 +1158,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1170,7 +1170,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -1186,7 +1186,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Klettern" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Klettern}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_klettern}]]}} {{stat1=[[@{Eigenschaft1klettern}]]}} {{stat2=[[@{Eigenschaft2klettern}]]}} {{stat3=[[@{Eigenschaft3klettern}]]}} {{Talent=[[ { [[{0d1 + @{TaW_klettern} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft1klettern}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft2klettern}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft3klettern}, 0d1}kh1, 0d1 + @{TaW_klettern}}dh1]]}}"> <span>Klettern</span></button></div>
                     <select name="attr_Eigenschaft1klettern" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1202,7 +1202,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1215,7 +1215,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Klettern" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Klettern}} {{ebe=[[@{BE_TaW} * 2]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[@{BE_TaW} * 2]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_klettern}]]}} {{stat1=[[@{Eigenschaft1klettern}]]}} {{stat2=[[@{Eigenschaft2klettern}]]}} {{stat3=[[@{Eigenschaft3klettern}]]}} {{Talent=[[ { [[{0d1 + @{TaW_klettern} - [[@{BE_TaW} * 2]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft1klettern}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft2klettern}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_klettern}, 0d1}kh1]] - @{Eigenschaft3klettern}, 0d1}kh1, 0d1 + @{TaW_klettern}}dh1]]}}"> <span>BEx2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_klettern">
@@ -1228,7 +1228,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Körperbeherrschung" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Körperbeherrschung}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_korperbeherrschung}]]}} {{stat1=[[@{Eigenschaft1korperbeherrschung}]]}} {{stat2=[[@{Eigenschaft2korperbeherrschung}]]}} {{stat3=[[@{Eigenschaft3korperbeherrschung}]]}} {{Talent=[[ { [[{0d1 + @{TaW_korperbeherrschung} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_korperbeherrschung}, 0d1}kh1]] - @{Eigenschaft1korperbeherrschung}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_korperbeherrschung}, 0d1}kh1]] - @{Eigenschaft2korperbeherrschung}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_korperbeherrschung}, 0d1}kh1]] - @{Eigenschaft3korperbeherrschung}, 0d1}kh1, 0d1 + @{TaW_korperbeherrschung}}dh1]]}}"> <span>Körperbeherrschung</span></button></div>
                     <select name="attr_Eigenschaft1korperbeherrschung" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1241,7 +1241,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1255,7 +1255,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1273,7 +1273,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1286,7 +1286,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1299,7 +1299,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Reiten" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Reiten}} {{ebe=[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_reiten}]]}} {{stat1=[[@{Eigenschaft1reiten}]]}} {{stat2=[[@{Eigenschaft2reiten}]]}} {{stat3=[[@{Eigenschaft3reiten}]]}} {{Talent=[[ { [[{0d1 + @{TaW_reiten} - [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_reiten}, 0d1}kh1]] - @{Eigenschaft1reiten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_reiten}, 0d1}kh1]] - @{Eigenschaft2reiten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_reiten}, 0d1}kh1]] - @{Eigenschaft3reiten}, 0d1}kh1, 0d1 + @{TaW_reiten}}dh1]]}}"> <span>BE−2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_reiten">
@@ -1312,7 +1312,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Schleichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Schleichen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schleichen}]]}} {{stat1=[[@{Eigenschaft1schleichen}]]}} {{stat2=[[@{Eigenschaft2schleichen}]]}} {{stat3=[[@{Eigenschaft3schleichen}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schleichen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schleichen}, 0d1}kh1]] - @{Eigenschaft1schleichen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schleichen}, 0d1}kh1]] - @{Eigenschaft2schleichen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schleichen}, 0d1}kh1]] - @{Eigenschaft3schleichen}, 0d1}kh1, 0d1 + @{TaW_schleichen}}dh1]]}}"> <span>Schleichen</span></button></div>
                     <select name="attr_Eigenschaft1schleichen" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1325,7 +1325,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1339,7 +1339,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1359,7 +1359,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1371,7 +1371,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3schwimmen" class="sheet-talent-eigenschaft">
@@ -1383,7 +1383,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Schwimmen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Schwimmen}} {{ebe=[[@{BE_TaW} * 2]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[@{BE_TaW} * 2]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_schwimmen}]]}} {{stat1=[[@{Eigenschaft1schwimmen}]]}} {{stat2=[[@{Eigenschaft2schwimmen}]]}} {{stat3=[[@{Eigenschaft3schwimmen}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schwimmen} - [[@{BE_TaW} * 2]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schwimmen}, 0d1}kh1]] - @{Eigenschaft1schwimmen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schwimmen}, 0d1}kh1]] - @{Eigenschaft2schwimmen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[@{BE_TaW} * 2]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schwimmen}, 0d1}kh1]] - @{Eigenschaft3schwimmen}, 0d1}kh1, 0d1 + @{TaW_schwimmen}}dh1]]}}"> <span>BEx2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schwimmen">
@@ -1396,7 +1396,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Selbstbeherrschung" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Selbstbeherrschung}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_selbstbeherrschung}]]}} {{stat1=[[@{Eigenschaft1selbstbeherrschung}]]}} {{stat2=[[@{Eigenschaft2selbstbeherrschung}]]}} {{stat3=[[@{Eigenschaft3selbstbeherrschung}]]}} {{Talent=[[ { [[{0d1 + @{TaW_selbstbeherrschung} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_selbstbeherrschung}, 0d1}kh1]] - @{Eigenschaft1selbstbeherrschung}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_selbstbeherrschung}, 0d1}kh1]] - @{Eigenschaft2selbstbeherrschung}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_selbstbeherrschung}, 0d1}kh1]] - @{Eigenschaft3selbstbeherrschung}, 0d1}kh1, 0d1 + @{TaW_selbstbeherrschung}}dh1]]}}"> <span>Selbstbeherrschung</span></button></div>
                     <select name="attr_Eigenschaft1selbstbeherrschung" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1413,7 +1413,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3selbstbeherrschung" class="sheet-talent-eigenschaft">
@@ -1425,7 +1425,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe">-</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_selbstbeherrschung">
@@ -1438,7 +1438,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="SichVerstecken" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Sich Verstecken}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_sichverstecken}]]}} {{stat1=[[@{Eigenschaft1sichverstecken}]]}} {{stat2=[[@{Eigenschaft2sichverstecken}]]}} {{stat3=[[@{Eigenschaft3sichverstecken}]]}} {{Talent=[[ { [[{0d1 + @{TaW_sichverstecken} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft1sichverstecken}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft2sichverstecken}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft3sichverstecken}, 0d1}kh1, 0d1 + @{TaW_sichverstecken}}dh1]]}}"> <span>Sich verstecken</span></button></div>
                     <select name="attr_Eigenschaft1sichverstecken" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1451,7 +1451,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1465,9 +1465,9 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="SichVerstecken" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Sich Verstecken}} {{ebe=[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_sichverstecken}]]}} {{stat1=[[@{Eigenschaft1sichverstecken}]]}} {{stat2=[[@{Eigenschaft2sichverstecken}]]}} {{stat3=[[@{Eigenschaft3sichverstecken}]]}} {{Talent=[[ { [[{0d1 + @{TaW_sichverstecken} - [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft1sichverstecken}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft2sichverstecken}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverstecken}, 0d1}kh1]] - @{Eigenschaft3sichverstecken}, 0d1}kh1, 0d1 + @{TaW_sichverstecken}}dh1]]}}"> <span>BE−2</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_sichverstecken">
@@ -1482,7 +1482,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1494,7 +1494,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1505,10 +1505,10 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe außer bei besonders lautem Singen oder Koloraturen" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei besonders lautem Singen oder Koloraturen">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="Singen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Singen}} {{ebe=[[{0d1 + @{BE_TaW} - 3, 0d1}kh1]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[{0d1 + @{BE_TaW} - 3, 0d1}kh1]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_singen}]]}} {{stat1=[[@{Eigenschaft1singen}]]}} {{stat2=[[@{Eigenschaft2singen}]]}} {{stat3=[[@{Eigenschaft3singen}]]}} {{Talent=[[ { [[{0d1 + @{TaW_singen} - [[{0d1 + @{BE_TaW} - 3, 0d1}kh1]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 3, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_singen}, 0d1}kh1]] - @{Eigenschaft1singen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 3, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_singen}, 0d1}kh1]] - @{Eigenschaft2singen}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 3, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_singen}, 0d1}kh1]] - @{Eigenschaft3singen}, 0d1}kh1, 0d1 + @{TaW_singen}}dh1]]}}"> <span>BE−3</span></button></div>
@@ -1523,7 +1523,7 @@
                     <select name="attr_Eigenschaft1sinnesscharfe" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1535,7 +1535,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1546,9 +1546,9 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei allen Sinnen außer dem Tastsinn" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe beim Tastsinn">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -1569,7 +1569,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1580,7 +1580,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1592,7 +1592,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe"><button name="SkiFahren" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente-eBE} {{name=Skifahren}} {{ebe=[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]]}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modebe=[[[[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + [[?{Erleichterung (−) oder Erschwernis (+)|0}]]]]}} {{taw=[[@{TaW_skifahren}]]}} {{stat1=[[@{Eigenschaft1skifahren}]]}} {{stat2=[[@{Eigenschaft2skifahren}]]}} {{stat3=[[@{Eigenschaft3skifahren}]]}} {{Talent=[[ { [[{0d1 + @{TaW_skifahren} - [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_skifahren}, 0d1}kh1]] - @{Eigenschaft1skifahren}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_skifahren}, 0d1}kh1]] - @{Eigenschaft2skifahren}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + [[{0d1 + @{BE_TaW} - 2, 0d1}kh1]] + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_skifahren}, 0d1}kh1]] - @{Eigenschaft3skifahren}, 0d1}kh1, 0d1 + @{TaW_skifahren}}dh1]]}}"> <span>BE−2</span></button></div>
@@ -1607,7 +1607,7 @@
                     <select name="attr_Eigenschaft1stimmenimmitieren" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1619,7 +1619,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1631,7 +1631,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1651,7 +1651,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1664,7 +1664,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1675,7 +1675,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -1690,7 +1690,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Taschendiebstahl" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Taschendiebstahl}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_taschendiebstahl}]]}} {{stat1=[[@{Eigenschaft1taschendiebstahl}]]}} {{stat2=[[@{Eigenschaft2taschendiebstahl}]]}} {{stat3=[[@{Eigenschaft3taschendiebstahl}]]}} {{Talent=[[ { [[{0d1 + @{TaW_taschendiebstahl} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_taschendiebstahl}, 0d1}kh1]] - @{Eigenschaft1taschendiebstahl}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_taschendiebstahl}, 0d1}kh1]] - @{Eigenschaft2taschendiebstahl}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_taschendiebstahl}, 0d1}kh1]] - @{Eigenschaft3taschendiebstahl}, 0d1}kh1, 0d1 + @{TaW_taschendiebstahl}}dh1]]}}"> <span>Taschendiebstahl</span></button></div>
                     <select name="attr_Eigenschaft1taschendiebstahl" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -1703,7 +1703,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1716,7 +1716,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -1734,7 +1734,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1749,7 +1749,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3zechen" class="sheet-talent-eigenschaft">
@@ -1761,7 +1761,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <div class="sheet-talent-cell sheet-talent-ebe">-</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zechen">
@@ -1816,7 +1816,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1828,7 +1828,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1839,7 +1839,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1856,7 +1856,7 @@
                     <select name="attr_Eigenschaft1etikette" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1868,7 +1868,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1880,7 +1880,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1897,7 +1897,7 @@
                     <select name="attr_Eigenschaft1gassenwissen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1909,7 +1909,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1921,7 +1921,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1938,7 +1938,7 @@
                     <select name="attr_Eigenschaft1lehren" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1950,7 +1950,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -1962,7 +1962,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -1979,7 +1979,7 @@
                     <select name="attr_Eigenschaft1menschenkenntnis" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -1991,7 +1991,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2003,7 +2003,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2019,7 +2019,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Schauspielerrei" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Schauspielerei}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schauspielerei}]]}} {{stat1=[[@{Eigenschaft1schauspielerei}]]}} {{stat2=[[@{Eigenschaft2schauspielerei}]]}} {{stat3=[[@{Eigenschaft3schauspielerei}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schauspielerei} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schauspielerei}, 0d1}kh1]] - @{Eigenschaft1schauspielerei}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schauspielerei}, 0d1}kh1]] - @{Eigenschaft2schauspielerei}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schauspielerei}, 0d1}kh1]] - @{Eigenschaft3schauspielerei}, 0d1}kh1, 0d1 + @{TaW_schauspielerei}}dh1]]}}"> <span>Schauspielerei</span></button></div>
                     <select name="attr_Eigenschaft1schauspielerei" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -2031,7 +2031,7 @@
                     <select name="attr_Eigenschaft2schauspielerei" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2044,7 +2044,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2061,7 +2061,7 @@
                     <select name="attr_Eigenschaft1schriftlicherausdruck" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2073,7 +2073,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2084,7 +2084,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2101,7 +2101,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="SichVerkleiden" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Sich Verkleiden}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_sichverkleiden}]]}} {{stat1=[[@{Eigenschaft1sichverkleiden}]]}} {{stat2=[[@{Eigenschaft2sichverkleiden}]]}} {{stat3=[[@{Eigenschaft3sichverkleiden}]]}} {{Talent=[[ { [[{0d1 + @{TaW_sichverkleiden} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverkleiden}, 0d1}kh1]] - @{Eigenschaft1sichverkleiden}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverkleiden}, 0d1}kh1]] - @{Eigenschaft2sichverkleiden}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_sichverkleiden}, 0d1}kh1]] - @{Eigenschaft3sichverkleiden}, 0d1}kh1, 0d1 + @{TaW_sichverkleiden}}dh1]]}}"> <span>Sich Verkleiden</span></button></div>
                     <select name="attr_Eigenschaft1sichverkleiden" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -2115,7 +2115,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2128,7 +2128,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -2142,7 +2142,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Uberreden" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Überreden}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_uberreden}]]}} {{stat1=[[@{Eigenschaft1uberreden}]]}} {{stat2=[[@{Eigenschaft2uberreden}]]}} {{stat3=[[@{Eigenschaft3uberreden}]]}} {{Talent=[[ { [[{0d1 + @{TaW_uberreden} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_uberreden}, 0d1}kh1]] - @{Eigenschaft1uberreden}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_uberreden}, 0d1}kh1]] - @{Eigenschaft2uberreden}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_uberreden}, 0d1}kh1]] - @{Eigenschaft3uberreden}, 0d1}kh1, 0d1 + @{TaW_uberreden}}dh1]]}}"> <span>Überreden</span></button></div>
                     <select name="attr_Eigenschaft1uberreden" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -2155,7 +2155,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2167,7 +2167,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2184,7 +2184,7 @@
                     <select name="attr_Eigenschaft1uberzeugen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2196,7 +2196,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2208,7 +2208,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2266,7 +2266,7 @@
                     <select name="attr_Eigenschaft1fahrtensuchen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2278,7 +2278,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2289,11 +2289,11 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei der Spurensuche an einer begrenzten Stelle" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei der längerfristigen Verfolgung einer Spur">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fahrtensuchen">
@@ -2307,7 +2307,7 @@
                     <select name="attr_Eigenschaft1fallenstellen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2321,7 +2321,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2335,7 +2335,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fallenstellen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_fallenstellen" min="-4" value="0">
@@ -2351,7 +2351,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2363,7 +2363,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -2376,7 +2376,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fesseln">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_fesseln" min="-4" value="0">
@@ -2390,7 +2390,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2401,9 +2401,9 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei der Beurteilung eines Gewässers">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe außer bei der Beurteilung eines Gewässers" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2411,13 +2411,13 @@
                     <select name="attr_Eigenschaft3fischen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe bei der Beurteilung eines Gewässers">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe außer bei der Beurteilung eines Gewässers" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fischen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_fischen" min="-4" value="0">
@@ -2430,7 +2430,7 @@
                     <select name="attr_Eigenschaft1orientierung" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2442,7 +2442,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2453,7 +2453,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2471,7 +2471,7 @@
                     <select name="attr_Eigenschaft1wettervorhersage" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2483,7 +2483,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2494,7 +2494,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2513,7 +2513,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2527,7 +2527,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -2539,7 +2539,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wildnisleben">
@@ -2588,7 +2588,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Anatomie" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Anatomie}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_anatomie}]]}} {{stat1=[[@{Eigenschaft1anatomie}]]}} {{stat2=[[@{Eigenschaft2anatomie}]]}} {{stat3=[[@{Eigenschaft3anatomie}]]}} {{Talent=[[ { [[{0d1 + @{TaW_anatomie} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_anatomie}, 0d1}kh1]] - @{Eigenschaft1anatomie}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_anatomie}, 0d1}kh1]] - @{Eigenschaft2anatomie}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_anatomie}, 0d1}kh1]] - @{Eigenschaft3anatomie}, 0d1}kh1, 0d1 + @{TaW_anatomie}}dh1]]}}"> <span>Anatomie</span></button></div>
                     <select name="attr_Eigenschaft1anatomie" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -2600,7 +2600,7 @@
                     <select name="attr_Eigenschaft2anatomie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2614,7 +2614,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2630,7 +2630,7 @@
                     <select name="attr_Eigenschaft1baukunst" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2641,7 +2641,7 @@
                     <select name="attr_Eigenschaft2baukunst" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2655,7 +2655,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2671,7 +2671,7 @@
                     <select name="attr_Eigenschaft1brettspiel" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2682,7 +2682,7 @@
                     <select name="attr_Eigenschaft2brettspiel" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2694,7 +2694,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2712,7 +2712,7 @@
                     <select name="attr_Eigenschaft1geographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2723,7 +2723,7 @@
                     <select name="attr_Eigenschaft2geographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2735,7 +2735,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2753,7 +2753,7 @@
                     <select name="attr_Eigenschaft1geschichtswissen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2764,7 +2764,7 @@
                     <select name="attr_Eigenschaft2geschichtswissen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2776,7 +2776,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2794,7 +2794,7 @@
                     <select name="attr_Eigenschaft1gesteinskunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2806,7 +2806,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2819,7 +2819,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2835,7 +2835,7 @@
                     <select name="attr_Eigenschaft1gotter" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2846,7 +2846,7 @@
                     <select name="attr_Eigenschaft2gotter" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2858,7 +2858,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2876,7 +2876,7 @@
                     <select name="attr_Eigenschaft1heraldik" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2887,7 +2887,7 @@
                     <select name="attr_Eigenschaft2heraldik" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2901,7 +2901,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -2917,7 +2917,7 @@
                     <select name="attr_Eigenschaft1huttenkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2929,7 +2929,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -2944,7 +2944,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_huttenkunde">
@@ -2957,7 +2957,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Kriegskunst" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Kriegskunst}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_kriegskunst}]]}} {{stat1=[[@{Eigenschaft1kriegskunst}]]}} {{stat2=[[@{Eigenschaft2kriegskunst}]]}} {{stat3=[[@{Eigenschaft3kriegskunst}]]}} {{Talent=[[ { [[{0d1 + @{TaW_kriegskunst} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_kriegskunst}, 0d1}kh1]] - @{Eigenschaft1kriegskunst}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_kriegskunst}, 0d1}kh1]] - @{Eigenschaft2kriegskunst}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_kriegskunst}, 0d1}kh1]] - @{Eigenschaft3kriegskunst}, 0d1}kh1, 0d1 + @{TaW_kriegskunst}}dh1]]}}"> <span>Kriegskunst</span></button></div>
                     <select name="attr_Eigenschaft1kriegskunst" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -2969,7 +2969,7 @@
                     <select name="attr_Eigenschaft2kriegskunst" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -2982,7 +2982,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -2999,7 +2999,7 @@
                     <select name="attr_Eigenschaft1kryptographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3010,7 +3010,7 @@
                     <select name="attr_Eigenschaft2kryptographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3022,7 +3022,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3040,7 +3040,7 @@
                     <select name="attr_Eigenschaft1magiekunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3051,7 +3051,7 @@
                     <select name="attr_Eigenschaft2magiekunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3063,7 +3063,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3081,7 +3081,7 @@
                     <select name="attr_Eigenschaft1mechanik" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3092,7 +3092,7 @@
                     <select name="attr_Eigenschaft2mechanik" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3106,7 +3106,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -3122,7 +3122,7 @@
                     <select name="attr_Eigenschaft1pflanzenkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3134,7 +3134,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3147,7 +3147,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -3163,7 +3163,7 @@
                     <select name="attr_Eigenschaft1philosophie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3174,7 +3174,7 @@
                     <select name="attr_Eigenschaft2philosophie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3186,7 +3186,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3204,7 +3204,7 @@
                     <select name="attr_Eigenschaft1rechnen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3215,7 +3215,7 @@
                     <select name="attr_Eigenschaft2rechnen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3227,7 +3227,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3245,7 +3245,7 @@
                     <select name="attr_Eigenschaft1rechtskunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3256,7 +3256,7 @@
                     <select name="attr_Eigenschaft2rechtskunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3268,7 +3268,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3286,7 +3286,7 @@
                     <select name="attr_Eigenschaft1sagenlegenden" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3298,7 +3298,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3310,7 +3310,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -3327,7 +3327,7 @@
                     <select name="attr_Eigenschaft1schatzen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3339,7 +3339,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3350,7 +3350,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3368,7 +3368,7 @@
                     <select name="attr_Eigenschaft1sprachenkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3379,7 +3379,7 @@
                     <select name="attr_Eigenschaft2sprachenkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3391,7 +3391,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3409,7 +3409,7 @@
                     <select name="attr_Eigenschaft1staatskunst" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3421,7 +3421,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3433,7 +3433,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -3450,7 +3450,7 @@
                     <select name="attr_Eigenschaft1sternkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3461,7 +3461,7 @@
                     <select name="attr_Eigenschaft2sternkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3473,7 +3473,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -3490,7 +3490,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Tierkunde" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Tierkunde}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_tierkunde}]]}} {{stat1=[[@{Eigenschaft1tierkunde}]]}} {{stat2=[[@{Eigenschaft2tierkunde}]]}} {{stat3=[[@{Eigenschaft3tierkunde}]]}} {{Talent=[[ { [[{0d1 + @{TaW_tierkunde} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tierkunde}, 0d1}kh1]] - @{Eigenschaft1tierkunde}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tierkunde}, 0d1}kh1]] - @{Eigenschaft2tierkunde}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tierkunde}, 0d1}kh1]] - @{Eigenschaft3tierkunde}, 0d1}kh1, 0d1 + @{TaW_tierkunde}}dh1]]}}"> <span>Tierkunde</span></button></div>
                     <select name="attr_Eigenschaft1tierkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -3502,7 +3502,7 @@
                     <select name="attr_Eigenschaft2tierkunde" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -3514,7 +3514,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4201,7 +4201,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Abrichten" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Abrichten}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_abrichten}]]}} {{stat1=[[@{Eigenschaft1abrichten}]]}} {{stat2=[[@{Eigenschaft2abrichten}]]}} {{stat3=[[@{Eigenschaft3abrichten}]]}} {{Talent=[[ { [[{0d1 + @{TaW_abrichten} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_abrichten}, 0d1}kh1]] - @{Eigenschaft1abrichten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_abrichten}, 0d1}kh1]] - @{Eigenschaft2abrichten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_abrichten}, 0d1}kh1]] - @{Eigenschaft3abrichten}, 0d1}kh1, 0d1 + @{TaW_abrichten}}dh1]]}}"> <span>Abrichten</span></button></div>
                     <select name="attr_Eigenschaft1abrichten" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -4214,7 +4214,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4226,7 +4226,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -4244,7 +4244,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4257,7 +4257,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4270,7 +4270,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_ackerbau">
@@ -4283,7 +4283,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Alchimie" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Alchimie}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_alchimie}]]}} {{stat1=[[@{Eigenschaft1alchimie}]]}} {{stat2=[[@{Eigenschaft2alchimie}]]}} {{stat3=[[@{Eigenschaft3alchimie}]]}} {{Talent=[[ { [[{0d1 + @{TaW_alchimie} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alchimie}, 0d1}kh1]] - @{Eigenschaft1alchimie}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alchimie}, 0d1}kh1]] - @{Eigenschaft2alchimie}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alchimie}, 0d1}kh1]] - @{Eigenschaft3alchimie}, 0d1}kh1, 0d1 + @{TaW_alchimie}}dh1]]}}"> <span>Alchimie</span></button></div>
                     <select name="attr_Eigenschaft1alchimie" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -4295,7 +4295,7 @@
                     <select name="attr_Eigenschaft2alchimie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4309,7 +4309,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4326,7 +4326,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4341,7 +4341,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3bergbau" class="sheet-talent-eigenschaft">
@@ -4353,7 +4353,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_bergbau">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_bergbau" min="-4" value="0">
@@ -4366,7 +4366,7 @@
                     <select name="attr_Eigenschaft1bogenbau" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4378,7 +4378,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4391,7 +4391,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4411,7 +4411,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -4423,7 +4423,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3bootefahren" class="sheet-talent-eigenschaft">
@@ -4435,7 +4435,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_bootefahren">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_bootefahren" min="-4" value="0">
@@ -4448,7 +4448,7 @@
                     <select name="attr_Eigenschaft1brauer" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4462,7 +4462,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4476,7 +4476,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_brauer">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_brauer" min="-4" value="0">
@@ -4489,7 +4489,7 @@
                     <select name="attr_Eigenschaft1drucker" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4503,7 +4503,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4517,7 +4517,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_drucker">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_drucker" min="-4" value="0">
@@ -4531,7 +4531,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4543,7 +4543,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -4555,7 +4555,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4570,7 +4570,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Falschspiel" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Falschspiel}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_falschspiel}]]}} {{stat1=[[@{Eigenschaft1falschspiel}]]}} {{stat2=[[@{Eigenschaft2falschspiel}]]}} {{stat3=[[@{Eigenschaft3falschspiel}]]}} {{Talent=[[ { [[{0d1 + @{TaW_falschspiel} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_falschspiel}, 0d1}kh1]] - @{Eigenschaft1falschspiel}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_falschspiel}, 0d1}kh1]] - @{Eigenschaft2falschspiel}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_falschspiel}, 0d1}kh1]] - @{Eigenschaft3falschspiel}, 0d1}kh1, 0d1 + @{TaW_falschspiel}}dh1]]}}"> <span>Falschspiel</span></button></div>
                     <select name="attr_Eigenschaft1falschspiel" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -4584,7 +4584,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -4596,7 +4596,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4612,7 +4612,7 @@
                     <select name="attr_Eigenschaft1feinmechanik" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4626,7 +4626,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4637,7 +4637,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4653,7 +4653,7 @@
                     <select name="attr_Eigenschaft1feuersteinbearbeitung" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4667,7 +4667,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4678,7 +4678,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4694,7 +4694,7 @@
                     <select name="attr_Eigenschaft1fleischer" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4708,7 +4708,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4722,7 +4722,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fleischer">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_fleischer" min="-4" value="0">
@@ -4735,7 +4735,7 @@
                     <select name="attr_Eigenschaft1gerber" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4749,7 +4749,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4762,7 +4762,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_gerber">
@@ -4779,7 +4779,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4790,7 +4790,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4803,7 +4803,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_glaskunst">
@@ -4820,7 +4820,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4833,7 +4833,7 @@
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
-                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" selected="selected">KO</option>
+                        <option value="@{KO}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
                     <select name="attr_Eigenschaft3grobschmied" class="sheet-talent-eigenschaft">
@@ -4845,7 +4845,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_grobschmied">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_grobschmied" min="-4" value="0">
@@ -4858,7 +4858,7 @@
                     <select name="attr_Eigenschaft1handel" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4870,7 +4870,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4882,7 +4882,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -4900,7 +4900,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4912,7 +4912,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -4924,7 +4924,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -4939,7 +4939,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="HeilkundeGift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Heilkunde Gift}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_heilkundegift}]]}} {{stat1=[[@{Eigenschaft1heilkundegift}]]}} {{stat2=[[@{Eigenschaft2heilkundegift}]]}} {{stat3=[[@{Eigenschaft3heilkundegift}]]}} {{Talent=[[ { [[{0d1 + @{TaW_heilkundegift} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundegift}, 0d1}kh1]] - @{Eigenschaft1heilkundegift}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundegift}, 0d1}kh1]] - @{Eigenschaft2heilkundegift}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundegift}, 0d1}kh1]] - @{Eigenschaft3heilkundegift}, 0d1}kh1, 0d1 + @{TaW_heilkundegift}}dh1]]}}"> <span>Heilkunde Gift</span></button></div>
                     <select name="attr_Eigenschaft1heilkundegift" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -4951,7 +4951,7 @@
                     <select name="attr_Eigenschaft2heilkundegift" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -4963,7 +4963,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -4980,7 +4980,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="HeilkundeKrankheiten" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Heilkunde Krankheiten}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_heilkundekrankheiten}]]}} {{stat1=[[@{Eigenschaft1heilkundekrankheiten}]]}} {{stat2=[[@{Eigenschaft2heilkundekrankheiten}]]}} {{stat3=[[@{Eigenschaft3heilkundekrankheiten}]]}} {{Talent=[[ { [[{0d1 + @{TaW_heilkundekrankheiten} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundekrankheiten}, 0d1}kh1]] - @{Eigenschaft1heilkundekrankheiten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundekrankheiten}, 0d1}kh1]] - @{Eigenschaft2heilkundekrankheiten}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_heilkundekrankheiten}, 0d1}kh1]] - @{Eigenschaft3heilkundekrankheiten}, 0d1}kh1, 0d1 + @{TaW_heilkundekrankheiten}}dh1]]}}"> <span>Heilkunde Krankheiten</span></button></div>
                     <select name="attr_Eigenschaft1heilkundekrankheiten" class="sheet-talent-eigenschaft">
                         <option>---</option>
-                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" selected="selected">MU</option>
+                        <option value="@{MU}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
@@ -4992,7 +4992,7 @@
                     <select name="attr_Eigenschaft2heilkundekrankheiten" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5005,7 +5005,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -5023,7 +5023,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5035,7 +5035,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -5046,7 +5046,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -5063,7 +5063,7 @@
                     <select name="attr_Eigenschaft1heilkundewunden" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5076,7 +5076,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -5088,7 +5088,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5104,7 +5104,7 @@
                     <select name="attr_Eigenschaft1holzbearbeitung" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5118,7 +5118,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5132,7 +5132,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_holzbearbeitung">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_holzbearbeitung" min="-4" value="0">
@@ -5145,7 +5145,7 @@
                     <select name="attr_Eigenschaft1instrumentenbauer" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5157,7 +5157,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5170,7 +5170,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5186,7 +5186,7 @@
                     <select name="attr_Eigenschaft1karthographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5197,7 +5197,7 @@
                     <select name="attr_Eigenschaft2karthographie" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5211,7 +5211,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5227,7 +5227,7 @@
                     <select name="attr_Eigenschaft1kochen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5239,7 +5239,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5252,7 +5252,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5268,7 +5268,7 @@
                     <select name="attr_Eigenschaft1kristallzucht" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5280,7 +5280,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5293,7 +5293,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5309,7 +5309,7 @@
                     <select name="attr_Eigenschaft1lederarbeiten" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5323,7 +5323,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5334,7 +5334,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5350,7 +5350,7 @@
                     <select name="attr_Eigenschaft1malenzeichnen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5362,7 +5362,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5375,7 +5375,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5394,7 +5394,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5406,7 +5406,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -5419,7 +5419,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_maurer">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_maurer" min="-4" value="0">
@@ -5432,7 +5432,7 @@
                     <select name="attr_Eigenschaft1metallguss" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5446,7 +5446,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5460,7 +5460,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_metallguss">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_metallguss" min="-4" value="0">
@@ -5474,7 +5474,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5486,7 +5486,7 @@
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
-                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" selected="selected">CH</option>
+                        <option value="@{CH}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
@@ -5498,7 +5498,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5515,7 +5515,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5528,7 +5528,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5539,7 +5539,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5555,7 +5555,7 @@
                     <select name="attr_Eigenschaft1schnapsbrennen" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5567,7 +5567,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5580,7 +5580,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5596,7 +5596,7 @@
                     <select name="attr_Eigenschaft1schneidern" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5610,7 +5610,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5621,7 +5621,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5640,7 +5640,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5652,7 +5652,7 @@
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
-                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" selected="selected">GE</option>
+                        <option value="@{GE}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
                     </select>
@@ -5665,7 +5665,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_seefahrt">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_seefahrt" min="-4" value="0">
@@ -5681,7 +5681,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5692,7 +5692,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5706,7 +5706,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_seiler">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_seiler" min="-4" value="0">
@@ -5722,7 +5722,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5733,7 +5733,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5747,7 +5747,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_steinmetz">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_steinmetz" min="-4" value="0">
@@ -5761,7 +5761,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5774,7 +5774,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5785,7 +5785,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5801,7 +5801,7 @@
                     <select name="attr_Eigenschaft1stellmacher" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5815,7 +5815,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5829,7 +5829,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_stellmacher">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_stellmacher" min="-4" value="0">
@@ -5842,7 +5842,7 @@
                     <select name="attr_Eigenschaft1stoffefarben" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5856,7 +5856,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5870,7 +5870,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_stoffefarben">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_stoffefarben" min="-4" value="0">
@@ -5884,7 +5884,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5897,7 +5897,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5908,7 +5908,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5924,7 +5924,7 @@
                     <select name="attr_Eigenschaft1topfern" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5938,7 +5938,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5949,7 +5949,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -5965,7 +5965,7 @@
                     <select name="attr_Eigenschaft1viehzucht" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -5977,7 +5977,7 @@
                         <option>---</option>
                         <option value="@{MU}">MU</option>
                         <option value="@{KL}">KL</option>
-                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" selected="selected">IN</option>
+                        <option value="@{IN}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
@@ -5993,7 +5993,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_viehzucht">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_viehzucht" min="-4" value="0">
@@ -6009,7 +6009,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -6020,7 +6020,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -6034,7 +6034,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_webkunst">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_webkunst" min="-4" value="0">
@@ -6047,7 +6047,7 @@
                     <select name="attr_Eigenschaft1winzer" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -6061,7 +6061,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -6075,7 +6075,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_winzer">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_winzer" min="-4" value="0">
@@ -6088,7 +6088,7 @@
                     <select name="attr_Eigenschaft1zimmermann" class="sheet-talent-eigenschaft">
                         <option>---</option>
                         <option value="@{MU}">MU</option>
-                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" selected="selected">KL</option>
+                        <option value="@{KL}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
                         <option value="@{FF}">FF</option>
@@ -6102,7 +6102,7 @@
                         <option value="@{KL}">KL</option>
                         <option value="@{IN}">IN</option>
                         <option value="@{CH}">CH</option>
-                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" selected="selected">FF</option>
+                        <option value="@{FF}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
                         <option value="@{KK}">KK</option>
@@ -6116,7 +6116,7 @@
                         <option value="@{FF}">FF</option>
                         <option value="@{GE}">GE</option>
                         <option value="@{KO}">KO</option>
-                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" selected="selected">KK</option>
+                        <option value="@{KK}" class="sheet-talent-default-eigenschaft" title="Standardeigenschaft für diese Teilprobe" selected="selected">KK</option>
                     </select>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zimmermann">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zimmermann" min="-4" value="0">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12924,10 +12924,10 @@
 <rolltemplate class="sheet-rolltemplate-DSA-Eigenschaft">
 {{#rollGreater() Probe -1}}
     {{#rollWasCrit() Probe}}
-    <table class="sheet-templates-succ-uncr">
+    <table class="sheet-templates-succ-crc">
     {{/rollWasCrit() Probe}}
     {{#rollWasFumble() Probe}}
-    <table class="sheet-templates-fail-uncr">
+    <table class="sheet-templates-fail-crc">
     {{/rollWasFumble() Probe}}
     {{#^rollWasCrit() Probe}}
         {{#^rollWasFumble() Probe}}
@@ -12937,10 +12937,10 @@
 {{/rollGreater() Probe -1}}
 {{#rollLess() Probe 0}}
     {{#rollWasCrit() Probe}}
-    <table class="sheet-templates-succ-uncr">
+    <table class="sheet-templates-succ-crc">
     {{/rollWasCrit() Probe}}
     {{#rollWasFumble() Probe}}
-    <table class="sheet-templates-fail-uncr">
+    <table class="sheet-templates-fail-crc">
     {{/rollWasFumble() Probe}}
     {{#^rollWasCrit() Probe}}
         {{#^rollWasFumble() Probe}}

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -11347,12 +11347,12 @@
                     <td><button name="PA+-" type="roll" value="@{gm_roll_opt} &{template:DSA-Nahkampf-PA} {{name=Nahkampfparade}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modansage=[[-1]]}} {{ansage=[[-1]]}} {{wert=[[@{PA_Aktiv}]]}} {{eff_wert=[[[[@{PA_Aktiv}]] - (?{Erleichterung (−) oder Erschwernis (+)|0})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>+/−</span></button></td>
                 </tr>
                 <tr>
-                    <td><button name="Ausweichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Ausweichen}} {{mod=[[0]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{wert=[[@{Ausweichen_Kampf}]]}} {{eff_wert=[[@{Ausweichen_Kampf}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Ausweichen</span></button></td>
-                    <td><button name="Ausweichen+-" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Ausweichen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{wert=[[@{Ausweichen_Kampf}]]}} {{eff_wert=[[[[@{Ausweichen_Kampf}]] - (?{Erleichterung (−) oder Erschwernis (+)|0})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>+/−</span></button></td>
+                    <td><button name="Ausweichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Ausweichen}} {{ausweichenmod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}))]]}} {{probenmod=[[0]]}} {{mod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII})) + (@{BE_TaW})]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{pa=[[@{PABasis}]]}} {{be=[[@{BE_TaW}]]}} {{wert=[[@{PABasis}]]}} {{eff_wert=[[@{PABasis} + (@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}) - (@{BE_TaW})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Ausweichen</span></button></td>
+                    <td><button name="Ausweichen+-" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Ausweichen}} {{ausweichenmod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}))]]}} {{probenmod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{mod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII})) + ?{Erleichterung (−) oder Erschwernis (+)|0} + (@{BE_TaW})]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{pa=[[@{PABasis}]]}} {{be=[[@{BE_TaW}]]}} {{wert=[[@{PABasis}]]}} {{eff_wert=[[@{PABasis} + (@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}) - (@{BE_TaW}) - (?{Erleichterung (−) oder Erschwernis (+)|0})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>+/−</span></button></td>
                 </tr>
                 <tr class="sheet-hideable-man-gezieltes-ausweichen">
-                    <td><button name="Gezieltes_Ausweichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Gezieltes Ausweichen}} {{mod=[[0]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{wert=[[@{Ausweichen_Kampf}]]}} {{eff_wert=[[@{Ausweichen_Kampf}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Gezieltes Ausweichen</span></button></td>
-                    <td><button name="Gezieltes_Ausweichen+-" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Gezieltes Ausweichen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{modansage=[[-1]]}} {{ansage=[[-1]]}} {{wert=[[@{Ausweichen_Kampf}]]}} {{eff_wert=[[[[@{Ausweichen_Kampf}]] - (?{Erleichterung (−) oder Erschwernis (+)|0})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>+/−</span></button></td>
+                    <td><button name="Gezieltes_Ausweichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Gezieltes Ausweichen}} {{ausweichenmod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}))]]}} {{probenmod=[[0]]}} {{mod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII})) + (@{BE_TaW})]]}} {{ansage=[[-1]]}} {{modansage=[[-1]]}} {{pa=[[@{PABasis}]]}} {{be=[[@{BE_TaW}]]}} {{wert=[[@{PABasis}]]}} {{eff_wert=[[@{PABasis} + (@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}) - (@{BE_TaW})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Gezieltes Ausweichen</span></button></td>
+                    <td><button name="Gezieltes_Ausweichen+-" type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Ausweichen} {{name=Gezieltes Ausweichen}} {{ausweichenmod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}))]]}} {{probenmod=[[?{Erleichterung (−) oder Erschwernis (+)|0}]]}} {{mod=[[(-1)*((@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII})) + ?{Erleichterung (−) oder Erschwernis (+)|0} + (@{BE_TaW})]]}} {{modansage=[[-1]]}} {{ansage=[[-1]]}} {{pa=[[@{PABasis}]]}} {{be=[[@{BE_TaW}]]}} {{wert=[[@{PABasis}]]}} {{eff_wert=[[@{PABasis} + (@{sf_ausweichenI}) + (@{sf_ausweichenII}) + (@{sf_ausweichenIII}) - (@{BE_TaW}) - (?{Erleichterung (−) oder Erschwernis (+)|0})]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>+/−</span></button></td>
                 </tr>
                 <tr>
                     <td colspan="2"><button name="PA-Patzer" type="roll" value="@{gm_roll_opt} &{template:DSA-Nahkampf-Patzer} {{name=Nahkampfparadepatzer}} {{wurf=[[2d6cs1cf6]]}}"> <span>Patzer</span></button></td>
@@ -12752,8 +12752,8 @@
                 PA-Wert aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
                 <input type="number" name="attr_PA_Aktiv" disabled="true" value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4})">
 
-                Ausweichen-Wert für den Kampf
-                <input type="number" name="attr_Ausweichen_Kampf" disabled="true" value="@{PABasis} + @{sf_ausweichenI} + @{sf_ausweichenII} + @{sf_ausweichenIII} - @{Ges_BE}">
+                Ausweichen-Wert für den Kampf (quasi deaktiviert im Zuge der Umstellung auf das WdS-System zum Ausweichen)
+                <input type="number" name="attr_Ausweichen_Kampf" disabled="true" value="@{PABasis} - @{BE_TaW}">
             </div>
         </div>
     </div>
@@ -13591,49 +13591,60 @@
     {{/^rollWasCrit() wurf}}
 {{/rollGreater() wurf eff_wert}}
         <tr>
-            <th colspan="3">{{name}}</th>
+            <th colspan="2">{{name}}</th>
         </tr>
 {{#rollGreater() ansage 0}}
         <tr>
-            <td colspan="3" class="sheet-templates-result">Ausweichen {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}{{#rollTotal() mod 0}}&#177;{{mod}}{{/rollTotal() mod 0}}{{#rollGreater() mod 0}}+{{mod}}{{/rollGreater() mod 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
+            <td colspan="2" class="sheet-templates-result">Ausweichen {{#rollLess() modansage 0}}{{modansage}}{{/rollLess() modansage 0}}{{#rollTotal() modansage 0}}&#177;{{modansage}}{{/rollTotal() modansage 0}}{{#rollGreater() modansage 0}}+{{modansage}}{{/rollGreater() modansage 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
         </tr>
         <tr>
-            <td>Ausweichenwert: {{wert}}</td>
-            <td><span class="sheet-abbr" title="Modifikator">Mod.</span>: {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}{{#rollTotal() mod 0}}&#177;{{mod}}{{/rollTotal() mod 0}}{{#rollGreater() mod 0}}+{{mod}}{{/rollGreater() mod 0}}</td>
-            <td>Ansage: {{ansage}}</td>
+            <td><span class="sheet-abbr" title="Parade-Basiswert. Ausgangswert für Ausweichen-Proben und daher auch als &bdquo;Ausweichenwert&ldquo; bezeichnet.">PA-Basis</span>: {{pa}}</td>
+            <td><span class="sheet-abbr" title="Behinderung">BE</span>: {{be}}</td>
+        </tr>
+        <tr>
+            <td><span class="sheet-abbr" title="Fester Modifikator für Ausweichen-Proben. Berücksichtigt momentan nur die Sonderfertigkeiten &bdquo;Ausweichen I&ldquo;, &bdquo;Ausweichen II&ldquo; und &bdquo;Ausweichen III&ldquo;.">A.-Mod.</span>: {{ausweichenmod}}</td>
+            <td><span class="sheet-abbr" title="Variabler Modifikator für diese Probe, händisch eingegeben">P.-Mod.</span>: {{#rollLess() probenmod 0}}{{probenmod}}{{/rollLess() probenmod 0}}{{#rollTotal() probenmod 0}}&#177;{{probenmod}}{{/rollTotal() probenmod 0}}{{#rollGreater() probenmod 0}}+{{probenmod}}{{/rollGreater() probenmod 0}}</td>
+        </tr>
+        <tr>
+            <td colspan="2">Ansage: {{ansage}}</td>
         </tr>
 {{/rollGreater() ansage 0}}
 {{#^rollGreater() ansage 0}}
         <tr>
-            <td colspan="3" class="sheet-templates-result">Ausweichen {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}{{#rollTotal() mod 0}}&#177;{{mod}}{{/rollTotal() mod 0}}{{#rollGreater() mod 0}}+{{mod}}{{/rollGreater() mod 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
+            <td colspan="2" class="sheet-templates-result">Ausweichen {{#rollLess() mod 0}}{{mod}}{{/rollLess() mod 0}}{{#rollTotal() mod 0}}&#177;{{mod}}{{/rollTotal() mod 0}}{{#rollGreater() mod 0}}+{{mod}}{{/rollGreater() mod 0}} <span class="sheet-templates-result-content"></span> ({{wurf}}).</td>
         </tr>
         <tr>
-            <td colspan="3">Ausweichenwert: {{wert}}</td>
+            <td><span class="sheet-abbr" title="Parade-Basiswert. Ausgangswert für Ausweichen-Proben und daher auch als &bdquo;Ausweichenwert&ldquo; bezeichnet.">PA-Basis</span>: {{pa}}</td>
+            <td><span class="sheet-abbr" title="Behinderung">BE</span>: {{be}}</td>
+        </tr>
+        <tr>
+            <td><span class="sheet-abbr" title="Fester Modifikator für Ausweichen-Proben. Berücksichtigt momentan nur die Sonderfertigkeiten &bdquo;Ausweichen I&ldquo;, &bdquo;Ausweichen II&ldquo; und &bdquo;Ausweichen III&ldquo;.">A.-Mod.</span>: {{ausweichenmod}}</td>
+            <td><span class="sheet-abbr" title="Variabler Modifikator für diese Probe, händisch eingegeben">P.-Mod.</span>: {{#rollLess() probenmod 0}}{{probenmod}}{{/rollLess() probenmod 0}}{{#rollTotal() probenmod 0}}&#177;{{probenmod}}{{/rollTotal() probenmod 0}}{{#rollGreater() probenmod 0}}+{{probenmod}}{{/rollGreater() probenmod 0}}</td>
         </tr>
 {{/^rollGreater() ansage 0}}
         {{#rollLess() eff_wert 0}}
         <tr>
-            <td colspan="3" class="sheet-templates-warning"><span class="sheet-abbr" title="Falls die Erschwernis eine Ansage enthält und WdS 59 sinngemäß auf alle Abwehraktionen und damit auch auf die Ausweichenprobe angewendet wird, ist es möglich, dass dieses Ausweichen nicht hätte gewürfelt werden dürfen.">Hohe Erschwernis.</span></td>
+            <td colspan="2" class="sheet-templates-warning"><span class="sheet-abbr" title="Falls die Erschwernis eine Ansage enthält und WdS 59 sinngemäß auf alle Abwehraktionen und damit auch auf die Ausweichenprobe angewendet wird, ist es möglich, dass dieses Ausweichen nicht hätte gewürfelt werden dürfen.">Hohe Erschwernis.</span></td>
         </tr>
         {{/rollLess() eff_wert 0}}
         {{#rollWasCrit() wurf}}
         <tr>
             {{#rollWasCrit() pruefwurf}}
-                    <td colspan="3" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
+                    <td colspan="2" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
             {{/rollWasCrit() pruefwurf}}
             {{#rollWasFumble() pruefwurf}}
-                    <td colspan="3" class="sheet-templates-warning">Gewöhnliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
+                    <td colspan="2" class="sheet-templates-warning">Gewöhnliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
             {{/rollWasFumble() pruefwurf}}
             {{#^rollWasCrit() pruefwurf}}
                 {{#^rollWasFumble() pruefwurf}}
                     {{#rollTotal() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
+                        <td colspan="2" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
                     {{/rollTotal() pruefwurf eff_wert}}
                     {{#rollLess() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
+                        <td colspan="2" class="sheet-templates-warning">Glückliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
                     {{/rollLess() pruefwurf eff_wert}}
                     {{#rollGreater() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Gewöhnliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
+                        <td colspan="2" class="sheet-templates-warning">Gewöhnliches Ausweichen! Prüfwurf: {{pruefwurf}}.</td>
                     {{/rollGreater() pruefwurf eff_wert}}
                 {{/^rollWasFumble() pruefwurf}}
             {{/^rollWasCrit() pruefwurf}}
@@ -13642,26 +13653,29 @@
         {{#rollWasFumble() wurf}}
         <tr>
             {{#rollWasCrit() pruefwurf}}
-                <td colspan="3" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
+                <td colspan="2" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
             {{/rollWasCrit() pruefwurf}}
             {{#rollWasFumble() pruefwurf}}
-                <td colspan="3" class="sheet-templates-warning">Bestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen erwürfeln.</td>
+                <td colspan="2" class="sheet-templates-warning">Bestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen erwürfeln.</td>
             {{/rollWasFumble() pruefwurf}}
             {{#^rollWasCrit() pruefwurf}}
                 {{#^rollWasFumble() pruefwurf}}
                     {{#rollTotal() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
+                        <td colspan="2" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
                     {{/rollTotal() pruefwurf eff_wert}}
                     {{#rollLess() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
+                        <td colspan="2" class="sheet-templates-warning">Unbestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen zum Glück verhindert.</td>
                     {{/rollLess() pruefwurf eff_wert}}
                     {{#rollGreater() pruefwurf eff_wert}}
-                        <td colspan="3" class="sheet-templates-warning">Bestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen erwürfeln.</td>
+                        <td colspan="2" class="sheet-templates-warning">Bestätigter Ausweichenpatzer! Prüfwurf: {{pruefwurf}}. Auswirkungen erwürfeln.</td>
                     {{/rollGreater() pruefwurf eff_wert}}
                 {{/^rollWasFumble() pruefwurf}}
             {{/^rollWasCrit() pruefwurf}}
         </tr>
         {{/rollWasFumble() wurf}}
+        <tr>
+            <td colspan="2" class="sheet-templates-warning"><span class="sheet-abbr" title="Ausweichen-Proben werden momentan nach den Regeln aus &bdquo;Wege des Schwerts&ldquo; gewürfelt. Dies bedeutet, dass die Ausweichen-Probe grundsätzlich auf den Paradebasiswert gewürfelt wird. Die Probe wird bislang vom Charakterbogen aus erschwert um die Behinderung, erleichtert für die Sonderfertigkeiten &bdquo;Ausweichen I&ldquo; bis &bdquo;Ausweichen III&ldquo; und modifiziert um den händisch eingetragenen Probenmodifikator. Dieser Probenmodifikator sollte vom Meister entsprechend &bdquo;Wege des Schwerts&ldquo; gewählt werden. Folgende Effekte könnten vom Charakterbogen sinnvoll berücksichtigt werden, müssen momentan aber noch händisch über den Probenmodifikator berücksichtigt werden: niedrige Ausdauer, niedrige Lebensenergie und der Akrobatiktalentwert.">Hinweise zu Ausweichen-Proben.</span></td>
+        </tr>
     </table>
 </rolltemplate>
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -184,6 +184,8 @@
         </table>
         <input type="checkbox" class="sheet-versteckeMagie sheet-default-hide" name="attr_MagieTab">
         <input type="checkbox" class="sheet-versteckeLiturgien sheet-default-hide" name="attr_LiturgienTab">
+        <input type="checkbox" class="sheet-verstecke-erschoepfung sheet-default-hide" name="attr_verstecke_erschoepfung">
+        <input type="checkbox" class="sheet-verstecke-ueberanstrengung sheet-default-hide" name="attr_verstecke_ueberanstrengung">
         <table>
             <th>Grundwert</th>
             <th>Basis</th>
@@ -203,6 +205,20 @@
                 <td><input type="number" name="attr_AusZugeK" style="width: 3em;" value="0"></td>
                 <td><input type="text" class="sheet-stat-immutable" name="attr_Aus_max" value="@{AusGrundW} + @{AusZugeK}" disabled="true"></td>
                 <td><input type="number" name="attr_AusAktuell" style="width: 3em" value="@{Aus_max}"></td>
+            </tr>
+            <tr class="sheet-hideable-exhaustion">
+                <td>Erschöpfung</td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_basis" value="@{KO_Basis}" disabled="true"></td>
+                <td><input type="number" name="attr_erschoepfung_mod" style="width: 3em;" value="0" min="-2" max="2"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_max" value="(@{erschoepfung_basis}) + (@{erschoepfung_mod})" disabled="true"></td>
+                <td><input type="number" name="attr_erschoepfung" style="width: 3em" value="0" min="0"></td>
+            </tr>
+            <tr class="sheet-hideable-overstrain">
+                <td>Überanstrengung</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_ueberanstrengung_max" value="@{KO_Basis}" disabled="true"></td>
+                <td><input type="number" name="attr_ueberanstrengung" style="width: 3em" value="0" min="0"></td>
             </tr>
             <tr class="sheet-hideable-ae">
                 <td>Astralenergie</td>
@@ -12728,6 +12744,14 @@
             <br>
             <label class="sheet-lone-input-label">
                <input type="checkbox" class="sheet-versteckeLiturgien" name="attr_LiturgienTab"> Verstecke Götterwirken
+            </label>
+            <br>
+            <label class="sheet-lone-input-label">
+               <input type="checkbox" class="sheet-verstecke-erschoepfung" name="attr_verstecke_erschoepfung"> Verstecke Erschöpfung
+            </label>
+            <br>
+            <label class="sheet-lone-input-label">
+               <input type="checkbox" class="sheet-verstecke-ueberanstrengung" name="attr_verstecke_ueberanstrengung"> Verstecke Überanstrengung
             </label>
             <br>
             <label class="sheet-lone-input-label">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12783,7 +12783,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-09-04"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-10-14"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12783,7 +12783,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="2017-10-14"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="20171014"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>


### PR DESCRIPTION
This PR fixes several minor issues I wanted to get done prior to the conversion to sheet worker scripts.

* New features: Add a place for exhaustion and overstrain (ca2da3b)
* Interface: Show all relevant information for evasion checks in the roll template and adapt roll buttons (ddf9561)
* Style: Use colours for combat 1/20 for stat checks as well (3d1efe8), use different background and text colour for highlighting default stats of talent checks instead of just using bold face (3501303)
* New attributes: erschoepfung, erschoepfung_max, erschoepfung_basis, ueberanstrengung, ueberanstrengung_max, ueberanstrengung_basis (ca2da3b)