### PR TITLE
A series of minor fixes and updates

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -5,43 +5,43 @@
 
 <div class="tab-content tab1">
     <div class="record"><img height="100px" width="300px" src="http://i.imgur.com/DzKBH23.png"/> <br />
-            	<span data-i18n="character-sheet">Character Record Sheet</span></div>
+            	<span>Character Record Sheet</span></div> 
     <div class="table left classHeader">
         <div class="table-row">
-			<span class="table-data long">	<label data-i18n="class">Class:</label>		</span>
+			<span class="table-data long">	<label>Class:</label>		</span>
 			<span class="table-data">		<input type="text" name="attr_rank" title="List of class levels @{rank}" style="width:100%" />	</span>	
 		</div>
 	</div>
 	<div class="table left classHeader">
 		<div class="table-row">
-			<span class="table-data long"><label data-i18n="level">Level:</label>		</span>
-			<span class="table-data">	<input type="number" name="attr_level" title="Total number of Heroic levels @{level}" value="1" /> <input type="number" name="attr_level_max" value="[[(floor((@{level}+@{nonlevel})/2))]]"  title="Half Level @{level|max}" disabled="true" /></span>
+			<span class="table-data long"><label>Level:</label>		</span>
+			<span class="table-data">	<input type="number" name="attr_level" title="Total number of Heroic levels @{level}" value="1" /> <input type="number" name="attr_level_max" value="[[(floor((@{level}+@{nonlevel})/2))]]"  title="Half Level @{level|max}" disabled="true" /></span>  <input type="hidden" name="attr_hlevel_max" value="[[(floor((@{level})/2))]]"  title="Half Heroic Level @{hlevel|max}" disabled="true" /></span>
 			<span class="table-data" style="width:15px"></span>	
-			<span class="table-data"><label><span data-i18n="background">Background:</span></label>		</span>
+			<span class="table-data"><label><span>Background:</span></label>		</span>
 			<span class="table-data">	<input type="text" name="attr_background" title="Background @{Background}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span data-i18n="species">Species:</span></label>		</span>
+			<span class="table-data"><label><span>Species:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_species" title="Species @{Species}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span data-i18n="destiny">Destiny:</span></label>		</span>
+			<span class="table-data"><label><span>Destiny:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_destiny" title="Destiny @{Destiny}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span data-i18n="gender">Gender:</span></label>		</span>
+			<span class="table-data"><label><span>Gender:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_gender" title="Gender @{Gender}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span data-i18n="size">Size:</span></label>		</span>
+			<span class="table-data"><label><span>Size:</span></label>		</span>
             <span class="table-data">	<select name="attr_Size" style="width:100%" title="Racial size. @{Size}">
-					<option value="Colossal" data-i18n="size-colossal">Colossal</option>                
-					<option value="Gargantuan" data-i18n="size-gargantuan">Gargantuan</option>
-					<option value="Huge" data-i18n="size-huge">Huge</option>
-					<option value="Large" data-i18n="size-large">Large</option>
-					<option value="Medium" data-i18n="size-medium" selected>Medium</option>
-					<option value="Small" data-i18n="size-small">Small</option>
-					<option value="Tiny" data-i18n="size-tiny">Tiny</option>
-					<option value="Diminutive" data-i18n="size-diminutive">Diminutive</option>
-					<option value="Fine" data-i18n="size-fine">Fine</option>
+					<option value="Colossal">Colossal</option>                
+					<option value="Gargantuan">Gargantuan</option>
+					<option value="Huge">Huge</option>
+					<option value="Large">Large</option>
+					<option value="Medium" selected>Medium</option>
+					<option value="Small">Small</option>
+					<option value="Tiny">Tiny</option>
+					<option value="Diminutive">Diminutive</option>
+					<option value="Fine">Fine</option>
 			</select>	</span> 
 			
 		</div>
@@ -51,39 +51,39 @@
 	<div class="3colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead"><span data-i18n="attributes">Attributes</div>	</tr>
+				<tr><div class="textHead"><span>Attributes</div>	</tr>
 				<tr>
-					<td class="col1">STR<br><div class="small"><span data-i18n="strength">Strength</span></div></td>
+					<td class="col1">STR<br><div class="small"><span>Strength</span></div></td>
 					<td><input type="number" name="attr_STR" value="8" title="Strength Score @{STR}" /></td>
 					<td><input type="number" name="attr_STR_max" value="[[floor(@{STR}/2-5)]]" disabled="true" title="Strength Modifier @{STR|max}" /></td>
 					<td><button type="roll" name="roll_STRCheck" value="&{template:skill} {{name=Strength}} {{skill=[[1d20+@{STR|max}[STR]+@{CT}[CT]]]}}" title="Roll Strength %{STRCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">DEX<br><div class="small"><span data-i18n="dexterity">Dexterity</span></div></td>
+					<td class="col1">DEX<br><div class="small"><span>Dexterity</span></div></td>
 					<td><input type="number" name="attr_DEX" value="8" title="Dexterity Score @{DEX}" /></td>
 					<td><input type="number" name="attr_DEX_max" value="[[floor(@{DEX}/2-5)]]" disabled="true" title="Dexterity Modifier @{DEX|max}" /></td>
 					<td><button type="roll" name="roll_DEXCheck" value="&{template:skill} {{name=Dexterity}} {{skill=[[1d20+@{Dex|max}[DEX]+@{CT}[CT]]]}}" title="Roll Dexterity  %{DEXCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CON<br><div class="small"><span data-i18n="constitution">Constitution</span></div></td>
+					<td class="col1">CON<br><div class="small"><span>Constitution</span></div></td>
 					<td><input type="number" name="attr_CON" value="8" title="Constitution Score @{CON}" /></td>
 					<td><input type="number" name="attr_CON_max" value="[[floor(@{CON}/2-5)]]" disabled="true" title="Constitution Modifier @{CON|max}" /></td>
 					<td><button type="roll" name="roll_CONCheck" value="&{template:skill} {{name=Constitution}} {{skill=[[ 1d20+@{Con|max}[CON]+@{CT}[CT]]]}}" title="Roll Constitution %{CONCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">INT<br><div class="small"><span data-i18n="intelligence">Intelligence</span></div></td>
+					<td class="col1">INT<br><div class="small"><span>Intelligence</span></div></td>
 					<td><input type="number" name="attr_INT" value="8" title="Intelligence Score @{INT}" /></td>
 					<td><input type="number" name="attr_INT_max" value="[[floor(@{INT}/2-5)]]" disabled="true" title="Intelligence Modifier @{INT|max}}" /></td>
 					<td><button type="roll" name="roll_INTCheck" value="&{template:skill} {{name=Intelligence}} {{skill=[[ 1d20+@{INT|max}[INT]+@{CT}[CT]]]}}" title="Roll Intelligence %{INTCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">WIS<br><div class="small"><span data-i18n="wisdom">Wisdom</span></div></td>
+					<td class="col1">WIS<br><div class="small"><span>Wisdom</span></div></td>
 					<td><input type="number" name="attr_WIS" value="8" title="Wisdom Score" /></td>
 					<td><input type="number" name="attr_WIS_max" value="[[floor(@{WIS}/2-5)]]" disabled="true" title="Wisdom Modifier" /></td>
 					<td><button type="roll" name="roll_WISCheck" value="&{template:skill} {{name=Wisdom}} {{skill=[[ 1d20+@{WIS|max}[WIS]+@{CT}[CT]]]}}" title="Roll Wisdom %{WISCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CHA<br><div class="small"><span data-i18n="charisma">Charisma</span></div></td>
+					<td class="col1">CHA<br><div class="small"><span>Charisma</span></div></td>
 					<td><input type="number" name="attr_CHA" value="8" title="Charisma Score @{CHA}" /></td>
 					<td><input type="number" name="attr_CHA_max" value="[[floor(@{CHA}/2-5)]]" disabled="true" title="Charisma Modifier @{CHA|max}" /></td>
 					<td><button type="roll" name="roll_CHACheck" value="&{template:skill} {{name=Charisma}} {{skill=[[ 1d20+@{CHA|max}[CHA]+@{CT}[CT]]]}}" title="Roll Charisma %{CHACheck}"></button></td>
@@ -92,50 +92,50 @@
 		</div>
 		<div class="col">
 			<table>		
-				<tr>	<td colspan="3"><div class="textHead"><span data-i18n="hit-points">Hit Points</span></div> </td>	
+				<tr>	<td colspan="3"><div class="textHead"><span>Hit Points</span></div> </td>	
 						<td></td> 	
 						<td width="15px" rowspan="7"></td>	
-						<td><div class="textHead"><span data-i18n="condition">Condition</span></div></td>	</tr>
+						<td><div class="textHead"><span>Condition</span></div></td>	</tr>
 				<tr><th>Current</th>		<th></th>	<th>Total</th>
 					<td></td>
 					<!-- rowspan placholder -->
 					<td rowspan="5" style="text-align:left">		
-						<input type="radio" value="0" name="attr_CT" checked="true" /> <span data-i18n="ct_normal">Normal</span><br />
+						<input type="radio" value="0" name="attr_CT" checked="true" /> <span>Normal</span><br />
 						<input type="radio" value="-1" name="attr_CT" /> -1<br />
 						<input type="radio" value="-2" name="attr_CT" /> -2<br />
 						<input type="radio" value="-5" name="attr_CT" /> -5<br />
 						<input type="radio" value="-10" name="attr_CT" /> -10<br />
-						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span data-i18n="ct_helpless">Helpless</span></td>		
+						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span>Helpless</span></td>		
 				</tr>
 				<tr>	
 					<td> <input type="number" name="attr_HP" value="0" title="Current HP @{HP}" /></td>
 					<td>&nbsp;/&nbsp;</td>
 					<td><input type="number" name="attr_HP_max" value="0" title="Max HP @{HP|max}" /></td>
 				</tr>
-				<tr>	<td colspan="4"><div class="textHead"><span data-i18n="threshold">Threshold</span></div> </td>			</tr>
-				<tr>	<th><span data-i18n="total">Total</span></th>	<th></th>	<th><span data-i18n="defense">Defense</span></th> 	<th><span data-i18n="misc">Misc</span></th>		</tr>
+				<tr>	<td colspan="4"><div class="textHead"><span>Threshold</span></div> </td>			</tr>
+				<tr>	<th><span>Total</span></th>	<th></th>	<th><span>Defense</span></th> 	<th><span>Misc</span></th>		</tr>
 				<tr>	
 					<td><input type="number" name="attr_DT" value="@{DamageThresholdDefense}+@{DamageThresholdSize}[Size]+@{DamageThresholdMisc}[Misc]"  disabled="true" title="Damage Threshold @{DT}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_DamageThresholdDefense" class="modtype" title="Damage Threshold Defense @{DamageThresholdDefense}">
-					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" data-i18n="fortitude" selected>Fort</option>
-					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" data-i18n="will">Will</option>
+					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" selected>Fort</option>
+					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" >Will</option>
 					</select></td>
 					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier @{DamageThresholdMisc}" />
 						<input type="number" value="0" name="attr_DamageThresholdSize" class="hidden" /></td>
 				</tr>
 			</table>
-			<p><span data-i18n="ignore_ct">Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
+			<p><span>Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
 			
-			<span class="displayInline-block"><label><span data-i18n="damage_reduction">Damage Reduction</span></label></span>
+			<span class="displayInline-block"><label><span>Damage Reduction</span></label></span>
 				<input type="checkbox" class="DRShow hideCheckbox" style="width:140px; margin-left:-156px;" value="1" name="attr_DR-Show" title="Show/Hide Damage Reduction" />	
 				<span class="DRBody not-sheet-show"><input type="number" name="attr_DR" value="0" title="Damage Reduction @{DR}" />	</span>
 			<br />
-			<span class="displayInline-block"><label><span data-i18n="shield_rating">Shield Rating</span></label></span>
+			<span class="displayInline-block"><label><span>Shield Rating</span></label></span>
 				<input type="checkbox" class="SRShow hideCheckbox" style="width:102px; margin-left:-118px;" value="1" name="attr_SR-Show" title="Show/Hide Shield Rating" />			
 					<span class="not-sheet-show SRBody"><input type="number" name="attr_SR" value="0" title="Current Shield Rating @{SR}" /> / <input type="number" name="attr_SR_max" value="0" title="Max Shield Rating @{SR|max}" /></span>
 			<br />
-			<span class="displayInline-block"><label><span data-i18n="immune">Immune</span></label></span>
+			<span class="displayInline-block"><label><span>Immune</span></label></span>
 				<input type="checkbox" class="immuneShow hideCheckbox" style="width:64px; margin-left:-80px;" value="1" name="attr_immune-Show"  title="Show/Hide Immunities"  />
 				<span class="not-sheet-show immuneBody"><input type="text" name="attr_Immune" value="" title="Immunities @{Immune}" style="width:75%" /> </span>
 			<span></span>	
@@ -146,8 +146,8 @@
 		<div class="col">				
 			<table class="spacing">
 				<tr>			
-					<td colspan="4"><div class="textHead"><span data-i18n="force_points">Force Points</span></div></td>			
-					<td colspan="2"><div class="textHead"><span data-i18n="destiny_points">Destiny Pts</span></div></td>
+					<td colspan="4"><div class="textHead"><span>Force Points</span></div></td>			
+					<td colspan="2"><div class="textHead"><span>Destiny Pts</span></div></td>
 				</tr>
 				<tr>
 					<td colspan="4"><input type="number" name="attr_FP" value="5" title="Current Force Points @{FP}" />  
@@ -156,9 +156,9 @@
 					<td colspan="2"><input type="number" name="attr_DP" value="0" title="Destiny Points" /></td>						
 				</tr>
 				<tr>						
-					<td colspan="2"><div class="textHead"><span data-i18n="bab">BAB</span></div></td>
-					<td colspan="2"><div class="textHead"><span data-i18n="speed">Speed</span></div></td>	
-					<td colspan="2"><div class="textHead"><span data-i18n="dark_side_points">Dark Side Pts</span></div></td>		
+					<td colspan="2"><div class="textHead"><span>BAB</span></div></td>
+					<td colspan="2"><div class="textHead"><span>Speed</span></div></td>	
+					<td colspan="2"><div class="textHead"><span>Dark Side Pts</span></div></td>		
 				</tr>
 				<tr>	
 					<td colspan="2"><input type="number" name="attr_BAB" value="0" title="Base Attack Bonus @{BAB}" /></td>
@@ -170,8 +170,8 @@
 			<div class="table left">			
 				<div class="table-row">
 					<span class="table-data">	
-						<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
-						<label><span data-i18n="perception">Perception</span></label>
+					<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
+						<label><span>Perception</span></label>
 						<input type="checkbox" class="PerceptionShow hideCheckbox" style="width:84px; margin-left:-100px;" value="1" name="attr_Perception-Show"  title="Show/Hide Perception Notes" />	
 						<br />
 						<input class="PerceptionBody" style="margin-left:50px" type="text" name="attr_Perception_max" placeholder="Senses Notes" title="Senses Notes @{Perception|max}" />	 	</span>
@@ -180,27 +180,27 @@
 				<div class="table-row">
 					<span class="table-data">	
 						<button type="roll" name="roll_InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Dex Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
-						<label><span data-i18n="initiative">Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox"  value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked /><span data-i18n="init_dex_decimal" class="sheet-not-sheet-show">Dex Score as Decimal</span>
+						<label><span>Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox" value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked />Dex Score as Decimal</span>
 					</span>
 				</div>
 			</div>
 			<table>
 				<tr>		
-					<td colspan="6"><div class="textHead"><span data-i18n="grapple">Grapple</span></div></td>		
+					<td colspan="6"><div class="textHead"><span>Grapple</span></div></td>		
 				</tr>
 				<tr>		
 					<th colspan="3"></th>
-					<th><span data-i18n="mod">Mod</span></th>		
+					<th><span>Mod</span></th>		
 					<th></th>
-					<th><span data-i18n="misc">Misc<span></th>
+					<th><span>Misc<span></th>
 				</tr>			
 				<tr>
 					<td><button type="roll" name="roll_GrappleCheck" value="&{template:skill} {{name=Grapple}} {{skill=[[1d20+@{Grapple}+?{Other Modifiers|0}[Other]]]}}" title="Roll Grapple %{GrappleCheck}"></button></td>		
 					<td><input type="number" name="attr_Grapple" value="@{BAB}[BAB]+@{GrpMod}[Mod]+@{GrappleSize}[Size]+@{GrpMod|max}[Misc]+@{CT}[CT]" disabled="true" title="Grapple @{Grapple}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier @{GrpMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
 					</select></td>				
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" value="0" name="attr_GrappleSize" class="hidden" />	<input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier @{GrpMod|max}" /></td>
@@ -213,38 +213,38 @@
 	<div class="2colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead2Col"><span data-i18n="defenses">Defenses</span></div></tr>
+				<tr><div class="textHead2Col"><span>Defenses</span></div></tr>
 				<thead>
 					<tr>
 						<th></th>
-						<th><span data-i18n="total">Total</span></th>
+						<th><span>Total</span></th>
 						<th></th>
-						<th style="min-width:50px">	<span><span data-i18n="level">Level</span> /<br /><span data-i18n="armor">Armor</span></span>	</th>
-						<th><span data-i18n="class">Class</span></th>					
-						<th><span data-i18n="mod">Mod</span></th>
-						<th><span data-i18n="misc">Misc</span></th>
+						<th style="min-width:50px">	<span><span>Level</span> /<br /><span>Armor</span></span>	</th>
+						<th><span>Class</span></th>					
+						<th><span>Mod</span></th>
+						<th><span>Misc</span></th>
 					</tr>
 				</thead>	
 			  <tbody>
 				<tr>
-					<td class="col1" rowspan="2"><span data-i18n="reflex">Reflex</span></td>
+					<td class="col1" rowspan="2"><span>Reflex</span></td>
 					<td><input type="number" name="attr_Reflex" value="10+@{RefMod}[Mod]+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex @{Reflex}" /></td> 
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_RefLevel" value="@{RefLevel|max}"  disabled="true" title="Reflex Level / Armor bonus @{RefLevel}"/>	<input type="text" name="attr_RefLevel_max" value="@{level}" title="Reflex Level Formula @{RefLevel|max}"  class="hidden" /></td>	
 					<td><input type="number" name="attr_RefClass" value="0" title="Reflex Class bonus @{RefClass}" /></td>
 					<td> <select name="attr_RefMod" class="modtype" title="Reflex Ability Modifier (default DEX) @{RefMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex" selected>DEX</option>					  
-					  <option value="@{ArmorDex}" data-i18n="dex_max">DEX (Max Armor)</option>
-					  <option value="@{con|max}" data-i18n="con">CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}"  selected>DEX</option>					  
+					  <option value="@{ArmorDex}" >DEX (Max Armor)</option>
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_RefMisc" value="0" title="Reflex Miscellaneous Modifier @{RefMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><div class="small"><span data-i18n="flatfooted">Flatfooted</span></div></td>
+					<td class="col1"><div class="small"><span>Flatfooted</span></div></td>
 					<td><input type="number" name="attr_ReflexFlatFooted" value="10+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefFlatFootedMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex Flat Footed @{ReflexFlatFooted}" /></td>
 					<td></td>
 					<td colspan="2" align="right">
@@ -254,34 +254,34 @@
 				</tr>
 						
 				<tr>
-					<td class="col1"><span data-i18n="fortitude">Fortitude</span></td>
+					<td class="col1"><span>Fortitude</span></td>
 					<td><input type="number" name="attr_Fortitude" value="10+@{FortMod}[Mod]+@{FortLevel}[Level]+@{FortClass}[Class]+@{FortMisc}[Misc]+@{CT}[CT]" disabled="true" title="Fortitude  @{Fortitude}" />
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_FortLevel" value="@{FortLevel|max}"  disabled="true"  title="Fortitude Level / Armor bonus @{FortLevel}" />	<input type="text" name="attr_FortLevel_max" value="@{level}" title="Fortitude Level Formula @{FortLevel|max}" class="hidden" /></td>	
 					<td><input type="number" name="attr_FortClass" value="0" title="Fortitude Class bonus @{FortClass}" /></td>
 					<td> <select name="attr_FortMod" class="modtype " title="Fortitude Ability Modifier (default CON) @{FortMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-					  <option value="@{con|max}" data-i18n="con" selected>CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}"  selected>CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_FortMisc" value="0" title="Fortitude Miscellaneous Modifier @{FortMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><span data-i18n="will">Will</span></td>
+					<td class="col1"><span>Will</span></td>
 					<td><input type="number" name="attr_Will" value="10+@{WillMod}[Mod]+@{WillLevel}[Level]+@{WillClass}[Class]+@{WillMisc}[Misc]+@{CT}[CT]" disabled="true" title="Will @{Will}" /></td>
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_WillLevel" value="@{level}"  disabled="true" title="Will Level / Armor bonus @{WillLevel}"/></td>		
 					<td><input type="number" name="attr_WillClass" value="0" title="Will Class bonus @{WillClass}" /></td>
 					<td> <select name="attr_WillMod" class="modtype" title="Will Ability Modifier (default WIS) @{WillMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-					  <option value="@{con|max}" data-i18n="con">CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}"  selected>WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_WillMisc" value="0" title="Will Miscellaneous Modifier @{WillMisc}" /></td>
 				</tr>
@@ -365,9 +365,9 @@
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
 								<span class="table-data center" style="min-width:80px">
 									<select name="attr_attackMod" class="modtype" title="Attack Modifier @{repeating_attack_X_attackMod}">           
-									  <option value="@{str|max}" data-i18n="str">STR</option>
-									  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+									  <option value="@{str|max}" >STR</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="@{cha|max}" >CHA</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
 								<span class="table-data center" style="min-width:50px">
@@ -399,11 +399,11 @@
 								<span class="table-data center" style="min-width:80px">	
 									<select name="attr_damageMod" class="modtype" title="Weapon Damage modifier @{repeating_attack_X_damageMod}">
 									  <option value="0" selected>None</option>                
-									  <option value="@{str|max}" data-i18n="str">STR</option>
+									  <option value="@{str|max}" >STR</option>
 									  <option value="[[@{str|max}*2]]">STRx2</option>
-									  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+									  <option value="@{dex|max}" >DEX</option>	
 									  <option value="[[@{dex|max}*2]]">DEXx2</option>
-									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+									  <option value="@{cha|max}" >CHA</option>
 									  <option value="[[@{cha|max}*2]]">CHAx2</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
@@ -416,7 +416,7 @@
 							<span class="table-data" style="width:44px">		</span> 
 							<span class="table-data atkFormula">	
 								<span class="small"><b>Damage Modifier Total Formula</b></span>	<br />						
-								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{level|max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
+								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{hlevel_max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
 								<span class="small"><b>Damage Roll Formula</b></span>	<br />					
 								<textarea type="text" name="attr_WeaponDamage" class="atkFormula" title="Damage formula @{repeating_attack_X_WeaponDamage}" >@{damage}[Damage] + @{DamageTotal}</textarea> 
 							</span>
@@ -479,12 +479,12 @@
 						<span class="table-data"><input type="number" name="attr_Acrobatics" value="@{AcrobaticsFormula}" disabled="true" title="Acrobatics Total @{Acrobatics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_AcrobaticsMod" class="modtype" title="Acrobatics Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat" title="Trained in Acrobatics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat_max" title="Focused in Acrobatics?" /></span> <!-- Skill Focus -->
@@ -523,11 +523,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_ClimbMod" class="modtype" title="Climb Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat" title="Trained in Climb?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat_max" title="Focused in Climb?" /></span> <!-- Skill Focus -->
@@ -565,12 +565,12 @@
 						<span class="table-data"><input type="number" name="attr_Deception" value="@{DeceptionFormula}" disabled="true" title="Deception Total @{Deception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_DeceptionMod" class="modtype" title="Deception Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat" title="Trained in Deception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat_max" title="Focused in Deception?" /></span> <!-- Skill Focus -->
@@ -608,12 +608,12 @@
 						<span class="table-data"><input type="number" name="attr_Endurance" value="@{EnduranceFormula}" disabled="true" title="Endurance Total @{Endurance}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_EnduranceMod" class="modtype" title="Endurance Mod (default CON)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con" selected>CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}"  selected>CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat" title="Trained in Endurance?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat_max" title="Focused in Endurance?" /></span> <!-- Skill Focus -->
@@ -651,12 +651,12 @@
 						<span class="table-data"><input type="number" name="attr_GatherInformation" value="@{GatherInformationFormula}" disabled="true" title="Gather Information Total @{GatherInformation}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_GatherInformationMod" class="modtype" title="GatherInformation Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat" title="Trained in Gather Information?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat_max" title="Focused in Gather Information?" /></span> <!-- Skill Focus -->
@@ -694,12 +694,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -738,11 +738,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_JumpMod" class="modtype" title="Jump Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat" title="Trained in Jump?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat_max" title="Focused in Jump?" /></span> <!-- Skill Focus -->
@@ -782,12 +782,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Bureaucracy" value="@{Knowledge-BureaucracyFormula}" disabled="true" title="Knowledge (Bureaucracy) Total @{Knowledge-Bureaucracy}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-BureaucracyMod" class="modtype" title="Knowledge (Bureaucracy) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat" title="Trained in Knowledge (Bureaucracy)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat_max" title="Focused in Knowledge (Bureaucracy)?" /></span> <!-- Skill Focus -->
@@ -826,12 +826,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-GalacticLore" value="@{Knowledge-GalacticLoreFormula}" disabled="true" title="Knowledge (Galactic Lore) Total @{Knowledge-GalacticLore}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-GalacticLoreMod" class="modtype" title="Knowledge (Galactic Lore) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat" title="Trained in Knowledge (Galactic Lore)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat_max" title="Focused in Knowledge (Galactic Lore)?" /></span> <!-- Skill Focus -->
@@ -870,12 +870,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-LifeSciences" value="@{Knowledge-LifeSciencesFormula}" disabled="true" title="Knowledge (Life Sciences) Total @{Knowledge-LifeSciences}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-LifeSciencesMod" class="modtype" title="Knowledge (Life Sciences) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat" title="Trained in Knowledge (Life Sciences)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat_max" title="Focused in Knowledge (Life Sciences)?" /></span> <!-- Skill Focus -->
@@ -914,12 +914,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-PhysicalScience" value="@{Knowledge-PhysicalScienceFormula}" disabled="true" title="Knowledge (Physical Science) Total @{Knowledge-PhysicalScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-PhysicalScienceMod" class="modtype" title="Knowledge (Physical Science) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat" title="Trained in Knowledge (Physical Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat_max" title="Focused in Knowledge (Physical Science)?" /></span> <!-- Skill Focus -->
@@ -958,12 +958,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-SocialScience" value="@{Knowledge-SocialScienceFormula}" disabled="true" title="Knowledge (Social Science) Total @{Knowledge-SocialScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-SocialScienceMod" class="modtype" title="Knowledge (Social Science) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat" title="Trained in Knowledge (Social Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat_max" title="Focused in Knowledge (Social Science)?" /></span> <!-- Skill Focus -->
@@ -1002,12 +1002,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Tactics" value="@{Knowledge-TacticsFormula}" disabled="true" title="Knowledge (Tactics) Total @{Knowledge-Tactics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TacticsMod" class="modtype" title="Knowledge (Tactics) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat" title="Trained in Knowledge (Tactics)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat_max" title="Focused in Knowledge (Tactics)?" /></span> <!-- Skill Focus -->
@@ -1046,12 +1046,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Technology" value="@{Knowledge-TechnologyFormula}" disabled="true" title="Knowledge (Technology) Total @{Knowledge-Technology}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TechnologyMod" class="modtype" title="Knowledge (Technology) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat" title="Trained in Knowledge (Technology)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat_max" title="Focused in Knowledge (Technology)?" /></span> <!-- Skill Focus -->
@@ -1090,12 +1090,12 @@
 						<span class="table-data"><input type="number" name="attr_Mechanics" value="@{MechanicsFormula}" disabled="true" title="Mechanics Total @{Mechanics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_MechanicsMod" class="modtype" title="Mechanics Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat" title="Trained in Mechanics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat_max" title="Focused in Mechanics?" /></span> <!-- Skill Focus -->
@@ -1133,12 +1133,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -1176,12 +1176,12 @@
 						<span class="table-data"><input type="number" name="attr_Persuasion" value="@{PersuasionFormula}" disabled="true" title="Persuasion Total @{Persuasion}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PersuasionMod" class="modtype" title="Persuasion Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat" title="Trained in Persuasion?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat_max" title="Focused in Persuasion?" /></span> <!-- Skill Focus -->
@@ -1219,12 +1219,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -1262,12 +1262,12 @@
 						<span class="table-data"><input type="number" name="attr_Ride" value="@{RideFormula}" disabled="true" title="Ride Total @{Ride}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_RideMod" class="modtype" title="Ride Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat" title="Trained in Ride?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat_max" title="Focused in Ride?" /></span> <!-- Skill Focus -->
@@ -1305,12 +1305,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
@@ -1349,12 +1349,12 @@
 						<span class="table-data"><input type="number" name="attr_Survival" value="@{SurvivalFormula}" disabled="true" title="Survival Total @{Survival}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SurvivalMod" class="modtype" title="Survival Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat" title="Trained in Survival?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat_max" title="Focused in Survival?" /></span> <!-- Skill Focus -->
@@ -1393,11 +1393,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SwimMod" class="modtype" title="Swim Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat" title="Trained in Swim?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat_max" title="Focused in Swim?" /></span> <!-- Skill Focus -->
@@ -1435,12 +1435,12 @@
 						<span class="table-data"><input type="number" name="attr_TreatInjury" value="@{TreatInjuryFormula}" disabled="true" title="Treat Injury Total @{TreatInjury}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_TreatInjuryMod" class="modtype" title="Treat Injury Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat" title="Trained in Treat Injury?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat_max" title="Focused in Treat Injury?" /></span> <!-- Skill Focus -->
@@ -1478,12 +1478,12 @@
 						<span class="table-data"><input type="number" name="attr_UseComputer" value="@{UseComputerFormula}" disabled="true" title="Use Computer Total @{UseComputer}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_UseComputerMod" class="modtype" title="Use Computer Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat" title="Trained in Use Computer?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat_max" title="Focused in Use Computer?" /></span> <!-- Skill Focus -->
@@ -1521,12 +1521,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" data-i18n="str">STR</option>
-						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-						  <option value="@{con|max}" data-i18n="con">CON</option>
-						  <option value="@{int|max}" data-i18n="int">INT</option>
-						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+						  <option value="@{str|max}" >STR</option>
+						  <option value="@{dex|max}" >DEX</option>	
+						  <option value="@{con|max}" >CON</option>
+						  <option value="@{int|max}" >INT</option>
+						  <option value="@{wis|max}" >WIS</option>
+						  <option value="@{cha|max}"  selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->
@@ -1849,29 +1849,31 @@
 				<tr><th>Current</th>		<th></th>	<th>Total</th>	
 					<td colspan="3"></td>
 					<td rowspan="4" style="text-align:left">		
-						<input type="radio" value="0" name="attr_NPC-CT" checked="true" /> Normal<br />
-						<input type="radio" value="-1" name="attr_NPC-CT" /> -1<br />
-						<input type="radio" value="-2" name="attr_NPC-CT" /> -2<br />
-						<input type="radio" value="-5" name="attr_NPC-CT" /> -5<br />
-						<input type="radio" value="-10" name="attr_NPC-CT" /> -10<br />
-						<input type="radio" value="-10[Helpless]" name="attr_NPC-CT" /> Helpless</td>		
+                        <input type="radio" value="0" name="attr_CT" checked="true" /> <span>Normal</span><br />
+						<input type="radio" value="-1" name="attr_CT" /> -1<br />
+						<input type="radio" value="-2" name="attr_CT" /> -2<br />
+						<input type="radio" value="-5" name="attr_CT" /> -5<br />
+						<input type="radio" value="-10" name="attr_CT" /> -10<br />
+						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span>Helpless</span></td>	
 				</tr>
 				<tr>	
 					<td> <input type="number" name="attr_HP" value="0" title="Current HP"/></td>
 					<td>&nbsp;/&nbsp;</td>
 					<td><input type="number" name="attr_HP_max" value="0" title="Max HP" /></td>
 				</tr>
-				<tr>	<td colspan="5"><div class="textHead">Threshold</div> </td>		<td width="15px"></td>	</tr>
-				<tr><th>Total</th>	<th></th>	<th>Defense</th> <th>Misc</th>		</tr>
+<tr>	<td colspan="4"><div class="textHead"><span>Threshold</span></div> </td>			</tr>
+				<tr>	<th><span>Total</span></th>	<th></th>	<th><span>Defense</span></th> 	<th><span>Misc</span></th>		</tr>
 				<tr>	
-					<td><input type="number" name="attr_NPC-DT" value="@{NPC-DamageThresholdDefense}+@{DamageThresholdMisc}[Misc]+@{DamageThresholdSize}[Size]+@{NPC-CTIgnoreDT}"  disabled="true" title="Damage Threshold" /></td>
+					<td><input type="number" name="attr_DT" value="@{DamageThresholdDefense}+@{DamageThresholdSize}[Size]+@{DamageThresholdMisc}[Misc]"  disabled="true" title="Damage Threshold @{DT}" /></td>
 					<td>&nbsp;=&nbsp;</td>
-					<td><select name="attr_NPC-DamageThresholdDefense" class="modtype" title="Damage Threshold Defense">
-					  <option value="@{NPC-Fortitude}" selected>Fort</option>
-					  <option value="@{NPC-Will}">Will</option>
+					<td> <select name="attr_DamageThresholdDefense" class="modtype" title="Damage Threshold Defense @{DamageThresholdDefense}">
+					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" selected>Fort</option>
+					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" >Will</option>
 					</select></td>
-					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier" /></td>
-				</tr>	
+					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier @{DamageThresholdMisc}" />
+						<input type="number" value="0" name="attr_DamageThresholdSize" class="hidden" /></td>
+				</tr>				
+
 			</table>
 			<p>Ignore CT? <input type="checkbox" value="-@{npc-ct}" name="attr_NPC-CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track?" /></p>
 			
@@ -1929,8 +1931,8 @@
 					<td><input type="number" name="attr_NPC-Grapple" value="@{BAB} + @{GrpMod}[Mod] + @{GrpMod|max} + @{GrappleSize} +@{npc-ct}" disabled="true" title="Grapple" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
 					</select></td>
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier" /></td>
@@ -1941,91 +1943,223 @@
 	 <br />
 	<div class="2colrow">
 		<div class="col">
-			<div class="textHead">Defenses</div>
 			<table class="spacing">
+				<tr><div class="textHead2Col"><span>Defenses</span></div></tr>
+				<thead>
+					<tr>
+						<th></th>
+						<th><span>Total</span></th>
+						<th></th>
+						<th style="min-width:50px">	<span><span>Level</span> /<br /><span>Armor</span></span>	</th>
+						<th><span>Class</span></th>					
+						<th><span>Mod</span></th>
+						<th><span>Misc</span></th>
+					</tr>
+				</thead>	
+			  <tbody>
 				<tr>
-					<th></th>
-					<th></th>
-					<th>Total <br> after CT</th>
-					<th>Total</th>
+					<td class="col1" rowspan="2"><span>Reflex</span></td>
+					<td><input type="number" name="attr_Reflex" value="10+@{RefMod}[Mod]+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex @{Reflex}" /></td> 
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_RefLevel" value="@{RefLevel|max}"  disabled="true" title="Reflex Level / Armor bonus @{RefLevel}"/>	<input type="text" name="attr_RefLevel_max" value="@{level}" title="Reflex Level Formula @{RefLevel|max}"  class="hidden" /></td>	
+					<td><input type="number" name="attr_RefClass" value="0" title="Reflex Class bonus @{RefClass}" /></td>
+					<td> <select name="attr_RefMod" class="modtype" title="Reflex Ability Modifier (default DEX) @{RefMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}"  selected>DEX</option>					  
+					  <option value="@{ArmorDex}" >DEX (Max Armor)</option>
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_RefMisc" value="0" title="Reflex Miscellaneous Modifier @{RefMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1" rowspan="2">Reflex</td>
+					<td class="col1"><div class="small"><span>Flatfooted</span></div></td>
+					<td><input type="number" name="attr_ReflexFlatFooted" value="10+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefFlatFootedMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex Flat Footed @{ReflexFlatFooted}" /></td>
 					<td></td>
-					<td><input type="number" name="attr_NPC-Reflex" value="@{RefTotal}+@{npc-ct}" disabled="true"  title="Reflex" /></td> 
-					<td><input type="text" name="attr_RefTotal" value="10+@{level}+@{Dex|max}+@{RefSizeMod}"  title="Reflex Total (You can use formulas, for example: 10+@{level|max}[Half Level]+@{Dex|max} or enter the total Defence Score)"/></td>
+					<td colspan="2" align="right">
+						<input type="number" value="0" name="attr_RefSizeMod" class="hidden" />
+					</td>
+					<td><input type="number" name="attr_RefFlatFootedMisc" value="0" title="Reflex Flat Footed Miscellaneous Modifier @{RefFlatFootedMisc}" /></td>
+				</tr>
+						
+				<tr>
+					<td class="col1"><span>Fortitude</span></td>
+					<td><input type="number" name="attr_Fortitude" value="10+@{FortMod}[Mod]+@{FortLevel}[Level]+@{FortClass}[Class]+@{FortMisc}[Misc]+@{CT}[CT]" disabled="true" title="Fortitude  @{Fortitude}" />
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_FortLevel" value="@{FortLevel|max}"  disabled="true"  title="Fortitude Level / Armor bonus @{FortLevel}" />	<input type="text" name="attr_FortLevel_max" value="@{level}" title="Fortitude Level Formula @{FortLevel|max}" class="hidden" /></td>	
+					<td><input type="number" name="attr_FortClass" value="0" title="Fortitude Class bonus @{FortClass}" /></td>
+					<td> <select name="attr_FortMod" class="modtype " title="Fortitude Ability Modifier (default CON) @{FortMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}"  selected>CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_FortMisc" value="0" title="Fortitude Miscellaneous Modifier @{FortMisc}" /></td>
 				</tr>
 				<tr>
-					<!-- rowspan placeholder -->
-					<td class="col1"><div class="small">Flatfooted</div></td>
-					<td><input type="number" name="attr_NPC-ReflexFlatFooted" value="@{RefTotal|max}+@{npc-ct}" disabled="true"  title="Reflex Flat Footed" /></td>					 
-					<td><input type="text" name="attr_RefTotal_max" value="10+@{level}+@{RefSizeMod}"  title="FlatFooted Reflex Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+					<td class="col1"><span>Will</span></td>
+					<td><input type="number" name="attr_Will" value="10+@{WillMod}[Mod]+@{WillLevel}[Level]+@{WillClass}[Class]+@{WillMisc}[Misc]+@{CT}[CT]" disabled="true" title="Will @{Will}" /></td>
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_WillLevel" value="@{level}"  disabled="true" title="Will Level / Armor bonus @{WillLevel}"/></td>		
+					<td><input type="number" name="attr_WillClass" value="0" title="Will Class bonus @{WillClass}" /></td>
+					<td> <select name="attr_WillMod" class="modtype" title="Will Ability Modifier (default WIS) @{WillMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}"  selected>WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_WillMisc" value="0" title="Will Miscellaneous Modifier @{WillMisc}" /></td>
+				</tr>
+			  </tbody>
+			</table>
+			<br />			
+			<input type="checkbox" class="sect-show hidden" value="1" name="attr_armor-show" /> 		
+			<table class="spacing sect table2col">
+				<tr colspan="7">	<div class="textHead2Col">Armor&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Armor Section" name="attr_armor-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span></div></tr>
+				<tr>	
+					<th width="50%" colspan="3">Armor Worn <input type="checkbox" value="1" name="attr_ArmorWornCheck" title="Armor equiped @{ArmorWornCheck}" /></th>		
+					<th class="small">Ref Def<br />Bonus</th>		
+					<th class="small">Fort Def<br />Bonus</th>		
+					<th class="small">Max Dex<br />Bonus</th>		
+					<th>Speed</th>		</tr>
+				<tr>
+					<td colspan="3"><input type="text" name="attr_ArmorWorn" style="width:100%" title="Armor Name @{ArmorWorn}" /></td>
+					<td><input type="number" name="attr_ArmorRef" value="0"  title="Armor Reflex Defense Bonus @{ArmorRef}" /></td>
+					<td><input type="number" name="attr_ArmorFort" value="0" title="Armor Fortitude Defense Bonus @{ArmorFort}"  /></td>
+					<td><input type="number" name="attr_ArmorDex" value="0"  title="Armor Max DEX @{ArmorDex}" /></td>
+					<td><input type="number" name="attr_Speed_max" value="0" title="Armor Max Speed @{Speed|max}"  /></td>
 				</tr>
 				<tr>
-					<td class="col1">Fortitude</td>
-					<td rowspan="2"></td>
-					<td><input type="number" name="attr_NPC-Fortitude" value="@{FortTotal}+@{npc-ct}" disabled="true" />					 
-					<td><input type="text" name="attr_FortTotal" value="10+@{level}+@{CON|max}"  title="Fortitude Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+					<th class="small">Proficiency<br /><input type="checkbox" value="1" name="attr_ArmorProf" title="Proficient in armor worn @{ArmorProf}" /></th>
+					<th class="small">Armor Def.<br /><input type="checkbox" value="1" name="attr_ArmorDefense" title="Armor Specialist: Armor Defense @{ArmorDefense}" /></th>				
+					<th class="small">Improved<br />Armor Def.<br /><input type="checkbox" value="1" name="attr_ImpArmorDefense" title="Armor Specialist: Improved Armor Defense @{ArmorDefense}" /></th>
+					<th class="small" colspan="2">Armor Type<br/>
+						<select name="attr_ArmorType" style="width:90px" title="Armor Type @{ArmorType}">           
+							  <option value="Light">Light</option>
+							  <option value="Medium">Medium</option>
+							  <option value="Heavy">Heavy</option>
+						</select>
+						<input type="number" name="attr_ArmorType_max" value="0" class="hidden" title="Armor Penalty @{ArmorType|max}"  /> </th>
+					<th class="small" colspan="2">Helmet Package<br/>
+						<select name="attr_ArmorPerception" style="width:90px" title="Helmet Package Perception bonus @{ArmorPerception}">           
+						  <option value="None" selected>None</option>
+						  <option value="Standard">Standard</option>
+						  <option value="Superior">Superior</option>
+					</select></th>
+				</tr>	
+				<tr>	
+					
 				</tr>
-				<tr>
-					<td class="col1">Will</td>					
-					<!-- rowspan placeholder -->
-					<td><input type="number" name="attr_NPC-Will" value="@{WillTotal}+@{npc-ct}" disabled="true" /></td>					 
-					<td><input type="text" name="attr_WillTotal" value="10+@{level}+@{Wis|max}"  title="Will Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+				<tr>		
+					<td colspan="7"><textarea type="text" name="attr_ArmorNotes" class="atkNotes" title="Armor Notes @{ArmorNotes}"  placeholder="Armor Notes"></textarea></td>
 				</tr>
 			</table>
-		<div class="textHead2Col">Attacks</div>
-			<fieldset class="repeating_NPC-attack">	
+			<br />			
+			<div class="textHead2Col">Attacks</div>
+				<fieldset class="repeating_attack">	
 				<div class="table">	
 					<div class="table-row">
 						<div class="table">	
 							<div class="table-row">												
 								<span class="table-data">	<button  type="roll" name="roll_WeaponCheck" value="@{AttackFormula}" title="Attack Roll"> </button>	</span>
-								<span class="table-data" style="width:55%">	<input type="text" name="attr_WeaponName" placeholder="Weapon Name" style="width:100%"  title="Weapon Name @{repeating_npc-attack_X_WeaponName}" />	</span>
-								<span class="table-data">	<input type="text" name="attr_WeaponName_max" placeholder="Type" style="width:100%" title="Weapon Type @{repeating_npc-attack_X_WeaponName|max}" />	</span>
-							</div>
+								<span class="table-data" style="width:50%">	<input type="text" name="attr_WeaponName" placeholder="Weapon Name" style="width:100%"  title="Weapon Name @{repeating_attack_X_WeaponName}" />	</span>
+								<span class="table-data">	<input type="text" name="attr_WeaponName_max" placeholder="Type" style="width:100%" title="Weapon Type @{repeating_attack_X_WeaponName|max}" />	</span>
+								<span class="table-data" style="width:35px">		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sectAttack-show" title="Show/Hide Attack & Damage" name="attr_AttackDamage-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>
+							</div>							
 						</div>						
-					</div>				
+					</div>
+					<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>						
 					<div class="table-row">
 						<span class="table-data">	<div class="table">	
 							<div class="table-row">
 								<span class="table-header" style="min-width:44px"></span>
-								<span class="table-header" style="min-width:55px"></span>
-								<span class="table-header" style="min-width:130px">Total</span>
-								<span class="table-header"></span>
-								<span class="table-header">Mod</span>
-							</div>	
-							<div class="table-row">
-								<span class="table-data" style="min-width:44px">		</span>
-								<span class="table-data col1"  style="min-width:55px">	Attack	</span>
-								<span class="table-data center" style="min-width:130px">
-									<input type="number" name="attr_AttackTotal" value="@{Attack}+@{npc-ct}"  disabled="true" title="Attack Total Preview @{repeating_npc-attack_X_AttackTotal}" />	</span>
-								<span class="table-data center">	&nbsp;|&nbsp;</span>
-								<span class="table-data center">	<input type="text" name="attr_Attack" value="@{BAB}+@{STR|max}"  title="Attack Total (You can use formulas, for example: @{BAB}+@{STR|max} or enter the total attack modifier) @{repeating_npc-attack_X_attack}" style="width:100%" />	</span>
+								<span class="table-header" style="min-width:55px;"></span>
+							<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>	
+								<span class="table-header sectAttack not-sheet-show" style="min-width:130px">Total</span>
+								<span class="table-header sectAttack"></span>
+								<span class="table-header sectAttack" style="min-width:80px">Mod</span>					
+								<span class="table-header sectAttack"></span>
+								<span class="table-header sectAttack" style="min-width:50px">Misc</span>
 							</div>
-						</div>	</span>
-					</div>		
-					<div class="table-row">
-						<span class="table-data">	<div class="table">	
-							<div class="table-row">
+							<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>		
+							<div class="table-row sectAttack">
 								<span class="table-data" style="min-width:44px">		</span>
-								<span class="table-data col1"  style="min-width:55px">	Damage	</span>
-								<span class="table-data" style="min-width:130px">	
-									<input type="text" name="attr_damage" placeholder="2d8"  style="width:60px" title="Weapon Damage @{repeating_npc-attack_X_damage}"/>
-									&nbsp;+&nbsp;	
-									<input type="number" name="attr_DamageTotal" value="@{damage|max}" disabled="true"  title="Damage Total @{repeating_npc-attack_X_DamageTotal}" />	</span>
+								<span class="table-data col1"  style="min-width:55px">	<span>Attack</span>	<input type="checkbox" class="sect-show skillsHideCheckbox" title="Show/Hide Attack Formula" name="attr_attack-show" value="1" style="width: 38px; margin-left: -41px;" />	</span>
+								<span class="table-data center" style="min-width:130px">
+									<input type="number" name="attr_AttackTotal_max" value="@{AttackTotal}" disabled="true"  title="Attack Total  @{repeating_attack_X_AttackTotal|max}" />	</span>
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
-								<span class="table-data center">	<input type="text" name="attr_damage_max" value="@{STR|max}+@{level|max}"  style="width:100%" title="Weapon Damage Bonus (You can use formulas, for example: (@{STR|max}*2)+@{level|max} or enter the entire Damage roll for example: 6) @{repeating_npc-attack_X_damage|max}"/>	</span>								
+								<span class="table-data center" style="min-width:80px">
+									<select name="attr_attackMod" class="modtype" title="Attack Modifier @{repeating_attack_X_attackMod}">           
+									  <option value="@{str|max}" >STR</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="@{cha|max}" >CHA</option>
+									</select>	</span>
+								<span class="table-data center">	&nbsp;+&nbsp;	</span>
+								<span class="table-data center" style="min-width:50px">
+									<input type="number" name="attr_attackModMisc" placeholder="Misc" value="0" style="width:40px"  title="Attack Miscellaneous Modifier @{repeating_attack_X_attackModMisc}" />	</span>
 							</div>
 						</div>	</span>
 					</div>
-					<div class="table-row">
+					<div style="width:100%">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_attack-show" />
+						<div class="table-row sect">
+							<span class="table-data" style="min-width:44px">		</span> 
+							<span class="table-data atkFormula">
+								<span class="small"><b>Attack Modifier Total Formula</b></span>	<br />
+								<textarea type="text" name="attr_AttackTotal" class="atkFormula" title="Attack Total formula @{repeating_attack_X_AttackTotal}" >@{BAB}[BAB] + @{attackMod}[Mod] + @{attackModMisc}[Misc] +@{CT}[CT] +@{ArmorType|max}[Armor Penalty] </textarea> 							
+								<span class="small"><b>Attack Roll Formula</b></span>	<br />
+								<textarea type="text" name="attr_WeaponAttack" class="atkFormula" title="Attack formula @{repeating_attack_X_WeaponAttack}" >1d20cs>@{WeaponCrit}[Critical Range] + @{attackTotal} + ?{Other Modifiers (Attack)|0}[Other]</textarea> 
+							</span>
+						</div>
+					</div>				
+					<div class="table-row sectAttack">
+						<span class="table-data">	<div class="table">	
+							<div class="table-row">
+								<span class="table-data" style="min-width:44px">		</span>
+								<span class="table-data col1"  style="min-width:55px">	<span>Damage</span>	<input type="checkbox" class="sect-show skillsHideCheckbox" title="Show/Hide Attack Formula" name="attr_damage-show" value="1" style="width: 50px; margin-left: -53px;" />	</span>
+								<span class="table-data" style="min-width:130px">	
+									<input type="text" name="attr_damage" placeholder="2d8" value="2d8"  style="width:60px" title="Weapon Damage @{repeating_attack_X_damage}"/>
+									&nbsp;+&nbsp;	
+									<input type="number" name="attr_DamageTotal_max" value="@{damageTotal}" disabled="true"  title="Damage Total  @{repeating_attack_X_DamageTotal|max}" />	</span>
+								<span class="table-data center">	&nbsp;|&nbsp;</span>
+								<span class="table-data center" style="min-width:80px">	
+									<select name="attr_damageMod" class="modtype" title="Weapon Damage modifier @{repeating_attack_X_damageMod}">
+									  <option value="0" selected>None</option>                
+									  <option value="@{str|max}" >STR</option>
+									  <option value="[[@{str|max}*2]]">STRx2</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="[[@{dex|max}*2]]">DEXx2</option>
+									  <option value="@{cha|max}" >CHA</option>
+									  <option value="[[@{cha|max}*2]]">CHAx2</option>
+									</select>	</span>
+								<span class="table-data center">	&nbsp;+&nbsp;	</span>
+								<span class="table-data center" style="min-width:50px">	<input type="number" name="attr_damageMisc" placeholder="Misc" value="0" style="width:40px" title="Weapon Damage Miscellaneous Modifier @{repeating_attack_X_damageMisc}"  />	</span>
+							</div>
+						</div>	</span>
+					</div>
+					<div style="width:100%">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_damage-show" />
+						<div class="table-row sect">
+							<span class="table-data" style="width:44px">		</span> 
+							<span class="table-data atkFormula">	
+								<span class="small"><b>Damage Modifier Total Formula</b></span>	<br />						
+								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{hlevel_max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
+								<span class="small"><b>Damage Roll Formula</b></span>	<br />					
+								<textarea type="text" name="attr_WeaponDamage" class="atkFormula" title="Damage formula @{repeating_attack_X_WeaponDamage}" >@{damage}[Damage] + @{DamageTotal}</textarea> 
+							</span>
+						</div>
+					</div>
+					<div class="table-row  sectAttack">
 						<span class="table-data">	<div class="table">	
 							<div class="table-row">
 								<span class="table-data" style="min-width:44px">		</span>
 								<span class="table-data" style="min-width:110px">	<b>Critical Info</b>	</span>
-								<span class="table-data">	<span class="small"><b>Range</b></span> 	<input type="number" name="attr_WeaponCrit" placeholder="Crit" value="20" title="Weapon Critical Starting Range ie.20 @{repeating_npc-attack_X_WeaponCrit}" />	</span>
-								<span class="table-data">		<span class="small"><b>Multiplier</b></span>	 <input type="number" name="attr_WeaponCrit_max" value="2" title="Weapon Crit Damage Multiplier @{repeating_npc-attack_X_WeaponCrit|max}" />		</span>
+								<span class="table-data">	<span class="small"><b>Range</b></span> 	<input type="number" name="attr_WeaponCrit" placeholder="Crit" value="20" title="Weapon Critical Starting Range ie.20 @{repeating_attack_X_WeaponCrit}" />	</span>
+								<span class="table-data">		<span class="small"><b>Multiplier</b></span>	 <input type="number" name="attr_WeaponCrit_max" value="2" title="Weapon Crit Damage Multiplier @{repeating_attack_X_WeaponCrit|max}" />		</span>
 								<span class="table-data">	<b>Template <br/>Formula</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Attack Template Formula" name="attr_AttackFormula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>
 							</div>
 						</div>	</span>
@@ -2036,7 +2170,7 @@
 							<span class="table-data" style="width:44px">		</span> 
 							<span class="table-data atkFormula">							
 								<span class="small"><b>Template Formula</b></span>	<br />						
-								<textarea type="text" name="attr_AttackFormula" class="atkFormula" title="Attack Template formula @{repeating_npc-attack_X_AttackFormula}" >&{template:attack} {{name=@{WeaponName}}} {{type=@{WeaponName|max}}} {{attack=[[1d20cs>@{WeaponCrit} + @{AttackTotal} + ?{Other Modifiers (Attack)|0}]]}} {{atkeffect=@{WeaponNotes|max}}} {{damage=[[@{damage}+@{damageTotal}]]}} {{dmgcrit=[[(@{damage}+@{damageTotal})*@{WeaponCrit|max}]]}}</textarea> 
+								<textarea type="text" name="attr_AttackFormula" class="atkFormula" title="Attack Template formula @{repeating_attack_X_AttackFormula}" >&{template:attack} {{name=@{WeaponName}}} {{type=@{WeaponName|max}}}  {{atkeffect=@{WeaponNotes|max}}} {{attack=[[@{WeaponAttack}]]}} {{damage=[[@{WeaponDamage}]]}} {{dmgcrit=[[(@{WeaponDamage})*@{WeaponCrit|max}[Critical Multiplier]]]}}</textarea> 
 							</span>
 						</div>	</span>
 					</div>
@@ -2045,14 +2179,14 @@
 							<div class="table-row">
 								<span class="table-data" style="width:44px">		</span> 
 								<span class="table-data">							
-									<textarea type="text" name="attr_WeaponNotes_max" placeholder="Attack Notes" class="atkNotes" title="Attack Notes: ie Devesating Attack, Rapid Strike, Point Blank Shot @{repeating_npc-attack_X_WeaponNotes|max}" ></textarea>
-									<textarea type="text" name="attr_WeaponNotes" placeholder="Weapon Notes" class="atkNotes" title="Weapon Notes @{repeating_npc-attack_X_WeaponNotes}"></textarea>
+									<textarea type="text" name="attr_WeaponNotes_max" placeholder="Attack Notes" class="atkNotes" title="Attack Notes: ie Devesating Attack, Rapid Strike, Point Blank Shot @{repeating_attack_X_WeaponNotes|max}" ></textarea>
+									<textarea type="text" name="attr_WeaponNotes" placeholder="Weapon Notes" class="atkNotes" title="Weapon Notes @{repeating_attack_X_WeaponNotes}"></textarea>
 								</span>
 							</div>
 						</div>	</span>
 					</div>
 				</div>
-			</fieldset>
+				</fieldset>
 		</div>	
 		<div class="col">
 			<div class="textHead2Col">Skills</div>
@@ -2075,12 +2209,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -2118,12 +2252,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -2161,12 +2295,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -2204,12 +2338,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
@@ -2247,12 +2381,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" data-i18n="str">STR</option>
-						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-						  <option value="@{con|max}" data-i18n="con">CON</option>
-						  <option value="@{int|max}" data-i18n="int">INT</option>
-						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+						  <option value="@{str|max}" >STR</option>
+						  <option value="@{dex|max}" >DEX</option>	
+						  <option value="@{con|max}" >CON</option>
+						  <option value="@{int|max}" >INT</option>
+						  <option value="@{wis|max}" >WIS</option>
+						  <option value="@{cha|max}"  selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->
@@ -2283,23 +2417,52 @@
 					</div>	</div>
 				</div>	</div>		
 			</div>
+			
 			<fieldset class="repeating_npc-skill">	
 				<table class="spacing">
-					<tr>
-						<td class="skillsCol1"><input type="text" name="attr_Skill" placeholder="Skill Name" title="Skill Name" /></td>
-						<td><button type="roll" name="roll_SkillCheck" value="@{formula}" title="Roll Skill"></button></td>
-						<td><input type="number" name="attr_SkillTotal" value="@{skill|max}+@{npc-ct}"  disabled="true" title="Skill Total Preview" /></td>
-						<td style="min-width:75px">	<b>Formulas & Notes</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Skill Template Formula" name="attr_Skill-Formula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</td>
-					</tr>
-					<tr>
-						<td colspan="4" align="left">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Formula-show" />	<div class="sect">
-							<input type="text" name="attr_SkillNotes" placeholder="Skill Notes" title="Skill Notes" style="margin-left:10%; width:90%;" /> <br />
-							<span class="small" style="margin-left:10%;"><b>Skill Total Formula</b></span>	<br />
-							<input type="text" style="margin-left:10%; width:90%;" name="attr_skill_max" value="@{str|max}+@{level|max}[Half Level]" title="Skill Total (Can Include formula, for example: (@{str|max}+@{level|max}[Half Level]+5+5) or enter the total) " /> <br />
-							<span class="small" style="margin-left:10%;"><b>Skill Roll Formula</b></span>	<br />
-							<!-- Skill Formula -->	<textarea type="text" name="attr_Formula" class="atkFormula" style="margin-left:10%; width:90%;" title="Skill Template formula" >&{template:skill} {{name=@{Skill}}} {{skill=[[1d20+@{SkillTotal}+?{Other Modifiers|0}[Other]]]}}</textarea>	
-						</div>	</td>
-					</tr>
+				<div class="table-row"><div class="table">
+					<div class="table-row">
+						<Span class="skillsCol1"><input type="text" name="attr_SkillName" style="width:95%" placeholder="Skill Name" title="Skill Name" /></span> 
+						<span class="table-data"><button type="roll" name="roll_SkillCheck" value="@{SkillFormula|max}"></button></span>
+						<span class="table-data"><input type="number" name="attr_Skill" value="@{SkillFormula}" disabled="true" title="Skill Total @{Skill}" class="skills" /></span> 
+						<span class="table-data">&nbsp;=&nbsp;</span>	
+						<span class="table-data"><select name="attr_SkillMod" class="modtype" title="Skill Mod (default STR)">
+							  <option value="@{str|max}"   selected>STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
+							</select></span>
+						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SkillFeat" title="Trained in Skill?" /></span> <!-- Skill Training -->
+						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SkillFeat_max" title="Focused in Skill?" /></span> <!-- Skill Focus -->
+						<span class="table-data"><input type="number" name="attr_SkillMisc" title="Skill Miscellaneous Modifier" value="0" class="skills" /></span>
+					</div>
+				</div></div>
+				<div>		
+					<!-- Pilot Notes -->	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Skill-Show" />
+					<div class="table-row sect"><div class="table">
+						<div class="table-row">
+							<span class="table-data" style="min-width:50px">	</span>
+							<span class="table-data">	<input class="skillsNotes" type="text" name="attr_Skill_max" placeholder="Skill Notes" title="Skill Notes @{Pilot|max}" />	</span>
+							<span class="table-data" style="min-width:15px">	</span>
+							<span class="table-data">	<b>Formula</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Skill Template Formula_max" name="attr_Skill-Skill-Formula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>							
+						</div>
+					</div>	</div>	
+					<!-- Pilot Formula -->	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Skill-Formula-Show" />	
+					<div class="table-row sect">	<div class="table">
+						<div class="table-row">
+							<span class="table-data" style="min-width:50px">	</span>
+							<span class="table-data atkFormula">							
+								<span class="small"><b>Skill Modifier Total Formula</b></span>	<br />
+								<textarea type="text" name="attr_SkillFormula" class="atkFormula" title="Skill Total formula @{SkillFormula}" >@{level|max}[Half Level]+@{SkillMod}[Mod]+@{SkillFeat}[Training]+@{SkillFeat|max}[Focus]+@{SkillMisc}[Misc]+@{CT}[CT]</textarea> 
+								<span class="small"><b>Template Formula</b></span>	<br />
+								<textarea type="text" name="attr_SkillFormula_max" class="atkFormula" title="Skill Template formula @{SkillFormula|max}" >&{template:skill} {{name=@{SkillName}}} {{skill=[[1d20 + @{Skill} + ?{Other Modifiers|0}[Other]]]}}</textarea> 
+							</span>
+						</div>
+					</div>	</div>
+				</div>
+				<div>		
 				</table>
 			</fieldset>	
 			<br />			
@@ -3217,15 +3380,11 @@ For Help, please see the wiki page. <input type="text" name="attr_vehicle-Equipm
 // Github:   https://github.com/shdwjk/TheAaronSheet/blob/master/TheAaronSheet.js
 // By:       The Aaron, Arcane Scriptomancer
 // Contact:  https://app.roll20.net/users/104025/the-aaron
-
 var TAS = TAS || (function(){
     'use strict';
-
     var version = '0.2.0',
         lastUpdate = 1448523710,
-
 		queuedUpdates = {}, //< Used for delaying saves till the last momment.
-
 	log = function(){
         _.each(arguments,function(m){
             switch(typeof m){
@@ -3242,16 +3401,13 @@ var TAS = TAS || (function(){
             }
         });
 	},
-
     prepareUpdate = function( attribute, value ){
         queuedUpdates[attribute]=value;
     },
-
     applyQueuedUpdates = function() {
       setAttrs(queuedUpdates);
       queuedUpdates = {};
     },
-
 	namesFromArgs = function(args,base){
         return _.chain(args)
             .reduce(function(memo,attr){
@@ -3265,7 +3421,6 @@ var TAS = TAS || (function(){
             .uniq()
             .value();
 	},
-
 	addId = function(obj,value){
 		Object.defineProperty(obj,'id',{
 			value: value,
@@ -3273,13 +3428,11 @@ var TAS = TAS || (function(){
 			enumerable: false
 		});
 	},
-
 	addProp = function(obj,prop,value,fullname){
 		(function(){
             var pname=(_.contains(['S','F','I','D'],prop) ? '_'+prop : prop),
 			    full_pname = fullname || prop,
                 pvalue=value;
-
             _.each(['S','I','F'],function(p){
                 if( !_.has(obj,p)){
                     Object.defineProperty(obj, p, {
@@ -3303,8 +3456,6 @@ var TAS = TAS || (function(){
                     readonly: true
                 });
             }
-
-
             // Raw value
 			Object.defineProperty(obj, pname, {
                 enumerable: true,
@@ -3329,7 +3480,6 @@ var TAS = TAS || (function(){
 					return pvalue.toString();
 				}
 			});
-
             // int value
 			Object.defineProperty(obj.I, pname, {
                 enumerable: true,
@@ -3342,7 +3492,6 @@ var TAS = TAS || (function(){
 					return parseInt(pvalue,10) || 0;
 				}
 			});
-
             // float value
 			Object.defineProperty(obj.F, pname, {
                 enumerable: true,
@@ -3368,7 +3517,6 @@ var TAS = TAS || (function(){
                     }
                 });
             });
-
 		}());
 	},
 	
@@ -3428,7 +3576,6 @@ var TAS = TAS || (function(){
 					attrSet = {},
 					fieldIds = [],
 					fullFieldNames = [];
-
 				// call each operation per row.
 				// call each operation's final
 				getSectionIDs("repeating_"+sectionName,function(ids){
@@ -3444,7 +3591,6 @@ var TAS = TAS || (function(){
 								addProp(attrSet,aname,values[aname]);
 							}
 						});
-
 						rowSet = _.reduce(fieldIds,function(memo,id){
 							var r={};
 							addId(r,id);
@@ -3452,33 +3598,27 @@ var TAS = TAS || (function(){
 								var fn = 'repeating_'+sectionName+'_'+id+'_'+name;  
 								addProp(r,name,values[fn],fn);
 							});
-
 							memo[id]=r;
-
 							return memo;
 						},{});
-
                         _.each(operations,function(op){
                             var res;
                             switch(op.type){
                                 case 'tap':
                                     _.bind(op.final,op.context,rowSet,attrSet)();
                                     break;
-
                                 case 'each':
                                     _.each(rowSet,function(r){
                                         _.bind(op.func,op.context,r,attrSet,r.id,rowSet)();
                                     });
                                     _.bind(op.final,op.context,rowSet,attrSet)();
                                     break;
-
                                 case 'map':
                                     res = _.map(rowSet,function(r){
                                         return _.bind(op.func,op.context,r,attrSet,r.id,rowSet)();
                                     });
                                     _.bind(op.final,op.context,res,rowSet,attrSet)();
                                     break;
-
                                 case 'reduce':
                                     res = op.memo;
                                     _.each(rowSet,function(r){
@@ -3488,7 +3628,6 @@ var TAS = TAS || (function(){
                                     break;
                             }
                         });
-
                         // finalize attrs
                         applyQueuedUpdates();
 					});
@@ -3498,33 +3637,25 @@ var TAS = TAS || (function(){
 			return {
 				attrs: repAttrs,
 				attr: repAttrs,
-
 				column: repFields,
 				columns: repFields,
 				field: repFields,
 				fields: repFields,
-
 				reduce: repReduce,
 				inject: repReduce,
 				foldl: repReduce,
-
 				map: repMap,
 				collect: repMap,
-
 				each: repEach,
                 forEach: repEach,
-
                 tap: repTap,
                 'do': repTap,
-
 				execute: repExecute,
 				go: repExecute,
 				run: repExecute
 			};
 		}(section));
 	},
-
-
     repeatingSimpleSum = function(section, field, destination){
         repeating(section)
             .attr(destination)
@@ -3536,17 +3667,13 @@ var TAS = TAS || (function(){
             })
             .execute();
     };
-
     console.log('-=> TheAaronSheet v'+version+' <=-  ['+(new Date(lastUpdate*1000))+']');
-
     return {
         repeatingSimpleSum: repeatingSimpleSum,
 		repeating: repeating
     };
 }());
-
 /* ---- END: TheAaronSheet.js ---- */
-
 // ====== PC /NPC Sheet ====== \\
 on("change:level", function() {
 	ArmorUpdate();
@@ -3554,11 +3681,9 @@ on("change:level", function() {
 on("change:size", function() {
 	SizeUpdate();
 });
-
 on("change:dex", function() {
 	ArmorUpdate();
 });
-
 //Changes to Armor
 on("change:armorworncheck", function() {
 	ArmorUpdate();
@@ -3571,11 +3696,9 @@ on("change:armorperception", function() {
 	ArmorPerception();
 });
 // ====== Vehicle Sheet ====== \\
-
 on("change:vehicle-size", function() {
 	VehicleSizeUpdate();
 });
-
 // When something in inventory is changed...
 on("change:repeating_equipment remove:repeating_equipment",function(){
     //TAS.repeatingSimpleSum('equipment','equipmentwt','equipmentrunningtotal');	
@@ -3601,7 +3724,6 @@ on("change:repeating_equipment remove:repeating_equipment",function(){
         })
         .execute(); 
 });
-
 on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:str",function(){	
 	getAttrs(["ArmorWt","EquipmentWtRunningTotal", "STR", "ArmorCarry"], function(v) {
 		EquipmentCapacity = parseFloat(v["STR"]/2)*(v["STR"]/2).toFixed(1);
@@ -3638,8 +3760,6 @@ on("change:inventoryrunningsummary change:ArmorWorn",function(){
 		setAttrs({"inventory": summary});
 	});
 });
-
-
 // ====== Functions ====== \\
 var ArmorPerception = function() {
 	getAttrs(["ArmorWornCheck", "ArmorPerception","ArmorPerception_max", "PerceptionMisc"], function(v) {
@@ -3669,16 +3789,13 @@ var ArmorPerception = function() {
 		setAttrs({"PerceptionMisc": newPerception, "ArmorPerception_max": perception});
 	});
 };
-
 var ArmorUpdate = function() {
 	getAttrs(["ArmorWornCheck", "ArmorDefense", "ImpArmorDefense", "ArmorProf", "ArmorRef", "level", "ArmorType", "ArmorDex", "DEX", "RefMod"], function(v) {
-
 /*	console.log("ArmorWornCheck = " + v["ArmorWornCheck"] + '\n' +  
 				"ArmorDefense = " + v["ArmorDefense"]   + '\n' + 
 				"ImpArmorDefense = " + v["ImpArmorDefense"] + '\n' + 
 				"ArmorProf = " + v["ArmorProf"] + '\n' + 
 				"ArmorType = " + v["ArmorType"]	);		*/
-
 	//Defenses	
 	ImpArmorDefense = parseInt(v["level"]) + Math.floor(parseInt(v["ArmorRef"]/ 2))
 	if (v["ArmorProf"] == "0") {setAttrs({"ArmorDefense": "0", "ImpArmorDefense": "0" });}
@@ -3729,7 +3846,6 @@ var ArmorUpdate = function() {
 			armorFortitude = "@{level}"
 			setAttrs({"ArmorCarry": "0"}); //Armor is not Carried
 		}
-
 	console.log("armorReflex = " + armorReflex + '\n' + "armorFortitude = " + armorFortitude + '\narmorPenalty = ' + armorPenalty );
 		setAttrs({
 			"RefLevel_max": armorReflex,
@@ -3754,7 +3870,6 @@ var ArmorUpdate = function() {
 	else{console.log("== NO OPTIONS ==" + '\n' + "dexmod = " +dexMod + '\n' + "ArmorDex = " +v["ArmorDex"] + "\nRefMod = " + v["RefMod"]);}
 	}); //End 
 };
-
 var SizeUpdate = function() {
 	getAttrs(["Size"], function(v) {
 	console.log("Size = " + v["Size"])
@@ -3834,7 +3949,6 @@ var VehicleSizeUpdate = function() {
 		console.log("vehicle-sizeMod = " + sizeMod   + '\n' + 
 			"vehicle-GrpSize = " + grappleSize + '\n' + 
 			"vehicle-DTSizeMod = " + dtSize);
-
 		setAttrs({
 			"vehicle-sizeMod": sizeMod,
 			"vehicle-GrpSize": grappleSize,


### PR DESCRIPTION
•	Changed the NPC’s Defenses section to make it more like the PC’s
•	Added an Armor Section for the NPC sheet
•	Changed the NPC’s Attacks Section to make it more like the PC’s.
•	Removed the red text from the sheet to make it more pleasing to the eye.
•	Changed the Repeating Skills Section on the NPC Sheet to be more like the PC skills.
•	Fixed NPC Sheet’s Damage Threshold 
•	Fix NPC Sheet’s Condition Tracker
•	Fix NPC Grapple and Skills
•	Fix PC and NPC Sheet’s Weapon Damage, it should not be counting Non-Heroic Levels for damage.