### PR TITLE
Fix some repeating section display bugs

### DIFF
--- a/AW/style.css
+++ b/AW/style.css
@@ -305,7 +305,8 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
 }
 
 .sheet-harm-checkbox{
-    margin-left: 8px;
+    margin-left: 5px;
+    margin-right: 4px;
 }
 
 .sheet-harm-checkbox.sheet-harm-0:checked ~ .sheet-clock {
@@ -400,4 +401,13 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
     background-color: transparent;
     color: #B31515;
     border: none;
+}
+
+/* fix some display bugs */
+.itemcontrol {
+  left: 0;
+  top: 0;
+}
+.repcontrol {
+  height: 28px;
 }

--- a/AW2E/style.css
+++ b/AW2E/style.css
@@ -270,7 +270,8 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
 }
 
 .sheet-harm-checkbox{
-    margin-left: 8px;
+    margin-left: 5px;
+    margin-right: 4px;
 }
 
 .sheet-harm-checkbox.sheet-harm-0:checked ~ .sheet-clock {
@@ -365,4 +366,13 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
     background-color: transparent;
     color: #B31515;
     border: none;
+}
+
+/* fix some display bugs */
+.itemcontrol {
+  left: 0;
+  top: 0;
+}
+.repcontrol {
+  height: 28px;
 }

--- a/Urban_Shadows/style.css
+++ b/Urban_Shadows/style.css
@@ -302,3 +302,12 @@ input.sheet-showhide:checked ~ .sheet-subbox {display: none;}
     color: #B31515;
     border: none;
 }
+
+/* fix some display bugs */
+.itemcontrol {
+  left: 0;
+  top: 0;
+}
+.repcontrol {
+  height: 28px;
+}


### PR DESCRIPTION
This is a simple fix for the CSS of the AW, AW2E, and Urban Shadows
sheets to display repeating sections better. Also added some margins
to the harm radios for AW 1+2.