### PR TITLE
Suppr. "max-height" dans .sheet-desc du Template

### DIFF
--- a/ChroniquesOubliees/co.css
+++ b/ChroniquesOubliees/co.css
@@ -289,3 +289,7 @@ textarea.sheet-voixdesc{
     border-style: solid;
     border-radius: 50%;
 }
+.sheet-rolltemplate-co1 div.sheet-desc {
+    padding-top: 0px !important;
+    max-height: none !important;
+}


### PR DESCRIPTION
Bonjour,

Il y a un max-height  qui, à mon sens, n'est pas très utile (je peux me tromper).
Serait-il possible d'ajouter cet ajout CSS afin de régler le souci ?

Voici le changement que ça apporterait : https://i.imgur.com/crt6N9P.jpg