### PR TITLE
Mongoose Traveller 2E: fix Deception skill roller not working.

### DIFF
--- a/Mongoose_Traveller2e/MongooseTraveller.html
+++ b/Mongoose_Traveller2e/MongooseTraveller.html
@@ -672,7 +672,7 @@
                             <th style="width:55px;"></th>
                         </tr>
                         <tr>
-                            <th><button name="roll_Deception" type="roll" value='&{template:skill-general} {{skill= Deception }} {{character= @{character_name} }} {{roll= [[(2d6 + [[@{skilltotal-Computers}]] + ?{Modifier|0}[MOD])]] }} {{bb=[[(1d6)]]}}' ><div class="sheet-button_header">Deception</div></button></th>
+                            <th><button name="roll_Deception" type="roll" value='&{template:skill-general} {{skill= Deception }} {{character= @{character_name} }} {{roll= [[(2d6 + [[@{skilltotal-Deception}]] + ?{Modifier|0}[MOD])]] }} {{bb=[[(1d6)]]}}' ><div class="sheet-button_header">Deception</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Deception" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>


### PR DESCRIPTION
Just a leftover, the skill was still called "Computer" in there from 1E