### PR TITLE
[Open Legend] GUI Rolls Improved & Minor

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.css
+++ b/Open Legend Basic by Great Moustache/Open Legend.css
@@ -923,3 +923,34 @@ input.sheet-checkboxSliderInvis {
 .sheet-rolltemplate-openLegend .sheet-row:nth-child(even) {
     background-color: rgba(61,153,112,0.1); /* Olive color at 10% transparent */
 }
+
+.sheet-rolltemplate-openLegend .sheet-powerLevel {
+    font-size: 3.5em;
+}
+
+/* Override default dice roll display */
+.sheet-rolltemplate-openLegend .sheet-roll {
+    font-size: 5em;
+    line-height: 1em;
+}
+
+.sheet-rolltemplate-openLegend .inlinerollresult {
+    color: #111111;
+    background-color: transparent;
+    border: none;
+}
+
+.sheet-rolltemplate-openLegend .inlinerollresult.fullcrit {
+    background-color: transparent;
+    border: none;
+}
+
+.sheet-rolltemplate-openLegend .inlinerollresult.fullfail {
+    background-color: transparent;
+    border: none;
+}
+
+.sheet-rolltemplate-openLegend .inlinerollresult.importantroll {
+    background-color: transparent;
+    border: none;
+}

--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -2100,12 +2100,7 @@
         			if(score === 0) {
         				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
         			} else {
-        			    if(isNaN(v["repeating_actions_" + currentID + "_dice_roll_d20"])) {
-        			        update["repeating_actions_" + currentID + "_dice_roll_d20"] = "1d20!!";
-            				roll = "[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|0}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
-        			    } else {
-            				roll = "[[" + v["repeating_actions_" + currentID + "_dice_roll_d20"] + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_actions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
-        			    }
+        				roll = "[[" + v["repeating_actions_" + currentID + "_dice_roll_d20"] + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_actions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
         			}
                     if(v["repeating_actions_" + currentID + "_use_power_level"] === "Yes") {
                         update["repeating_actions_" + currentID + "_power_target"] = "[[10 + " + v["repeating_actions_" + currentID + "_power_level"]*2 + "]]";
@@ -2215,12 +2210,7 @@
         			if(score === 0) {
         				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
         			} else {
-        			    if(isNaN(v["repeating_otheractions_" + currentID + "_dice_roll_d20"])) {
-        			        updateother["repeating_otheractions_" + currentID + "_dice_roll_d20"] = "1d20!!";
-            				roll = "[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|0}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
-        			    } else {
-            				roll = "[[" + v["repeating_otheractions_" + currentID + "_dice_roll_d20"] + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_otheractions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
-        			    }
+        				roll = "[[" + v["repeating_otheractions_" + currentID + "_dice_roll_d20"] + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_otheractions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,h|Disadvantage,l}" + number + "]]";
         			}
                     if(v["repeating_otheractions_" + currentID + "_use_power_level"] === "Yes") {
                         updateother["repeating_otheractions_" + currentID + "_power_target"] = "[[10 + " + v["repeating_otheractions_" + currentID + "_power_level"]*2 + "]]";
@@ -2625,7 +2615,7 @@ on("change:repeating_featsLeft", function() {
 <!-- Main body of Character Sheet -->
 <div class="container">     <!-- defines the width/height & behavior of the page -->
     <div class="row width100 padBottom">
-        <div class="column textSmall textRight padRight">Max Attribute Value is now 10 for NPCs | Chat output shows Attribute Score next to Attribute :: 2017.10.16 <span class="bold">Version 1.8.9.6 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
+        <div class="column textSmall textRight padRight">GUI improvements to Chat Window Rolls | Default advantage working as intended | Attribute descriptions updated :: 2017.11.18 <span class="bold">Version 1.8.9.6 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
     </div>
     <div class="row width100">
         <div class="column sliders inlineBlock textSmall bold">Character Info</div>
@@ -2810,7 +2800,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="agility_display_settings_flag" name="attr_agility_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Dodge attacks, move with stealth, perform acrobatics, shoot a bow, pick a pocket</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_cost_modifier" value=0 /></div>
@@ -2878,8 +2868,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="fortitude_display_settings_flag" name="attr_fortitude_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, exert yourself physically, wear heavy armor</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, survive in a desert, wear heavy armor</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_cost_modifier" value=0 /></div>
@@ -2947,8 +2937,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="might_display_settings_flag" name="attr_might_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Shake off attacks, swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_cost_modifier" value=0 /></div>
@@ -3030,8 +3020,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="learning_display_settings_flag" name="attr_learning_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Recall facts about history, arcane magic, the natural world, etc.</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Recall facts about history, arcane magic, the natural world, or any information you picked up from an external source</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_cost_modifier" value=0 /></div>
@@ -3099,8 +3089,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="logic_display_settings_flag" name="attr_logic_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Solve riddles, decipher a code, improvise a tool, understand the enemy’s strategy, find a loophole</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Innovate a new crafting method, decipher a code, jury-rig a device, get the gist of a language you don’t speak</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_cost_modifier" value=0 /></div>
@@ -3169,7 +3159,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="perception_display_settings_flag" name="attr_perception_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_cost_modifier" value=0 /></div>
@@ -3237,8 +3227,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="will_display_settings_flag" name="attr_will_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Maintain your resolve, overcome adversity, resist torture, stay awake on watch, stave off insanity</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Maintain your resolve, resist torture, study long hours, stay awake on watch, stave off insanity</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_cost_modifier" value=0 /></div>
@@ -3319,7 +3309,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="deception_display_settings_flag" name="attr_deception_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Tell a lie, bluff at cards, disguise yourself, spread rumors, swindle a sucker</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_cost_modifier" value=0 /></div>
@@ -3388,7 +3378,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="persuasion_display_settings_flag" name="attr_persuasion_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Negotiate a deal, convince someone, haggle a good price, pry information</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_cost_modifier" value=0 /></div>
@@ -3457,7 +3447,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="presence_display_settings_flag" name="attr_presence_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Give a speech, sing a song, inspire an army, exert your force of personality, have luck smile upon you</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_cost_modifier" value=0 /></div>
@@ -3538,7 +3528,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="alteration_display_settings_flag" name="attr_alteration_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Change shape, alter molecular structures, transmute one material into another</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_cost_modifier" value=0 /></div>
@@ -3606,8 +3596,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="creation_display_settings_flag" name="attr_creation_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Channeling higher powers for healing, creation, resurrection, divine might, etc.</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Channel higher powers, manifest something from nothing, regenerate, divinely bolster</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_cost_modifier" value=0 /></div>
@@ -3675,8 +3665,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="energy_display_settings_flag" name="attr_energy_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Create and control the elements–fire, cold, electricity, etc.</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Create and control the elements—fire, cold, electricity</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_cost_modifier" value=0 /></div>
@@ -3745,7 +3735,7 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             <input type="hidden" class="entropy_display_settings_flag" name="attr_entropy_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Disintegrate matter, kill with a word, create undead, sicken others</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_cost_modifier" value=0 /></div>
@@ -3813,8 +3803,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="influence_display_settings_flag" name="attr_influence_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Control the minds of others, speak telepathically, instill supernatural fear, create illusory figments, cloak with invisibility</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Control the minds of others, speak telepathically, instill fear, create illusory figments, cloak with invisibility</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_cost_modifier" value=0 /></div>
@@ -3882,8 +3872,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="movement_display_settings_flag" name="attr_movement_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Teleport, fly, hasten, slow</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Teleport, fly, hasten, telekinetically push</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_cost_modifier" value=0 /></div>
@@ -3951,8 +3941,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="prescience_display_settings_flag" name="attr_prescience_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">See the future, read minds or auras, detect magic or evil, scry, communicate with extraplanar entities</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">See the future, read minds or auras, view from afar, detect magic or evil, communicate with extraplanar entities</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_cost_modifier" value=0 /></div>
@@ -4020,8 +4010,8 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
             </div>
             <input type="hidden" class="protection_display_settings_flag" name="attr_protection_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Protect from damage, break supernatural influence, dispel magic, bind demons</div>
-                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Protect from damage, break supernatural influence, dispel magic, exile extradimensional beings</div>
+                <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_cost_modifier" value=0 /></div>
@@ -5122,42 +5112,75 @@ remove this line to add Sanity back in (and corresponding 2 other areas) -->
       <!-- Display target plus the roll if target given -->
         {{#target}}
         <div class="row">
-            <div class="column textCenter width30 inlineBlock">{{roll}}</div>
-            <div class="column textCenter width10 inlineBlock">vs</div>
-            <div class="column textCenter width60 inlineBlock bold">{{target}}</div>
+            <div class="column textCenter width100 roll">{{roll}}</div>
+            <div class="column textCenter width100 bold">vs {{target}}</div>
         </div>
         {{/target}}
       <!-- Display just the roll if no target given -->
         {{^target}}{{#roll}}
         <div class="row">
-            <div class="column textCenter width30 inlineBlock">{{roll}}</div>
-            <div class="column textCenter width65 inlineBlock">Total Roll</div>
+            <div class="column textCenter width100 roll">{{roll}}</div>
+            <div class="column textCenter width100">Total Roll</div>
         </div>
         {{/roll}}{{/target}}
       <!-- Display power level if provided -->
         {{#powertarget}}
         <div class="row textCenter">
+            <div class="column width90 inlineBlock textCenter textLarge bold borderBottom">Boon Power Level</div>
+            <div class="column width30 textCenter inlineBlock bold textSmall">Min Needed</div>
+            <div class="column width30 textCenter inlineBlock bold textSmall">Achieved</div>
+            <div class="column width30 textCenter inlineBlock bold textSmall">Max Allowed</div>
+            <div class="width30 inlineBlock textCenter">
+                <div class="column width100 textCenter">PL <span class="bold">{{powerlevel}}</span></div>
+                <div class="column width100 textCenter">CR {{powertarget}}</div>
+            </div>
+            {{#rollLess() roll 12}}
+            <div class="column width30 inlineBlock textCenter powerLevel textRed">0</div>
+            {{/rollLess() roll 12}}
+            {{#rollBetween() roll 12 13}}
+            <div class="column width30 inlineBlock textCenter powerLevel">1</div>
+            {{/rollBetween() roll 12 13}}
+            {{#rollBetween() roll 14 15}}
+            <div class="column width30 inlineBlock textCenter powerLevel">2</div>
+            {{/rollBetween() roll 14 15}}
+            {{#rollBetween() roll 16 17}}
+            <div class="column width30 inlineBlock textCenter powerLevel">3</div>
+            {{/rollBetween() roll 16 17}}
+            {{#rollBetween() roll 18 19}}
+            <div class="column width30 inlineBlock textCenter powerLevel">4</div>
+            {{/rollBetween() roll 18 19}}
+            {{#rollBetween() roll 20 21}}
+            <div class="column width30 inlineBlock textCenter powerLevel">5</div>
+            {{/rollBetween() roll 20 21}}
+            {{#rollBetween() roll 22 23}}
+            <div class="column width30 inlineBlock textCenter powerLevel">6</div>
+            {{/rollBetween() roll 22 23}}
+            {{#rollBetween() roll 24 25}}
+            <div class="column width30 inlineBlock textCenter powerLevel">7</div>
+            {{/rollBetween() roll 24 25}}
+            {{#rollBetween() roll 26 27}}
+            <div class="column width30 inlineBlock textCenter powerLevel">8</div>
+            {{/rollBetween() roll 26 27}}
+            {{#rollGreater() roll 27}}
+            <div class="column width30 inlineBlock textCenter powerLevel">9</div>
+            {{/rollGreater() roll 27}}
+            <div class="width30 inlineBlock textCenter">
+                <div class="column width100 textCenter">PL <span class="bold">{{powerlevelmax}}</span></div>
+                <div class="column width100 textCenter">CR {{powertargetmax}}</div>
+            </div>
             {{#rollLess() roll powertarget}}
             <div class="column width90 inlineBlock red textLarge bold">Success with Twist<br />or Failure</div>
             {{/rollLess() roll powertarget}}
             {{#^rollLess() roll powertarget}}
             <div class="column width90 inlineBlock green textLarge bold">Success</div>
             {{/^rollLess() roll powertarget}}
-            <div class="column width55 inlineBlock textCenter bold borderRight">Challenge Rating</div>
-            <div class="column width40 inlineBlock textCenter bold">Power Level</div>
-            <div class="column width15 inlineBlock textCenter bold textSmall">Min</div>
-            <div class="column width40 inlineBlock textCenter borderRight">{{powertarget}}</div>
-            <div class="column width40 inlineBlock textCenter">{{powerlevel}}</div>
-            <div class="column width15 inlineBlock textCenter bold textSmall">Max</div>
-            <div class="column width40 inlineBlock textCenter borderRight">{{powertargetmax}}</div>
-            <div class="column width40 inlineBlock textCenter">{{powerlevelmax}}</div>
         </div>
         {{/powertarget}}
       <!-- Display description if provided -->
         {{#description}}
         <div class="row">
             <div class="column width100 textCenter bold borderBottom">Description/Flavor Text</div>
-            <div class="column width100 textCenter scroll" style="max-height: 80px;">{{description}}</div>
+            <div class="column width100 textCenter scroll" style="max-height: 120px;">{{description}}</div>
         </div>
         {{/description}}
     </div>

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,16 @@
 
 ### Changelog
 
+### 1.8.9.9 on 2017 November 18th
+* Fixed Default (Dis)Advantage not always popping up correctly
+* Updated Attribute description text
+* GUI update to chat window rolls
+	- Rolled Value much larger
+	- Power Level display changed
+		- No shows you the Achieved Power Level based on your roll
+		- Shows the Min Needed to Succeed as well as the Max Allowed (based on what is entered in Actions)
+	- Increased the Description areas to display a max of 7 lines (mouse scroll wheels jump 6-7 lines at a time)
+
 ### 1.8.9.6 on 2017 October 16th
 * Fixed HP/Lethal Damage having odd error that locks up HP calculations on sheet
 * Outputs to chat show Attribute Score next to the Attribute now


### PR DESCRIPTION
### 1.8.9.9 on 2017 November 18th
* Fixed Default (Dis)Advantage not always popping up correctly
* Updated Attribute description text
* GUI update to chat window rolls
	- Rolled Value much larger
	- Power Level display changed
		- No shows you the Achieved Power Level based on your roll
		- Shows the Min Needed to Succeed as well as the Max Allowed (based on what is entered in Actions)
	- Increased the Description areas to display a max of 7 lines (mouse scroll wheels jump 6-7 lines at a time)