### PR TITLE
Fallout Patch

### DIFF
--- a/Fallout 3.5/Fallout 3.5.html
+++ b/Fallout 3.5/Fallout 3.5.html
@@ -571,13 +571,13 @@
                     <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-normal" value="0" /></td>
                 </tr>
                 <tr>
-                    <td>Explosion</td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_explosion" value="@{damage_threshold_mod-explosion} + @{damage_threshold_base-explosion}" disabled="true"/></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_explosion" value="@{damage_resistance_mod-explosion} + @{damage_resistance_base-explosion}" disabled="true"/></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_mod-explosion" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_mod-explosion" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_base-explosion" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-explosion" value="0" /></td>
+                    <td>Laser</td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_laser" value="@{damage_threshold_mod-laser} + @{damage_threshold_base-laser}" disabled="true"/></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_laser" value="@{damage_resistance_mod-laser} + @{damage_resistance_base-laser}" disabled="true"/></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_mod-laser" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_mod-laser" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_base-laser" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-laser" value="0" /></td>
                 </tr>
                 <tr>
                     <td>Fire</td>
@@ -589,15 +589,6 @@
                     <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-fire" value="0" /></td>
                 </tr>
                 <tr>
-                    <td>Laser</td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_laser" value="@{damage_threshold_mod-laser} + @{damage_threshold_base-laser}" disabled="true"/></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_laser" value="@{damage_resistance_mod-laser} + @{damage_resistance_base-laser}" disabled="true"/></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_mod-laser" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_mod-laser" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_base-laser" value="0" /></td>
-                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-laser" value="0" /></td>
-                </tr>
-                <tr>
                     <td>Plasma</td>
                     <td><input type="number" class="sheet-number" name="attr_damage_threshold_plasma" value="@{damage_threshold_mod-plasma} + @{damage_threshold_base-plasma}" disabled="true"/></td>
                     <td><input type="number" class="sheet-number" name="attr_damage_resistance_plasma" value="@{damage_resistance_mod-plasma} + @{damage_resistance_base-plasma}" disabled="true"/></td>
@@ -605,6 +596,15 @@
                     <td><input type="number" class="sheet-number" name="attr_damage_resistance_mod-plasma" value="0" /></td>
                     <td><input type="number" class="sheet-number" name="attr_damage_threshold_base-plasma" value="0" /></td>
                     <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-plasma" value="0" /></td>
+                </tr>
+                <tr>
+                    <td>Explosion</td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_explosion" value="@{damage_threshold_mod-explosion} + @{damage_threshold_base-explosion}" disabled="true"/></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_explosion" value="@{damage_resistance_mod-explosion} + @{damage_resistance_base-explosion}" disabled="true"/></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_mod-explosion" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_mod-explosion" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_threshold_base-explosion" value="0" /></td>
+                    <td><input type="number" class="sheet-number" name="attr_damage_resistance_base-explosion" value="0" /></td>
                 </tr>
                 <tr>
                     <td>Condition</td>


### PR DESCRIPTION
Changing order of damage type to be same as in the book. Due to not same order as in the book, it was hard to write down damage numbers correctly.