### PR TITLE
dsa5 sheet: roll template fix

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -5849,16 +5849,16 @@
                             	<input type="number" name="attr_AT_Aktiv" style='width: 3em' value="@{AT_Aktiv_Waffe} + @{Situationen_AT_Mod} + @{Basismanoever_AT_Mod} + @{Spezialmanoever_AT_Mod} + @{Passiv_AT_Mod} + @{Zustand_Mod_max_abzl_BE} - @{Ges_BE}" disabled="true" />
                             </td>
                             <td>
-                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv})]]}}" />
-                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv})]]}}" />
+                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Attacke}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{AT_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
                             </td>
                         </tr>
                         <tr>
                             <td colspan="2">Passierschlag:</td>
                             <td><input type="number" name="attr_Passierschlag" style='width: 3em' value="(@{AT_Aktiv}) - 4" disabled="true" /></td>
                             <td>
-                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Nahkampf}} {{subtags=Passierschlag}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Passierschlag})]]}}" />
-                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Nahkampf}} {{subtags=Passierschlag}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Passierschlag}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Nahkampf}} {{subtags=Passierschlag}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Passierschlag})]]}}" />
+                                <button type="roll" value="&{template:DSA-Nahkampf-AT} {{name=Nahkampf}} {{subtags=Passierschlag}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Passierschlag}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
                             </td>
                         </tr>
                         <tr>
@@ -5893,11 +5893,11 @@
                     <div class="sheet-humanoid">
                         <div style="display:inline-block; width:9em;">Waffenparade:</div>
                         <input type="number" name="attr_PA_Aktiv" style='width: 3em' value="@{PA_Aktiv_Waffe} + @{PA_Schild_Bonus} + @{PA_Parierwaffe_Bonus} - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod}  + @{Passiv_PA_Mod} + @{Zustand_Mod_max_abzl_BE}" disabled="true" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})]]}} {{mod=[[d0]]}}" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Parade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})]]}} {{mod=[[d0]]}}" />
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Parade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Parade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Parade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Parade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
                     <div class="sheet-humanoid">
                         <div style="display:inline-block; width:12em;">Waffenparadepatzer:</div>
@@ -5909,11 +5909,11 @@
                         <div style="display:inline-block; width:9em;">Schildparade:</div>
                         <input class="hidden" type="number" name="attr_Schild_PA_Aktiv_Ausgeruestet" />
                         <input type="number" name="attr_Schild_PA_Aktiv" style='width: 3em' value="@{Schild_PA_Aktiv_Ausgeruestet} - @{Ges_BE} + @{Situationen_PA_Mod} + @{Spezialmanoever_PA_Mod} + @{Zustand_Mod_max_abzl_BE} + @{Passiv_Verteidigungshaltung_PA_Mod}" disabled="true" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})]]}} {{mod=[[d0]]}}" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Schild_PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Schildparade}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})]]}} {{mod=[[d0]]}}" />
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Schildparade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Schildparade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Schild_PA_Aktiv})/2)]]}} {{mod=0}}">1/2</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Schildparade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Schildparade}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Schild_PA_Aktiv})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
                     <div class="sheet-humanoid sheet-schilde">
                         <div style="display:inline-block; width:12em;">Schildparadepatzer:</div>
@@ -5924,18 +5924,18 @@
                     <div class="sheet-humanoid">
                         <div style="display:inline-block; width:9em;">Ausweichen:</div>
                         <input type="number"  name="attr_Ausweichen_Kampf" style='width: 3em' value="@{Ausweichen_Wert} - @{Ges_BE}  + @{Zustand_Mod_max_abzl_BE}" disabled="true">
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})]]}}" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbiertes Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Ausweichen_Kampf})/2)]]}} {{mod=0}}">1/2</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Ausweichen}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Ausweichen}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})]]}}" />
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Ausweichen}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbiertes Ausweichen}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Ausweichen_Kampf})/2)]]}} {{mod=0}}">1/2</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=2. Ausweichen}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-3]]}} {{mod=[[-3+1d0]]}}">2.</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=3. Ausweichen}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Ausweichen_Kampf})-6]]}} {{mod=[[-6+1d0]]}}">3.</button>
                     </div>
                     <div class="sheet-nicht-humanoid">
                         <div style="display:inline-block; width:9em;">Verteidigung:</div>
                         <input type="number"  name="attr_Verteidigung_Kampf" style='width: 3em' value="@{Verteidigung_Wert} + @{Zustand_Mod_max_abzl_BE}" disabled="true">
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf})]]}}" />
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
-                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Verteidigung}} {{subtags=Nahkampf}}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Verteidigung_Kampf})/2)]]}} {{mod=0}}">1/2</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf})]]}}" />
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Verteidigung}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[(@{Verteidigung_Kampf}+(?{Erleichterung(+) / Erschwernis(-)|0}))]]}} {{mod=[[(?{Erleichterung(+) / Erschwernis(-)|0})]]}}">+/-</button>
+                        <button type="roll" value="&{template:DSA-Nahkampf-VE} {{name=Halbierte Verteidigung}} {{subtags=Nahkampf}} {{wurf=[[1d20cs1cf20]]}} {{wert=[[ceil((@{Verteidigung_Kampf})/2)]]}} {{mod=0}}">1/2</button>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
most of the attack and defense templates had one } too many, was always shown in the roll as text