### PR TITLE
Corrected file type for image file in JSON

### DIFF
--- a/Honey Heist - Simple/sheet.json
+++ b/Honey Heist - Simple/sheet.json
@@ -3,6 +3,6 @@
 	"css": "honeyheistsimple.css",
 	"authors": "Joe Dankowski (@spacebandito)",
 	"roll20userid": "1625496",
-	"preview": "honeyheistsimple.jpg",
+	"preview": "honeyheistsimple.PNG",
 	"instructions": "This sheet is designed for use with the rpg Honey Heist. Contains basic attributes and skill rolls with templates. Skill fields do not inversely update with each other, so both must be adjusted when changing values."
 }


### PR DESCRIPTION
Preview file type was incorrectly listed as JPEG instead of PNG, as the original was a JPEG type file. The JSON file has been updated to reflect correct file type to prevent conflict. Apologies for the slip.