### PR TITLE
[D6 Star Wars WEG] minor layout fixes

### DIFF
--- a/D6StarWars/D6StarWars.css
+++ b/D6StarWars/D6StarWars.css
@@ -46,6 +46,9 @@
 .charsheet input[type=number].sheet-mediumnumber{
     width:60px;
 }
+.charsheet input[type=number].sheet-pipnumber{
+    width:33px;
+}
 
 .charsheet input[type=text].sheet-smalltext{
     width:60px;

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -27,7 +27,7 @@
             <div class="sheet-col">
                 <label>Credits <input type="number" min="0" class="sheet-credits" name="attr_credits" /></label>
                 <label>Physical Description
-                <textarea style="padding-top:2px; padding-bottom:2px;" rows="5" name="attr_Physical_Description"></textarea></label>
+                <textarea style="padding-top:2px; padding-bottom:2px;" rows="4" name="attr_Physical_Description"></textarea></label>
             </div>
         </div>
     </div>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -64,7 +64,7 @@
 				
 				<label>
 					Initiative bonus
-					<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber sheet-left" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				</label>
 				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative(select you token first)</button>
 				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -209,7 +209,7 @@
 				<td style="width:80px">Physical</td>
 				<td style="width:80px">Energy</td>
 				<td style="width:180px">Other</td>
-				<td style="width:180px">Rolls</td>
+				<td style="width:180px">Damage Soak Rolls</td>
 			</tr>
 		</table>
 			<fieldset class="repeating_armors">
@@ -217,9 +217,9 @@
 				<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				<input class="sheet-skilltext" type="text" name="attr_armor_other"/>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Soak Physical</button>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Soak Energy</button>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Soak</button>	  
+				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Physical</button>
+				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Energy</button>
+				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Str only</button>	  
 			</fieldset>
 	</div>
     <div class="sheet-section" style="text-align: Left;"> <!-- id="Force" -->

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -184,9 +184,9 @@
 				<td style="width:35px">Short</td>
 				<td style="width:30px">Med</td>
 				<td style="width:35px">Long</td>
-				<td style="width:30px">ROF</td>
-				<td style="width:30px">Ammo</td>
-				<td style="width:30px">Skill</td>
+				<td style="width:40px">ROF</td>
+				<td style="width:35px">Ammo</td>
+				<td style="width:70px">Skill</td>
 			</tr>
 		</table>	
 			<fieldset class="repeating_weapons">

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -347,7 +347,7 @@
 					<td>
 						<label>Additional Notes</label>
 						<div>
-							<textarea name="attr_connections"></textarea>
+							<textarea name="attr_notes"></textarea>
 						</div>
 					</td>
 				</tr>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -27,7 +27,7 @@
             <div class="sheet-col">
                 <label>Credits <input type="number" min="0" class="sheet-credits" name="attr_credits" /></label>
                 <label>Physical Description
-                <textarea style="padding-top:2px; padding-bottom:2px;" rows="4" name="attr_Physical_Description"></textarea></label>
+                <textarea rows="4" name="attr_Physical_Description"></textarea></label>
             </div>
         </div>
     </div>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -186,7 +186,7 @@
 				<td style="width:35px">Long</td>
 				<td style="width:40px">ROF</td>
 				<td style="width:35px">Ammo</td>
-				<td style="width:70px">Skill</td>
+				<td style="width:70px;text-align:center;">Skill</td>
 			</tr>
 		</table>	
 			<fieldset class="repeating_weapons">
@@ -194,9 +194,9 @@
 				<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_shortrange"/>
 				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_medrange"/>
-				<input class="sheet-smallnumber sheet-mediumnumber" type="number" name="attr_longrange"/>
+				<input class="sheet-mediumnumber" type="number" name="attr_longrange"/>
 				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_ROF"/>
-				<input class="sheet-smallnumber sheet-mediumnumber" type="number" name="attr_Ammo"/>
+				<input class="sheet-mediumnumber" type="number" name="attr_Ammo"/>
 				<input class="sheet-skilltext" type="text"  style="width:150px" name="attr_skill"/>
 				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Damage</button>
 			</fieldset>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -271,17 +271,6 @@
 								  <option value="6">Yes</option>
 								</select>
 					</td></tr>
-					<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
-						This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
-						If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
-						this check could be added back. -Andreas.J 2017-12-3
-					<tr><td>
-							<span style="padding-top:8px; padding-bottom:12px;" title="Negates any WoundLevel penalties to rolls if active" >Control Pain/Resist Stun active?</span>Negates any wound penalties to rolls if active
-								<select name="attr_Force_ControlPain_ResistStun" class="sheet-smallselect">
-								  <option value="0" selected="selected">No</option>
-								  <option value="abs(@{WoundLevel})">Yes</option>
-								</select>
-					</td></tr> --->
 					<tr><td><!---Force Powers active --->
 						<span>Number of powers active?<!---gives penalty to all rolls thanks to concentration/distraction --->
 							<select name="attr_Force_Up" class="sheet-smallselect" title="The number of power active is subtracted from all roll as a MultiActionPenalty">
@@ -294,6 +283,18 @@
 							</select>
 						</span>
 					</td></tr>
+					<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
+						This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
+						If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
+						this check could be added back. -Andreas.J 2017-12-3 
+						--->
+					<tr><td>
+							<span style="padding-top:8px; padding-bottom:12px;" title="Negates any WoundLevel penalties to rolls if active" >Control Pain/Resist Stun active?(deactivated, not working)</span>
+								<select name="attr_Force_ControlPain_ResistStun" class="sheet-smallselect">
+								  <option value="0" selected="selected">No</option>
+								  <option value="0">Yes</option>
+								</select>
+					</td></tr>					
 				</table>				
 			</div>
 			<div class='sheet-col'>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -1,8 +1,8 @@
 <div class="sheet-sheet" style=" position:relative;">
     <div style="text-align: Center;"> <!-- id="header"-->
-        <img src="http://www.hkgsi.com/test/crystal.dice.red.big.jpg" style="max-height: 50px;" />
+        <img src="http://rs8.pbsrc.com/albums/a35/VPP3/d62_zpstllyo5ds.png?w=480&h=480&fit=clip" style="max-height: 60px;" />
         <img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 90px;" />
-        <img src="http://www.hkgsi.com/test/crystal.dice.blue.big.jpg" style="max-height: 50px;" />
+        <img src="http://rs8.pbsrc.com/albums/a35/VPP3/d61_zps5ef1qprz.png?w=480&h=480&fit=clip" style="max-height: 60px;" />
     </div>
     <div class="sheet-section"> <!-- id="Characterinfo"-->
         <div class="sheet-2colrow">

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -64,7 +64,7 @@
 				
 				<label>
 					Initiative bonus
-					<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber sheet-left" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber sheet-left" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				</label>
 				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative(select you token first)</button>
 				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>
@@ -80,7 +80,7 @@
                         <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Perception</button>
                         <div style="float:right;">
                             <input type="number" name="attr_perception" class="sheet-smallnumber"  min="1" value="3"/>D
-							+<input type="number" name="attr_perceptionpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+							+<input type="number" name="attr_perceptionpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
                         </div>
                     </div>
 					<fieldset class="repeating_perckills"> <!---Perc Skills --->
@@ -88,7 +88,7 @@
                           <input class="sheet-skilltext" type="text" name="attr_perckillname"/> <!-- Misspelled attr name iis to be left as it is, otherwise it wipes char sheets from perseption skills-->
                           <div class="sheet-right">
                           <input type="number" name="attr_perckilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D 
-                          +<input type="number" name="attr_perckillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+                          +<input type="number" name="attr_perckillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                           </div>
                     </fieldset>
                 </td>
@@ -96,7 +96,7 @@
                         <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
                         <div style="float:right;">
                             <input type="number" name="attr_strength" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_strengthpip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
+							+<input type="number" name="attr_strengthpip" class="sheet-pipnumber" min="0" max="2" value="0"/>  
                         </div>
                     </div>
                     <fieldset class="repeating_strskills"> <!---Str Skills --->
@@ -104,14 +104,15 @@
                           <input class="sheet-skilltext" type="text" name="attr_strskillname"/> 
                           <div class="sheet-right">
 							<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="0"/>D
-							+<input type="number" name="attr_strskillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							+<input type="number" name="attr_strskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                           </div>
                     </fieldset>			
                 </td> 
                 <td class="sheet-tdborder"><div class="sheet-bold"><!---Tech Attribute --->
                         <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
                         <div style="float:right;">
-                            <input type="number" name="attr_technical" class="sheet-smallnumber" min="1" value="3"/>D+<input type="number" name="attr_technicalpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
+                            <input type="number" name="attr_technical" class="sheet-smallnumber" min="1" value="3"/>D
+							+<input type="number" name="attr_technicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>    
                         </div>
                     </div>
                     <fieldset class="repeating_techskills">  <!---Tech Skills --->
@@ -119,7 +120,7 @@
                           <input class="sheet-skilltext" type="text" name="attr_techskillname"/> 
                           <div class="sheet-right">
                           <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_techskillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2"/> 
+						  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
                           </div>
                     </fieldset>
                 </td class="sheet-tdborder"> 
@@ -129,7 +130,7 @@
                         <button class="sheet-d6-dice" type='roll'value='&{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
                         <div style="float:right;">
                             <input type="number" name="attr_dexterity" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_dexteritypip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+							+<input type="number" name="attr_dexteritypip" class="sheet-pipnumber" min="0" max="2" value="0"/>
                         </div>
                     </div>
                     <fieldset class="repeating_dexskills"> <!---Dex Skills --->
@@ -137,7 +138,7 @@
                           <input class="sheet-skilltext" type="text" name="attr_dexskillname"/>
                           <div class="sheet-right">		
                           <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_dexskillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2"/>
+						  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/>
                           </div>
                     </fieldset>
                 </td>
@@ -145,7 +146,7 @@
                         <button class="sheet-d6-dice" type='roll' value='&{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
                         <div style="float:right;">
                             <input type="number" name="attr_knowledge" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_knowledgepip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+							+<input type="number" name="attr_knowledgepip" class="sheet-pipnumber" min="0" max="2" value="0"/>
                         </div>
                     </div>
                     <fieldset class="repeating_knowskills">  <!---Know Skills --->
@@ -153,14 +154,15 @@
                           <input class="sheet-skilltext" type="text" name="attr_knowskillname"/> 
                           <div class="sheet-right">
                           <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_knowskillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2"/> 
+						  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
                           </div>
                     </fieldset>
                 </td> 
                 <td class="sheet-tdborder"><div class="sheet-bold"><!---Mech Attribute --->
                         <button class="sheet-d6-dice"  type='roll' value='&{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Mechanical</button>
                         <div style="float:right;">
-                            <input type="number" name="attr_mechanical" class="sheet-smallnumber" min="1" value="3"/>D+<input type="number" name="attr_mechanicalpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+                            <input type="number" name="attr_mechanical" class="sheet-smallnumber" min="1" value="3"/>D
+							+<input type="number" name="attr_mechanicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
                         </div>
                     </div>
                     <fieldset class="repeating_mechskills">  <!---Mech Skills --->      
@@ -168,7 +170,7 @@
                          <input class="sheet-skilltext" type="text" name="attr_mechskillname"/> 
                          <div class="sheet-right">
                          <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						 +<input type="number" name="attr_mechskillpip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2"/> 
+						 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
                          </div>
                     </fieldset>
                 </td> 
@@ -191,7 +193,7 @@
 		</table>	
 			<fieldset class="repeating_weapons">
 				<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_weapon"/>
-				<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
+				<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_shortrange"/>
 				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_medrange"/>
 				<input class="sheet-mediumnumber" type="number" name="attr_longrange"/>
@@ -214,15 +216,15 @@
 		</table>
 			<fieldset class="repeating_armors">
 				<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_armorname"/>
-				<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
-				<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-smallnumber sheet-shortnumber" min="0" max="2" value="0"/>
+				<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+				<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
 				<input class="sheet-skilltext" type="text" name="attr_armor_other"/>
 				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Physical</button>
 				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Energy</button>
 				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} +@{Force_ControlPain_ResistStun} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Str only</button>	  
 			</fieldset>
 	</div>
-    <div class="sheet-section" style="text-align: Left;"> <!-- id="Force" -->
+    <div class="sheet-section"> <!-- id="Force" -->
 		<input type="checkbox" class="sheet-hide"><!-- Checkbox to hide force section -->
 		<label style="text-align: center">Force Section</label>
 		<div class='sheet-2colrow sheet-body-to-hide'>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -1,7 +1,7 @@
 <div class="sheet-sheet" style=" position:relative;">
     <div style="text-align: Center;"> <!-- id="header"-->
         <img src="http://www.hkgsi.com/test/crystal.dice.red.big.jpg" style="max-height: 50px;" />
-        <img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 80px;" />
+        <img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 90px;" />
         <img src="http://www.hkgsi.com/test/crystal.dice.blue.big.jpg" style="max-height: 50px;" />
     </div>
     <div class="sheet-section"> <!-- id="Characterinfo"-->

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -294,10 +294,8 @@
 			</div>
 			<div class='sheet-col'>
 				<div><!-- Force Power list -->
-					<table>
-						<th><label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label></th>
-						<tr><td><textarea name="attr_forcePowers" rows="16"  style="width:220px"></textarea></td></tr>
-					</table>
+					<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
+					<textarea name="attr_forcePowers" rows="16"  style="width:220px"></textarea>
 				</div>				
 			</div>		
 		</div>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -51,7 +51,7 @@
             </div>          
             <div class='sheet-col'>
                 <label style="text-decoration:underline;">
-					Wound Status
+					Wound Level
 					<select name="attr_WoundLevel" class="sheet-mediumselect" class="sheet-left" >
 					  <option value="0" selected="selected">Healthy</option>
 					  <option value="-1">Stunned</option>
@@ -271,13 +271,17 @@
 								  <option value="6">Yes</option>
 								</select>
 					</td></tr>
-					<tr><td><!---Force Control pain/ resist stun --->
-							<span style="padding-top:8px; padding-bottom:12px;" title="Negates any WoundLevel penalties to rolls if active" >Control Pain/Resist Stun active?</span><!---Negates any wound penalties to rolls if active --->
+					<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
+						This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
+						If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
+						this check could be added back. -Andreas.J 2017-12-3
+					<tr><td>
+							<span style="padding-top:8px; padding-bottom:12px;" title="Negates any WoundLevel penalties to rolls if active" >Control Pain/Resist Stun active?</span>Negates any wound penalties to rolls if active
 								<select name="attr_Force_ControlPain_ResistStun" class="sheet-smallselect">
 								  <option value="0" selected="selected">No</option>
 								  <option value="abs(@{WoundLevel})">Yes</option>
 								</select>
-					</td></tr>
+					</td></tr> --->
 					<tr><td><!---Force Powers active --->
 						<span>Number of powers active?<!---gives penalty to all rolls thanks to concentration/distraction --->
 							<select name="attr_Force_Up" class="sheet-smallselect" title="The number of power active is subtracted from all roll as a MultiActionPenalty">


### PR DESCRIPTION
**Changes:**
- made physical description section a row shorter
- made inert a dysfunctional tracker in force section
- enlargen star wars logo & change dice pic to one with transparent background
- init bonus line fix
- Force powers textarea expanded
- Armor section minor text changes
- unify weapon stat blocks
- made pip input boxes smaller(need only a single digit as opposed to any other input box)
- fixed duplicating textfield