### PR TITLE
Mainly Minor Changes to NPC Sheet and Re-adding Translation Material

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -84,7 +84,7 @@
 						<td><p>STR</p></td>
 						<td><input type="number" name="attr_STR" /></td>	
 							<td >
-							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|5}]] Effort Roll" >Effort</button>	
+							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Effort Roll" >Effort</button>	
 						</td>
 						<td><p>Dmg. Bonus</p></td>
 						<td colspan="3">	
@@ -95,7 +95,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>CON</p></td>
 						<td><input type="number" name="attr_CON" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|5}]] Stamina Roll" >Stamina</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Stamina Roll" >Stamina</button></td>
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank"><p >Siz SR</p></div>
@@ -135,7 +135,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>INT</p></td>
 						<td><input type="number" name="attr_INT" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|5}]] Idea Roll" >Idea</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Idea Roll" >Idea</button></td>
 						<td><p>MOV</p></td><td><input type="number" name="attr_mov" /></td>		
 						<td></td>
 						<td></td>						
@@ -145,7 +145,7 @@
 						<td ><input type="checkbox" name="att_power-check" /><td>
 						<td><p>POW</p></td>
 						<td><input class="sheet-plain" type="number" name="attr_POW" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|5}]] Luck Roll" >&nbsp;Luck</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Luck Roll" >&nbsp;Luck</button></td>
 						<td><p>Hit Pts.</p></td>
 						<td><input type="number" name="attr_cur_hp" />
 						<td>/</td>
@@ -156,7 +156,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>DEX</p></td>
 						<td><input type="number" name="attr_DEX" /></td>	
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|5}]] Agility Roll" >Agility</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Agility Roll" >Agility</button></td>
 						<td><p>Power Pts.</p></td>
 						<td><input type="number" name="attr_cur_mp" />
 						<td>/</td>
@@ -167,7 +167,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>APP</p></td>
 						<td><input type="number" name="attr_APP" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Mulitplier|5}]] Charisma Roll" >Charisma</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Charisma Roll" >Charisma</button></td>
 							
 							<div class="sheet-hpbl">
 								<td>
@@ -221,229 +221,235 @@
 <hr/>
 <!-- ********************************************************************************************************************* -->
 <!-- Start of alpahbetical skills-->
-<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic"  style="display: none">
+<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic" checked="checked"  style="display: none">
 <div class="sheet-skills-alphabetical" />
-<h3 class="sheet-skills-header">Skills</h3>
-<div class='sheet-3colrow'>
-	<div class='sheet-col'>
-		<!-- Col 1 -->                
-		<table style="width: 100%">
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-				<td class="sheet-skillname">Appraise (15%)</td>
-				<td><input type="number" name="attr_Appraise"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Appraise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
-			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Art(05):</td>
-			</tr>
-		</table>				
-		<fieldset class='repeating_artskills'>
-			<table style="width: 100%;">	
-				<tr>
-				<td><input type="checkbox" name="attr_artSuccess"  /></td>
-				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-				<td><input type="number" name="attr_artScore" /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{artScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-				</tr>
-			</table>
-		</fieldset>	
-		<table style="width: 100%">
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
-				<td class="sheet-skillname">Bargain (05%)</td>
-				<td><input type="number" name="attr_Bargain"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Climb"  /></td>
-				<td class="sheet-skillname">Climb (40%)</td>
-				<td><input type="number" name="attr_Climb"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Climb}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Command"  /></td>
-				<td class="sheet-skillname">Command (05)</td>
-				<td><input type="number" name="attr_Command"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{success=[[ceil(@{Command}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
-			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Craft(05):</td>
-			</tr>	
-		</table>
-		<fieldset class='repeating_craftskills'>
-			<table style="width: 100%">	
-				<td><input type="checkbox" name="attr_craftSuccess"  /></td>
-				<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
-				<td><input type="number" name="attr_craftScore" /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{craftScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
-			</table>	
-		</fieldset>
-		<table style="width: 100%">
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-				<td class="sheet-skillname">Demolition (01%)</td>
-				<td><input type="number" name="attr_Demolition"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Demolition}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>				
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-				<td class="sheet-skillname">Disguise (01)</td>
-				<td><input type="number" name="attr_Disguise"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}    {{success=[[ceil(@{Disguise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-				<td class="sheet-skillname">Dodge (DEX x02%)</td>
-				<td><input type="number" name="attr_Dodge"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Dodge}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
-			</tr>				
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Drive(Varies):</td>
-			</tr>	
-		</table>
-		<fieldset class='repeating_DriveSkills'>
-			<input type="checkbox" name="attr_DriveSucess"  />
-			<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-			<input type="number" name="attr_DriveScore" />
-			<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{DriveScore}*?{Multipler|1})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{Drive Skill}}}"/>
-		</fieldset>	
-		<table style="width: 100%">	
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-				<td class="sheet-skillname">Etiquette (05)</td>
-				<td><input type="number" name="attr_Etiquette"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Etiquette}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
-				<td class="sheet-skillname">Fast Talk (05%)</td>
-				<td><input type="number" name="attr_FastTalk" /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FastTalk}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
-			</tr>					
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-				<td class="sheet-skillname">Fine Manipulation (05%)</td>
-				<td><input type="number" name="attr_FineManipulation" /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FineManipulation}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-				<td class="sheet-skillname">First Aid (30% or INT x1)</td>
-				<td><input type="number" name="attr_FirstAid"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{FirstAid}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-				<td class="sheet-skillname">Gaming (INT+POW)</td>
-				<td><input type="number" name="attr_Gaming"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Gaming}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
-			</tr>		
+<p>
+    <h3 class="sheet-skills-header">Skills</h3> 
+    <div class='sheet-3colrow'>
+        <div class='sheet-col'>
+				<!-- Col 1 -->                
+				<table style="width: 100%">
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+						<td class="sheet-skillname">Appraise (15%)</td>
+						<td><input type="number" style="width:105%" value="15" name="attr_Appraise"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multiplier|Normal - x1, 1|Easy - x2, 2|Difficult -x1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+@{Mods})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}        {{success=[[ceil(@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+					</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Art(05):</td>
+					</tr>
+				</table>				
+				<fieldset class='repeating_artskills'>
+					<table style="width: 100%;">	
+						<tr>
+						<td><input type="checkbox" name="attr_artSuccess"  /></td>
+						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+						<td><input type="number" style="width:105%" value="5" name="attr_artScore" /></td>
+					   <td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[ceil(@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+					   </tr>
+					</table>
+				</fieldset>	
+				<table style="width: 100%">
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
+						<td class="sheet-skillname">Bargain (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Bargain"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Climb"  /></td>
+						<td class="sheet-skillname">Climb (40%)</td>
+						<td><input type="number" style="width:105%" value="40" name="attr_Climb"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Command"  /></td>
+						<td class="sheet-skillname">Command (05)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Command"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
+					</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Craft(05):</td>
+					</tr>	
+				</table>
+				<fieldset class='repeating_craftskills'>
+					<table style="width: 100%">	
+						<td><input type="checkbox" name="attr_craftSuccess"  /></td>
+						<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
+						<td><input type="number" style="width:105%" value="5" style="width:105%" value="5" name="attr_craftScore" /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+					</table>	
+				</fieldset>
+				<table style="width: 100%">
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+						<td class="sheet-skillname">Demolition (01%)</td>
+						<td><input type="number" style="width:105%" value="1" name="attr_Demolition"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+						<td class="sheet-skillname">Disguise (01)</td>
+						<td><input type="number" style="width:105%" value="1"  name="attr_Disguise"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+						<td class="sheet-skillname">Dodge (DEX x02%)</td>
+						<td><input type="number" style="width:105%"  name="attr_Dodge"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+					</tr>				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Drive(Varies):</td>
+					</tr>	
+				</table>
+				<fieldset class='repeating_DriveSkills'>
+					<table style="width: 100%">	
+					<td><input type="checkbox" name="attr_DriveSucess"  /></td>
+					 <td><input type="text" name="attr_DriveSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_DriveScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Drive}}"/></td>																																																	 				 				 				 					 					 					 					 					 					
+				</fieldset>	
+				<table style="width: 100%">	
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+						<td class="sheet-skillname">Etiquette (05)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Etiquette"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
+						<td class="sheet-skillname">Fast Talk (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_FastTalk" /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
+					</tr>					
+					<tr>
+						<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+						<td class="sheet-skillname">Fine Manipulation (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_FineManipulation" /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+					</tr>
 
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Heavy Machine (01%):</td>
-			</tr>	
-		</table>
-		
-		<fieldset class='repeating_hMachineSkills'>
-			<input type="checkbox" name="attr_hMachineSuccess"  />
-			<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-			<input type="number" name="attr_hMachineScore" />
-			<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{hMachineScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
-		</fieldset>					
-		<table style="width: 100%">		
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Hide"  /></td>
-				<td class="sheet-skillname">Hide (10%)</td>
-				<td><input type="number" name="attr_Hide"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{Hide}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Insight"  /></td>
-				<td class="sheet-skillname">Insight (05%)</td>
-				<td><input type="number" name="attr_Insight"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Insight}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
-			</tr>
-		</table>
-		<!-- End of Col 1 -->	
-	</div> <!-- col 1 close -->     
-	<div class='sheet-col'><!-- col 2 start --> 
-	<!-- Start of Col 2 -->									
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
+                    <td><input type="number" style="width:105%" value="30"  name="attr_FirstAid"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[ceil(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+                    <td class="sheet-skillname">Gaming (INT+POW)</td>
+                    <td><input type="number" style="width:105%" name="attr_Gaming"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+                </tr>		
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Heavy Machine (01%):</td>
+				</tr>	
+				</table>
+				<fieldset class='repeating_hMachineSkills'>
+					<table style="width: 100%">					    
+						 <td><input type="checkbox" name="attr_hMachineSuccess"  /></td>
+						 <td><input type="text" name="attr_hMachineSkills" class="sheet-skillname"/></td>
+						 <td><input type="number" style="width:105%" value="1" name="attr_hMachineScore" /></td>
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+				</fieldset>					
+				<table style="width: 100%">		
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Hide"  /></td>
+						<td class="sheet-skillname">Hide (10%)</td>
+						<td><input type="number" style="width:105%" value="10" name="attr_Hide"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Insight"  /></td>
+						<td class="sheet-skillname">Insight (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Insight"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+					</tr>
+				</table>
+				<!-- End of Col 1 -->	
+		</div> <!-- col 1 close -->     
+        <div class='sheet-col'><!-- col 2 start --> 
+        <!-- Start of Col 2 -->					
 		<table style="width: 100%">				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Jump"  /></td>
 				<td class="sheet-skillname">Jump (25%)</td>
-				<td><input type="number" name="attr_Jump"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Jump}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Jump"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
 			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Knowledge (Varies):</td>
-			</tr>	
+
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Knowledge (Varies):</td>
+				</tr>	
 		</table>
 			<fieldset class='repeating_KnowSkills'>
-				<input type="checkbox" name="attr_KnowSucess"  />
-				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_KnowScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{KnowScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
+				<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
+					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+
 			</fieldset>	
 			<table style="width: 100%">					
 				<tr>
 					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
 					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
-					<td><input type="number" name="attr_ownLang"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{ownLang}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>
+					<td><input type="number"  style="width:105%"  name="attr_ownLang"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
 				</tr>			
 			</table>
 			<fieldset class='repeating_Langskills'>
-				<tr>
-					<input type="checkbox" name="attr_LangSuccess"  />
-					<input type="text" name="attr_LangSkillname" class="sheet-skillname" />
-					<input type="number" name="attr_LangScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{LangScore}*?{Multipler|1}+?{Mods|0})]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
-				</tr>		
+				<table style="width: 100%;">			
+					 <td><input type="checkbox" name="attr_LangSuccess"  /></td>
+					 <td><input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" /></td>
+					 <td><input type="number"  style="width:105%" name="attr_LangScore" /></td></td>
+				 	 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/></td>
 			</fieldset>
+			</table>				
 			<table style="width: 100%">								
-				<tr>
+				 <tr>
 					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
 					<td class="sheet-skillname">Listen (25%)</td>
-					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/5)+1]]}}   {{success=[[ceil(@{Listen}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
-				</tr>			
+					<td><input type="number"  style="width:105%" value="25" name="attr_Listen"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+				 </tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Literacy (Varies):</td>
 				</tr>	
 			</table>
 			<fieldset class='repeating_LitSkills'>
-				<input type="checkbox" name="attr_LitSucess"  />
-				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_LitScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{LitScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>
+					<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_LitSucess"  /></td>
+					 <td><input type="text" name="attr_LitSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_LitScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
 			</fieldset>				
 			<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-					<td class="sheet-skillname">Martial Arts (01%)</td>
-					<td><input type="number" name="attr_MartialArts"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{MartialArts}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-					<td class="sheet-skillname">Medicine (05%)</td>
-					<td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Medicine}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>
-				</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+						<td class="sheet-skillname">Martial Arts (01%)</td>
+						<td><input type="number" style="width:105%" value="1" name="attr_MartialArts"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>																																																							
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+						<td class="sheet-skillname">Medicine (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Medicine"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+					</tr>
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
 					<td class="sheet-skillname">Navigate (10%)</td>
-					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Navigate}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
+					<td><input type="number" style="width:105%" value="10" name="attr_Navigate"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -451,17 +457,18 @@
 				</tr>								
 			</table>
 			<fieldset class='repeating_PerformSkills'>
-				<input type="checkbox" name="attr_Success-Perform"  />
-				<input type="text" name="attr_PerformSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_Perform" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Perform}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/>
+					<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_Success-Perform"  /></td>
+					 <td><input type="text" name="attr_PerformSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="5" name="attr_Perform" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
-			<table style="width: 100%;">
+				<table style="width: 100%;">	
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
 					<td class="sheet-skillname">Persuade (15%)</td>
-					<td><input type="number" name="attr_Persuade"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Persuade}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
+					<td><input type="number" style="width:105%" value="15" name="attr_Persuade"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -469,41 +476,42 @@
 				</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-				<input type="checkbox" name="attr_PilotSucess"  />
-				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PilotScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{PilotScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_PilotSucess"  /></td>
+					 <td><input type="text" name="attr_PilotSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_PilotScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
 				<table style="width: 100%;">				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
+					<td class="sheet-skillname">Projection(DEX x02%)</td>
+					<td><input type="number" style="width:105%" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																														
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+					<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
+					<td><input type="number" style="width:105%" value="0" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																														
+				</tr>								
 					<tr>
-						<td><input type="checkbox" name="attr_Success-Projection"  /></td>
-						<td class="sheet-skillname">Projection(DEX x02%)</td>
-						<td><input type="number" name="attr_Projection"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Projection}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-						<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
-						<td><input type="number" name="attr_Psychotherapy"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
-					</tr>								
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td class="sheet-skillname">Repair (15%)</td>
+					    <td class="sheet-chkfiller"></td>
+					    <td class="sheet-skillname">Repair (15%)</td>
 					</tr>
 				</table>
 				<fieldset class='repeating_repairSkills'>
-					<input type="checkbox" name="attr_repairSuccess"  />
-					<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-					<input type="number" name="attr_repairScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{repairScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/>
+						 <input type="checkbox" name="attr_repairSuccess"  />
+						 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
+						 <input type="number" name="attr_repairScore" />
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
 				</fieldset>				
 				<table style="width: 100%;">				
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Research"  /></td>
 					<td class="sheet-skillname">Research (25%)</td>
-					<td><input type="number" name="attr_Research"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Research}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
+					<td><input type="number" style="width:105%" value="25" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
 				</tr>						
 					<tr>
 						<td class="sheet-chkfiller"></td>
@@ -511,112 +519,116 @@
 					</tr>	
 				</table>
 				<fieldset class='repeating_RideSkills'>
-					<input type="checkbox" name="attr_RideSucess"  />
-					<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_RideScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{RideScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_RideSucess"  /></td>
+							 <td><input type="text" name="attr_RideSkill" class="sheet-skillname"/></td>
+							 <td><input type="number" style="width:105%" value="1" name="attr_RideScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20 }+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}       {{success=[[ceil(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 				</fieldset>				 
 				<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Science (01%)</td>
-					</tr>
+						<tr>
+							<td class="sheet-chkfiller"></td>
+							<td>Science (01%)</td>
+						</tr>	
 				</table>
 				<fieldset class='repeating_ScienceSkills'>
-					<input type="checkbox" name="attr_ScienceSucess"  />
-					<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_ScienceScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ScienceScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
+					<table style="width: 100%">	
+						 <td><input type="checkbox" name="attr_ScienceSucess"  /></td>
+						 <td><input type="text" name="attr_ScienceSkill" class="sheet-skillname"/></td>
+						 <td><input type="number" style="width:105%" value="1" name="attr_ScienceScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
 				</fieldset>	
-			
-		</div><!-- col 2 close --> 
-		<div class="sheet-col">			
+        </div><!-- col 2 close --> 
+        <div class="sheet-col">
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Sense"  /></td>
 				<td class="sheet-skillname">Sense (10%)</td>
-				<td><input type="number" name="attr_Sense"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Sense}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Sense"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
 				<td class="sheet-skillname">Sleight of Hand (05%)</td>
-				<td><input type="number" name="attr_SleightofHandScore"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_SleightofHandScore"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Spot"  /></td>
 				<td class="sheet-skillname">Spot (25%)</td>
-				<td><input type="number" name="attr_Spot"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Spot}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Spot"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
 			</tr>				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Status"  /></td>
 				<td class="sheet-skillname">Status (05%)</td>
-				<td><input type="number" name="attr_Status"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Status}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_Status"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
 				<td class="sheet-skillname">Stealth (10%)</td>
-				<td><input type="number" name="attr_Stealth"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/5)+1]]}}     {{success=[[ceil(@{Stealth}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Stealth"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
 				<td class="sheet-skillname">Strategy (01%)</td>
-				<td><input type="number" name="attr_Strategy"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Strategy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>
+				<td><input type="number" style="width:105%" value="1" style="width:105%" value="1" name="attr_Strategy"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
 			</tr>		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Swim"  /></td>
 				<td class="sheet-skillname">Swim (25%)</td>
-				<td><input type="number" name="attr_Swim"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Swim}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Swim"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
 			</tr>	
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Teach"  /></td>
 				<td class="sheet-skillname">Teach (10%)</td>
-				<td><input type="number" name="attr_Teach"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}*?{Multipler|1}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Teach"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
 			</tr>	
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Technical Skill(Varies):</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Technical Skill(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_TechSkills'>
-				<input type="checkbox" name="attr_TechSucess"  />
-				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_TechScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{TechScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
+					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Throw"  /></td>
 				<td class="sheet-skillname">Throw (25%)</td>
-				<td><input type="number" name="attr_throw"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{throw}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_throw"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
 			</tr>			
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Track "  /></td>
 				<td class="sheet-skillname">Track (10%)</td>
-				<td><input type="number" name="attr_Track"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Track}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Track"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
 			</tr>					
 			</table>		
 			<br />
 			<table style="width: 100%;">					
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td><strong>Other Skills</strong></td>
-				</tr>					
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td><strong>Other Skills</strong></td>
+					</tr>					
 			</table>
 			<fieldset class='repeating_OtherSkills'>
-				<input type="checkbox" name="attr_OtherSucess"  />
-				<input type="text" name="attr_OtherSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_OtherScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{OtherScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/>
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_OtherSucess"  /></td>
+					 <td><input type="text" name="attr_OtherSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_OtherScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/></td>
 			</fieldset>	
 			<br />
 				<table style="width: 100%;">					
@@ -631,12 +643,13 @@
 						<td>Melee (Physical)</td>
 					</tr>	
 				</table>	
-
+				
 				<fieldset class='repeating_meleeSkills'>
-					<input type="checkbox" name="attr_meleeSucess"  />
-					<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_meleeScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{meleeScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_meleeSucess"  /></td>
+							 <td><input type="text" name="attr_meleeSkill" class="sheet-skillname"/></td>
+							 <td><input type="number" style="width:105%" name="attr_meleeScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
 				</fieldset>				
 
 				<table style="width: 100%;">
@@ -646,28 +659,32 @@
 				</tr>	
 				</table>
 				<fieldset class='repeating_rangedSkills'>
-					<input type="checkbox" name="attr_rangedSucess"  />
-					<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_rangedScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{rangedScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_rangedSucess"  /></td>
+							 <td><input type="text" name="attr_rangedSkill" class="sheet-skillname"/></td>
+							 <td><input type="number"  style="width:105%" name="attr_rangedScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 				</fieldset>
 				
 				<table style="width: 100%;">
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Artillery (Manip.)</td>
+                    <td>Artillery (Manip.)</td>
 				</tr>	
 				</table>
 				<fieldset class='repeating_artillerySkills'>
-					<input type="checkbox" name="attr_ArtillerySucess"  />
-					<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-					<input type="number" name="attr_ArtilleryScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/>
-				</fieldset>				
+					<table style="width: 100%">	
+
+							 <td><input type="checkbox" name="attr_ArtillerySucess"  /></td>
+							 <td><input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/></td>
+							 <td><input type="number"  style="width:105%" name="attr_ArtilleryScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>	
 				<br />					
-			<br>
-		</div>
-	</div>
+            <br>
+        </div>
+    </div>
+</p>
 </div>
 <!--End of alabetical skills-->
 <!-- ********************************************************************************************************************* -->
@@ -683,88 +700,84 @@
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Communication</b></td>
-					<td><input type="number" name="attr_Communication" value="0"/></td>
+					<td><input type="number" name="attr_Communication" value="0"  /></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Bargain"/></td>
-					<td class="sheet-skillname">Bargain (5%)</td>
-					<td><input type="number" name="attr_Bargain"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Bargain}}} {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Command"  /></td>
-					<td class="sheet-skillname">Command (5%)</td>
-					<td><input type="number" name="attr_Command"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Command}}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-					<td class="sheet-skillname">Disguise (1%)</td>
-					<td><input type="number" name="attr_Disguise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Disguise}}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-					<td class="sheet-skillname">Etiquette (5%)</td>
-					<td><input type="number" name="attr_Etiquette"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Etiquette}}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
-					<td class="sheet-skillname">Fast Talk (5%)</td>
-					<td><input type="number" name="attr_FastTalk" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FastTalk}}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
-				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
-					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
-					<td><input type="number" name="attr_ownLang"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ownLang}}} {{roll=[[1d100]]}} {{skillname=ownLang}}"/></td>
-				</tr>
-			</table>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Bargain"  /></td>
+                    <td class="sheet-skillname">Bargain (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Bargain"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{fumble=[[ceil(95+((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{1/2success=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{success=[[ceil((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20})+?{Mods|0}]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Command"  /></td>
+                    <td class="sheet-skillname">Command (05)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Command"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Command}}} {{fumble=[[ceil(95+((@{Command}+@{Communication})*?{Multiplier|1}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[(@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+                    <td class="sheet-skillname">Disguise (01)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Disguise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}    {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+                    <td class="sheet-skillname">Etiquette (05)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Etiquette"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-ownLang"  /></td>
+                    <td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
+                    <td><input type="number" style="width:105%" name="attr_ownLang"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
+                </tr>
+		    </table>
+			
 			<fieldset class='repeating_Langskills'>
-				<input type="checkbox" name="attr_LangSuccess"  />
-				<input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" />
-				<input type="number" name="attr_LangScore" /></td>
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LangScore}}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
-			</fieldset>		
-			<table style="width:100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Perform"  /></td>
-					<td class="sheet-skillname">Perform (5%)</td>
-					<td><input type="number" name="attr_Perform"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Perform}}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>
-				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
-					<td class="sheet-skillname">Persuade (15%)</td>
-					<td><input type="number" name="attr_Persuade"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Persuade}}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Status"  /></td>
-					<td class="sheet-skillname">Status (15%)</td>
-					<td><input type="number" name="attr_Status"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Status}}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Teach"  /></td>
-					<td class="sheet-skillname">Teach (10%)</td>
-					<td><input type="number" name="attr_Teach"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Teach}}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
-				</tr>
-			</table>	
-			<fieldset class='repeating_commskills'>
-				<table style="width: 100%;">	
-					<tr>
-						<td><input type="checkbox" name="attr_ComSuccess"  /></td>
-						<td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td>
-						<td><input type="number" name="attr_ComScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ComScore}}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
-					</tr>
-				</table>
+				<table style="width: 100%;">			
+					 <td><input type="checkbox" name="attr_LangSuccess"  /></td>
+					 <td><input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" /></td>
+					 <td><input type="number"  style="width:105%" name="attr_LangScore" /></td></td>
+				 	 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/></td>
 			</fieldset>
-			<!-- Manipulation -->
+			</table>			
+			<table style="width:100%;">	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Perform"  /></td>
+                    <td class="sheet-skillname">Perform (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Perform"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>
+                </tr>				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Persuade"  /></td>
+                    <td class="sheet-skillname">Persuade (15%)</td>
+                    <td><input type="number" style="width:105%" value="15" name="attr_Persuade"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Status"  /></td>
+                    <td class="sheet-skillname">Status (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Status"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Status}}} {{fumble=[[ceil(95+((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Teach"  /></td>
+                    <td class="sheet-skillname">Teach (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Teach"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
+                </tr>				
+		  </table>	
+		<fieldset class='repeating_commskills'>
+			<table style="width: 100%;">	
+			<tr>
+				 <td><input type="checkbox" name="attr_ComSuccess"  /></td>
+				 <td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td> 
+				 <td><input type="number" style="width:105%" name="attr_ComScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ComScore}}} {{fumble=[[ceil(95+((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
+			</tr>		
+			</table>			
+		</fieldset>
 			<table style="width: 100%;">
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -773,89 +786,93 @@
 				</tr>					
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Art(5%):</td>
+					<td>Art(05):</td>
 				</tr>			
 			</table>
-			<fieldset class='repeating_artskills'>
-				<table style="width: 100%;">	
-					<tr>
-						<td><input type="checkbox" name="attr_artSuccess"  /></td>
-						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-						<td><input type="number" name="attr_artScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{artScore}}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-					</tr>
-				</table>
-			</fieldset>
-			<table style="width: 100%;">				
+		<fieldset class='repeating_artskills'>
+			<table style="width: 100%;">	
+				<tr>
+				<td><input type="checkbox" name="attr_artSuccess"  /></td>
+				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_artScore" /></td>
+			   <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+			   </tr>
+			</table>
+		</fieldset>			
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Craft(5%):</td>
+					<td>Craft(05):</td>
 				</tr>	
-			</table>
-			<fieldset class='repeating_craftskills'>
-				<input type="checkbox" name="attr_craftSuccess"  />
-				<input type="text" name="attr_craftSkillname" class="sheet-skillname"/>
-				<input type="number" name="attr_craftScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{craftScore}}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>
-			</fieldset>				
+		</table>
+		<fieldset class='repeating_craftskills'>
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-					<td class="sheet-skillname">Demolition (1%)</td>
-					<td><input type="number" name="attr_Demolition"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Demolition}}} {{roll=[[1d100]]}} {{skillname=Demolition}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-					<td class="sheet-skillname">Fine Manipulation (5%)</td>
-					<td><input type="number" name="attr_FineManipulation" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FineManipulation}}} {{roll=[[1d100]]}} {{skillname=Fine Manipulation}"/></td>
-				</tr>
-			</table>
+
+				 <td><input type="checkbox" name="attr_craftSuccess"  /></td>
+				 <td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="5" name="attr_craftScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+		</fieldset>				
 			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+                    <td class="sheet-skillname">Demolition (01%)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Demolition"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+                    <td class="sheet-skillname">Fine Manipulation (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_FineManipulation" /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+                </tr>
+			</table>
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Heavy Machine (1%):</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_hMachineSkills'>
-				<input type="checkbox" name="attr_hMachineSuccess"  />
-				<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_hMachineScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{hMachineScore}}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">				
+					<td>Heavy Machine (01%):</td>
+				</tr>	
+		</table>
+		<fieldset class='repeating_hMachineSkills'>
+			<table style="width: 100%;">
+				 <td><input type="checkbox" name="attr_hMachineSuccess"  /></td>
+				 <td><input type="text" name="attr_hMachineSkills" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="1" name="attr_hMachineScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+		</fieldset>				
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td class="sheet-skillname">Repair (15%)</td>
 				</tr>	
-			</table>
-			<fieldset class='repeating_repairSkills'>
-				<input type="checkbox" name="attr_repairSuccess"  />
-				<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_repairScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{repairScore}}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>
-			</fieldset>				
+		</table>
+		<fieldset class='repeating_repairSkills'>
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
-					<td class="sheet-skillname">Sleight of Hand (5%)</td>
-					<td><input type="number" name="attr_SleightofHandScore"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{SleightofHandScore}}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
-				</tr>
-			</table>
-			<fieldset class='repeating_manipkills'>	
-				<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_manipSuccess"  /></td>
-					<td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
-					<td><input type="number" name="attr_manipScore" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{manipScore}}} {{roll=[[1d100]]}} {{skillname=@{{manipSkillname}}}"/></td>
-				</tr>		
-				</table>			
-			</fieldset>
-		</div>
-		<!-- Mental -->
+				 <td><input type="checkbox" name="attr_repairSuccess"  /></td>
+				 <td><input type="text" name="attr_repairSkills" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="15" name="attr_repairScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
+		</fieldset>				
+			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
+                    <td class="sheet-skillname">Sleight of Hand (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_SleightofHandScore"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+                </tr>
+            </table>
+		<fieldset class='repeating_manipkills'>
+			<table style="width: 100%;">	
+			<tr>
+				 <td><input type="checkbox" name="attr_manipSuccess"  /></td>
+				 <td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
+				 <td><input type="number" style="width:105%" name="attr_manipScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{manipScore}}} {{fumble=[[ceil(95+((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{manipSkillname}}}"/></td>
+			</tr>		
+			</table>			
+		</fieldset>			
+        </div>
+  		<!-- Mental -->      
 		<div class='sheet-col'>
 			<table style="width: 100%;">
 				<tr>
@@ -863,94 +880,99 @@
 					<td><b class="sheet-cat_header">Mental</b></td>
 					<td><input type="number" name="attr_Mental" value="0"/></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-					<td class="sheet-skillname">Appraise (15%)</td>
-					<td><input type="number" name="attr_Appraise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Appraise}}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-					<td class="sheet-skillname">First Aid (30%)</td>
-					<td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FirstAid}}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-					<td class="sheet-skillname">Gaming (INT+POW)</td>
-					<td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Gaming}}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>
-				</tr>              
-			</table>
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Knowledge (varies):</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_KnowSkills'>
-				<input type="checkbox" name="attr_KnowSucess"  />
-				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_KnowScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{KnowScore}}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Literacy (varies):</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_LitSkills'>
-				<input type="checkbox" name="attr_LitSucess"  />
-				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_LitScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LitScore}}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/>
-			</fieldset>					
-			<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-					<td class="sheet-skillname">Medicine (5%)</td>
-					<td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Medicine}}} {{roll=[[1d100]]}} {{skillname=Medicine}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-					<td class="sheet-skillname">Psychotherapy (varies)</td>
-					<td><input type="number" name="attr_Psychotherapy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Psychotherapy}}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
-				</tr>
-			</table>
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Science (1%)</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_ScienceSkills'>
-				<input type="checkbox" name="attr_ScienceSucess"  />
-				<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_ScienceScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ScienceScore}}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
-			</fieldset>				
-			<table style="width: 100%;">				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
-					<td class="sheet-skillname">Strategy (1%)</td>
-					<td><input type="number" name="attr_Strategy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Strategy}}} {{roll=[[1d100]]}} {{skillname=Strategy}"/></td>
-				</tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+                    <td class="sheet-skillname">Appraise (15%)</td>
+                    <td><input type="number" style="width:105%" value="15" name="attr_Appraise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
+                    <td><input type="number" style="width:105%" value="30" name="attr_FirstAid"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+                    <td class="sheet-skillname">Gaming (INT+POW)</td>
+                    <td><input type="number" style="width:105%" name="attr_Gaming"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Gaming}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+                    <td class="sheet-skillname">Psychotherapy (00 or 01)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|1Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																																																		
+                </tr>                
 			</table>	
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Technical Skill (varies):</td>
-				</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Knowledge (Varies):</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_knowSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
+					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+			</fieldset>				
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Literacy (Varies):</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_LitSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_LitSucess"  /></td>
+					 <td><input type="text" name="attr_LitSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_LitScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
+			</fieldset>				
+			<table style="width: 100%;">	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+                    <td class="sheet-skillname">Medicine (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Medicine"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+                </tr>
+			</table>
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Science (01%)</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_ScienceSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_ScienceSucess"  /></td>
+					 <td><input type="text" name="attr_ScienceSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_ScienceScore" /></td>
+    					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
+			</fieldset>				
+			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Strategy"  /></td>
+                    <td class="sheet-skillname">Strategy (01%)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Strategy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{success=[[(@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
+                </tr>
+			</table>	
+			
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Technical Skill(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_TechSkills'>
-				<input type="checkbox" name="attr_TechSucess"  />
-				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_TechScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{TechScore}}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
+					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>
 			<!-- Perception -->
 			<table style="width: 100%;">								
@@ -959,215 +981,216 @@
 					<td class="sheet-skillname"><b class="sheet-cat_header">Perception</b></td>
 					<td><input type="number" name="attr_Perception" value="0" /></td>
 				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Insight"  /></td>
-					<td class="sheet-skillname">Insight (5%)</td>
-					<td><input type="number" name="attr_Insight"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Insight}}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
-					<td class="sheet-skillname">Listen (25%)</td>
-					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Listen}}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
-					<td class="sheet-skillname">Navigate (10%)</td>
-					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Navigate}}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Research"  /></td>
-					<td class="sheet-skillname">Research (25%)</td>
-					<td><input type="number" name="attr_Research"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Research}}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>
-				</tr>                
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Sense"  /></td>
-					<td class="sheet-skillname">Sense (10%)</td>
-					<td><input type="number" name="attr_Sense"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Sense}}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Spot"  /></td>
-					<td class="sheet-skillname">Spot (25%)</td>
-					<td><input type="number" name="attr_Spot"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Spot}}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
-				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Track "  /></td>
-					<td class="sheet-skillname">Track (10%)</td>
-					<td><input type="number" name="attr_Track"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Track}}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
-				</tr>
-			</table>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Insight"  /></td>
+                    <td class="sheet-skillname">Insight (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Insight"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Listen"  /></td>
+                    <td class="sheet-skillname">Listen (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Listen"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Navigate"  /></td>
+                    <td class="sheet-skillname">Navigate (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Navigate"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Research"  /></td>
+                    <td class="sheet-skillname">Research (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Research}}} {{fumble=[[ceil(95+((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																																																																																
+                </tr>                
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Sense"  /></td>
+                    <td class="sheet-skillname">Sense (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Sense"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Spot"  /></td>
+                    <td class="sheet-skillname">Spot (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Spot"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
+                </tr>				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Track "  /></td>
+                    <td class="sheet-skillname">Track (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Track"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Track}}} {{fumble=[[ceil(95+((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
+                </tr>					
+            </table>
 			<fieldset class='repeating_PercepSkills'>
-				<input type="checkbox" name="attr_PercepSucess"  />
-				<input type="text" name="attr_PercepSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PercepScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_PercepSucess"  /></td>
+					 <td><input type="text" name="attr_PercepSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PercepScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
-		</div>
-		<div class="sheet-col">
-			<!-- Physical -->
+        </div>
+        <div class="sheet-col">
+            <!-- Physical -->
 			<table style="width: 100%;">
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Physical</b></td>
 					<td><input type="number" name="attr_Physical" value="0" /></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Climb"  /></td>
-					<td class="sheet-skillname">Climb (40%)</td>
-					<td><input type="number" name="attr_Climb"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Climb}}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-					<td class="sheet-skillname">Dodge (DEX x2%)</td>
-					<td><input type="number" name="attr_Dodge"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Dodge}}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
-				</tr>
-			</table>		
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Climb"  /></td>
+                    <td class="sheet-skillname">Climb (40%)</td>
+                    <td><input type="number" style="width:105%" value="40" name="attr_Climb"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}       {{success=[[(@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+                    <td class="sheet-skillname">Dodge (DEX x02%)</td>
+                    <td><input type="number" style="width:105%" name="attr_Dodge"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}        {{success=[[(@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+                </tr>
+		</table>		
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Drive (varies)</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Drive(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_DriveSkills'>
-				<input type="checkbox" name="attr_DriveSucess"  />
-				<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_DriveScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{DriveScore}}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/>
-			</fieldset>				
-
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Hide"  /></td>
-					<td class="sheet-skillname">Hide (10%)</td>
-					<td><input type="number" name="attr_Hide"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Hide}}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Jump"  /></td>
-					<td class="sheet-skillname">Jump (25%)</td>
-					<td><input type="number" name="attr_Jump"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Jump}}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
-				</tr>
-			</table>		
+					 <td><input type="checkbox" name="attr_DriveSucess"  /></td>
+					 <td><input type="text" name="attr_DriveSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_DriveScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}        {{success=[[(@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 
+			</fieldset>				
+		<table style="width: 100%;">
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Hide"  /></td>
+                    <td class="sheet-skillname">Hide (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Hide"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Jump"  /></td>
+                    <td class="sheet-skillname">Jump (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Jump"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
+                </tr>
+		</table>		
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Pilot (varies)</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Pilot(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-				<input type="checkbox" name="attr_PilotSucess"  />
-				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PilotScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PilotScore}}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/>
-			</fieldset>				
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
-					<td class="sheet-skillname">Projection (DEX x2%)</td>
-					<td><input type="number" name="attr_Projection"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Projection}}} {{roll=[[1d100]]}} {{skillname=Projection}}"/>
-				</tr>
-			</table>		
-
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Ride (varies)</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_RideSkills'>
-				<input type="checkbox" name="attr_RideSucess"  />
-				<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_RideScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{RideScore}}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/>
+					 <td><input type="checkbox" name="attr_PilotSucess"  /></td>
+					 <td><input type="text" name="attr_PilotSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PilotScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>				
-
-			<table style="width: 100%;">		
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
-					<td class="sheet-skillname">Stealth (10%)</td>
-					<td><input type="number" name="attr_Stealth"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Stealth}}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Swim"  /></td>
-					<td class="sheet-skillname">Swim (25%)</td>
-					<td><input type="number" name="attr_Swim"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Swim}}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
-				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Throw"  /></td>
-					<td class="sheet-skillname">Throw (25%)</td>
-					<td><input type="number" name="attr_throw"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{throw}}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
-				</tr>
-			</table>
-			<fieldset class='repeating_PhysicalSkills'>
-				<input type="checkbox" name="attr_PhysicalSucess"  />
-				<input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PhysicalScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PhysicalScore}}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>
-			</fieldset>	
-			<!-- Combat -->
+		<table style="width: 100%;">
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Projection"  /></td>
+                    <td class="sheet-skillname">Projection (DEX x02%)</td>
+                    <td><input type="number" style="width:105%" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																																																																																																																																							
+                </tr>			
+		</table>		
+		<table style="width: 100%;">				
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Ride(Varies):</td>
+			</tr>	
+		</table>
+		<fieldset class='repeating_RideSkills'>
+			<table style="width: 100%;">				
+					 <td><input type="checkbox" name="attr_RideSucess"  /></td>
+					 <td><input type="text" name="attr_RideSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_RideScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+		</fieldset>				
+		<table style="width: 100%;">		
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Stealth"  /></td>
+                    <td class="sheet-skillname">Stealth (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Stealth"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[(@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Swim"  /></td>
+                    <td class="sheet-skillname">Swim (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Swim"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
+                </tr>	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Throw"  /></td>
+                    <td class="sheet-skillname">Throw (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_throw"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{throw}}} {{fumble=[[ceil(95+((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
+                </tr>	
+		</table>
+		<fieldset class='repeating_PhysicalSkills'>
+			<table style="width: 100%;">	
+					 <td><input type="checkbox" name="attr_PhysicalSucess"  /></td>
+					 <td><input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PhysicalScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PhysicalScore}}} {{fumble=[[ceil(95+((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+		</fieldset>	
+        <!-- Combat -->
 			<table style="width: 100%;">					
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Combat</b></td>
 					<td><input type="number" name="attr_Combat" value="0"/></td>
 				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-					<td class="sheet-skillname">Martial Arts (1%)</td>
-					<td><input type="number" name="attr_MartialArts"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{MartialArts}}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
-				</tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+                    <td class="sheet-skillname">Martial Arts (1%)</td>
+                    <td><input type="number" name="attr_MartialArts"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=MartialArts}}"/></td>																																																																																																																																							
+                </tr>				
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Melee</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_meleeSkills'>
-				<input type="checkbox" name="attr_meleeSucess"  />
-				<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_meleeScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{meleeScore}}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">					
+				</tr>	
+		        </table>	
+				<fieldset class='repeating_meleeSkills'>
+							 <input type="checkbox" name="attr_meleeSucess"  />
+							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_meleeScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+				</fieldset>				
+	        	<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Ranged</td>
-				</tr>
-			</table>			
-			<fieldset class='repeating_rangedSkills'>
-				<input type="checkbox" name="attr_rangedSucess"  />
-				<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_rangedScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{rangedScore}}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"
-				/></td>
-			</fieldset>
-			<table style="width: 100%;">					
+				</tr	>	
+		        </table>			
+				<fieldset class='repeating_rangedSkills'>
+							 <input type="checkbox" name="attr_rangedSucess"  />
+							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_rangedScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>
+		<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td> 
 					<td>Artillery</td>
-				</tr>
-			</table>	
-			<fieldset class='repeating_artillerySkills'>
-				<input type="checkbox" name="attr_ArtillerySucess"  />
-				<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-				<input type="number" name="attr_ArtilleryScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ArtilleryScore}}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>
-			</fieldset>
-		</div>
-	</div>
+				</tr>	
+		</table>	
+				<fieldset class='repeating_artillerySkills'>
+							 <input type="checkbox" name="attr_ArtillerySucess"  />
+							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_ArtilleryScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>					
+       </div>
+    </div>
 </p>
 </div>
 <!--End of Skills by category-->
@@ -1208,27 +1231,27 @@
 					</td>
 					<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_length">
-							<option value="">S</option>
-							<option value="">M</option>
-							<option value="">M/L</option>
-							<option value="">L</option>								
-							<option value="">ALL</option>								
+								<option value=""selected>S</option>
+								<option value="">M</option>
+								<option value="">M/L</option>
+								<option value="">L</option>								
+								<option value="">ALL</option>									
 						</select>
 					</td>
 					
-					<td ><input style="width:50px" type="number" name="attr_Brawl" /></td>
+						<td ><input style="width:50px" value="25" type="number" name="attr_Brawl" /></td>
 					<td >
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_spcl">
-							<option value="Bl">Bl</option>
-							<option value="Im">Im</option>
-							<option value="Cr">Cr</option>
-							<option value="En">En</option>								
+								<option value="Bl">Bl</option>
+								<option value="Im">Im</option>
+								<option value="Cr"selected>Cr</option>
+								<option value="En">En</option>								
 						</select>
 					</td>	
 					<td ><input type="text" name="attr_Brawl-Damage" style="width: 60px" /></td>
 					<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
 					<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
 				</tr>
 				
 				<tr>
@@ -1242,28 +1265,28 @@
 						</td>
 					<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_length">
-							<option value="">S</option>
-							<option value="">M</option>
-							<option value="">M/L</option>
-							<option value="">L</option>								
-							<option value="">ALL</option>								
+								<option value=""selected>S</option>
+								<option value="">M</option>
+								<option value="">M/L</option>
+								<option value="">L</option>								
+								<option value="">ALL</option>								
 						</select>
 					</td>						
 					
 					
-					<td><input  style="width:50px" type="number" name="attr_Grapple" /></td>
+						<td><input  style="width:50px" value="25" type="number" name="attr_Grapple" /></td>
 					<td>
 					<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_spcl">
-							<option value="Bl">Bl</option>
-							<option value="Im">Im</option>
-							<option value="Cr">Cr</option>
-							<option value="En">En</option>								
+								<option value="Bl">Bl</option>
+								<option value="Im">Im</option>
+								<option value="Cr">Cr</option>
+								<option value="En"Selected>En</option>							
 					</select>
 					</td>
 					<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
 					<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
 					<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
 				</tr>
 				
 			</tbody>
@@ -1297,7 +1320,7 @@
 					<td><input style="width:62px" type="text" name="attr_Damagex"  /></td>
 					<td><input style="width:36px; margin-right:3px" type="number" name="attr_Attacks-Round" /></td>
 					<td><input  style="width:40px" type="text" name="attr_HP" /></td>
-					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
+					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
 				</tr>
 			</table>
 		</fieldset>
@@ -1331,7 +1354,7 @@
 						<option value="0.5">Yes</option>
 					</select>
 					</td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
 				</tr>				
 			</tbody>
 		</table>
@@ -1352,7 +1375,7 @@
 						<option value="0.5">Yes</option>
 					</select>						
 					</td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
 				</tr>
 			</table>
 		</fieldset>
@@ -1566,9 +1589,9 @@
 		</button>
 	</div>
 	<div style="display: inline">Hit Pts.
-		<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_max_hp" />
-		<p style="display:inline">/</p>
-		<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_cur_hp" />
+				<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_cur_hp" />
+				<p style="display:inline">/</p>
+				<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_max_hp" />
 	</div> 		
 </div>
 
@@ -1735,40 +1758,41 @@
 			 
 			{{#rollBetween() roll fumble 100}} 
 				<td class="template_value">Fumble</td>
-			{{/rollBetween() roll fumble 100}} 
+		{{/rollBetween() roll fumble 100}} 
+		
+		{{#^rollBetween() roll fumble 100}}
+		
+			{{#rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
+					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
+				{{/^rollLess() roll crit}}
+
+			{{/rollGreater() success 99}}
 			
-			{{#^rollBetween() roll fumble 100}}
-			
-				{{#rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-	
-				{{/rollGreater() success 99}}
-				
-				{{#^rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}
-							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-							{{#^rollBetween() roll special success}}
-								{{#rollLess() roll fumble}}
-									<td class="template_value">Failure</td>
-								{{/rollLess() roll fumble}}
-								{{#^rollLess() roll fumble}}
-									<td class="template_value">fumble</td>
-								{{/^rollLess() roll fumble}}							
-							{{/^rollBetween() roll special success}}											
-						{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-				{{/^rollGreater() success 99}}
-			{{/^rollBetween() roll fumble 100}}
-			
-			
-			{{#rollLess() roll success}}
+						{{#^rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					{{#^rollLess() roll special}}
+						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+						{{#^rollBetween() roll special success}}
+							{{#rollLess() roll fumble}}
+								<td class="template_value">Failure</td>
+							{{/rollLess() roll fumble}}
+							{{#^rollLess() roll fumble}}
+								<td class="template_value">fumble</td>
+							{{/^rollLess() roll fumble}}							
+						{{/^rollBetween() roll special success}}											
+					{{/^rollLess() roll special}}
+				{{/^rollLess() roll crit}}
+			{{/^rollGreater() success 99}}
+		{{/^rollBetween() roll fumble 100}}
+		
+		
+		{{#rollLess() roll success}}
 				<tr>
 					<td class="template_label"><b>Damage:</b></td>
 					<td style="text-align: right"; class="template_value">{{tot}}<td>
@@ -1830,40 +1854,44 @@
 	
 			{{#rollBetween() roll fumble 100}} 
 					<td class="template_value">Fumble</td>
-			{{/rollBetween() roll fumble 100}} 
+		{{/rollBetween() roll fumble 100}} 
+		
+		{{#^rollBetween() roll fumble 100}}
+		
+			{{#rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
+					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
+				{{/^rollLess() roll crit}}
+
+			{{/rollGreater() success 99}}
 			
-			{{#^rollBetween() roll fumble 100}}
+			{{#^rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					{{#^rollLess() roll special}}
+						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+						{{#^rollBetween() roll special success}}
+							{{#rollLess() roll fumble}}
+								<td class="template_value">Failure</td>
+							{{/rollLess() roll fumble}}
+							{{#^rollLess() roll fumble}}
+								<td class="template_value">fumble</td>
+							{{/^rollLess() roll fumble}}							
+						{{/^rollBetween() roll special success}}						
+					
+					{{/^rollLess() roll special}}
+				{{/^rollLess() roll crit}}
 			
-				{{#rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-	
-				{{/rollGreater() success 99}}
-				
-				{{#^rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}
-							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-							{{#^rollBetween() roll special success}}
-								{{#rollLess() roll fumble}}
-									<td class="template_value">Failure</td>
-								{{/rollLess() roll fumble}}
-								{{#^rollLess() roll fumble}}
-									<td class="template_value">fumble</td>
-								{{/^rollLess() roll fumble}}							
-							{{/^rollBetween() roll special success}}						
-						
-						{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-				
-				{{/^rollGreater() success 99}}
-	
-			{{/^rollBetween() roll fumble 100}}
+			
+			
+			{{/^rollGreater() success 99}}
+
+			
+		{{/^rollBetween() roll fumble 100}}
 			</tr>
 		</table>
 	</rolltemplate>

--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -1,52 +1,45 @@
-<p>
-
-    <div class="sheet-row" style="width: 100% ">
-        <img style="display: block ; margin-left: auto ; margin-right: auto" src="./Stormbringer _ Roll20_files/saved_resource(1)">
-        <div class="sheet-cdiv">
-            <input class="sheet-HideConfig" type="checkbox" checked="checked" name="attr_is_config"><span class="sheet-is-config"><span style="font-family: &quot;pictos&quot;">y</span></span>
-            <div class="sheet-config" style="border-style: dotted ; border-color: gray ; padding: 5px ; background-color: white ; background-image: none">
-    			finderski sheet version: 01 August 2015
-				
-				<div class="sheet-row"><h2 class="sheet-sectionHeader">CONFIGURATION</h2></div>
-					<div class='sheet-2colrow'>
-						<div class='sheet-col'>
-							<input type="checkbox" name="attr_showhpbl" checked="checked"> Show "Fatigue Points"<br>
-							<input type="checkbox" name="attr_showmjrwnd" > Show "Major Wound"<br>
-							<input type="checkbox" name="attr_showedufld" checked="checked" >Show EDU<br />
-							<input type="checkbox" name="attr_showhitloc" checked="checked" >Show Hit Locations<br />
-							<input type="checkbox" name="attr_showstrike-rank" checked="checked" >Show Strike Ranks<br />
-							<input type="checkbox"  name="attr_toggle-categories" checked="checked">Skills By Category<br />
-						</div>
-						<div class='sheet-col'>
-							<input type="checkbox" name="attr_toggle-alphabetic" >Alphabetical Skills<br />
-							<input type="checkbox" class="sheet-toggle-magic1" name="attr_toggle-magic1" />Magic / Powers <br />
-						</div>
-					</div>
+<div class="sheet-row">
+	<div class="sheet-cdiv">
+		<input class="sheet-HideConfig" type="checkbox" checked="checked" name="attr_is_config"><span class="sheet-is-config"><span style="font-family: &quot;pictos&quot;">y</span></span>
+		<div class="sheet-config" style="border-style: dotted ; border-color: gray ; padding: 5px ; background-color: white ; background-image: none">
+			<div class="sheet-row"><h2 class="sheet-sectionHeader">CONFIGURATION</h2></div>
+			<div class='sheet-2colrow'>
+				<div class='sheet-col'>
+					<input type="checkbox" name="attr_showhpbl" checked="checked"> Show "Fatigue Points"<br>
+					<input type="checkbox" name="attr_showmjrwnd" > Show "Major Wound"<br>
+					<input type="checkbox" name="attr_showedufld" checked="checked" >Show EDU<br />
+					<input type="checkbox" name="attr_showhitloc" checked="checked" >Show Hit Locations<br />
+					<input type="checkbox" name="attr_showstrike-rank" checked="checked" >Show Strike Ranks<br />
+					<input type="checkbox"  name="attr_toggle-categories" checked="checked">Skills By Category<br />
+				</div>
+				<div class='sheet-col'>
+					<input type="checkbox" name="attr_toggle-alphabetic" >Alphabetical Skills<br />
+					<input type="checkbox" class="sheet-toggle-magic1" name="attr_toggle-magic1" />Magic / Powers <br />
+				</div>
 			</div>
 		</div>
 	</div>
-
-    <div class='sheet-2colrow'>
+	<div class='sheet-2colrow'>
 		<div style="width:100%">
-	     <img src="https://i.imgur.com/HhFlHyf.png" />
-		 </div>
-        <div class='sheet-col'>
-
-            <table style="width: 100%;">
-                <tr>
-                    <td>Name</td>
-                    <td><input type="text" name="attr_Name" style="width: 300px" /></td>
-                </tr>
-    			<tr>
-                    <td>Race</td>
+			<img src="https://i.imgur.com/HhFlHyf.png" />
+		</div>
+		<!-- General character descriptions -->
+		<div class='sheet-col'>
+			<table style="width: 100%;">
+				<tr>
+					<td>Name</td>
+					<td><input type="text" name="attr_Name" style="width: 300px" /></td>
+				</tr>
+				<tr>
+					<td>Race</td>
 					<td>
 						<input type="text" name="attr_Race" style="width: 219px" /> 
 						Sex 
 						<input type="text" name="attr_Sex" style="width: 50px" />
 					</td>				
 				</tr>
-    			<tr>
-                    <td>Handedness</td>
+				<tr>
+					<td>Handedness</td>
 					<td>
 						<input type="text" name="attr_Handedness" style="width: 106px" />
 						Height
@@ -54,135 +47,55 @@
 						Weight
 						<input type="text" name="attr_Weight" style="width: 50px" /> 						
 					</td>				
-				</tr>				
-				
-				
-				<tr>
-						<td>Description</td>
-						<td><textarea rows="3" name="attr_Description" style="margin-bottom: 0px;height: 4em; width: 289px;" ></textarea></td>
 				</tr>
 				<tr>
-						<td>Distinctive </br />Features</td>
-						<td><textarea rows="3" name="attr_Features" style="margin-bottom: 0px;height: 4em; width: 289px;" ></textarea></td>
+					<td>Description</td>
+					<td><textarea rows="3" name="attr_Description" style="margin-bottom: 0px;height: 4em; width: 289px;" ></textarea></td>
+				</tr>
+				<tr>
+					<td>Distinctive </br />Features</td>
+					<td><textarea rows="3" name="attr_Features" style="margin-bottom: 0px;height: 4em; width: 289px;" ></textarea></td>
 				</tr>				
-                <tr>
-                    <td>Gods/Religion</td>
-                    <td><input type="text" name="attr_Religion" style="width: 221px" />
+				<tr>
+					<td>Gods/Religion</td>
+					<td><input type="text" name="attr_Religion" style="width: 221px" />
 						Age<input type="text" name="attr_Age" style="width: 50px" />
 					</td>
-					
-                </tr>
-                <tr>
-                    <td>Profession</td>
-                    <td>
+				</tr>
+				<tr>
+					<td>Profession</td>
+					<td>
 						<input type="text" name="attr_Profession" style="width: 200px" /> 
 						Wealth 
 						<input type="text" name="attr_Wealth" style="width: 50px" />
 					</td>
-                </tr>				
-            </table>
-<!--			
-			*/Mental Disorders <textarea name="attr_Disorders" style="height: 80px"></textarea>*/
-			<h3 style="color: #FFF; background-color: #000; text-align: center;">
-                Resistance Roll
-                <button type="roll" value="/roll 1d100<@{Chance-of-Success}"></button>
-            </h3>
-            <table style="width: 100%">
-                <tr>
-                    <td></td>
-                    <td style="width: 75%">
-                        <table style="width: 100%;">
-                            <tr>
-                                <td></td>
-                                <td><input type="number" name="attr_Aminus2" value="@{Active}-2" disabled="true" /></td>
-                                <td><input type="number" name="attr_Aminus1" value="@{Active}-1" disabled="true" /></td>
-                                <td><input type="number" name="attr_Active" value="10" /></td>
-                                <td><input type="number" name="attr_Aplus1" value="@{Active}+1" disabled="true" /></td>
-                                <td><input type="number" name="attr_Aplus2" value="@{Active}+2" disabled="true" /></td>
-                            </tr>
-                            <tr>
-                                <td><input type="number" name="attr_Pminus2" value="@{Passive}-2" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm2m2" value="@{Chance-of-Success}" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm1m2" value="@{Chance-of-Success}+5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoS0m2" value="@{Chance-of-Success}+10" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp1m2" value="@{Chance-of-Success}+15" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp2m2" value="@{Chance-of-Success}+20" disabled="true" /></td>
-                            </tr>
-                            <tr>
-                                <td><input type="number" name="attr_Pminus1" value="@{Passive}-1" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm2m1" value="@{Chance-of-Success}-5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm1m1" value="@{Chance-of-Success}" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoS0m1" value="@{Chance-of-Success}+5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp1m1" value="@{Chance-of-Success}+10" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp2m1" value="@{Chance-of-Success}+15" disabled="true" /></td>
-                            </tr>
-                            <tr>
-                                <td><input type="number" name="attr_Passive" value="10" /></td>
-                                <td><input type="number" name="attr_CoSm20" value="@{Chance-of-Success}-10" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm10" value="@{Chance-of-Success}-5" disabled="true" /></td>
-                                <td><input type="number" name="attr_Chance-of-Success" value="[[(5*(@{Active}-@{Passive}))+50]]" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp10" value="@{Chance-of-Success}+5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp20" value="@{Chance-of-Success}+10" disabled="true" /></td>
-                            </tr>
-                            <tr>
-                                <td><input type="number" name="attr_Pplus1" value="@{Passive}+1" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm2p1" value="@{Chance-of-Success}-15" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm1p1" value="@{Chance-of-Success}-10" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoS0p1" value="@{Chance-of-Success}-5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp1p1" value="@{Chance-of-Success}" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp2p1" value="@{Chance-of-Success}+5" disabled="true" /></td>
-                            </tr>
-                            <tr>
-                                <td><input type="number" name="attr_Pplus2" value="@{Passive}+2" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm2p2" value="@{Chance-of-Success}-20" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSm1p2" value="@{Chance-of-Success}-15" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoS0p2" value="@{Chance-of-Success}-10" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp1p2" value="@{Chance-of-Success}-5" disabled="true" /></td>
-                                <td><input type="number" name="attr_CoSp2p2" value="@{Chance-of-Success}" disabled="true" /></td>
-                            </tr>
-                        </table>
-                    </td>
-                    <td></td>
-                </tr>
-            </table>-->			
-        </div>
-        <div class='sheet-col'>
-
-            <h3 style="margin-bottom: 0px; text-align: center; color: #FFF; background-color: #000;">Characteristics & Rolls</h3>
-
-            <table class="sheet-characteristics">
-                <tbody>
-           
-                    <!--<tr>
-                        <td>SAN</td>
-                        <td><input type="number" name="attr_SAN" value="5*@{POW}" disabled="true" /></td>
-                    </tr>-->
+				</tr>				
+			</table>
+		</div>
+		<!-- Characteristics & Rolls -->
+		<div class='sheet-col'>
+			<h3 style="margin-bottom: 0px; text-align: center; color: #FFF; background-color: #000;">Characteristics & Rolls</h3>
+			<table class="sheet-characteristics">
+				<tbody>
 					<tr>
 					</tr>					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>STR</p></td>
-                        <td><input type="number" name="attr_STR" /></td>	
-                        <!-- <td><input type="number" name="attr_Effort" value="[[5*@{STR}]]" disabled="true" /></td>-->
-						<!--<td>Effort</td>-->
-					   	<td >
+						<td><p>STR</p></td>
+						<td><input type="number" name="attr_STR" /></td>	
+							<td >
 							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|5}]] Effort Roll" >Effort</button>	
 						</td>
 						<td><p>Dmg. Bonus</p></td>
 						<td colspan="3">	
 							<input type="text" name="attr_Damage_Bonus" style="margin-bottom: 0px;height: 24px ; width: 75px">
-
-					</tr>
-					
-					<tr>
-
 					</tr>
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>CON</p></td>
-                        <td><input type="number" name="attr_CON" /></td>
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|5}]] Stamina Roll" >Stamina</button></td>
+						<td><p>CON</p></td>
+						<td><input type="number" name="attr_CON" /></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|5}]] Stamina Roll" >Stamina</button></td>
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank"><p >Siz SR</p></div>
@@ -197,11 +110,10 @@
 						<td></td>						
 					</tr>
 					
-					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>SIZ</p></td>
-                        <td><input type="number" name="attr_SIZ" /></td>									
+						<td><p>SIZ</p></td>
+						<td><input type="number" name="attr_SIZ" /></td>									
 						<td ></td>	
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
@@ -221,10 +133,9 @@
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>INT</p></td>
-                        <td><input type="number" name="attr_INT" /></td>
-                        <!--<td><input type="number" name="attr_Idea" value="[[5*@{INT}]]" disabled="true" /></td>-->
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|5}]] Idea Roll" >Idea</button></td>
+						<td><p>INT</p></td>
+						<td><input type="number" name="attr_INT" /></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|5}]] Idea Roll" >Idea</button></td>
 						<td><p>MOV</p></td><td><input type="number" name="attr_mov" /></td>		
 						<td></td>
 						<td></td>						
@@ -232,10 +143,9 @@
 					
 					<tr>
 						<td ><input type="checkbox" name="att_power-check" /><td>
-					    <td><p>POW</p></td>
-                        <td><input class="sheet-plain" type="number" name="attr_POW" /></td>
-                        <!--<td><input type="number" name="attr_Luck" value="[[5*@{POW}]]" disabled="true" /></td>-->
-                        <td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|5}]] Luck Roll" >&nbsp;Luck</button></td>
+						<td><p>POW</p></td>
+						<td><input class="sheet-plain" type="number" name="attr_POW" /></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|5}]] Luck Roll" >&nbsp;Luck</button></td>
 						<td><p>Hit Pts.</p></td>
 						<td><input type="number" name="attr_cur_hp" />
 						<td>/</td>
@@ -244,9 +154,9 @@
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>DEX</p></td>
-                        <td><input type="number" name="attr_DEX" /></td>	
-                        <td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|5}]] Agility Roll" >Agility</button></td>
+						<td><p>DEX</p></td>
+						<td><input type="number" name="attr_DEX" /></td>	
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|5}]] Agility Roll" >Agility</button></td>
 						<td><p>Power Pts.</p></td>
 						<td><input type="number" name="attr_cur_mp" />
 						<td>/</td>
@@ -255,9 +165,9 @@
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td><p>APP</p></td>
-                        <td><input type="number" name="attr_APP" /></td>
-                        <td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Mulitplier|5}]] Charisma Roll" >Charisma</button></td>
+						<td><p>APP</p></td>
+						<td><input type="number" name="attr_APP" /></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Mulitplier|5}]] Charisma Roll" >Charisma</button></td>
 							
 							<div class="sheet-hpbl">
 								<td>
@@ -276,21 +186,19 @@
 									<div class="sheet-hpbl"><input type="number" name="attr_max_ftgp" /></div>
 								</td>
 							</div>
-						
-
 					</tr>					
 					
 					<tr>
 						<td class=".sheet-chkfiller"><td>
-                        <td>
+						<td>
 						<input type="checkbox" class="sheet-showedufld" name="attr_showedufld" checked="checked" style="display: none">
 						<div class="sheet-edufld"><p>EDU</p><div>
 						</td>
-                        <td>
+						<td>
 							<input type="checkbox" class="sheet-showedufld" name="attr_showedufld" checked="checked" style="display: none">
 							<div class="sheet-edufld"><input type="number" name="attr_EDU" /></div>
 						</td>	
-                        <td >
+						<td >
 							<input type="checkbox" class="sheet-showedufld" name="attr_showedufld" checked="checked" style="display: none">
 							<div class="sheet-edufld">
 							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{EDU}*?{Multiplier|5}]] Know Roll">Know</button>
@@ -298,546 +206,244 @@
 						</td>
 						
 						<td>
-							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<@{cur_san}"><p>SAN</p></button>
+							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<@{cur_san}">SAN</button>
 						</td>
-						<!--<td><p>SAN Pts.</p></td>-->
 						<td><input type="number" name="attr_cur_san" /></td>
 						<td>/</td>
-						<td><input type="number" name="attr_max_san" /></td>
-										
-										
+						<td><input type="number" name="attr_max_san" /></td>           
 					</tr>					
 					
-                </tbody>
-            </table>
-
-            <table style="width: 100%;">
-                <tr>
-                    
- 
-					</td>
-                </tr>
-            </table>
-        </div>
-    </div>
-</p>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
 <hr/>
-<!--
-<p>
-    <div class='sheet-2colrow'>
-        <div class='sheet-col'>
-            <h3 style="text-align: center; color: #FFF; background-color: #000;">
-                Sanity Points
-                <button type="roll" value="/roll 1d100<@{Sanity}"></button>
-            </h3>
-            <table style="width: 100%; font-size: 10px;">
-                <tr>
-                    <td><strong>Insanity</strong></td>
-                </tr>
-            </table>
-            <table style="width: 100%; text-align: right; font-size: 10px;">
-                <tr>
-                    <td></td>
-                    <td></td>
-                    <td><strong>0</strong><br><input type="radio" value="0" name="attr_Sanity" /></td>
-                    <td>1<br><input type="radio" value="1" name="attr_Sanity" /></td>
-                    <td>2<br><input type="radio" value="2" name="attr_Sanity" /></td>
-                    <td>3<br><input type="radio" value="3" name="attr_Sanity" /></td>
-                    <td>4<br><input type="radio" value="4" name="attr_Sanity" /></td>
-                    <td>5<br><input type="radio" value="5" name="attr_Sanity" /></td>
-                    <td>6<br><input type="radio" value="6" name="attr_Sanity" /></td>
-                    <td>7<br><input type="radio" value="7" name="attr_Sanity" /></td>
-                    <td>8<br><input type="radio" value="8" name="attr_Sanity" /></td>
-                    <td>9<br><input type="radio" value="9" name="attr_Sanity" /></td>
-                    <td>10<br><input type="radio" value="10" name="attr_Sanity" /></td>
-                    <td>11<br><input type="radio" value="11" name="attr_Sanity" /></td>
-                    <td>12<br><input type="radio" value="12" name="attr_Sanity" /></td>
-                    <td>13<br><input type="radio" value="13" name="attr_Sanity" /></td>
-                    <td>14<br><input type="radio" value="14" name="attr_Sanity" /></td>
-                </tr>
-                <tr>
-                    <td>15<br><input type="radio" value="15" name="attr_Sanity" /></td>
-                    <td>16<br><input type="radio" value="16" name="attr_Sanity" /></td>
-                    <td>17<br><input type="radio" value="17" name="attr_Sanity" /></td>
-                    <td>18<br><input type="radio" value="18" name="attr_Sanity" /></td>
-                    <td>19<br><input type="radio" value="19" name="attr_Sanity" /></td>
-                    <td>20<br><input type="radio" value="20" name="attr_Sanity" /></td>
-                    <td>21<br><input type="radio" value="21" name="attr_Sanity" /></td>
-                    <td>22<br><input type="radio" value="22" name="attr_Sanity" /></td>
-                    <td>23<br><input type="radio" value="23" name="attr_Sanity" /></td>
-                    <td>24<br><input type="radio" value="24" name="attr_Sanity" /></td>
-                    <td>25<br><input type="radio" value="25" name="attr_Sanity" /></td>
-                    <td>26<br><input type="radio" value="26" name="attr_Sanity" /></td>
-                    <td>27<br><input type="radio" value="27" name="attr_Sanity" /></td>
-                    <td>28<br><input type="radio" value="28" name="attr_Sanity" /></td>
-                    <td>29<br><input type="radio" value="29" name="attr_Sanity" /></td>
-                    <td>30<br><input type="radio" value="30" name="attr_Sanity" /></td>
-                    <td>31<br><input type="radio" value="31" name="attr_Sanity" /></td>
-                </tr>
-                <tr>
-                    <td>32<br><input type="radio" value="32" name="attr_Sanity" /></td>
-                    <td>33<br><input type="radio" value="33" name="attr_Sanity" /></td>
-                    <td>34<br><input type="radio" value="34" name="attr_Sanity" /></td>
-                    <td>35<br><input type="radio" value="35" name="attr_Sanity" /></td>
-                    <td>36<br><input type="radio" value="36" name="attr_Sanity" /></td>
-                    <td>37<br><input type="radio" value="37" name="attr_Sanity" /></td>
-                    <td>38<br><input type="radio" value="38" name="attr_Sanity" /></td>
-                    <td>39<br><input type="radio" value="39" name="attr_Sanity" /></td>
-                    <td>40<br><input type="radio" value="40" name="attr_Sanity" /></td>
-                    <td>41<br><input type="radio" value="41" name="attr_Sanity" /></td>
-                    <td>42<br><input type="radio" value="42" name="attr_Sanity" /></td>
-                    <td>43<br><input type="radio" value="43" name="attr_Sanity" /></td>
-                    <td>44<br><input type="radio" value="44" name="attr_Sanity" /></td>
-                    <td>45<br><input type="radio" value="45" name="attr_Sanity" checked="true" /></td>
-                    <td>46<br><input type="radio" value="46" name="attr_Sanity" /></td>
-                    <td>47<br><input type="radio" value="47" name="attr_Sanity" /></td>
-                    <td>48<br><input type="radio" value="48" name="attr_Sanity" /></td>
-                </tr>
-                <tr>
-                    <td>49<br><input type="radio" value="49" name="attr_Sanity" /></td>
-                    <td>50<br><input type="radio" value="50" name="attr_Sanity" /></td>
-                    <td>51<br><input type="radio" value="51" name="attr_Sanity" /></td>
-                    <td>52<br><input type="radio" value="52" name="attr_Sanity" /></td>
-                    <td>53<br><input type="radio" value="53" name="attr_Sanity" /></td>
-                    <td>54<br><input type="radio" value="54" name="attr_Sanity" /></td>
-                    <td>55<br><input type="radio" value="55" name="attr_Sanity" /></td>
-                    <td>56<br><input type="radio" value="56" name="attr_Sanity" /></td>
-                    <td>57<br><input type="radio" value="57" name="attr_Sanity" /></td>
-                    <td>58<br><input type="radio" value="58" name="attr_Sanity" /></td>
-                    <td>59<br><input type="radio" value="59" name="attr_Sanity" /></td>
-                    <td>60<br><input type="radio" value="60" name="attr_Sanity" /></td>
-                    <td>61<br><input type="radio" value="61" name="attr_Sanity" /></td>
-                    <td>62<br><input type="radio" value="62" name="attr_Sanity" /></td>
-                    <td>63<br><input type="radio" value="63" name="attr_Sanity" /></td>
-                    <td>64<br><input type="radio" value="64" name="attr_Sanity" /></td>
-                    <td>65<br><input type="radio" value="65" name="attr_Sanity" /></td>
-                </tr>
-                <tr>
-                    <td>66<br><input type="radio" value="66" name="attr_Sanity" /></td>
-                    <td>67<br><input type="radio" value="67" name="attr_Sanity" /></td>
-                    <td>68<br><input type="radio" value="68" name="attr_Sanity" /></td>
-                    <td>69<br><input type="radio" value="69" name="attr_Sanity" /></td>
-                    <td>70<br><input type="radio" value="70" name="attr_Sanity" /></td>
-                    <td>71<br><input type="radio" value="71" name="attr_Sanity" /></td>
-                    <td>72<br><input type="radio" value="72" name="attr_Sanity" /></td>
-                    <td>73<br><input type="radio" value="73" name="attr_Sanity" /></td>
-                    <td>74<br><input type="radio" value="74" name="attr_Sanity" /></td>
-                    <td>75<br><input type="radio" value="75" name="attr_Sanity" /></td>
-                    <td>76<br><input type="radio" value="76" name="attr_Sanity" /></td>
-                    <td>77<br><input type="radio" value="77" name="attr_Sanity" /></td>
-                    <td>78<br><input type="radio" value="78" name="attr_Sanity" /></td>
-                    <td>79<br><input type="radio" value="79" name="attr_Sanity" /></td>
-                    <td>80<br><input type="radio" value="80" name="attr_Sanity" /></td>
-                    <td>81<br><input type="radio" value="81" name="attr_Sanity" /></td>
-                    <td>82<br><input type="radio" value="82" name="attr_Sanity" /></td>
-                </tr>
-                <tr>
-                    <td>83<br><input type="radio" value="83" name="attr_Sanity" /></td>
-                    <td>84<br><input type="radio" value="84" name="attr_Sanity" /></td>
-                    <td>85<br><input type="radio" value="85" name="attr_Sanity" /></td>
-                    <td>86<br><input type="radio" value="86" name="attr_Sanity" /></td>
-                    <td>87<br><input type="radio" value="87" name="attr_Sanity" /></td>
-                    <td>88<br><input type="radio" value="88" name="attr_Sanity" /></td>
-                    <td>89<br><input type="radio" value="89" name="attr_Sanity" /></td>
-                    <td>90<br><input type="radio" value="90" name="attr_Sanity" /></td>
-                    <td>91<br><input type="radio" value="91" name="attr_Sanity" /></td>
-                    <td>92<br><input type="radio" value="92" name="attr_Sanity" /></td>
-                    <td>93<br><input type="radio" value="93" name="attr_Sanity" /></td>
-                    <td>94<br><input type="radio" value="94" name="attr_Sanity" /></td>
-                    <td>95<br><input type="radio" value="95" name="attr_Sanity" /></td>
-                    <td>96<br><input type="radio" value="96" name="attr_Sanity" /></td>
-                    <td>97<br><input type="radio" value="97" name="attr_Sanity" /></td>
-                    <td>98<br><input type="radio" value="98" name="attr_Sanity" /></td>
-                    <td>99<br><input type="radio" value="99" name="attr_Sanity" /></td>
-                </tr>
-            </table>
-        </div>
-        <div class='sheet-col'>
-            <div class='sheet-2colrow'>
-                <div class='sheet-col'>
-                    <h3 style="text-align: center; color: #FFF; background-color: #000;">Magic Points</h3>
-                    <table style="width: 100%; font-size: 10px;">
-                        <tr>
-                            <td><strong>Unconscious</strong></td>
-                        </tr>
-                    </table>
-                    <table style="width: 100%; text-align: right; font-size: 10px;">
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td><strong>0</strong><br><input type="radio" value="0" name="attr_MP" /></td>
-                            <td>1<br><input type="radio" value="1" name="attr_MP" /></td>
-                            <td>2<br><input type="radio" value="2" name="attr_MP" /></td>
-                        </tr>
-                        <tr>
-                            <td>3<br><input type="radio" value="3" name="attr_MP" /></td>
-                            <td>4<br><input type="radio" value="4" name="attr_MP" /></td>
-                            <td>5<br><input type="radio" value="5" name="attr_MP" /></td>
-                            <td>6<br><input type="radio" value="6" name="attr_MP" /></td>
-                            <td>7<br><input type="radio" value="7" name="attr_MP" /></td>
-                            <td>8<br><input type="radio" value="8" name="attr_MP" /></td>
-                            <td>9<br><input type="radio" value="9" name="attr_MP" checked="true" /></td>
-                        </tr>
-                        <tr>
-                            <td>10<br><input type="radio" value="10" name="attr_MP" /></td>
-                            <td>11<br><input type="radio" value="11" name="attr_MP" /></td>
-                            <td>12<br><input type="radio" value="12" name="attr_MP" /></td>
-                            <td>13<br><input type="radio" value="13" name="attr_MP" /></td>
-                            <td>14<br><input type="radio" value="14" name="attr_MP" /></td>
-                            <td>15<br><input type="radio" value="15" name="attr_MP" /></td>
-                            <td>16<br><input type="radio" value="16" name="attr_MP" /></td>
-                        </tr>
-                        <tr>
-                            <td>17<br><input type="radio" value="17" name="attr_MP" /></td>
-                            <td>18<br><input type="radio" value="18" name="attr_MP" /></td>
-                            <td>19<br><input type="radio" value="19" name="attr_MP" /></td>
-                            <td>20<br><input type="radio" value="20" name="attr_MP" /></td>
-                            <td>21<br><input type="radio" value="21" name="attr_MP" /></td>
-                            <td>22<br><input type="radio" value="22" name="attr_MP" /></td>
-                            <td>23<br><input type="radio" value="23" name="attr_MP" /></td>
-                        </tr>
-                        <tr>
-                            <td>24<br><input type="radio" value="24" name="attr_MP" /></td>
-                            <td>25<br><input type="radio" value="25" name="attr_MP" /></td>
-                            <td>26<br><input type="radio" value="26" name="attr_MP" /></td>
-                            <td>27<br><input type="radio" value="27" name="attr_MP" /></td>
-                            <td>28<br><input type="radio" value="28" name="attr_MP" /></td>
-                            <td>29<br><input type="radio" value="29" name="attr_MP" /></td>
-                            <td>30<br><input type="radio" value="30" name="attr_MP" /></td>
-                        </tr>
-                        <tr>
-                            <td>31<br><input type="radio" value="31" name="attr_MP" /></td>
-                            <td>32<br><input type="radio" value="32" name="attr_MP" /></td>
-                            <td>33<br><input type="radio" value="33" name="attr_MP" /></td>
-                            <td>34<br><input type="radio" value="34" name="attr_MP" /></td>
-                            <td>35<br><input type="radio" value="35" name="attr_MP" /></td>
-                            <td>36<br><input type="radio" value="36" name="attr_MP" /></td>
-                            <td>37<br><input type="radio" value="37" name="attr_MP" /></td>
-                        </tr>
-                    </table>
-                </div>
-                <div class='sheet-col'>
-                    <h3 style="text-align: center; color: #FFF; background-color: #000;">Hit Points</h3>
-                    <table style="width: 100%; font-size: 10px;">
-                        <tr>
-                            <td><strong>Dead</strong></td>
-                            <td style="text-align: right;">Unconscious</td>
-                        </tr>
-                    </table>
-                    <table style="width: 100%; text-align: right; font-size: 10px;">
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td><strong>-2</strong><br><input type="radio" value="-2" name="attr_HP" /></td>
-                            <td><strong>-1</strong><br><input type="radio" value="-1" name="attr_HP" /></td>
-                            <td><strong>0</strong><br><input type="radio" value="0" name="attr_HP" /></td>
-                            <td>+1<br><input type="radio" value="1" name="attr_HP" /></td>
-                            <td>+2<br><input type="radio" value="2" name="attr_HP" /></td>
-                        </tr>
-                        <tr>
-                            <td>3<br><input type="radio" value="3" name="attr_HP" /></td>
-                            <td>4<br><input type="radio" value="4" name="attr_HP" /></td>
-                            <td>5<br><input type="radio" value="5" name="attr_HP" /></td>
-                            <td>6<br><input type="radio" value="6" name="attr_HP" /></td>
-                            <td>7<br><input type="radio" value="7" name="attr_HP" /></td>
-                            <td>8<br><input type="radio" value="8" name="attr_HP" /></td>
-                            <td>9<br><input type="radio" value="9" name="attr_HP" /></td>
-                        </tr>
-                        <tr>
-                            <td>10<br><input type="radio" value="10" name="attr_HP" /></td>
-                            <td>11<br><input type="radio" value="11" name="attr_HP" /></td>
-                            <td>12<br><input type="radio" value="12" name="attr_HP" /></td>
-                            <td>13<br><input type="radio" value="13" name="attr_HP" /></td>
-                            <td>14<br><input type="radio" value="14" name="attr_HP" /></td>
-                            <td>15<br><input type="radio" value="15" name="attr_HP" checked="true" /></td>
-                            <td>16<br><input type="radio" value="16" name="attr_HP" /></td>
-                        </tr>
-                        <tr>
-                            <td>17<br><input type="radio" value="17" name="attr_HP" /></td>
-                            <td>18<br><input type="radio" value="18" name="attr_HP" /></td>
-                            <td>19<br><input type="radio" value="19" name="attr_HP" /></td>
-                            <td>20<br><input type="radio" value="20" name="attr_HP" /></td>
-                            <td>21<br><input type="radio" value="21" name="attr_HP" /></td>
-                            <td>22<br><input type="radio" value="22" name="attr_HP" /></td>
-                            <td>23<br><input type="radio" value="23" name="attr_HP" /></td>
-                        </tr>
-                        <tr>
-                            <td>24<br><input type="radio" value="24" name="attr_HP" /></td>
-                            <td>25<br><input type="radio" value="25" name="attr_HP" /></td>
-                            <td>26<br><input type="radio" value="26" name="attr_HP" /></td>
-                            <td>27<br><input type="radio" value="27" name="attr_HP" /></td>
-                            <td>28<br><input type="radio" value="28" name="attr_HP" /></td>
-                            <td>29<br><input type="radio" value="29" name="attr_HP" /></td>
-                            <td>30<br><input type="radio" value="30" name="attr_HP" /></td>
-                        </tr>
-                        <tr>
-                            <td>31<br><input type="radio" value="31" name="attr_HP" /></td>
-                            <td>32<br><input type="radio" value="32" name="attr_HP" /></td>
-                            <td>33<br><input type="radio" value="33" name="attr_HP" /></td>
-                            <td>34<br><input type="radio" value="34" name="attr_HP" /></td>
-                            <td>35<br><input type="radio" value="35" name="attr_HP" /></td>
-                            <td>36<br><input type="radio" value="36" name="attr_HP" /></td>
-                            <td>37<br><input type="radio" value="37" name="attr_HP" /></td>
-                        </tr>
-                    </table>
-                </div>c
-            </div>
-        </div>
-    </div>
-</p>
-<hr/>
--->
 <!-- ********************************************************************************************************************* -->
 <!-- Start of alpahbetical skills-->
 <input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic"  style="display: none">
 <div class="sheet-skills-alphabetical" />
-<p>
-    <h3 class="sheet-skills-header">Skills</h3>
-    <div class='sheet-3colrow'>
-        <div class='sheet-col'>
-				<!-- Col 1 -->                
-				<table style="width: 100%">
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-						<td class="sheet-skillname">Appraise (15%)</td>
-						<td><input type="number" name="attr_Appraise"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Appraise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
-						<!--<td><button type="roll" value="/roll 1d100<@{Appraise}" /></td>-->
-					</tr>
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Art(05):</td>
-					</tr>
-				</table>				
-				<fieldset class='repeating_artskills'>
-					<table style="width: 100%;">	
-						<tr>
-						<td><input type="checkbox" name="attr_artSuccess"  /></td>
-						<!--<input  type="text" name="attr_artSkillname" class="sheet-skillname" />-->
-						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-						<td><input type="number" name="attr_artScore" /></td>
-					   <td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{artScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-					   </tr>
-					</table>
-				</fieldset>	
-				<table style="width: 100%">
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
-						<td class="sheet-skillname">Bargain (05%)</td>
-						<td><input type="number" name="attr_Bargain"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Climb"  /></td>
-						<td class="sheet-skillname">Climb (40%)</td>
-						<td><input type="number" name="attr_Climb"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Climb}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Command"  /></td>
-						<td class="sheet-skillname">Command (05)</td>
-						<td><input type="number" name="attr_Command"  /></td>
-						<!--<td><button type="roll" value="/roll 1d100<@{Command}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{success=[[ceil(@{Command}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
-					</tr>
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Craft(05):</td>
-					</tr>	
-				</table>
-				<fieldset class='repeating_craftskills'>
-					<table style="width: 100%">	
-						<td><input type="checkbox" name="attr_craftSuccess"  /></td>
-						<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
-						<td><input type="number" name="attr_craftScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{craftScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
-					</table>	
-				</fieldset>
-				<table style="width: 100%">
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-						<td class="sheet-skillname">Demolition (01%)</td>
-						<td><input type="number" name="attr_Demolition"  /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Demolition}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
-						<!--<td><button type="roll" value="/roll 1d100<@{Demolition}" /></td>-->					
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-						<td class="sheet-skillname">Disguise (01)</td>
-						<td><input type="number" name="attr_Disguise"  /></td>
-						<!--<td><button type="roll" value="/roll 1d100<@{Disguise}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}    {{success=[[ceil(@{Disguise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-						<td class="sheet-skillname">Dodge (DEX x02%)</td>
-						<td><input type="number" name="attr_Dodge"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Dodge}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
-						<!--<td><button type="roll" value="/roll 1d100<@{Dodge}" /></td>-->
-					</tr>				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Drive(Varies):</td>
-					</tr>	
-				</table>
-				<fieldset class='repeating_DriveSkills'>
-					 <input type="checkbox" name="attr_DriveSucess"  />
-					 <input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_DriveScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{DriveScore}*?{Multipler|1})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{Drive Skill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					
-				</fieldset>	
-				<table style="width: 100%">	
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-						<td class="sheet-skillname">Etiquette (05)</td>
-						<td><input type="number" name="attr_Etiquette"  /></td>
-						<!--<td><button type="roll" value="/roll 1d100<@{Etiquette}" /></td>-->
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Etiquette}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
-						<td class="sheet-skillname">Fast Talk (05%)</td>
-						<td><input type="number" name="attr_FastTalk" /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FastTalk}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
-						<!--<td><button type="roll" value="/roll 1d100<@{FastTalk}" /></td>-->
-					</tr>					
-					<tr>
-						<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-						<td class="sheet-skillname">Fine Manipulation (05%)</td>
-						<td><input type="number" name="attr_FineManipulation" /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FineManipulation}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
-						<!--<td><button type="roll" value="/roll 1d100<@{FineManipulation}" /></td>-->
-					</tr>
-
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
-                    <td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{FirstAid}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
-                    <!--<td><button type="roll" value="/roll 1d100<@{FirstAid}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-                    <td class="sheet-skillname">Gaming (INT+POW)</td>
-                    <td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Gaming}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
-                </tr>		
-
+<h3 class="sheet-skills-header">Skills</h3>
+<div class='sheet-3colrow'>
+	<div class='sheet-col'>
+		<!-- Col 1 -->                
+		<table style="width: 100%">
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+				<td class="sheet-skillname">Appraise (15%)</td>
+				<td><input type="number" name="attr_Appraise"  /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Appraise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
+			</tr>
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Art(05):</td>
+			</tr>
+		</table>				
+		<fieldset class='repeating_artskills'>
+			<table style="width: 100%;">	
 				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Heavy Machine (01%):</td>
-				</tr>	
-				</table>
-				
-				<fieldset class='repeating_hMachineSkills'>
-						 <input type="checkbox" name="attr_hMachineSuccess"  />
-						 <input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-						 <input type="number" name="attr_hMachineScore" />
-						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{hMachineScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
-				</fieldset>					
-				<table style="width: 100%">		
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Hide"  /></td>
-						<td class="sheet-skillname">Hide (10%)</td>
-						<td><input type="number" name="attr_Hide"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{Hide}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
-						<!--<td><button type="roll" value="/roll 1d100<@{Spot-Hide}" /></td>-->
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Insight"  /></td>
-						<td class="sheet-skillname">Insight (05%)</td>
-						<td><input type="number" name="attr_Insight"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Insight}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
-						<!--<td><button type="roll" value="/roll 1d100<@{Insight}" /></td>-->
-					</tr>
-				</table>
-				<!-- End of Col 1 -->	
-		</div> <!-- col 1 close -->     
-        <div class='sheet-col'><!-- col 2 start --> 
+				<td><input type="checkbox" name="attr_artSuccess"  /></td>
+				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+				<td><input type="number" name="attr_artScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{artScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+				</tr>
+			</table>
+		</fieldset>	
+		<table style="width: 100%">
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
+				<td class="sheet-skillname">Bargain (05%)</td>
+				<td><input type="number" name="attr_Bargain"  /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Climb"  /></td>
+				<td class="sheet-skillname">Climb (40%)</td>
+				<td><input type="number" name="attr_Climb"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Climb}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Command"  /></td>
+				<td class="sheet-skillname">Command (05)</td>
+				<td><input type="number" name="attr_Command"  /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{success=[[ceil(@{Command}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
+			</tr>
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Craft(05):</td>
+			</tr>	
+		</table>
+		<fieldset class='repeating_craftskills'>
+			<table style="width: 100%">	
+				<td><input type="checkbox" name="attr_craftSuccess"  /></td>
+				<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
+				<td><input type="number" name="attr_craftScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{craftScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+			</table>	
+		</fieldset>
+		<table style="width: 100%">
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+				<td class="sheet-skillname">Demolition (01%)</td>
+				<td><input type="number" name="attr_Demolition"  /></td>
+				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Demolition}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>				
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+				<td class="sheet-skillname">Disguise (01)</td>
+				<td><input type="number" name="attr_Disguise"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}    {{success=[[ceil(@{Disguise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+				<td class="sheet-skillname">Dodge (DEX x02%)</td>
+				<td><input type="number" name="attr_Dodge"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Dodge}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
+			</tr>				
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Drive(Varies):</td>
+			</tr>	
+		</table>
+		<fieldset class='repeating_DriveSkills'>
+			<input type="checkbox" name="attr_DriveSucess"  />
+			<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
+			<input type="number" name="attr_DriveScore" />
+			<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{DriveScore}*?{Multipler|1})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{Drive Skill}}}"/>
+		</fieldset>	
+		<table style="width: 100%">	
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+				<td class="sheet-skillname">Etiquette (05)</td>
+				<td><input type="number" name="attr_Etiquette"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Etiquette}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
+				<td class="sheet-skillname">Fast Talk (05%)</td>
+				<td><input type="number" name="attr_FastTalk" /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FastTalk}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
+			</tr>					
+			<tr>
+				<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+				<td class="sheet-skillname">Fine Manipulation (05%)</td>
+				<td><input type="number" name="attr_FineManipulation" /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FineManipulation}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+				<td class="sheet-skillname">First Aid (30% or INT x1)</td>
+				<td><input type="number" name="attr_FirstAid"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{FirstAid}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+				<td class="sheet-skillname">Gaming (INT+POW)</td>
+				<td><input type="number" name="attr_Gaming"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Gaming}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+			</tr>		
 
-<!-- Start of Col 2 -->					
-				
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Heavy Machine (01%):</td>
+			</tr>	
+		</table>
+		
+		<fieldset class='repeating_hMachineSkills'>
+			<input type="checkbox" name="attr_hMachineSuccess"  />
+			<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
+			<input type="number" name="attr_hMachineScore" />
+			<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{hMachineScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
+		</fieldset>					
+		<table style="width: 100%">		
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Hide"  /></td>
+				<td class="sheet-skillname">Hide (10%)</td>
+				<td><input type="number" name="attr_Hide"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{Hide}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
+			</tr>
+			<tr>
+				<td><input type="checkbox" name="attr_Success-Insight"  /></td>
+				<td class="sheet-skillname">Insight (05%)</td>
+				<td><input type="number" name="attr_Insight"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Insight}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
+			</tr>
+		</table>
+		<!-- End of Col 1 -->	
+	</div> <!-- col 1 close -->     
+	<div class='sheet-col'><!-- col 2 start --> 
+	<!-- Start of Col 2 -->									
 		<table style="width: 100%">				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Jump"  /></td>
 				<td class="sheet-skillname">Jump (25%)</td>
 				<td><input type="number" name="attr_Jump"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Jump}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
-				<!--<td><button type="roll" value="/roll 1d100<@{Jump}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Jump}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
 			</tr>
-
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Knowledge (Varies):</td>
-				</tr>	
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Knowledge (Varies):</td>
+			</tr>	
 		</table>
 			<fieldset class='repeating_KnowSkills'>
-					 <input type="checkbox" name="attr_KnowSucess"  />
-					 <input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-					 <input type="number" name="attr_KnowScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{KnowScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
-
+				<input type="checkbox" name="attr_KnowSucess"  />
+				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
+				<input type="number" name="attr_KnowScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{KnowScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
 			</fieldset>	
 			<table style="width: 100%">					
 				<tr>
 					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
 					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
 					<td><input type="number" name="attr_ownLang"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{ownLang}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{ownLang}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{ownLang}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>
 				</tr>			
 			</table>
 			<fieldset class='repeating_Langskills'>
 				<tr>
-					 <input type="checkbox" name="attr_LangSuccess"  />
-					 <input type="text" name="attr_LangSkillname" class="sheet-skillname" />
-					 <input type="number" name="attr_LangScore" />
+					<input type="checkbox" name="attr_LangSuccess"  />
+					<input type="text" name="attr_LangSkillname" class="sheet-skillname" />
+					<input type="number" name="attr_LangScore" />
 					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{LangScore}*?{Multipler|1}+?{Mods|0})]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
 				</tr>		
 			</fieldset>
 			<table style="width: 100%">								
-				 <tr>
+				<tr>
 					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
 					<td class="sheet-skillname">Listen (25%)</td>
 					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/5)+1]]}}   {{success=[[ceil(@{Listen}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
-				 </tr>			
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/5)+1]]}}   {{success=[[ceil(@{Listen}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
+				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Literacy (Varies):</td>
 				</tr>	
 			</table>
 			<fieldset class='repeating_LitSkills'>
-					 <input type="checkbox" name="attr_LitSucess"  />
-					 <input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_LitScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{LitScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{LitScore}" />-->
+				<input type="checkbox" name="attr_LitSucess"  />
+				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_LitScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{LitScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>
 			</fieldset>				
 			<table style="width: 100%;">	
-					<tr>
-						<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-						<td class="sheet-skillname">Martial Arts (01%)</td>
-						<td><input type="number" name="attr_MartialArts"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{MartialArts}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>																																																							
-						<!--<td><button type="roll" value="/roll 1d100<@{MartialArts}" /></td>-->
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-						<td class="sheet-skillname">Medicine (05%)</td>
-						<td><input type="number" name="attr_Medicine"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Medicine}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
-						<!--<td><button type="roll" value="/roll 1d100<@{Medicine}" /></td>-->
-					</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+					<td class="sheet-skillname">Martial Arts (01%)</td>
+					<td><input type="number" name="attr_MartialArts"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{MartialArts}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+					<td class="sheet-skillname">Medicine (05%)</td>
+					<td><input type="number" name="attr_Medicine"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Medicine}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>
+				</tr>
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
 					<td class="sheet-skillname">Navigate (10%)</td>
 					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Navigate}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
-					<!--<td><button type="roll" value="/roll 1d100<@{Navigate}" /></td>-->
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Navigate}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -845,17 +451,16 @@
 				</tr>								
 			</table>
 			<fieldset class='repeating_PerformSkills'>
-					 <input type="checkbox" name="attr_Success-Perform"  />
-					 <input type="text" name="attr_PerformSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_Perform" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Perform}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+				<input type="checkbox" name="attr_Success-Perform"  />
+				<input type="text" name="attr_PerformSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_Perform" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Perform}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/>
 			</fieldset>	
-				<table style="width: 100%;">	
+			<table style="width: 100%;">
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
 					<td class="sheet-skillname">Persuade (15%)</td>
 					<td><input type="number" name="attr_Persuade"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{Persuade}" /></td>-->
 					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Persuade}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
 				</tr>			
 				<tr>
@@ -864,48 +469,40 @@
 				</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-					 <input type="checkbox" name="attr_PilotSucess"  />
-					 <input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_PilotScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{PilotScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+				<input type="checkbox" name="attr_PilotSucess"  />
+				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_PilotScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{PilotScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
 				<table style="width: 100%;">				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
-					<td class="sheet-skillname">Projection(DEX x02%)</td>
-					<td><input type="number" name="attr_Projection"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{Projection}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Projection}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																														
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-					<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
-					<td><input type="number" name="attr_Psychotherapy"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{Psychotherapy}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																														
-				</tr>								
-						<tr>
-							<td class="sheet-chkfiller"></td>
-							<td class="sheet-skillname">Repair (15%)</td>
-						</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Projection"  /></td>
+						<td class="sheet-skillname">Projection(DEX x02%)</td>
+						<td><input type="number" name="attr_Projection"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Projection}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+						<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
+						<td><input type="number" name="attr_Psychotherapy"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
+					</tr>								
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td class="sheet-skillname">Repair (15%)</td>
+					</tr>
 				</table>
 				<fieldset class='repeating_repairSkills'>
-					 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-						 <input type="checkbox" name="attr_repairSuccess"  />
-						 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-						 <input type="number" name="attr_repairScore" />
-						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{repairScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
-						 <!--<button type="roll" value="/roll 1d100<@{repairScore" />-->
-
+					<input type="checkbox" name="attr_repairSuccess"  />
+					<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
+					<input type="number" name="attr_repairScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{repairScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/>
 				</fieldset>				
 				<table style="width: 100%;">				
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Research"  /></td>
 					<td class="sheet-skillname">Research (25%)</td>
 					<td><input type="number" name="attr_Research"  /></td>
-					<!--<td><button type="roll" value="/roll 1d100<@{Research}" /></td>-->
 					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Research}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
 				</tr>						
 					<tr>
@@ -914,153 +511,132 @@
 					</tr>	
 				</table>
 				<fieldset class='repeating_RideSkills'>
-						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-							 <input type="checkbox" name="attr_RideSucess"  />
-							 <input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_RideScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{RideScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
-
+					<input type="checkbox" name="attr_RideSucess"  />
+					<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
+					<input type="number" name="attr_RideScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{RideScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>
 				</fieldset>				 
 				<table style="width: 100%;">				
-						<tr>
-							<td class="sheet-chkfiller"></td>
-							<td>Science (01%)</td>
-						</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Science (01%)</td>
+					</tr>
 				</table>
 				<fieldset class='repeating_ScienceSkills'>
-						 <input type="checkbox" name="attr_ScienceSucess"  />
-						 <input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-						 <input type="number" name="attr_ScienceScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ScienceScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
+					<input type="checkbox" name="attr_ScienceSucess"  />
+					<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
+					<input type="number" name="attr_ScienceScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ScienceScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
 				</fieldset>	
 			
-        </div><!-- col 2 close --> 
-        <div class="sheet-col">
-
-			
+		</div><!-- col 2 close --> 
+		<div class="sheet-col">			
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Sense"  /></td>
 				<td class="sheet-skillname">Sense (10%)</td>
 				<td><input type="number" name="attr_Sense"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Sense}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
-				<!--<td><button type="roll" value="/roll 1d100<@{Sense}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Sense}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
 				<td class="sheet-skillname">Sleight of Hand (05%)</td>
 				<td><input type="number" name="attr_SleightofHandScore"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
-
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Spot"  /></td>
 				<td class="sheet-skillname">Spot (25%)</td>
 				<td><input type="number" name="attr_Spot"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Spot}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
-				<!--<td><button type="roll" value="/roll 1d100<@{Spot}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Spot}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
 			</tr>				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Status"  /></td>
 				<td class="sheet-skillname">Status (05%)</td>
 				<td><input type="number" name="attr_Status"  /></td>
-				<!--<td><button type="roll" value="/roll 1d100<@{Status}" /></td>-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Status}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Status}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
 				<td class="sheet-skillname">Stealth (10%)</td>
 				<td><input type="number" name="attr_Stealth"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/5)+1]]}}     {{success=[[ceil(@{Stealth}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
-				<!--<td><button type="roll" value="/roll 1d100<@{Stealth}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/5)+1]]}}     {{success=[[ceil(@{Stealth}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
 				<td class="sheet-skillname">Strategy (01%)</td>
 				<td><input type="number" name="attr_Strategy"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Strategy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
-				<!--<td><button type="roll" value="/roll 1d100<@{Strategy}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Strategy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>
 			</tr>		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Swim"  /></td>
 				<td class="sheet-skillname">Swim (25%)</td>
 				<td><input type="number" name="attr_Swim"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Swim}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
-				<!--<td><button type="roll" value="/roll 1d100<@{Swim}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Swim}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
 			</tr>	
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Teach"  /></td>
 				<td class="sheet-skillname">Teach (10%)</td>
 				<td><input type="number" name="attr_Teach"  /></td>
-				<!--<td><button type="roll" value="/roll 1d100<@{Teach}" /></td>-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}*?{Multipler|1}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}*?{Multipler|1}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
 			</tr>	
-
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Technical Skill(Varies):</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Technical Skill(Varies):</td>
+				</tr>	
 			</table>
 			<fieldset class='repeating_TechSkills'>
-					 <input type="checkbox" name="attr_TechSucess"  />
-					 <input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_TechScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{TechScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+				<input type="checkbox" name="attr_TechSucess"  />
+				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_TechScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{TechScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
 			</fieldset>	
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Throw"  /></td>
 				<td class="sheet-skillname">Throw (25%)</td>
 				<td><input type="number" name="attr_throw"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{throw}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
-				<!--<td><button type="roll" value="/roll 1d100<@{Throw}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{throw}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
 			</tr>			
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Track "  /></td>
 				<td class="sheet-skillname">Track (10%)</td>
 				<td><input type="number" name="attr_Track"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Track}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
-				<!--<td><button type="roll" value="/roll 1d100<@{Track}" /></td>-->
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Track}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
 			</tr>					
 			</table>		
 			<br />
 			<table style="width: 100%;">					
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td><strong>Other Skills</strong></td>
-					</tr>					
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td><strong>Other Skills</strong></td>
+				</tr>					
 			</table>
 			<fieldset class='repeating_OtherSkills'>
-					 <input type="checkbox" name="attr_OtherSucess"  />
-					 <input type="text" name="attr_OtherSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_OtherScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{OtherScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/></td>
+				<input type="checkbox" name="attr_OtherSucess"  />
+				<input type="text" name="attr_OtherSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_OtherScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{OtherScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/>
 			</fieldset>	
 			<br />
 				<table style="width: 100%;">					
-			
 					<tr>
 						<td class="sheet-chkfiller"></td>
 						<td><strong>Combat</strong></td>
 						<td></td>
 						<td></td>
 					</tr>
-					
 					<tr>
 						<td class="sheet-chkfiller"></td>
 						<td>Melee (Physical)</td>
 					</tr>	
-				
 				</table>	
 
 				<fieldset class='repeating_meleeSkills'>
-							 <input type="checkbox" name="attr_meleeSucess"  />
-							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_meleeScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{meleeScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+					<input type="checkbox" name="attr_meleeSucess"  />
+					<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
+					<input type="number" name="attr_meleeScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{meleeScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/>
 				</fieldset>				
 
 				<table style="width: 100%;">
@@ -1070,801 +646,629 @@
 				</tr>	
 				</table>
 				<fieldset class='repeating_rangedSkills'>
-						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-							 <input type="checkbox" name="attr_rangedSucess"  />
-							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_rangedScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{rangedScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
+					<input type="checkbox" name="attr_rangedSucess"  />
+					<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
+					<input type="number" name="attr_rangedScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{rangedScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/>
 				</fieldset>
 				
 				<table style="width: 100%;">
 				<tr>
 					<td class="sheet-chkfiller"></td>
-                    <td>Artillery (Manip.)</td>
+					<td>Artillery (Manip.)</td>
 				</tr>	
 				</table>
 				<fieldset class='repeating_artillerySkills'>
-						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-							 <input type="checkbox" name="attr_ArtillerySucess"  />
-							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_ArtilleryScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
+					<input type="checkbox" name="attr_ArtillerySucess"  />
+					<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+					<input type="number" name="attr_ArtilleryScore" />
+					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/>
 				</fieldset>				
 				<br />					
-            <br>
-        </div>
-    </div>
-</p>
+			<br>
+		</div>
+	</div>
 </div>
-<!--End of alabetical skills>
+<!--End of alabetical skills-->
 <!-- ********************************************************************************************************************* -->
 <!-- Start of skills by category-->
 <input type="checkbox" class="sheet-toggle-categories" name="attr_toggle-categories"  checked="checked" style="display: none">
 <div class="sheet-skills-by-category" />
 <p>
-    <h3 class="sheet-skills-header">Skills</h3>
-    <div class='sheet-3colrow'>
-        <div class='sheet-col'>
-            <table style="width: 100%;">
-				<tr>
-					<td style="width="20px"></td>
-					<td><b class="sheet-cat_header">Communication</b></td>
-					<td><input type="number" name="attr_Communication" value="0"  /></td>
-				</tr>	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Bargain"  /></td>
-                    <td class="sheet-skillname">Bargain (05%)</td>
-                    <td><input type="number" name="attr_Bargain"  /></td>
-                    <!-- <td><button type="roll" value="/roll 1d100<@{Bargain}" /></td> -->
-					<!--<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Bargain}}}{{success=[[@{Bargain}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td>-->
-					<!-- <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{special=[[ floor((@{Bargain}+@{Communication})/5)]]}}  {{crit=[[ floor((@{Bargain}+@{Communication})/20)]]}} {{success=[[@{Bargain}+@{Communication}]]}} {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> -->	 
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{success=[[ceil((@{Bargain}+@{Communication})*?{Multipler|1})+?{Mods|0}]]}} {{fumble=[[ceil((95+((@{Bargain}+@{Communication})*?{Multipler|1})+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
-					<!-- {{crit=[[ floor((@{Bargain}+@{Communication})/20)]]}}  -->
-					
-					
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Command"  /></td>
-                    <td class="sheet-skillname">Command (05)</td>
-                    <td><input type="number" name="attr_Command"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Command}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}+@{Communication}+?{Mods|0})/5)+1]]}}  {{success=[[@{Command}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-                    <td class="sheet-skillname">Disguise (01)</td>
-                    <td><input type="number" name="attr_Disguise"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Disguise}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}+@{Communication}+?{Mods|0})/5)+1]]}}    {{success=[[@{Disguise}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-                    <td class="sheet-skillname">Etiquette (05)</td>
-                    <td><input type="number" name="attr_Etiquette"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Etiquette}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{Etiquette}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-ownLang"  /></td>
-                    <td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
-                    <td><input type="number" name="attr_ownLang"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{ownLang}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{ownLang}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
-                </tr>
-		    </table>
-			
-			<fieldset class='repeating_Langskills'>
-					 <input type="checkbox" name="attr_LangSuccess"  />
-					 <input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" />
-					 <input type="number" name="attr_LangScore" /></td>
-				 	 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{LangScore}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
-			</fieldset>
-			</table>			
-			<table style="width:100%;">	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Perform"  /></td>
-                    <td class="sheet-skillname">Perform (05%)</td>
-                    <td><input type="number" name="attr_Perform"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Perform}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{Perform}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>																									
-                </tr>				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Persuade"  /></td>
-                    <td class="sheet-skillname">Persuade (15%)</td>
-                    <td><input type="number" name="attr_Persuade"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Persuade}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}+@{Communication}+?{Mods|0})/5)+1]]}}       {{success=[[@{Persuade}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Status"  /></td>
-                    <td class="sheet-skillname">Status (05%)</td>
-                    <td><input type="number" name="attr_Status"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Status}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}+@{Communication}+?{Mods|0})/5)+1]]}}        {{success=[[@{Status}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Teach"  /></td>
-                    <td class="sheet-skillname">Teach (10%)</td>
-                    <td><input type="number" name="attr_Teach"  /></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Teach}" /></td>-->
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}+@{Communication}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
-                </tr>				
-				
-				
-				
-		  </table>	
-		<fieldset class='repeating_commskills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-			<table style="width: 100%;">	
-			<tr>
-				 <td><input type="checkbox" name="attr_ComSuccess"  /></td>
-				 <!-- <input type="text" name="attr_ComSkillname" style="width: 145px" /> -->
-				 <td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td> 
-				 <td><input type="number" name="attr_ComScore" /></td>
-				 <!--<button type="roll" value="/roll 1d100<@{ComScore}" />-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ComScore}}} {{fumble=[[ceil(95+(@{ComScore}+@{Communication}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ComScore}+@{Communication}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ComScore}+@{Communication}+?{Mods|0})/5)+1]]}}         {{success=[[@{ComScore}+@{Communication}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
-			</tr>		
-			</table>			
-		</fieldset>
-<!--		<br />-->	
+	<h3 class="sheet-skills-header">Skills</h3>
+	<div class='sheet-3colrow'>
+		<div class='sheet-col'>
+			<!-- Communication -->
 			<table style="width: 100%;">
 				<tr>
-					<!-- <td style="width="20px"></td> -->
+					<td style="width:20px"></td>
+					<td><b class="sheet-cat_header">Communication</b></td>
+					<td><input type="number" name="attr_Communication" value="0"/></td>
+				</tr>	
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Bargain"/></td>
+					<td class="sheet-skillname">Bargain (5%)</td>
+					<td><input type="number" name="attr_Bargain"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Bargain}}} {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Command"  /></td>
+					<td class="sheet-skillname">Command (5%)</td>
+					<td><input type="number" name="attr_Command"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Command}}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+					<td class="sheet-skillname">Disguise (1%)</td>
+					<td><input type="number" name="attr_Disguise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Disguise}}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+					<td class="sheet-skillname">Etiquette (5%)</td>
+					<td><input type="number" name="attr_Etiquette"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Etiquette}}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
+					<td class="sheet-skillname">Fast Talk (5%)</td>
+					<td><input type="number" name="attr_FastTalk" /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FastTalk}}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
+				</tr>	
+				<tr>
+					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
+					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
+					<td><input type="number" name="attr_ownLang"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ownLang}}} {{roll=[[1d100]]}} {{skillname=ownLang}}"/></td>
+				</tr>
+			</table>
+			<fieldset class='repeating_Langskills'>
+				<input type="checkbox" name="attr_LangSuccess"  />
+				<input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" />
+				<input type="number" name="attr_LangScore" /></td>
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LangScore}}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
+			</fieldset>		
+			<table style="width:100%;">	
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Perform"  /></td>
+					<td class="sheet-skillname">Perform (5%)</td>
+					<td><input type="number" name="attr_Perform"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Perform}}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>
+				</tr>				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
+					<td class="sheet-skillname">Persuade (15%)</td>
+					<td><input type="number" name="attr_Persuade"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Persuade}}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Status"  /></td>
+					<td class="sheet-skillname">Status (15%)</td>
+					<td><input type="number" name="attr_Status"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Status}}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Teach"  /></td>
+					<td class="sheet-skillname">Teach (10%)</td>
+					<td><input type="number" name="attr_Teach"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Teach}}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
+				</tr>
+			</table>	
+			<fieldset class='repeating_commskills'>
+				<table style="width: 100%;">	
+					<tr>
+						<td><input type="checkbox" name="attr_ComSuccess"  /></td>
+						<td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td>
+						<td><input type="number" name="attr_ComScore" /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ComScore}}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
+					</tr>
+				</table>
+			</fieldset>
+			<!-- Manipulation -->
+			<table style="width: 100%;">
+				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td><b class="sheet-cat_header">Manipulation</b></td>
 					<td><input type="number" name="attr_manipulation" value="0" /></td>
 				</tr>					
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Art(05):</td>
+					<td>Art(5%):</td>
 				</tr>			
 			</table>
-		
-
-		<fieldset class='repeating_artskills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-			<table style="width: 100%;">	
-				<tr>
-				<td><input type="checkbox" name="attr_artSuccess"  /></td>
-				<!--<input  type="text" name="attr_artSkillname" class="sheet-skillname" />-->
-				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-				<td><input type="number" name="attr_artScore" /></td>
-			   <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}          {{success=[[@{artScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-			   </tr>
-			</table>
-		</fieldset>			
-
-<!--		<br />	-->
-		<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Craft(05):</td>
-				</tr>	
-		</table>
-		<fieldset class='repeating_craftskills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-				 <input type="checkbox" name="attr_craftSuccess"  />
-				 <input type="text" name="attr_craftSkillname" class="sheet-skillname"/>
-				 <input type="number" name="attr_craftScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{craftScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
-				 <!--<button type="roll" value="/roll 1d100<@{craftScore}" />-->
-
-		</fieldset>				
-<!--		<br />	-->
-			
+			<fieldset class='repeating_artskills'>
+				<table style="width: 100%;">	
+					<tr>
+						<td><input type="checkbox" name="attr_artSuccess"  /></td>
+						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+						<td><input type="number" name="attr_artScore" /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{artScore}}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+					</tr>
+				</table>
+			</fieldset>
 			<table style="width: 100%;">				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-                    <td class="sheet-skillname">Demolition (01%)</td>
-                    <td><input type="number" name="attr_Demolition"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{Demolition}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
-                    <!--<td><button type="roll" value="/roll 1d100<@{Demolition}" /></td>-->					
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-                    <td class="sheet-skillname">Fine Manipulation (05%)</td>
-                    <td><input type="number" name="attr_FineManipulation" /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{FineManipulation}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{FineManipulation}" /></td>-->
-                </tr>
-			</table>
-		
-
-		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Heavy Machine (01%):</td>
+					<td>Craft(5%):</td>
 				</tr>	
-		</table>
-		<fieldset class='repeating_hMachineSkills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-				 <input type="checkbox" name="attr_hMachineSuccess"  />
-				 <input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-				 <input type="number" name="attr_hMachineScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{hMachineScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
-				 <!--<button type="roll" value="/roll 1d100<@{hMachineScore}" />-->
-
-		</fieldset>				
-<!--		<br />	-->
-			
-		<table style="width: 100%;">				
+			</table>
+			<fieldset class='repeating_craftskills'>
+				<input type="checkbox" name="attr_craftSuccess"  />
+				<input type="text" name="attr_craftSkillname" class="sheet-skillname"/>
+				<input type="number" name="attr_craftScore" />
+				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{craftScore}}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>
+			</fieldset>				
+			<table style="width: 100%;">
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+					<td class="sheet-skillname">Demolition (1%)</td>
+					<td><input type="number" name="attr_Demolition"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Demolition}}} {{roll=[[1d100]]}} {{skillname=Demolition}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+					<td class="sheet-skillname">Fine Manipulation (5%)</td>
+					<td><input type="number" name="attr_FineManipulation" /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FineManipulation}}} {{roll=[[1d100]]}} {{skillname=Fine Manipulation}"/></td>
+				</tr>
+			</table>
+			<table style="width: 100%;">				
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Heavy Machine (1%):</td>
+				</tr>
+			</table>
+			<fieldset class='repeating_hMachineSkills'>
+				<input type="checkbox" name="attr_hMachineSuccess"  />
+				<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
+				<input type="number" name="attr_hMachineScore" />
+				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{hMachineScore}}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
+			</fieldset>				
+			<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td class="sheet-skillname">Repair (15%)</td>
 				</tr>	
-		</table>
-		<fieldset class='repeating_repairSkills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-				 <input type="checkbox" name="attr_repairSuccess"  />
-				 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-				 <input type="number" name="attr_repairScore" />
-				 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{repairScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
-				 <!--<button type="roll" value="/roll 1d100<@{repairScore" />-->
-
-		</fieldset>				
-<!--		<br />	-->
-			
-			
-			<table style="width: 100%;">				
-                <tr>
-                    <td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
-                    <td class="sheet-skillname">Sleight of Hand (05%)</td>
-                    <td><input type="number" name="attr_SleightofHandScore"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}        {{success=[[@{SleightofHandScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
-					<!--<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Demolition}}}{{success=[[@{Demolition}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																								-->
-                    <!--<td><button type="roll" value="/roll 1d100<@{SleightofHandScore}" /></td>-->
-                </tr>
-			
- 
-            </table>
-			
-		<fieldset class='repeating_manipkills'>
-			 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-			<table style="width: 100%;">	
-			<tr>
-				 <td><input type="checkbox" name="attr_manipSuccess"  /></td>
-				 <!-- <input type="text" name="attr_ComSkillname" style="width: 145px" /> -->
-				 <td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
-				 <td><input type="number" name="attr_manipScore" /></td>
-				 <!--<button type="roll" value="/roll 1d100<@{ComScore}" />-->
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{manipScore}}} {{fumble=[[ceil(95+(@{manipScore}+@{Manipulation}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{manipScore}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{manipScore}+@{Manipulation}+?{Mods|0})/5)+1]]}}         {{success=[[@{manipScore}+@{Manipulation}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{manipSkillname}}}"/></td>
-			</tr>		
-			</table>			
-		</fieldset>			
-			
-			
-        </div>
-        <div class='sheet-col'>
-            <table style="width: 100%;">
+			</table>
+			<fieldset class='repeating_repairSkills'>
+				<input type="checkbox" name="attr_repairSuccess"  />
+				<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
+				<input type="number" name="attr_repairScore" />
+				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{repairScore}}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>
+			</fieldset>				
+			<table style="width: 100%;">
 				<tr>
-					<td style="width="20px"></td>
+					<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
+					<td class="sheet-skillname">Sleight of Hand (5%)</td>
+					<td><input type="number" name="attr_SleightofHandScore"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{SleightofHandScore}}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
+				</tr>
+			</table>
+			<fieldset class='repeating_manipkills'>	
+				<table style="width: 100%;">	
+				<tr>
+					<td><input type="checkbox" name="attr_manipSuccess"  /></td>
+					<td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
+					<td><input type="number" name="attr_manipScore" /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{manipScore}}} {{roll=[[1d100]]}} {{skillname=@{{manipSkillname}}}"/></td>
+				</tr>		
+				</table>			
+			</fieldset>
+		</div>
+		<!-- Mental -->
+		<div class='sheet-col'>
+			<table style="width: 100%;">
+				<tr>
+					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Mental</b></td>
 					<td><input type="number" name="attr_Mental" value="0"/></td>
 				</tr>	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-                    <td class="sheet-skillname">Appraise (15%)</td>
-                    <td><input type="number" name="attr_Appraise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{Appraise}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
-                    <!--<td><button type="roll" value="/roll 1d100<@{Appraise}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
-                    <td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}+@{Mental}+?{Mods|0})/5)+1]]}}       {{success=[[@{FirstAid}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
-                    <!--<td><button type="roll" value="/roll 1d100<@{FirstAid}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-                    <td class="sheet-skillname">Gaming (INT+POW)</td>
-                    <td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}+@{Manipulation}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Gaming}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
-                    <!--<td><button type="roll" value="/roll 1d100<@{Gaming}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-                    <td class="sheet-skillname">Psychotherapy (00 or 01)</td>
-                    <td><input type="number" name="attr_Psychotherapy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Psychotherapy}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																																																		
-                    <!--<td><button type="roll" value="/roll 1d100<@{Psychotherapy}" /></td>-->
-                </tr>                
-				
-			</table>	
-			
-			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Knowledge (Varies):</td>
-					</tr>	
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+					<td class="sheet-skillname">Appraise (15%)</td>
+					<td><input type="number" name="attr_Appraise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Appraise}}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+					<td class="sheet-skillname">First Aid (30%)</td>
+					<td><input type="number" name="attr_FirstAid"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FirstAid}}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+					<td class="sheet-skillname">Gaming (INT+POW)</td>
+					<td><input type="number" name="attr_Gaming"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Gaming}}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>
+				</tr>              
 			</table>
-			<fieldset class='repeating_repairSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_KnowSucess"  />
-					 <input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-					 <input type="number" name="attr_KnowScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}+@{Mental}?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}+@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{KnowScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
-					 <!--<button type="roll" value="/roll 1d100<@{KnowScore}" />-->
-			</fieldset>				
-<!--		<br />	-->
 			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Literacy (Varies):</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Knowledge (varies):</td>
+				</tr>	
+			</table>
+			<fieldset class='repeating_KnowSkills'>
+				<input type="checkbox" name="attr_KnowSucess"  />
+				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
+				<input type="number" name="attr_KnowScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{KnowScore}}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
+			</fieldset>				
+			<table style="width: 100%;">				
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Literacy (varies):</td>
+				</tr>	
 			</table>
 			<fieldset class='repeating_LitSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_LitSucess"  />
-					 <input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_LitScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{LitScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{LitScore}" />-->
-			</fieldset>				
-<!--		<br />	-->
-			
-			
-				
+				<input type="checkbox" name="attr_LitSucess"  />
+				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_LitScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LitScore}}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/>
+			</fieldset>					
 			<table style="width: 100%;">	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-                    <td class="sheet-skillname">Medicine (05%)</td>
-                    <td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Medicine}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
-                    <!--<td><button type="roll" value="/roll 1d100<@{Medicine}" /></td>-->
-                </tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+					<td class="sheet-skillname">Medicine (5%)</td>
+					<td><input type="number" name="attr_Medicine"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Medicine}}} {{roll=[[1d100]]}} {{skillname=Medicine}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+					<td class="sheet-skillname">Psychotherapy (varies)</td>
+					<td><input type="number" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Psychotherapy}}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
+				</tr>
 			</table>
-			
 			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Science (01%)</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Science (1%)</td>
+				</tr>
 			</table>
 			<fieldset class='repeating_ScienceSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_ScienceSucess"  />
-					 <input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_ScienceScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}+@{Mental}+?{Mods|0})/5)+1]]}}         {{success=[[@{ScienceScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{ScienceScore}" />-->
+				<input type="checkbox" name="attr_ScienceSucess"  />
+				<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_ScienceScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ScienceScore}}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
 			</fieldset>				
-<!--		<br />	-->
-			
 			<table style="width: 100%;">				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Strategy"  /></td>
-                    <td class="sheet-skillname">Strategy (01%)</td>
-                    <td><input type="number" name="attr_Strategy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{Strategy}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
-                    <!--<td><button type="roll" value="/roll 1d100<@{Strategy}" /></td>-->
-                </tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
+					<td class="sheet-skillname">Strategy (1%)</td>
+					<td><input type="number" name="attr_Strategy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Strategy}}} {{roll=[[1d100]]}} {{skillname=Strategy}"/></td>
+				</tr>
 			</table>	
-			
 			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Technical Skill(Varies):</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Technical Skill (varies):</td>
+				</tr>
 			</table>
 			<fieldset class='repeating_TechSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_TechSucess"  />
-					 <input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_TechScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}+@{Mental}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}+@{Mental}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}+@{Mental}+?{Mods|0})/5)+1]]}}        {{success=[[@{TechScore}+@{Mental}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
-			</fieldset>	
-			
-<!--		<br />	-->
-				
+				<input type="checkbox" name="attr_TechSucess"  />
+				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_TechScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{TechScore}}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
+			</fieldset>
+			<!-- Perception -->
 			<table style="width: 100%;">								
- 				<tr>
-					<td style="width="20px"></td>
+				<tr>
+					<td style="width:20px"></td>
 					<td class="sheet-skillname"><b class="sheet-cat_header">Perception</b></td>
 					<td><input type="number" name="attr_Perception" value="0" /></td>
 				</tr>				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Insight"  /></td>
-                    <td class="sheet-skillname">Insight (05%)</td>
-                    <td><input type="number" name="attr_Insight"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Insight}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
-                    <!--<td><button type="roll" value="/roll 1d100<@{Insight}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Listen"  /></td>
-                    <td class="sheet-skillname">Listen (25%)</td>
-                    <td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}+@{Perception}+?{Mods|0})/5)+1]]}}   {{success=[[@{Listen}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
-                    <!--<td><button type="roll" value="/roll 1d100<@{Listen}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Navigate"  /></td>
-                    <td class="sheet-skillname">Navigate (10%)</td>
-                    <td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Navigate}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
-                    <!--<td><button type="roll" value="/roll 1d100<@{Navigate}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Research"  /></td>
-                    <td class="sheet-skillname">Research (25%)</td>
-                    <td><input type="number" name="attr_Research"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Research}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																																																																																
-                    <!--<td><button type="roll" value="/roll 1d100<@{Research}" /></td>-->
-                </tr>                
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Sense"  /></td>
-                    <td class="sheet-skillname">Sense (10%)</td>
-                    <td><input type="number" name="attr_Sense"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Sense}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
-                    <!--<td><button type="roll" value="/roll 1d100<@{Sense}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Spot"  /></td>
-                    <td class="sheet-skillname">Spot (25%)</td>
-                    <td><input type="number" name="attr_Spot"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Spot}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
-                    <!--<td><button type="roll" value="/roll 1d100<@{Spot}" /></td>-->
-                </tr>				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Track "  /></td>
-                    <td class="sheet-skillname">Track (10%)</td>
-                    <td><input type="number" name="attr_Track"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{Track}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
-                    <!--<td><button type="roll" value="/roll 1d100<@{Track}" /></td>-->
-                </tr>					
-				
-
-            </table>
-			<fieldset class='repeating_PercepSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-
-
-					 <input type="checkbox" name="attr_PercepSucess"  />
-					 <input type="text" name="attr_PercepSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_PercepScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
-
-			</fieldset>	
-        </div>
-        <div class="sheet-col">
-            <table style="width: 100%;">
 				<tr>
-					<td style="width="20px"></td>
+					<td><input type="checkbox" name="attr_Success-Insight"  /></td>
+					<td class="sheet-skillname">Insight (5%)</td>
+					<td><input type="number" name="attr_Insight"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Insight}}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
+					<td class="sheet-skillname">Listen (25%)</td>
+					<td><input type="number" name="attr_Listen"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Listen}}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
+					<td class="sheet-skillname">Navigate (10%)</td>
+					<td><input type="number" name="attr_Navigate"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Navigate}}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Research"  /></td>
+					<td class="sheet-skillname">Research (25%)</td>
+					<td><input type="number" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Research}}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>
+				</tr>                
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Sense"  /></td>
+					<td class="sheet-skillname">Sense (10%)</td>
+					<td><input type="number" name="attr_Sense"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Sense}}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Spot"  /></td>
+					<td class="sheet-skillname">Spot (25%)</td>
+					<td><input type="number" name="attr_Spot"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Spot}}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
+				</tr>				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Track "  /></td>
+					<td class="sheet-skillname">Track (10%)</td>
+					<td><input type="number" name="attr_Track"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Track}}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
+				</tr>
+			</table>
+			<fieldset class='repeating_PercepSkills'>
+				<input type="checkbox" name="attr_PercepSucess"  />
+				<input type="text" name="attr_PercepSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_PercepScore" />
+				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>
+			</fieldset>	
+		</div>
+		<div class="sheet-col">
+			<!-- Physical -->
+			<table style="width: 100%;">
+				<tr>
+					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Physical</b></td>
 					<td><input type="number" name="attr_Physical" value="0" /></td>
 				</tr>	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Climb"  /></td>
-                    <td class="sheet-skillname">Climb (40%)</td>
-                    <td><input type="number" name="attr_Climb"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}+@{Physical}+?{Mods|0})/5)+1]]}}       {{success=[[@{Climb}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-                    <!--<td><button type="roll" value="/roll 1d100<@{Climb}" /></td>-->
-                </tr>
-					
-				
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-                    <td class="sheet-skillname">Dodge (DEX x02%)</td>
-                    <td><input type="number" name="attr_Dodge"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
-                    <!--<td><button type="roll" value="/roll 1d100<@{Dodge}" /></td>-->
-                </tr>
-		</table>		
-		
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Climb"  /></td>
+					<td class="sheet-skillname">Climb (40%)</td>
+					<td><input type="number" name="attr_Climb"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Climb}}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+					<td class="sheet-skillname">Dodge (DEX x2%)</td>
+					<td><input type="number" name="attr_Dodge"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Dodge}}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
+				</tr>
+			</table>		
 			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Drive(Varies):</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Drive (varies)</td>
+				</tr>	
 			</table>
 			<fieldset class='repeating_DriveSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_DriveSucess"  />
-					 <input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_DriveScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{DriveScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{DriveScore}" />-->
+				<input type="checkbox" name="attr_DriveSucess"  />
+				<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_DriveScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{DriveScore}}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/>
 			</fieldset>				
-<!--		<br />	-->
-		
-		
-		
-		<table style="width: 100%;">
-				<!--
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Fly"  /></td>
-                    <td class="sheet-skillname">Fly (Varies)</td>
-                    <td><input type="number" name="attr_Fly"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Fly}}} {{fumble=[[ceil(95+(@{Fly}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Fly}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Fly}+@{Physical}+?{Mods|0})/5)+1]]}}          {{success=[[@{Fly}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fly}}"/></td>																																																																																																									
-                    
-                </tr>-->
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Hide"  /></td>
-                    <td class="sheet-skillname">Hide (10%)</td>
-                    <td><input type="number" name="attr_Hide"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}+@{Physical}+?{Mods|0})/5)+1]]}}          {{success=[[@{Hide}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
-                    <!--<td><button type="roll" value="/roll 1d100<@{Spot-Hide}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Jump"  /></td>
-                    <td class="sheet-skillname">Jump (25%)</td>
-                    <td><input type="number" name="attr_Jump"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Jump}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
-                    <!--<td><button type="roll" value="/roll 1d100<@{Jump}" /></td>-->
-                </tr>
-		</table>		
-		
+
+			<table style="width: 100%;">
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Hide"  /></td>
+					<td class="sheet-skillname">Hide (10%)</td>
+					<td><input type="number" name="attr_Hide"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Hide}}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Jump"  /></td>
+					<td class="sheet-skillname">Jump (25%)</td>
+					<td><input type="number" name="attr_Jump"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Jump}}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
+				</tr>
+			</table>		
 			<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Pilot(Varies):</td>
-					</tr>	
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Pilot (varies)</td>
+				</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_PilotSucess"  />
-					 <input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_PilotScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}+@{Physical}+?{Mods|0})/5)+1]]}}         {{success=[[@{PilotScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{PilotScore}" />-->
+				<input type="checkbox" name="attr_PilotSucess"  />
+				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_PilotScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PilotScore}}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/>
 			</fieldset>				
-		<table style="width: 100%;">
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Projection"  /></td>
-                    <td class="sheet-skillname">Projection (DEX x02%)</td>
-                    <td><input type="number" name="attr_Projection"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Projection}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																																																																																																																																							
-                    <!--<td><button type="roll" value="/roll 1d100<@{Projection}" /></td>-->
-                </tr>			
-		</table>		
-<!--		<br />	-->
-		<table style="width: 100%;">				
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Ride(Varies):</td>
-			</tr>	
-		</table>
-		<fieldset class='repeating_RideSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_RideSucess"  />
-					 <input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_RideScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{RideScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{RideScore}" />-->
-		</fieldset>				
-<!--		<br />	-->
-		<table style="width: 100%;">		
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Stealth"  /></td>
-                    <td class="sheet-skillname">Stealth (10%)</td>
-                    <td><input type="number" name="attr_Stealth"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}+@{Physical}+?{Mods|0})/5)+1]]}}     {{success=[[@{Stealth}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
-                    <!--<td><button type="roll" value="/roll 1d100<@{Stealth}" /></td>-->
-                </tr>
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Swim"  /></td>
-                    <td class="sheet-skillname">Swim (25%)</td>
-                    <td><input type="number" name="attr_Swim"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{Swim}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
-                    <!--<td><button type="roll" value="/roll 1d100<@{Swim}" /></td>-->
-                </tr>	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-Throw"  /></td>
-                    <td class="sheet-skillname">Throw (25%)</td>
-                    <td><input type="number" name="attr_throw"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{throw}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
-                    <!--<td><button type="roll" value="/roll 1d100<@{Throw}" /></td>-->
-                </tr>	
-								
-			
-		</table>
-		<fieldset class='repeating_PhysicalSkills'>
-				 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-					 <input type="checkbox" name="attr_PhysicalSucess"  />
-					 <input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/>
-					 <input type="number" name="attr_PhysicalScore" />
-					 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PhysicalScore}}} {{fumble=[[ceil(95+(@{PhysicalScore}+@{Physical}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PhysicalScore}+@{Physical}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PhysicalScore}+@{Physical}+?{Mods|0})/5)+1]]}}        {{success=[[@{PhysicalScore}+@{Physical}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
-					 <!--<button type="roll" value="/roll 1d100<@{TechScore}" />-->
-		</fieldset>	
-		
-			
-		<table style="width: 100%;">					
+			<table style="width: 100%;">
 				<tr>
-					<td style="width="20px"></td>
+					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
+					<td class="sheet-skillname">Projection (DEX x2%)</td>
+					<td><input type="number" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Projection}}} {{roll=[[1d100]]}} {{skillname=Projection}}"/>
+				</tr>
+			</table>		
+
+			<table style="width: 100%;">				
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Ride (varies)</td>
+				</tr>	
+			</table>
+			<fieldset class='repeating_RideSkills'>
+				<input type="checkbox" name="attr_RideSucess"  />
+				<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_RideScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{RideScore}}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/>
+			</fieldset>				
+
+			<table style="width: 100%;">		
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
+					<td class="sheet-skillname">Stealth (10%)</td>
+					<td><input type="number" name="attr_Stealth"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Stealth}}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Swim"  /></td>
+					<td class="sheet-skillname">Swim (25%)</td>
+					<td><input type="number" name="attr_Swim"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Swim}}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
+				</tr>	
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Throw"  /></td>
+					<td class="sheet-skillname">Throw (25%)</td>
+					<td><input type="number" name="attr_throw"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{throw}}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
+				</tr>
+			</table>
+			<fieldset class='repeating_PhysicalSkills'>
+				<input type="checkbox" name="attr_PhysicalSucess"  />
+				<input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_PhysicalScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PhysicalScore}}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>
+			</fieldset>	
+			<!-- Combat -->
+			<table style="width: 100%;">					
+				<tr>
+					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Combat</b></td>
 					<td><input type="number" name="attr_Combat" value="0"/></td>
-				</tr>				
-                <tr>
-                    <td style="width: 20px;"></td>
-                    <td><strong>Combat</strong></td>
-                    <td></td>
-                    <td></td>
-                </tr>
-				
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+					<td class="sheet-skillname">Martial Arts (1%)</td>
+					<td><input type="number" name="attr_MartialArts"  /></td>
+					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{MartialArts}}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
+				</tr>
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Melee</td>
-				</tr>	
-				
-		</table>	
-				<fieldset class='repeating_meleeSkills'>
-							 <input type="checkbox" name="attr_meleeSucess"  />
-							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_meleeScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}+@{Combat}+?{Mods|0})/5)+1]]}}        {{success=[[@{meleeScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
-				</fieldset>				
-		<table style="width: 100%;">					
+				</tr>
+			</table>
+			<fieldset class='repeating_meleeSkills'>
+				<input type="checkbox" name="attr_meleeSucess"  />
+				<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_meleeScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{meleeScore}}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+			</fieldset>				
+			<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Ranged</td>
-				</tr	>	
-				
-		</table>			
-				<fieldset class='repeating_rangedSkills'>
-						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-							 <input type="checkbox" name="attr_rangedSucess"  />
-							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_rangedScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}+@{Combat}+?{Mods|0})/5)+1]]}}         {{success=[[@{rangedScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{rangedScore}" />-->
-				</fieldset>
-		<table style="width: 100%;">					
+				</tr>
+			</table>			
+			<fieldset class='repeating_rangedSkills'>
+				<input type="checkbox" name="attr_rangedSucess"  />
+				<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
+				<input type="number" name="attr_rangedScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{rangedScore}}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"
+				/></td>
+			</fieldset>
+			<table style="width: 100%;">					
 				<tr>
-				
 					<td class="sheet-chkfiller"></td> 
 					<td>Artillery</td>
-				</tr>	
-				
-		</table>	
-				<fieldset class='repeating_artillerySkills'>
-						 <!-- <div class='sheet-col' style='width: 69%; margin: 0px; padding: 0px;'></div> -->
-							 <input type="checkbox" name="attr_ArtillerySucess"  />
-							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-							 <input type="number" name="attr_ArtilleryScore" />
-							 <button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}+@{Combat}+?{Mods|0})/5)+1]]}}         {{success=[[@{ArtilleryScore}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
-							 <!--<button type="roll" value="/roll 1d100<@{ArtilleryScore}" />-->
-				</fieldset>					
-		<table style="width: 100%;">	
-                <tr>
-                    <td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-                    <td class="sheet-skillname">Martial Arts (1%)</td>
-                    <td><input type="number" name="attr_MartialArts"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}+@{Combat}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}+@{Combat}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}+@{Combat}+?{Mods|0})/5)+1]]}}        {{success=[[@{MartialArts}+@{Combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=MartialArts}}"/></td>																																																																																																																																							
-                    <!--<td><button type="roll" value="/roll 1d100<@{MartialArts}" /></td>-->
-                </tr>					
-		</table>				
-				<br />					
-			<table style="width: 100%;">			
-            </table>
-            <br>
-            <!--<fieldset class="repeating_Skills">
-               <input type="checkbox" name="attr_Success"  />
-               <input type="text" name="attr_Skillname" style="width: 145px" />
-               <input type="number" name="attr_Score" />
-               <button type="roll" value="/roll 1d100<@{Score}" />
-            </fieldset>-->
-        </div>
-    </div>
+				</tr>
+			</table>	
+			<fieldset class='repeating_artillerySkills'>
+				<input type="checkbox" name="attr_ArtillerySucess"  />
+				<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+				<input type="number" name="attr_ArtilleryScore" />
+				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ArtilleryScore}}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>
+			</fieldset>
+		</div>
+	</div>
 </p>
 </div>
 <!--End of Skills by category-->
 <hr />
 <div class='sheet-2colrow'>
-	    <div class='sheet-col sheet-big-col'>
-			
-			<h3 style="text-align: center; color: #FFF; background-color: #000;">Hand-To-Hand Weapons</h3>
-			<div style="font-align: center; width:100%; font-size:0.8em"><b>*For the button to work correctly fill in skill and damage and select a damage bonus*</b></div>
-			
-			<table style="width: 100%;">
-					<thead class="sheet-header-text">
-						<th></th>
-						<th style="text-align: left;">Weapon</th>					
-						<th>
-							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
-							<div class="sheet-strike-rank">
-								SR
-							</div>
-						</td>
-						<th>Range</th>
-						<th>Skill %</th>
-						<th>Special</th>
-						<th>Damage</th>
-						<th>Attacks</th>
-						<th>HP</th>
-						<th></th>
-					</thead>
-					<tbody>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Fist-Punch" /></td>
-						<td style="width: 122px;"><p style="width: 111px; margin-bottom: 0px">Brawl (25%)</p></td>
-						
-						<td >
+	<div class='sheet-col sheet-big-col'>
+		<h3 style="text-align: center; color: #FFF; background-color: #000;">Hand-To-Hand Weapons</h3>
+		<div style="text-align: center; width:100%; font-size:0.8em"><b>*For the button to work correctly fill in skill and damage and select a damage bonus*</b></div>
+		
+		<table style="width: 100%;">
+			<thead class="sheet-header-text">
+				<th></th>
+				<th style="text-align: left;">Weapon</th>					
+				<th>
+					<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
+					<div class="sheet-strike-rank">
+						SR
+					</div>
+				</td>
+				<th>Range</th>
+				<th>Skill %</th>
+				<th>Special</th>
+				<th>Damage</th>
+				<th>Attacks</th>
+				<th>HP</th>
+				<th></th>
+			</thead>
+			<tbody>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Fist-Punch" /></td>
+					<td style="width: 122px;"><p style="width: 111px; margin-bottom: 0px">Brawl (25%)</p></td>
+					
+					<td >
+						<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
+						<div class="sheet-strike-rank">					
+							<input  style="width:35px" type="number" name="attr_Brawl_sr" />
+						</div>
+					</td>
+					<td>
+						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_length">
+							<option value="">S</option>
+							<option value="">M</option>
+							<option value="">M/L</option>
+							<option value="">L</option>								
+							<option value="">ALL</option>								
+						</select>
+					</td>
+					
+					<td ><input style="width:50px" type="number" name="attr_Brawl" /></td>
+					<td >
+						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_spcl">
+							<option value="Bl">Bl</option>
+							<option value="Im">Im</option>
+							<option value="Cr">Cr</option>
+							<option value="En">En</option>								
+						</select>
+					</td>	
+					<td ><input type="text" name="attr_Brawl-Damage" style="width: 60px" /></td>
+					<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
+					<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
+				</tr>
+				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Grapple"  /></td>
+					<td style="width: 122px"><p style="width: 111px; margin-bottom: 0px">Grapple (25%)</p></td>						
+						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank">					
-								<input  style="width:35px" type="number" name="attr_Brawl_sr" />
+								<input style="width:35px" type="number" name="attr_Grapple_sr" />
 							</div>
 						</td>
-						<!--<td ><input  style="width:35px" type="number" name="attr_Brawl_length" /></td>-->
-						<td>
-							<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_length">
-								<option value="">S</option>
-								<option value="">M</option>
-								<option value="">M/L</option>
-								<option value="">L</option>								
-								<option value="">ALL</option>								
-							</select>
-						</td>
-						
-						<td ><input style="width:50px" type="number" name="attr_Brawl" /></td>
-						<td >
-							<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_spcl">
-								<option value="Bl">Bl</option>
-								<option value="Im">Im</option>
-								<option value="Cr">Cr</option>
-								<option value="En">En</option>								
-							</select>
-						</td>	
-						<td ><input type="text" name="attr_Brawl-Damage" style="width: 60px" /></td>
-						<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
-						<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
-						<!--//<td><button type="roll" value="/roll 1d100<@{Fist-Punch}" /></td>-->
-						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
-					</tr>
-					
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Grapple"  /></td>
-						<td style="width: 122px"><p style="width: 111px; margin-bottom: 0px">Grapple (25%)</p></td>						
-							<td>
-								<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
-								<div class="sheet-strike-rank">					
-									<input style="width:35px" type="number" name="attr_Grapple_sr" />
-								</div>
-							</td>
-						<td>
-							<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_length">
-								<option value="">S</option>
-								<option value="">M</option>
-								<option value="">M/L</option>
-								<option value="">L</option>								
-								<option value="">ALL</option>								
-							</select>
-						</td>						
-						
-						
-						<td><input  style="width:50px" type="number" name="attr_Grapple" /></td>
-						<td>
-						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_spcl">
-								<option value="Bl">Bl</option>
-								<option value="Im">Im</option>
-								<option value="Cr">Cr</option>
-								<option value="En">En</option>								
+					<td>
+						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_length">
+							<option value="">S</option>
+							<option value="">M</option>
+							<option value="">M/L</option>
+							<option value="">L</option>								
+							<option value="">ALL</option>								
 						</select>
-						</td>
-						<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
-						<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
-						<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
-						 <td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
-					</tr>
+					</td>						
 					
-				</tbody>
-			</table>
-			                               
-	                                                        
+					
+					<td><input  style="width:50px" type="number" name="attr_Grapple" /></td>
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_spcl">
+							<option value="Bl">Bl</option>
+							<option value="Im">Im</option>
+							<option value="Cr">Cr</option>
+							<option value="En">En</option>								
+					</select>
+					</td>
+					<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
+					<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
+					<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
+				</tr>
+				
+			</tbody>
+		</table>
+								
 		<input type="checkbox" class="sheet-check-melee-toggle" name="attr_showstrike-rank" style="display: none" />
 		<fieldset class="repeating_melee">
 			<table>
@@ -1898,824 +1302,669 @@
 			</table>
 		</fieldset>
 		
-		
-			<h3 style="text-align: center; color: #FFF; background-color: #000;">Ranged Weapons</h3>
-			<table style="width: 100%">
-				<thead class="sheet-header-text">
-					<th style="text-align: left"> Weapon</th>
-					<th style="" >Skill %</th>
-					<th style="" >Damage</th>
-					<th style="" >Range</th>
-					<th style="" >SR /<br />Attks</th>
-					<th style="" >Shots<br>in Gun</th>
-					<th style="" >Mal.</th>
-					<th style="">HP</th>
-					<th>Damage<br>Bonus?</td></th>	
-				</thead>
-				<tbody>
-					<tr>
-						<td><input type="text" name="attr_Firearm1" style="width: 93px" /></td>
-						<td><input type="number" name="attr_Score1" style="width: 50px" /></td>
-						<td><input type="text" name="attr_Damage1" style="width: 46px" /></td>
-						<td><input type="number" name="attr_Range1"style="width: 47px "/></td>
-						<td><input type="text" name="attr_Shots-per-Round1" style="width: 40px" /></td>
-						<td><input type="number" name="attr_Shots-in-Gun1" style="width: 50px" /></td>
-						<td><input type="number" name="attr_Malfunc-Num1" style="width: 40px"/></td>
-						<td><input type="number" name="attr_HP" style="width: 40px" /></td>
-						<!--<td><button type="roll" value="/roll 1d100" /></td>-->
-						<td>
-						<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type1">
-							<option selected="selected" value="0">No</option>
-							<option value="0.5">Yes</option>
-						</select>
-						</td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
-					</tr>				
-				</tbody>
-			</table>
-			<fieldset class="repeating_Firearms">
-				<table>
-					<tr>
-						<td><input type="text" name="attr_Firearm" style="width: 93px" /></td>
-						<td><input type="number" name="attr_Score" style="width: 50px" /></td>
-						<td><input type="text" name="attr_Damage" style="width: 46px" /></td>
-						<td><input type="number" name="attr_Range"style="width: 47px "/></td>
-						<td><input type="text" name="attr_Shots-per-Round" style="width: 40px" /></td>
-						<td><input type="number" name="attr_Shots-in-Gun" style="width: 50px" /></td>
-						<td><input type="number" name="attr_Malfunc-Num" style="width: 40px"/></td>
-						<td><input type="number" name="attr_HP" style="width: 40px" /></td>
-						<td>
-						<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type">
-							<option selected="selected" value="0">No</option>
-							<option value="0.5">Yes</option>
-						</select>						
-						</td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
-					</tr>
-				</table>
-			</fieldset>
-				
-		
-		
-		</div>
-		<div class='sheet-col sheet-small-col'>
-	
-				<input type="checkbox" class="sheet-showhitloc" name="attr_showhitloc" checked="checked" style="display: none">
-				<div class="sheet-hitloc">
-				<h3 style="text-align: center; color: #FFF; background-color: #000;">Hit Location & Armor</h3>
-				<table>
-				<thead class="sheet-header-text">
-					<tr><!-- <th>
-						<button name="roll_melee-location"  type="roll" value="/me rolls melee hit location [[1d20]]"   class="btn ui-draggable">
-							  <div class="sheet-button_header">Melee</div>
-						</button>
-					  </th>
-					  <th>Missle</th>-->
-					  
-					  <th>Location</th><th>Armor</th><th>AP</th><th>Max <br />HP</th><th>Cur. <br /> HP</th></tr>
-				</thead>
-				<tbody>
-					<tr>
-						<!--<td class="sheet-loc-text">01-04</td>
-						<td class="sheet-loc-text">01-03</td>-->
-						<td><input type="text" name="attr_armor-name" class="sheet-armor-name"/></td>
-						<td><input type="text" name="attr_r_leg_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_r_Leg_ap" /></td>
-						<td><input type="number" name="attr_r_leg_max_hp" /></td>
-						<td><input type="number" name="attr_r_leg_cur_hp" /></td>
-					</tr>
-					<tr>
-						<!--<td class="sheet-loc-text">05-08</td>
-						<td class="sheet-loc-text">04-06</td>-->
-						<td class="sheet-loc-text">Left Leg</td>
-						<td><input type="text" name="attr_l_leg_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_l_Leg_ap" /></td>
-						<td><input type="number" name="attr_l_leg_max_hp" /></td>
-						<td><input type="number" name="attr_l_leg_cur_hp" /></td>
-					</tr>				
-					<tr>
-						<!--<td class="sheet-loc-text">09-11</td>
-						<td class="sheet-loc-text">07-10</td>-->
-						<td class="sheet-loc-text">Abdomen</td>
-						<td ><input type="text" name="attr_abd_armor_name" class="sheet-armor-name"/></td>
-						<td ><input type="number" name="attr_abd_ap" /></td>
-						<td ><input type="number" name="attr_abd_max_hp" /></td>
-						<td ><input type="number" name="attr_abd_cur_hp" /></td>
-					</tr>								
-					<tr>
-						<!--<td class="sheet-loc-text">12</td>
-						<td class="sheet-loc-text">11-15</td>-->
-						<td class="sheet-loc-text">Chest</td>
-						<td><input type="text" name="attr_chst_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_chst_ap" /></td>
-						<td><input type="number" name="attr_chst_max_hp" /></td>
-						<td><input type="number" name="attr_chst_cur_hp" /></td>
-					</tr>												
-					<tr>
-						<!--<td class="sheet-loc-text">13-15</td>
-						<td class="sheet-loc-text">16-17</td>-->
-						<td class="sheet-loc-text">Right Arm</td>
-						<td ><input type="text" name="attr_r_arm_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_r_arm_ap" /></td>
-						<td><input type="number" name="attr_r_arm_max_hp" /></td>
-						<td><input type="number" name="attr_r_arm_cur_hp" /></td>
-					</tr>					
-					
-					<tr>
-						<!--<td class="sheet-loc-text">16-18</td>
-						<td class="sheet-loc-text">18-19</td>-->
-						<td class="sheet-loc-text">Left Arm</td>
-						<td><input type="text" name="attr_l_arm_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_l_arm_ap" /></td>
-						<td><input type="number" name="attr_l_arm_max_hp" /></td>
-						<td><input type="number" name="attr_l_arm_cur_hp" /></td>
-					</tr>									
-					<tr>
-						<!--<td class="sheet-loc-text">19-20</td>
-						<td class="sheet-loc-text">20</td>-->
-						<td class="sheet-loc-text">Head</td>
-						<td><input type="text" name="attr_hd_armor_name" class="sheet-armor-name"/></td>
-						<td><input type="number" name="attr_hd_ap" /></td>
-						<td><input type="number" name="attr_hd_max_hp" /></td>
-						<td><input type="number" name="attr_hd_cur_hp" /></td>
-					</tr>																
-					
-				</tbody>
-				</table>
-				<fieldset class="repeating_hlocations">
-					<table>
-						<tr>
-							<td><input type="text" name="attr_hloc" style="width: 59px" /></td>
-							<td><input class="sheet-armor-name" type="text" name="attr_atype"  /></td>
-							<td><input type="number" name="attr_app"  /></td>
-							<td><input type="number" name="attr_mhp"/></td>
-							<td><input type="number" name="attr_chp" /></td>
-						</tr>
-					</table>
-				</fieldset>
-				</div>
-				<input type="checkbox" class="sheet-showmjrwnd" name="attr_showmjrwnd"  style="display: none">
-				<div class="sheet-mjrwnd">
-					<h3 style="text-align: center; color: #FFF; background-color: #000;">Armor, Shield</h3>
-					<table style="width: 100%">
-					
-	<tr><!-- <th>
-						<button name="roll_melee-location"  type="roll" value="/me rolls melee hit location [[1d20]]"   class="btn ui-draggable">
-							  <div class="sheet-button_header">Melee</div>
-						</button>
-					  </th>
-					  <th>Missle</th>-->
-				<thead>
-					    
-	<tr>				     			
-					  <th>Armor</th><th>AV</th><th>Skill <br />Penalty</th><th>Energy <br />Points</th></tr>
-				</thead>					
-				<tbody>			
-<tr>
-						<!--<td class="sheet-loc-text">01-04</td>
-						<td class="sheet-loc-text">01-03</td>-->
-						<td><input style="width:125px" type="text" name="attr_armor_name" /></td>
-						<td ><input style="width:60px" type="text" name="attr_armor_value" /></td>
-						<td><input type="number" name="attr_armor_skill_penalty" /></td>
-						<td><input type="number" name="attr_armor_energy_points" /></td>
-						<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value}]] pts" /></td>
-					</tr>
-				</tbody>
-				</table>
-				<fieldset class="repeating_ armors">
-					<table>
-						<tr>
-						<td><input style="width:125px" type="text" name="attr_armor_name1" /></td>
-						<td ><input style="width:60px" type="text" name="attr_armor_value1" /></td>
-						<td><input type="number" name="attr_armor_skill_penalty1" /></td>
-						<td><input type="number" name="attr_armor_energy_points1" /></td>
-						<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value1}]] pts" /></td>
-						</tr>
-					</table>
-				</fieldset>
-					
-					<div style="width: 100%;font-size:0.8em">
-						<div style="display: inline">
-							<input type="checkbox" name="attr_shield_success" />
-							<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
-							<input type="number" name="attr_shield_skill" />
-							%&nbsp;
-						</div>
-						<div style="display:inline; float:right">
-							Attack Damage
-							<input style="width: 55px" type="text" name="attr_shield_damage" />
-						</div>
-					</div>
-					<div style="font-size:0.8em">
-						<div style="display:inline">
-							<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
-							<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
-							<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
-							<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
-						
-							Base Chance
-							<input type="number" name="attr_shield_base_chance" />
-						</div>
-						<div style="display: inline; float: right">
-							HP<input type="number" name="attr_shield_hp" />
-						</div>
-					</div>
-
-				<fieldset class="repeating_ shields">
-					<table>
-					<div style="width: 100%;font-size:0.8em">
-						<div style="display: inline">
-							<input type="checkbox" name="attr_shield_success" />
-							<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
-							<input type="number" name="attr_shield_skill" />
-							%&nbsp;
-						</div>
-						<div style="display:inline; float:right">
-							Attack Damage
-							<input style="width: 55px" type="text" name="attr_shield_damage" />
-						</div>
-					</div>
-					<div style="font-size:0.8em">
-						<div style="display:inline">
-							<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
-							<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
-							<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
-							<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
-						
-							Base Chance
-							<input type="number" name="attr_shield_base_chance" />
-						</div>
-						<div style="display: inline; float: right">
-							HP<input type="number" name="attr_shield_hp" />
-						</div>
-					</div>
-					</table>
-				</fieldset>
-					
-				</div >				
-				<div  style=" color: #FFF; background-color: #000;width: 100%" >
-					<div style="display: inline">			
-
-						<!--<input type="checkbox" name="attr_showmjrwnd" checked="checked" style="display: none">-->
-						<input type="checkbox" class="sheet-showmjrwnd" name="attr_showmjrwnd"  style="display: none">
-						<div class="sheet-mjrwnd" >
-							
-							<button type="roll" value="&{template:major-wound} {{roll=[[1d100]]}}" class="sheet-plain-major-wound">Major Wound</button>
-							<input style="color: #FFF; background-color: #000;border: none" type="number" disabled="true" name="attr_major_wound" value="ceil(@{max_hp}/2)" />
-							<input type="checkbox" name="attr_wounded" />
-						</div>
-					</div>
-				</div>
-	<!-- 		<table class="sheet-hit-location-selection">
-				<tr><td>	
-					Roll
-					<select name="attr_selected_hit_location" style="height: 24px ; width: 75px">
-						  <option>Human</option>
-					</select>	
-					Hit Location
-							 <button style="font-size:0;height:32px" name="roll_melee-location"  type="roll" value="&{template:HL-Melee} {{roll=[[1d20]]}}"   class="btn ui-draggable">						  
-							  <img src="https://i.imgur.com/Is6m9rX.png" />
-						</button>				
-						<button style="font-size:0;height:32px" name="roll_missle-location"  type="roll" value="&{template:HL-Missle} {{roll=[[1d20]]}}"   class="btn ui-draggable ">
-							<img src="https://i.imgur.com/IxuyBxY.png" />
-						</button>
+		<h3 style="text-align: center; color: #FFF; background-color: #000;">Ranged Weapons</h3>
+		<table style="width: 100%">
+			<thead class="sheet-header-text">
+				<th style="text-align: left"> Weapon</th>
+				<th style="" >Skill %</th>
+				<th style="" >Damage</th>
+				<th style="" >Range</th>
+				<th style="" >SR /<br />Attks</th>
+				<th style="" >Shots<br>in Gun</th>
+				<th style="" >Mal.</th>
+				<th style="">HP</th>
+				<th>Damage<br>Bonus?</td></th>	
+			</thead>
+			<tbody>
+				<tr>
+					<td><input type="text" name="attr_Firearm1" style="width: 93px" /></td>
+					<td><input type="number" name="attr_Score1" style="width: 50px" /></td>
+					<td><input type="text" name="attr_Damage1" style="width: 46px" /></td>
+					<td><input type="number" name="attr_Range1"style="width: 47px "/></td>
+					<td><input type="text" name="attr_Shots-per-Round1" style="width: 40px" /></td>
+					<td><input type="number" name="attr_Shots-in-Gun1" style="width: 50px" /></td>
+					<td><input type="number" name="attr_Malfunc-Num1" style="width: 40px"/></td>
+					<td><input type="number" name="attr_HP" style="width: 40px" /></td>
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type1">
+						<option selected="selected" value="0">No</option>
+						<option value="0.5">Yes</option>
+					</select>
 					</td>
-				</tr>	
-				</table> -->		
-			
-			
-        </div>
-</div>
-	
-		<div style="width: 100% display: inline; color: #FFF; background-color: #000;">
-			<div style="margin-left: 5px ; display: inline">
-				Dodge
-				<input style="width:47px" class="sheet-section-header" disabled="true" value="@{Dodge}" type="number" name="attr_Dodge_display" />
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
-			</div>
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
+				</tr>				
+			</tbody>
+		</table>
+		<fieldset class="repeating_Firearms">
+			<table>
+				<tr>
+					<td><input type="text" name="attr_Firearm" style="width: 93px" /></td>
+					<td><input type="number" name="attr_Score" style="width: 50px" /></td>
+					<td><input type="text" name="attr_Damage" style="width: 46px" /></td>
+					<td><input type="number" name="attr_Range"style="width: 47px "/></td>
+					<td><input type="text" name="attr_Shots-per-Round" style="width: 40px" /></td>
+					<td><input type="number" name="attr_Shots-in-Gun" style="width: 50px" /></td>
+					<td><input type="number" name="attr_Malfunc-Num" style="width: 40px"/></td>
+					<td><input type="number" name="attr_HP" style="width: 40px" /></td>
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type">
+						<option selected="selected" value="0">No</option>
+						<option value="0.5">Yes</option>
+					</select>						
+					</td>
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
+				</tr>
+			</table>
+		</fieldset>
+	</div>
+	<div class='sheet-col sheet-small-col'>
+		<input type="checkbox" class="sheet-showhitloc" name="attr_showhitloc" checked="checked" style="display: none">
+		<div class="sheet-hitloc">
+		<h3 style="text-align: center; color: #FFF; background-color: #000;">Hit Location & Armor</h3>
+		<table>
+			<thead class="sheet-header-text">
+				<tr>
+					<th>Location</th><th>Armor</th><th>AP</th><th>Max <br />HP</th><th>Cur. <br /> HP</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><input type="text" name="attr_armor-name" class="sheet-armor-name"/></td>
+					<td><input type="text" name="attr_r_leg_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_r_Leg_ap" /></td>
+					<td><input type="number" name="attr_r_leg_max_hp" /></td>
+					<td><input type="number" name="attr_r_leg_cur_hp" /></td>
+				</tr>
+				<tr>
+					<td class="sheet-loc-text">Left Leg</td>
+					<td><input type="text" name="attr_l_leg_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_l_Leg_ap" /></td>
+					<td><input type="number" name="attr_l_leg_max_hp" /></td>
+					<td><input type="number" name="attr_l_leg_cur_hp" /></td>
+				</tr>				
+				<tr>
+					<td class="sheet-loc-text">Abdomen</td>
+					<td ><input type="text" name="attr_abd_armor_name" class="sheet-armor-name"/></td>
+					<td ><input type="number" name="attr_abd_ap" /></td>
+					<td ><input type="number" name="attr_abd_max_hp" /></td>
+					<td ><input type="number" name="attr_abd_cur_hp" /></td>
+				</tr>								
+				<tr>
+					<td class="sheet-loc-text">Chest</td>
+					<td><input type="text" name="attr_chst_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_chst_ap" /></td>
+					<td><input type="number" name="attr_chst_max_hp" /></td>
+					<td><input type="number" name="attr_chst_cur_hp" /></td>
+				</tr>												
+				<tr>
+					<td class="sheet-loc-text">Right Arm</td>
+					<td ><input type="text" name="attr_r_arm_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_r_arm_ap" /></td>
+					<td><input type="number" name="attr_r_arm_max_hp" /></td>
+					<td><input type="number" name="attr_r_arm_cur_hp" /></td>
+				</tr>					
+				
+				<tr>
+					<td class="sheet-loc-text">Left Arm</td>
+					<td><input type="text" name="attr_l_arm_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_l_arm_ap" /></td>
+					<td><input type="number" name="attr_l_arm_max_hp" /></td>
+					<td><input type="number" name="attr_l_arm_cur_hp" /></td>
+				</tr>									
+				<tr>
+					<td class="sheet-loc-text">Head</td>
+					<td><input type="text" name="attr_hd_armor_name" class="sheet-armor-name"/></td>
+					<td><input type="number" name="attr_hd_ap" /></td>
+					<td><input type="number" name="attr_hd_max_hp" /></td>
+					<td><input type="number" name="attr_hd_cur_hp" /></td>
+				</tr>
+			</tbody>
+		</table>
+		<fieldset class="repeating_hlocations">
+			<table>
+				<tr>
+					<td><input type="text" name="attr_hloc" style="width: 59px" /></td>
+					<td><input class="sheet-armor-name" type="text" name="attr_atype"  /></td>
+					<td><input type="number" name="attr_app"  /></td>
+					<td><input type="number" name="attr_mhp"/></td>
+					<td><input type="number" name="attr_chp" /></td>
+				</tr>
+			</table>
+		</fieldset>
+	</div>
+	<input type="checkbox" class="sheet-showmjrwnd" name="attr_showmjrwnd"  style="display: none">
+	<div class="sheet-mjrwnd">
+		<h3 style="text-align: center; color: #FFF; background-color: #000;">Armor, Shield</h3>
+		<table style="width: 100%">						
+			<thead>	
+				<tr>				     			
+					<th>Armor</th><th>AV</th><th>Skill <br />Penalty</th><th>Energy <br />Points</th>
+				</tr>
+			</thead>					
+			<tbody>			
+				<tr>
+					<td><input style="width:125px" type="text" name="attr_armor_name" /></td>
+					<td ><input style="width:60px" type="text" name="attr_armor_value" /></td>
+					<td><input type="number" name="attr_armor_skill_penalty" /></td>
+					<td><input type="number" name="attr_armor_energy_points" /></td>
+					<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value}]] pts" /></td>
+				</tr>
+			</tbody>
+		</table>
+		<fieldset class="repeating_ armors">
+			<table>
+				<tr>
+				<td><input style="width:125px" type="text" name="attr_armor_name1" /></td>
+				<td ><input style="width:60px" type="text" name="attr_armor_value1" /></td>
+				<td><input type="number" name="attr_armor_skill_penalty1" /></td>
+				<td><input type="number" name="attr_armor_energy_points1" /></td>
+				<td style="text-align:center"><button type="roll" value="Armor deflects [[@{armor_value1}]] pts" /></td>
+				</tr>
+			</table>
+		</fieldset>
+				
+		<div style="width: 100%;font-size:0.8em">
 			<div style="display: inline">
-				Fumble 
-				<select name="attr_selected_fumble_table" style="margin-top: 7px; height: 24px ; width: 128px">
-					<option selected="selected" value="0">Melee Attack</option>
-					<option value="1">Melee Parry</option>				
-					<option value="2">Missle Attack</option>				
-					<option value="3">Natural Weapon</option>				
-				</select>
-				<button type="roll" value="&{template:Melee-Attack-Fumble} {{table=[[@{selected_fumble_table}]]}} {{roll=[[1d100]]}}" />		
+				<input type="checkbox" name="attr_shield_success" />
+				<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
+				<input type="number" name="attr_shield_skill" />
+				%&nbsp;
 			</div>
-			<input type="checkbox" class="sheet-showhitloc" name="attr_showhitloc" checked="checked" style="display: none">
-			<div  class="sheet-hitloc" style="margin-left: 15px; padding-top: 5px; padding-bottom: 5px">
-							Roll
-						<select name="attr_selected_hit_location" style="margin-top: 7px; height: 24px ; width: 75px">
-							  <option value="0">Human</option>
-						</select>	
-						Hit Location
-								 <button style="font-size:0;height:32px" name="roll_melee-location"  type="roll" value="&{template:HL-Melee} {{roll=[[1d20]]}}"   class="btn ui-draggable">						  
-								  <img src="https://i.imgur.com/Is6m9rX.png" />
-							</button>				
-							<button style="font-size:0;height:32px" name="roll_missle-location"  type="roll" value="&{template:HL-Missle} {{roll=[[1d20]]}}"   class="btn ui-draggable ">
-								<img src="https://i.imgur.com/IxuyBxY.png" />
-							</button>
-
+			<div style="display:inline; float:right">
+				Attack Damage
+				<input style="width: 55px" type="text" name="attr_shield_damage" />
 			</div>
-			<div style="margin-top: 5px;float: right;display: inline">Hit Pts.
-				<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_max_hp" />
-				<p style="display:inline">/</p>
-				<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_cur_hp" />
-				</div> 		
 		</div>
-	
+		<div style="font-size:0.8em">
+			<div style="display:inline">
+				<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
+				<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
+				<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
+				<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
+			
+				Base Chance
+				<input type="number" name="attr_shield_base_chance" />
+			</div>
+			<div style="display: inline; float: right">
+				HP<input type="number" name="attr_shield_hp" />
+			</div>
+		</div>
+
+		<fieldset class="repeating_ shields">
+			<table>
+			<div style="width: 100%;font-size:0.8em">
+				<div style="display: inline">
+					<input type="checkbox" name="attr_shield_success" />
+					<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
+					<input type="number" name="attr_shield_skill" />
+					%&nbsp;
+				</div>
+				<div style="display:inline; float:right">
+					Attack Damage
+					<input style="width: 55px" type="text" name="attr_shield_damage" />
+				</div>
+			</div>
+			<div style="font-size:0.8em">
+				<div style="display:inline">
+					<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
+					<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
+					<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
+					<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
+				
+					Base Chance
+					<input type="number" name="attr_shield_base_chance" />
+				</div>
+				<div style="display: inline; float: right">
+					HP<input type="number" name="attr_shield_hp" />
+				</div>
+			</div>
+			</table>
+		</fieldset>
+			
+		</div >				
+		<div  style=" color: #FFF; background-color: #000;width: 100%" >
+			<div style="display: inline">
+				<input type="checkbox" class="sheet-showmjrwnd" name="attr_showmjrwnd"  style="display: none">
+				<div class="sheet-mjrwnd" >
+					<button type="roll" value="&{template:major-wound} {{roll=[[1d100]]}}" class="sheet-plain-major-wound">Major Wound</button>
+					<input style="color: #FFF; background-color: #000;border: none" type="number" disabled="true" name="attr_major_wound" value="ceil(@{max_hp}/2)" />
+					<input type="checkbox" name="attr_wounded" />
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<br>
+<div style="width: 100%; color: #FFF; background-color: #000;">
+	<div style="margin-left: 5px ; display: inline">
+		Dodge
+		<input style="width:47px" class="sheet-section-header" disabled="true" value="@{Dodge}" type="number" name="attr_Dodge_display" />
+		<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}+?{Mods|0})/5)+1]]}}        {{success=[[@{Dodge}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+	</div>
+	<div style="display: inline">
+		Fumble 
+		<select name="attr_selected_fumble_table" style="margin-top: 7px; height: 24px ; width: 128px">
+			<option selected="selected" value="0">Melee Attack</option>
+			<option value="1">Melee Parry</option>				
+			<option value="2">Missle Attack</option>				
+			<option value="3">Natural Weapon</option>				
+		</select>
+		<button type="roll" value="&{template:Melee-Attack-Fumble} {{table=[[@{selected_fumble_table}]]}} {{roll=[[1d100]]}}" />		
+	</div>
+	<input type="checkbox" class="sheet-showhitloc" name="attr_showhitloc" checked="checked" style="display: none">
+	<div  class="sheet-hitloc" style="margin-left: 15px; padding-top: 5px; padding-bottom: 5px">
+		Roll
+		<select name="attr_selected_hit_location" style="margin-top: 7px; height: 24px ; width: 75px">
+			<option value="0">Human</option>
+		</select>	
+		Hit Location
+		<button style="font-size:0;height:32px" name="roll_melee-location"  type="roll" value="&{template:HL-Melee} {{roll=[[1d20]]}}"   class="btn ui-draggable">						  
+			<img src="https://i.imgur.com/Is6m9rX.png" />
+		</button>				
+		<button style="font-size:0;height:32px" name="roll_missle-location"  type="roll" value="&{template:HL-Missle} {{roll=[[1d20]]}}"   class="btn ui-draggable ">
+			<img src="https://i.imgur.com/IxuyBxY.png" />
+		</button>
+	</div>
+	<div style="display: inline">Hit Pts.
+		<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_max_hp" />
+		<p style="display:inline">/</p>
+		<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_cur_hp" />
+	</div> 		
+</div>
 
 <hr/>
 <input type="checkbox" class="sheet-toggle-magic1" name="attr_toggle-magic1"  style="display: none">
-<div class="sheet-skills-magic1" />
- <p>
-			<h3 class="sheet-section-header">Powers
-			<div style="float:right">Power Pts.
-				<input class="sheet-section-header" type="number" name="attr_cur_mp" />
-				/
-				<input class="sheet-section-header" type="number" name="attr_max_mp" />
-			<div> 
+<div class="sheet-skills-magic1">
+	<p>
+		<h3 class="sheet-section-header">Powers
+		<div style="float:right">Power Pts.
+			<input class="sheet-section-header" type="number" name="attr_cur_mp" />
+			/
+			<input class="sheet-section-header" type="number" name="attr_max_mp" />
+		<div> 
+		</h3>
+		<p>
+			<h3 class="sheet-section-header"><input  class="sheet-section-header" type="text" name="attr_magic_type-1" /> 
+			<input style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-1_Score" />%</h3>
+	
+			<table style="width: 100%">
+				<thead class="sheet-header-text">
+					<th style="width: 111px; text-align: left">Power</th>
+					<th style="width: 50px" >Skill</th>
+					<th style="width: 60px" >Range</th>
+					<th style="width: 60px" >Duration</th>
+					<th style="width: 40px" >Cost</th>
+					<th style="width: 430px" >Effect</th>
+					<th></th>
+				</thead>
+			</table>
+			<fieldset class="repeating_spells1">
+				<table>
+					<tr>
+						<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
+						<td><input type="number" name="attr_Score" style="width: 50px" /></td>
+						<td><input type="text" name="attr_Range" style="width: 60px" /></td>
+						<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
+						<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
+						<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
+						<td><button type="roll" value="/roll 1d100" /></td>
+					</tr>
+				</table>
+			</fieldset>
+		</p>		
+		<hr />
+		<p>
+			<h3 class="sheet-section-header">
+				<input  class="sheet-section-header" type="text" name="attr_magic_type-2" /> 
+				<input  style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-2_Score" />%
 			</h3>
-
-			<p>
-
-				<h3 class="sheet-section-header"><input  class="sheet-section-header" type="text" name="attr_magic_type-1" /> 
-				<input style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-1_Score" />%</h3>
-		
-				<table style="width: 100%">
-					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Power</th>
-						<th style="width: 50px" >Skill</th>
-						<th style="width: 60px" >Range</th>
-						<th style="width: 60px" >Duration</th>
-						<th style="width: 40px" >Cost</th>
-						<th style="width: 430px" >Effect</th>
-						<th></th>
-					</thead>
+			<table style="width: 100%">
+				<thead class="sheet-header-text">
+					<th style="width: 111px; text-align: left">Power</th>
+					<th style="width: 50px" >Skill</th>
+					<th style="width: 60px" >Range</th>
+					<th style="width: 60px" >Duration</th>
+					<th style="width: 40px" >Cost</th>
+					<th style="width: 430px" >Effect</th>
+					<th></th>
+				</thead>
+			</table>
+			<fieldset class="repeating_spells2">
+				<table>
+					<tr>
+						<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
+						<td><input type="number" name="attr_Score" style="width: 50px" /></td>
+						<td><input type="text" name="attr_Range" style="width: 60px" /></td>
+						<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
+						<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
+						<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
+						<td><button type="roll" value="/roll 1d100" /></td>
+					</tr>
 				</table>
-				<fieldset class="repeating_spells1">
-					<table>
-						<tr>
-							<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
-							<td><input type="number" name="attr_Score" style="width: 50px" /></td>
-							<td><input type="text" name="attr_Range" style="width: 60px" /></td>
-							<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
-							<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
-							<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
-							<td><button type="roll" value="/roll 1d100" /></td>
-						</tr>
-					</table>
-				</fieldset>
-
-
-			</p>		
-			<hr />
-			<p>
-
-				<h3 class="sheet-section-header">
-					<input  class="sheet-section-header" type="text" name="attr_magic_type-2" /> 
-					<input  style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-2_Score" />%
-				</h3>
-		
-				<table style="width: 100%">
-					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Power</th>
-						<th style="width: 50px" >Skill</th>
-						<th style="width: 60px" >Range</th>
-						<th style="width: 60px" >Duration</th>
-						<th style="width: 40px" >Cost</th>
-						<th style="width: 430px" >Effect</th>
-						<th></th>
-					</thead>
+			</fieldset>
+		</p>		
+		<hr />
+		<p>
+			<h3 class="sheet-section-header">
+				<input  class="sheet-section-header" type="text" name="attr_magic_type-3" /> 
+				<input  style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-3_Score" />%
+			</h3>
+	
+			<table style="width: 100%">
+				<thead class="sheet-header-text">
+					<th style="width: 111px; text-align: left">Power</th>
+					<th style="width: 50px" >Skill</th>
+					<th style="width: 60px" >Range</th>
+					<th style="width: 60px" >Duration</th>
+					<th style="width: 40px" >Cost</th>
+					<th style="width: 430px" >Effect</th>
+					<th></th>
+				</thead>
+			</table>
+			<fieldset class="repeating_spells3">
+				<table>
+					<tr>
+						<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
+						<td><input type="number" name="attr_Score" style="width: 50px" /></td>
+						<td><input type="text" name="attr_Range" style="width: 60px" /></td>
+						<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
+						<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
+						<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
+						<td><button type="roll" value="/roll 1d100" /></td>
+					</tr>
 				</table>
-				<fieldset class="repeating_spells2">
-					<table>
-						<tr>
-							<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
-							<td><input type="number" name="attr_Score" style="width: 50px" /></td>
-							<td><input type="text" name="attr_Range" style="width: 60px" /></td>
-							<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
-							<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
-							<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
-							<td><button type="roll" value="/roll 1d100" /></td>
-						</tr>
-					</table>
-				</fieldset>
-
-
-			</p>		
-			<hr />
-			<p>
-
-				<h3 class="sheet-section-header">
-					<input  class="sheet-section-header" type="text" name="attr_magic_type-3" /> 
-					<input  style="width: 4.5em" class="sheet-section-header" type="number" name="attr_magic_type-3_Score" />%
-				</h3>
-		
-				<table style="width: 100%">
-					<thead class="sheet-header-text">
-						<th style="width: 111px; text-align: left">Power</th>
-						<th style="width: 50px" >Skill</th>
-						<th style="width: 60px" >Range</th>
-						<th style="width: 60px" >Duration</th>
-						<th style="width: 40px" >Cost</th>
-						<th style="width: 430px" >Effect</th>
-						<th></th>
-					</thead>
-				</table>
-				<fieldset class="repeating_spells3">
-					<table>
-						<tr>
-							<td><input type="text" name="attr_spell-name" style="width: 111px" /></td>
-							<td><input type="number" name="attr_Score" style="width: 50px" /></td>
-							<td><input type="text" name="attr_Range" style="width: 60px" /></td>
-							<td><input type="text" name="attr_Duration"style="width: 60px "/></td>
-							<td><input type="number" name="attr_Cost" style="width: 40px" /></td>
-							<td><input type="text" name="attr_Effect" style="width: 430px" /></td>
-							<td><button type="roll" value="/roll 1d100" /></td>
-						</tr>
-					</table>
-				</fieldset>
-
-
-			</p>		
-			<hr />			
-		
-		
-<p>
-<hr/>
+			</fieldset>
+		</p>
+		<hr />	
+	</p>
+	<hr/>
 </div>
-    <h3 style="text-align: center; color: #FFF; background-color: #000;">Personal Data</h3>
-    <div class='sheet-2colrow'>
-        <div class='sheet-col'>
-            <!--Residence <textarea name="attr_Residence"></textarea><br>-->
-            Personal Description <textarea name="attr_Personal-Description"></textarea><br>
-            Family & Friends <textarea name="attr_Family-Friends"></textarea>
-        </div>
-        <div class='sheet-col'>
-            <!--Episodes of Insanity <textarea name="attr_Episodes-of-Insanity"></textarea><br>-->
-            Wounds & Injuries <textarea name="attr_Wounds-Injuries"></textarea><br>
-            Marks & Scars <textarea name="attr_Marks-Scars"></textarea>
-            </div>
-    </div>
-</p>
+<h3 style="text-align: center; color: #FFF; background-color: #000;">Personal Data</h3>
+<div class='sheet-2colrow'>
+	<div class='sheet-col'>
+		Personal Description <textarea name="attr_Personal-Description"></textarea><br>
+		Family & Friends <textarea name="attr_Family-Friends"></textarea>
+	</div>
+	<div class='sheet-col'>
+		Wounds & Injuries <textarea name="attr_Wounds-Injuries"></textarea><br>
+		Marks & Scars <textarea name="attr_Marks-Scars"></textarea>
+	</div>
+</div>
 <hr/>
-
-<!--<p>
-    <h3 style="text-align: center; color: #FFF; background-color: #000;">Investigator History</h3>
-    <textarea name="attr_Ivestigator-History"></textarea>
-</p>
-<hr/>-->
 <p>
- <!--   <div class='sheet-2colrow'>
-        <div class='sheet-col'>-->
-            <p>
-                <h3 style="text-align: center; color: #FFF; background-color: #000;">Income & Savings</h3>
-                <table>
-                    <tr>
-                        <td style="width: 45px">Income</td>
-                        <td><input type="text" name="attr_Income" style="width: 130px" /><br></td>
-                        <td>Cash on Hand</td>
-                        <td><input type="text" name="attr_Cash" style="width: 130px" /><br></td>
-                    </tr>
-                </table>
-                <table>
-                    <tr>
-                        <td style="width: 45px">Savings</td>
-                        <td><input type="text" name="attr_Savings" style="width: 345px" /><br></td>
-                    </tr>
-                </table>
-                Personal Property <textarea name="attr_Personal-Property"></textarea><br>
-                Real Estate <textarea name="attr_Real-Estate"></textarea>
-            </p>
-            <p>
-                <h3 style="text-align: center; color: #FFF; background-color: #000;">Adventuring Gear &amp; Other Possesions</h3>
-                <textarea name="attr_Gear-Possessions"></textarea> 
-            </p>
-		<!--	
-        </div>
-		
-        <div class='sheet-col'>
-            <p>
-                <h3 style="text-align: center; color: #FFF; background-color: #000;">Mythos Tomes Read</h3>
-                <textarea name="attr_Mythos-Tomes-Read"></textarea> 
-            </p>
-            <p>
-                <h3 style="text-align: center; color: #FFF; background-color: #000;">Magical Artifacts / Spells Known</h3>
-                <div class='sheet-2colrow'>
-                    <div class='sheet-col'>
-                        Artefacts <textarea name="attr_Artefacts"></textarea>
-                    </div>
-                    <div class='sheet-col'>
-                        Spells <textarea name="attr_Spells"></textarea>
-                    </div>
-                </div>
-            </p>
-            <p>
-                <h3 style="text-align: center; color: #FFF; background-color: #000;">Entities Encountered</h3>
-                <textarea name="attr_Entities-Encountered"></textarea> 
-            </p>
-        </div>
-	
-    </div>-->
+	<h3 style="text-align: center; color: #FFF; background-color: #000;">Income & Savings</h3>
+	<table>
+		<tr>
+			<td style="width: 45px">Income</td>
+			<td><input type="text" name="attr_Income" style="width: 130px" /><br></td>
+			<td>Cash on Hand</td>
+			<td><input type="text" name="attr_Cash" style="width: 130px" /><br></td>
+		</tr>
+	</table>
+	<table>
+		<tr>
+			<td style="width: 45px">Savings</td>
+			<td><input type="text" name="attr_Savings" style="width: 345px" /><br></td>
+		</tr>
+	</table>
+	Personal Property <textarea name="attr_Personal-Property"></textarea><br>
+	Real Estate <textarea name="attr_Real-Estate"></textarea>
 </p>
-
-
-
-
-
-<rolltemplate class="sheet-rolltemplate-melee-roll">
-    <table class="skillRoll" style="border 1px black">
-        <tr><th colspan="2">{{name}}</th></tr>
-		
-		<tr><th colspan="2">Weapon Roll</th></tr>
-		 <!--<tr><td>{{crit}}/{{special}}/{{fumble}}</td></tr>-->
-        <tr>
-			<tr>
-				<td class="template_label"><b>Rolling:</b> {{skillname}} {{skillvalue}}% </td> 
-				<td class="template_value"> ({{success}}%)</td>
-			</tr>
+<p>
+	<h3 style="text-align: center; color: #FFF; background-color: #000;">Adventuring Gear &amp; Other Possesions</h3>
+	<textarea name="attr_Gear-Possessions"></textarea> 
+</p>	
+	
+	<rolltemplate class="sheet-rolltemplate-melee-roll">
+		<table class="skillRoll" style="border 1px black">
+			<tr><th colspan="2">{{name}}</th></tr>
 			
-       </tr>
-        <tr>
-            <td class="template_label"><b>Rolled:</b></td>
-            <td class="template_value">&nbsp;{{roll}}</td>
-        </tr>
-		<tr>
-		 <td class="template_label"><b>Result:</b></td>
-		 
-		{{#rollBetween() roll fumble 100}} 
+			<tr><th colspan="2">Weapon Roll</th></tr>
+			<tr>
+				<tr>
+					<td class="template_label"><b>Rolling:</b> {{skillname}} {{skillvalue}}% </td> 
+					<td class="template_value"> ({{success}}%)</td>
+				</tr>
+		   	</tr>
+			<tr>
+				<td class="template_label"><b>Rolled:</b></td>
+				<td class="template_value">&nbsp;{{roll}}</td>
+			</tr>
+			<tr>
+				<td class="template_label"><b>Result:</b></td>
+			 
+			{{#rollBetween() roll fumble 100}} 
 				<td class="template_value">Fumble</td>
-		{{/rollBetween() roll fumble 100}} 
-		
-		{{#^rollBetween() roll fumble 100}}
-		
-			{{#rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-
-			{{/rollGreater() success 99}}
+			{{/rollBetween() roll fumble 100}} 
 			
-			{{#^rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}
-						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-						{{#^rollBetween() roll special success}}
-							{{#rollLess() roll fumble}}
-								<td class="template_value">Failure</td>
-							{{/rollLess() roll fumble}}
-							{{#^rollLess() roll fumble}}
-								<td class="template_value">fumble</td>
-							{{/^rollLess() roll fumble}}							
-						{{/^rollBetween() roll special success}}											
-					{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-			{{/^rollGreater() success 99}}
-		{{/^rollBetween() roll fumble 100}}
-		
-		
-		{{#rollLess() roll success}}
+			{{#^rollBetween() roll fumble 100}}
+			
+				{{#rollGreater() success 99}}
+					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+					{{#^rollLess() roll crit}}
+						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
+					{{/^rollLess() roll crit}}
+	
+				{{/rollGreater() success 99}}
+				
+				{{#^rollGreater() success 99}}
+					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+					{{#^rollLess() roll crit}}
+						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+						{{#^rollLess() roll special}}
+							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+							{{#^rollBetween() roll special success}}
+								{{#rollLess() roll fumble}}
+									<td class="template_value">Failure</td>
+								{{/rollLess() roll fumble}}
+								{{#^rollLess() roll fumble}}
+									<td class="template_value">fumble</td>
+								{{/^rollLess() roll fumble}}							
+							{{/^rollBetween() roll special success}}											
+						{{/^rollLess() roll special}}
+					{{/^rollLess() roll crit}}
+				{{/^rollGreater() success 99}}
+			{{/^rollBetween() roll fumble 100}}
+			
+			
+			{{#rollLess() roll success}}
+				<tr>
+					<td class="template_label"><b>Damage:</b></td>
+					<td style="text-align: right"; class="template_value">{{tot}}<td>
+				</tr>
+			{{/rollLess() roll success}}
+		</table>
+	</rolltemplate>
+	
+	<rolltemplate class="sheet-rolltemplate-HL-Melee">
+		<table class="skillRoll" style="border 1px black">
+			<tr><th colspan="1">Melee Hit location roll</th></tr>
 			<tr>
-				<td class="template_label"><b>Damage:</b></td>
-				<td style="text-align: right"; class="template_value">{{tot}}<td>
+			{{#rollBetween() roll 1 4}}<td class="template_label">Hit on the Left Leg</td>{{/rollBetween() roll 1 4}}
+			{{#rollBetween() roll 5 8}}<td class="template_label">Hit on the Right Leg</td>{{/rollBetween() roll 5 8}}
+			{{#rollBetween() roll 9 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 9 11}}
+					{{#rollTotal() roll 12}}
+						<td class="template_value">Hit on the Chest</td>
+					{{/rollTotal() roll 12}}
+			{{#rollBetween() roll 13 15}}<td class="template_label">Hit on the Right Arm</td>{{/rollBetween() roll 13 15}}
+			{{#rollBetween() roll 16 18}}<td class="template_label">Hit on the Left Arm</td>{{/rollBetween() roll 16 18}}
+			{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 19 20}}
 			</tr>
-		{{/rollLess() roll success}}
-    </table>
-</rolltemplate>
-
-
-<rolltemplate class="sheet-rolltemplate-HL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="1">Melee Hit location roll</th></tr>
-		<tr>
-		{{#rollBetween() roll 1 4}}<td class="template_label">Hit on the Left Leg</td>{{/rollBetween() roll 1 4}}
-		{{#rollBetween() roll 5 8}}<td class="template_label">Hit on the Right Leg</td>{{/rollBetween() roll 5 8}}
-		{{#rollBetween() roll 9 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 9 11}}
-				{{#rollTotal() roll 12}}
-					<td class="template_value">Hit on the Chest</td>
-				{{/rollTotal() roll 12}}
-		{{#rollBetween() roll 13 15}}<td class="template_label">Hit on the Right Arm</td>{{/rollBetween() roll 13 15}}
-		{{#rollBetween() roll 16 18}}<td class="template_label">Hit on the Left Arm</td>{{/rollBetween() roll 16 18}}
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 19 20}}
-		</tr>
-	</table>
-</rolltemplate>
-
-
-
-<rolltemplate class="sheet-rolltemplate-HL-Missle">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="1">Missle Hit location roll</th></tr>
-		<tr>
-		{{#rollBetween() roll 1 3}}<td class="template_label">Hit on the Left Leg</td>{{/rollBetween() roll 1 3}}
-		{{#rollBetween() roll 4 6}}<td class="template_label">Hit on the Right Leg</td>{{/rollBetween() roll 4 6}}
-		{{#rollBetween() roll 7 10}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 7 10}}
-		{{#rollBetween() roll 11 15}}<td class="template_label">Hit on the Chest</td>{{/rollBetween() roll 11 15}}
-		{{#rollBetween() roll 16 17}}<td class="template_label">Hit on the Right Arm</td>{{/rollBetween() roll 16 17}}
-		{{#rollBetween() roll 18 19}}<td class="template_label">Hit on the Left Arm</td>{{/rollBetween() roll 18 19}}
-		{{#rollTotal() roll 20}}
-			<td class="template_value">Hit on the Head</td>
-		{{/rollTotal() roll 20}}		
-		</tr>
-	</table>
-</rolltemplate>
-
-
-
-
-<rolltemplate class="sheet-rolltemplate-skillRoll">
-    <table class="skillRoll" style="width: 100%; border 1px black">
-        <!--<tr><th>{{name}}</th></tr>-->
-		<tr><th colspan="2">{{name}}</th></tr>
-		<tr><th colspan="2">Skill Roll</th></tr>
-		 <!--<tr><td>{{crit}}/{{special}}/{{fumble}}</td></tr>-->
-        <tr>
+		</table>
+	</rolltemplate>
+	
+	<rolltemplate class="sheet-rolltemplate-HL-Missle">
+		<table class="skillRoll" style="border 1px black">
+			<tr><th colspan="1">Missle Hit location roll</th></tr>
 			<tr>
-				<td class="template_label"><b>Rolling:</b> {{skillname}} {{skillvalue}}% </td> 
-				<td class="template_value"> ({{success}}%)</td>
+			{{#rollBetween() roll 1 3}}<td class="template_label">Hit on the Left Leg</td>{{/rollBetween() roll 1 3}}
+			{{#rollBetween() roll 4 6}}<td class="template_label">Hit on the Right Leg</td>{{/rollBetween() roll 4 6}}
+			{{#rollBetween() roll 7 10}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 7 10}}
+			{{#rollBetween() roll 11 15}}<td class="template_label">Hit on the Chest</td>{{/rollBetween() roll 11 15}}
+			{{#rollBetween() roll 16 17}}<td class="template_label">Hit on the Right Arm</td>{{/rollBetween() roll 16 17}}
+			{{#rollBetween() roll 18 19}}<td class="template_label">Hit on the Left Arm</td>{{/rollBetween() roll 18 19}}
+			{{#rollTotal() roll 20}}
+				<td class="template_value">Hit on the Head</td>
+			{{/rollTotal() roll 20}}		
 			</tr>
-			
-       </tr>
-        <tr>
-            <td class="template_label"><b>Rolled:</b></td>
-            <td class="template_value">&nbsp;{{roll}}</td>
-        </tr>
-		<tr>
-		 <td class="template_label"><b>Result:</b></td>
-
-		{{#rollBetween() roll fumble 100}} 
-				<td class="template_value">Fumble</td>
-		{{/rollBetween() roll fumble 100}} 
-		
-		{{#^rollBetween() roll fumble 100}}
-		
-			{{#rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-
-			{{/rollGreater() success 99}}
-			
-			{{#^rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}
-						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-						{{#^rollBetween() roll special success}}
-							{{#rollLess() roll fumble}}
-								<td class="template_value">Failure</td>
-							{{/rollLess() roll fumble}}
-							{{#^rollLess() roll fumble}}
-								<td class="template_value">fumble</td>
-							{{/^rollLess() roll fumble}}							
-						{{/^rollBetween() roll special success}}						
-					
-					{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-			
-			
-			
-			{{/^rollGreater() success 99}}
-
-			
-		{{/^rollBetween() roll fumble 100}}
-		</tr>
-    </table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-Melee-Attack-Fumble">
-	<table style="background-color: #ffffff;" class="sheet-rolltemplate-skillRoll">
+		</table>
+	</rolltemplate>
 	
-	{{#rollTotal() table 0}}
-		<th>Melee Attack Fumble </th>
-	{{/rollTotal() table 0}}
-	{{#rollTotal() table 1}}
-		<th>Melee Parry Fumble </th>
-	{{/rollTotal() table 1}}	
-	{{#rollTotal() table 2}}
-		<th>Missle Attack Fumble </th>
-	{{/rollTotal() table 2}}	
-	{{#rollTotal() table 3}}
-		<th>Natural Weapon Fumble </th>
-	{{/rollTotal() table 3}}
-	<!--<tr><td><b>Roll:</b>{{roll}}</td></tr>
-	<tr><td><b>Table:</b>{{table}}</td></tr>-->
-	<tr>
-	{{#rollTotal() table 0}}
-		{{#rollBetween() roll 1 15}}<td class="template_value">Lose the next combat round and are effectively helpless.</td>{{/rollBetween() roll 1 15}}
-		{{#rollBetween() roll 16 25}}<td class="template_value">Lose the next 1D3 combat rounds and are effectively helpless.</td>{{/rollBetween() roll 16 25}}		
-		{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
-		{{#rollBetween() roll 41 50}}<td class="template_value">Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
-		{{#rollBetween() roll 51 60}}<td class="template_value">Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
-		{{#rollBetween() roll 61 65}}<td class="template_value">Lose 1D10 points of weapons hit points.</td>{{/rollBetween() roll 61 65}}
-		{{#rollBetween() roll 66 75}}<td class="template_value">Vision obscured, lose 30% on all appropriate skills for 1D3 combat rounds.</td>{{/rollBetween() roll 66 75}}
-		{{#rollBetween() roll 76 85}}<td class="template_value">Hit nearest ally for normal damage, or Drop the weapon being used if no ally nearby.</td>{{/rollBetween() roll 76 85}}
-		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for special damage, or Throw weapon 1D10 meters away, if no ally nearby.</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 98}}<td class="template_value">Hit nearest ally for critical damage, or Lose 1D10 points of weapons hit points, if no ally nearby.</td>{{/rollBetween() roll 91 98}}
-		{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
-		{{#rollTotal() roll 00}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 00}}
-	{{/rollTotal() table 0}}
-	
-	{{#rollTotal() table 1}}
-		{{#rollBetween() roll 1 20}}<td>Lose the next combat round and are effectively helpless.</td>{{/rollBetween() roll 1 20}}
-		{{#rollBetween() roll 21 40}}<td>Fall down.</td>{{/rollBetween() roll 21 40}}		
-		{{#rollBetween() roll 41 50}}<td>Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
-		{{#rollBetween() roll 51 60}}<td>Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
-		{{#rollBetween() roll 61 75}}<td>Lose 1D10 points of weapons hit points.</td>{{/rollBetween() roll 61 75}}
-		{{#rollBetween() roll 76 85}}<td>Wide open; foe automatically hits with normal hit.</td>{{/rollBetween() roll 76 85}}
-		{{#rollBetween() roll 86 90}}<td>Wide open; foe automatically hits with special hit.</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 93}}<td>Wide open; foe automatically hits with critical hit</td>{{/rollBetween() roll 91 93}}
-		{{#rollBetween() roll 94 98}}<td>Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollBetween() roll 94 98}}
-		{{#rollBetween() roll 99 100}}<td>Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollBetween() roll 99 100}}
-	{{/rollTotal() table 1}}	
-	
-	{{#rollTotal() table 2}}
-		{{#rollBetween() roll 1 15}}<td class="template_value">Lose the next attack or other activity.</td>{{/rollBetween() roll 1 15}}
-		{{#rollBetween() roll 16 25}}<td class="template_value">Lose the next 1D3 combat rounds or other activity.</td>{{/rollBetween() roll 16 25}}		
-		{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
-		{{#rollBetween() roll 41 55}}<td class="template_value">Vision obscured; lose 30% on all appropriate skills for 1D3 combat rounds</td>{{/rollBetween() roll 41 55}}
-		{{#rollBetween() roll 56 65}}<td class="template_value">Drop weapon; which slides or bounces 1D61 meters away.</td>{{/rollBetween() roll 56 65}}
-		{{#rollBetween() roll 66 80}}<td class="template_value">Do 1D6 damage to weapons hit points or break if the weapon has no hit points.</td>{{/rollBetween() roll 66 80}}
-		{{#rollBetween() roll 81 85}}<td class="template_value">Break weapon.</td>{{/rollBetween() roll 81 85}}
-		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Drop weapon; which slides or bounces 1D61 meters away. if no ally nearby.</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 95}}<td class="template_value">Hit nearest ally for special damage, orDo 1D6 damage to weapons hit points or break if the weapon has no hit points, if no ally nearby.</td>{{/rollBetween() roll 91 95}}
-		{{#rollBetween() roll 96 98}}<td class="template_value">Hit nearest ally for critical damage, or Break weapon, if no ally nearby</td>{{/rollBetween() roll 96 98}}
-		{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
-		{{#rollTotal() roll 100}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 100}}
-	{{/rollTotal() table 2}}
-	
-	{{#rollTotal() table 3}}
-		{{#rollBetween() roll 1 25}}<td class="template_value">Lose the next combat round (or this one if no action has yet been taken).</td>{{/rollBetween() roll 1 25}}
-		{{#rollBetween() roll 26 30}}<td class="template_value">Lose the next 1D3 combat rounds (this includes this one if no action has yet been taken).</td>{{/rollBetween() roll 26 30}}		
-		{{#rollBetween() roll 31 50}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 31 50}}		
-		{{#rollBetween() roll 51 60}}<td class="template_value">Fall down and twist ankle; lose 1 meter/DEX rank of movement for 1D10 full turns (and all combat turns within them).</td>{{/rollBetween() roll 51 60}}
-		{{#rollBetween() roll 61 75}}<td class="template_value">Vision obscured; lose 30% on all appropriate skills for 1D3 combat rounds.</td>{{/rollBetween() roll 61 75}}
-		{{#rollBetween() roll 76 85}}<td class="template_value">Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used)</td>{{/rollBetween() roll 76 85}}
-		{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used), if no ally nearby</td>{{/rollBetween() roll 86 90}}
-		{{#rollBetween() roll 91 94}}<td class="template_value">Hit nearest ally for special damage, or Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used), if no ally nearby.</td>{{/rollBetween() roll 91 94}}
-		{{#rollBetween() roll 95 98}}<td class="template_value">Hit hard surface; do normal damage to self (in the attacking limb if hit locations are being used)..</td>{{/rollBetween() roll 95 98}}
-		{{#rollBetween() roll 96 98}}<td class="template_value">Hit nearest ally for critical damage, or Break weapon, if no ally nearby</td>{{/rollBetween() roll 96 98}}
-		{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
-		{{#rollTotal() roll 100}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 100}}
-	{{/rollTotal() table 3}}
-	
-
-	</tr>
-	</table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-major-wound">
-	<table style="background-color: #ffffff;" class="sheet-rolltemplate-skillRoll">
-		<tr>
-		<th>Major Wound</th>
-		</tr>
-		<tr>
-			{{#rollBetween() roll 1 10}} <td class="template_value"> Severed leg tendons cause limping; fused ankle bones cause limping; back muscles or spinal nerve damage bend the torso to the left or right; a shattered knee cannot bend; or make up a new wound effect. Lose 1D3 DEX. The maximum MOV is now reduced by the same 1D3 result. Your character is still able to fight. {{/rollBetween() roll 1 10}} </td>
-			{{#rollBetween() roll 11 20}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characters appearance; or make up a new wound effect. Lose 1D3 APP. The visible and unappealing deformity cannot be disguised. Your character is still able to fight. {{/rollBetween() roll 11 20}} </td>
-			{{#rollBetween() roll 21 30}} <td class="template_value"> Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D3 STR; this loss may change what weapons can be used. Your character is still able to fight with a weapon, but not a shield. {{/rollBetween() roll 21 30}} </td>
-			{{#rollBetween() roll 31 40}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D3 CON; maximum MOV is now reduced by the same 1D3, and hit points may be lowered. Your character is still able to fight. {{/rollBetween() roll 31 40}} </td>
-			{{#rollBetween() roll 41 50}} <td class="template_value"> Concussion damages hearing and limits Listen and Insight to maximums of 65 percent; injury to the head thereafter require Luck rolls each time to use any Mental skills; blows or cuts which affect depth perception leave missile weapon skill ratings at a maximum of 65%; multiple wounds to the face and neck limit the skills of any Communication skills to 65% maximum; or make up a new wound effect. Lose 1D3 INT; this loss may affect your characters ability to use any powers. Your character is still able to fight. {{/rollBetween() roll 41 50}} </td>
-			{{#rollBetween() roll 51 60}} <td class="template_value"> Refer to 0110 for what happened, which now expands to the loss of one or both arms or legs. Lose 1D6 DEX and reduce maximum MOV by that same amount. Your character is unable to fight.  {{/rollBetween() roll 51 60}} </td>
-			{{#rollBetween() roll 61 70}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characters appearance; or make up a new wound effect. . Lose 1D6 APP; it creates one or more visible deformities that cannot be disguised Your character is still able to fight. {{/rollBetween() roll 61 70}} </td>
-			{{#rollBetween() roll 71 80}} <td class="template_value">  Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D6 STR; change hit points and damage bonus. Your character is still able to fight. {{/rollBetween() roll 71 80}} </td>
-			{{#rollBetween() roll 81 90}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D6 CON; may affect hit points, damage bonus, and reduces MOV by that number of units equal to the 1D6 result rolled.Your character is unable to fight. {{/rollBetween() roll 81 90}} </td>
-			{{#rollBetween() roll 91 92}} <td class="template_value"> Bad facial and vocal-cord injuries. Lose 1D6 APP; lower the Charisma roll respectively. Your character is still able to fight. {{/rollBetween() roll 91 92}} </td>
-			{{#rollBetween() roll 93 94}} <td class="template_value"> Broken bones and severed ganglia. Lose 1D6 DEX; from now on your character can only use one-handed melee weapons. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll 93 94}} </td>
-			{{#rollBetween() roll95 96}} <td class="template_value"> Nerve damage to left or right arm (roll 1D6; a result of 13 is the left arm, 46 is the right arm). Lose 1D6 DEX; hereafter your character can only wield weapons or equipment in his or her undamaged arm. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll95 96}} </td>
-			{{#rollBetween() roll 97 98}} <td class="template_value"> Nerve damage to both arms. Lose 1D6 DEX; though the legs are fine, neither arms nor hands can wield anything. Your character is unable to fight, unless using his or her legs or head butts. {{/rollBetween() roll 97 98}} </td>
-			{{#rollTotal() roll 99}} <td class="template_value"> Your character is mutilated with vicious wounds. Lose 1D3 points each from APP, DEX, and CON, and describe the results. Your character is unable to fight. {{/rollTotal() roll 99}} </td>
+	<rolltemplate class="sheet-rolltemplate-skillRoll">
+		<table class="skillRoll" style="width: 100%; border: 1px solid black;">
+			<tr><th colspan="2">{{name}}</th></tr>
+			<tr><th colspan="2">Skill Roll</th></tr>
+			<tr>
+				<tr>
+					<td class="template_label"><b>Rolling:</b> {{skillname}} {{skillvalue}}% </td> 
+					<td class="template_value"> ({{success}}%)</td>
+				</tr>
+		   	</tr>
+			<tr>
+				<td class="template_label"><b>Rolled:</b></td>
+				<td class="template_value">&nbsp;{{roll}}</td>
 			</tr>
-	</table>
-</rolltemplate>
-
-
+			<tr>
+			 <td class="template_label"><b>Result:</b></td>
 	
-<!-- workers -->
-<script type="text/worker">
-
-
-on('sheet:opened',function(){
-sdfsfsdfsdfsdf	
-// Do something the first time the sheet is opened by a player in a session
-var x = document.getElementsByClassName("btn repcontrol_edit");
-var i;
-for (i = 0; i < x.length; i++) {
-    x[i].innerText = "";
-}
-
-});
-
-on("change:is_config", function() {
+			{{#rollBetween() roll fumble 100}} 
+					<td class="template_value">Fumble</td>
+			{{/rollBetween() roll fumble 100}} 
+			
+			{{#^rollBetween() roll fumble 100}}
+			
+				{{#rollGreater() success 99}}
+					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+					{{#^rollLess() roll crit}}
+						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
+					{{/^rollLess() roll crit}}
 	
-
-});
-</script>
+				{{/rollGreater() success 99}}
+				
+				{{#^rollGreater() success 99}}
+					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+					{{#^rollLess() roll crit}}
+						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+						{{#^rollLess() roll special}}
+							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+							{{#^rollBetween() roll special success}}
+								{{#rollLess() roll fumble}}
+									<td class="template_value">Failure</td>
+								{{/rollLess() roll fumble}}
+								{{#^rollLess() roll fumble}}
+									<td class="template_value">fumble</td>
+								{{/^rollLess() roll fumble}}							
+							{{/^rollBetween() roll special success}}						
+						
+						{{/^rollLess() roll special}}
+					{{/^rollLess() roll crit}}
+				
+				{{/^rollGreater() success 99}}
+	
+			{{/^rollBetween() roll fumble 100}}
+			</tr>
+		</table>
+	</rolltemplate>
+	
+	<rolltemplate class="sheet-rolltemplate-Melee-Attack-Fumble">
+		<table style="background-color: #ffffff;" class="sheet-rolltemplate-skillRoll">
+		
+		{{#rollTotal() table 0}}
+			<th>Melee Attack Fumble </th>
+		{{/rollTotal() table 0}}
+		{{#rollTotal() table 1}}
+			<th>Melee Parry Fumble </th>
+		{{/rollTotal() table 1}}	
+		{{#rollTotal() table 2}}
+			<th>Missle Attack Fumble </th>
+		{{/rollTotal() table 2}}	
+		{{#rollTotal() table 3}}
+			<th>Natural Weapon Fumble </th>
+		{{/rollTotal() table 3}}
+		<tr>
+		{{#rollTotal() table 0}}
+			{{#rollBetween() roll 1 15}}<td class="template_value">Lose the next combat round and are effectively helpless.</td>{{/rollBetween() roll 1 15}}
+			{{#rollBetween() roll 16 25}}<td class="template_value">Lose the next 1D3 combat rounds and are effectively helpless.</td>{{/rollBetween() roll 16 25}}		
+			{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
+			{{#rollBetween() roll 41 50}}<td class="template_value">Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
+			{{#rollBetween() roll 51 60}}<td class="template_value">Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
+			{{#rollBetween() roll 61 65}}<td class="template_value">Lose 1D10 points of weapons hit points.</td>{{/rollBetween() roll 61 65}}
+			{{#rollBetween() roll 66 75}}<td class="template_value">Vision obscured, lose 30% on all appropriate skills for 1D3 combat rounds.</td>{{/rollBetween() roll 66 75}}
+			{{#rollBetween() roll 76 85}}<td class="template_value">Hit nearest ally for normal damage, or Drop the weapon being used if no ally nearby.</td>{{/rollBetween() roll 76 85}}
+			{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for special damage, or Throw weapon 1D10 meters away, if no ally nearby.</td>{{/rollBetween() roll 86 90}}
+			{{#rollBetween() roll 91 98}}<td class="template_value">Hit nearest ally for critical damage, or Lose 1D10 points of weapons hit points, if no ally nearby.</td>{{/rollBetween() roll 91 98}}
+			{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
+			{{#rollTotal() roll 00}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 00}}
+		{{/rollTotal() table 0}}
+		
+		{{#rollTotal() table 1}}
+			{{#rollBetween() roll 1 20}}<td>Lose the next combat round and are effectively helpless.</td>{{/rollBetween() roll 1 20}}
+			{{#rollBetween() roll 21 40}}<td>Fall down.</td>{{/rollBetween() roll 21 40}}		
+			{{#rollBetween() roll 41 50}}<td>Drop the weapon being used.</td>{{/rollBetween() roll 41 50}}
+			{{#rollBetween() roll 51 60}}<td>Throw weapon 1D10 meters away.</td>{{/rollBetween() roll 51 60}}
+			{{#rollBetween() roll 61 75}}<td>Lose 1D10 points of weapons hit points.</td>{{/rollBetween() roll 61 75}}
+			{{#rollBetween() roll 76 85}}<td>Wide open; foe automatically hits with normal hit.</td>{{/rollBetween() roll 76 85}}
+			{{#rollBetween() roll 86 90}}<td>Wide open; foe automatically hits with special hit.</td>{{/rollBetween() roll 86 90}}
+			{{#rollBetween() roll 91 93}}<td>Wide open; foe automatically hits with critical hit</td>{{/rollBetween() roll 91 93}}
+			{{#rollBetween() roll 94 98}}<td>Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollBetween() roll 94 98}}
+			{{#rollBetween() roll 99 100}}<td>Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollBetween() roll 99 100}}
+		{{/rollTotal() table 1}}	
+		
+		{{#rollTotal() table 2}}
+			{{#rollBetween() roll 1 15}}<td class="template_value">Lose the next attack or other activity.</td>{{/rollBetween() roll 1 15}}
+			{{#rollBetween() roll 16 25}}<td class="template_value">Lose the next 1D3 combat rounds or other activity.</td>{{/rollBetween() roll 16 25}}		
+			{{#rollBetween() roll 26 40}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 26 40}}		
+			{{#rollBetween() roll 41 55}}<td class="template_value">Vision obscured; lose 30% on all appropriate skills for 1D3 combat rounds</td>{{/rollBetween() roll 41 55}}
+			{{#rollBetween() roll 56 65}}<td class="template_value">Drop weapon; which slides or bounces 1D61 meters away.</td>{{/rollBetween() roll 56 65}}
+			{{#rollBetween() roll 66 80}}<td class="template_value">Do 1D6 damage to weapons hit points or break if the weapon has no hit points.</td>{{/rollBetween() roll 66 80}}
+			{{#rollBetween() roll 81 85}}<td class="template_value">Break weapon.</td>{{/rollBetween() roll 81 85}}
+			{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Drop weapon; which slides or bounces 1D61 meters away. if no ally nearby.</td>{{/rollBetween() roll 86 90}}
+			{{#rollBetween() roll 91 95}}<td class="template_value">Hit nearest ally for special damage, orDo 1D6 damage to weapons hit points or break if the weapon has no hit points, if no ally nearby.</td>{{/rollBetween() roll 91 95}}
+			{{#rollBetween() roll 96 98}}<td class="template_value">Hit nearest ally for critical damage, or Break weapon, if no ally nearby</td>{{/rollBetween() roll 96 98}}
+			{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
+			{{#rollTotal() roll 100}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 100}}
+		{{/rollTotal() table 2}}
+		
+		{{#rollTotal() table 3}}
+			{{#rollBetween() roll 1 25}}<td class="template_value">Lose the next combat round (or this one if no action has yet been taken).</td>{{/rollBetween() roll 1 25}}
+			{{#rollBetween() roll 26 30}}<td class="template_value">Lose the next 1D3 combat rounds (this includes this one if no action has yet been taken).</td>{{/rollBetween() roll 26 30}}		
+			{{#rollBetween() roll 31 50}}<td class="template_value">Fall down.</td>{{/rollBetween() roll 31 50}}		
+			{{#rollBetween() roll 51 60}}<td class="template_value">Fall down and twist ankle; lose 1 meter/DEX rank of movement for 1D10 full turns (and all combat turns within them).</td>{{/rollBetween() roll 51 60}}
+			{{#rollBetween() roll 61 75}}<td class="template_value">Vision obscured; lose 30% on all appropriate skills for 1D3 combat rounds.</td>{{/rollBetween() roll 61 75}}
+			{{#rollBetween() roll 76 85}}<td class="template_value">Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used)</td>{{/rollBetween() roll 76 85}}
+			{{#rollBetween() roll 86 90}}<td class="template_value">Hit nearest ally for normal damage, or Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used), if no ally nearby</td>{{/rollBetween() roll 86 90}}
+			{{#rollBetween() roll 91 94}}<td class="template_value">Hit nearest ally for special damage, or Miss and strain something; lose 1 hit point (in the attacking limb if hit locations are being used), if no ally nearby.</td>{{/rollBetween() roll 91 94}}
+			{{#rollBetween() roll 95 98}}<td class="template_value">Hit hard surface; do normal damage to self (in the attacking limb if hit locations are being used)..</td>{{/rollBetween() roll 95 98}}
+			{{#rollBetween() roll 96 98}}<td class="template_value">Hit nearest ally for critical damage, or Break weapon, if no ally nearby</td>{{/rollBetween() roll 96 98}}
+			{{#rollTotal() roll 99}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 99}}
+			{{#rollTotal() roll 100}}<td class="template_value">Blow it; roll twice more on this table (cumulative if this result is rolled again)</td>{{/rollTotal() roll 100}}
+		{{/rollTotal() table 3}}
+		</tr>
+		</table>
+	</rolltemplate>
+	
+	<rolltemplate class="sheet-rolltemplate-major-wound">
+		<table style="background-color: #ffffff;" class="sheet-rolltemplate-skillRoll">
+			<tr>
+			<th>Major Wound</th>
+			</tr>
+			<tr>
+				{{#rollBetween() roll 1 10}} <td class="template_value"> Severed leg tendons cause limping; fused ankle bones cause limping; back muscles or spinal nerve damage bend the torso to the left or right; a shattered knee cannot bend; or make up a new wound effect. Lose 1D3 DEX. The maximum MOV is now reduced by the same 1D3 result. Your character is still able to fight. {{/rollBetween() roll 1 10}} </td>
+				{{#rollBetween() roll 11 20}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characters appearance; or make up a new wound effect. Lose 1D3 APP. The visible and unappealing deformity cannot be disguised. Your character is still able to fight. {{/rollBetween() roll 11 20}} </td>
+				{{#rollBetween() roll 21 30}} <td class="template_value"> Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D3 STR; this loss may change what weapons can be used. Your character is still able to fight with a weapon, but not a shield. {{/rollBetween() roll 21 30}} </td>
+				{{#rollBetween() roll 31 40}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D3 CON; maximum MOV is now reduced by the same 1D3, and hit points may be lowered. Your character is still able to fight. {{/rollBetween() roll 31 40}} </td>
+				{{#rollBetween() roll 41 50}} <td class="template_value"> Concussion damages hearing and limits Listen and Insight to maximums of 65 percent; injury to the head thereafter require Luck rolls each time to use any Mental skills; blows or cuts which affect depth perception leave missile weapon skill ratings at a maximum of 65%; multiple wounds to the face and neck limit the skills of any Communication skills to 65% maximum; or make up a new wound effect. Lose 1D3 INT; this loss may affect your characters ability to use any powers. Your character is still able to fight. {{/rollBetween() roll 41 50}} </td>
+				{{#rollBetween() roll 51 60}} <td class="template_value"> Refer to 0110 for what happened, which now expands to the loss of one or both arms or legs. Lose 1D6 DEX and reduce maximum MOV by that same amount. Your character is unable to fight.  {{/rollBetween() roll 51 60}} </td>
+				{{#rollBetween() roll 61 70}} <td class="template_value"> Much of the nose has been sliced away; multiple scars deface both hands; an ear has been cut off; a livid scar lends an evil cast to your characters appearance; or make up a new wound effect. . Lose 1D6 APP; it creates one or more visible deformities that cannot be disguised Your character is still able to fight. {{/rollBetween() roll 61 70}} </td>
+				{{#rollBetween() roll 71 80}} <td class="template_value">  Wrist or hand damage; a slab of arm or shoulder muscle has been cut away; a chunk was hewn from thigh or calf muscles; spinal nerves are damaged; several fingers or toes are severed; or make up a new wound effect. Lose 1D6 STR; change hit points and damage bonus. Your character is still able to fight. {{/rollBetween() roll 71 80}} </td>
+				{{#rollBetween() roll 81 90}} <td class="template_value"> A punctured lung leads to a weakened respiratory system; deep stomach wounds become chronically reinfected or belly wounds weaken digestion and general health; kidneys and liver are damaged; or make up a new wound effect. Lose 1D6 CON; may affect hit points, damage bonus, and reduces MOV by that number of units equal to the 1D6 result rolled.Your character is unable to fight. {{/rollBetween() roll 81 90}} </td>
+				{{#rollBetween() roll 91 92}} <td class="template_value"> Bad facial and vocal-cord injuries. Lose 1D6 APP; lower the Charisma roll respectively. Your character is still able to fight. {{/rollBetween() roll 91 92}} </td>
+				{{#rollBetween() roll 93 94}} <td class="template_value"> Broken bones and severed ganglia. Lose 1D6 DEX; from now on your character can only use one-handed melee weapons. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll 93 94}} </td>
+				{{#rollBetween() roll95 96}} <td class="template_value"> Nerve damage to left or right arm (roll 1D6; a result of 13 is the left arm, 46 is the right arm). Lose 1D6 DEX; hereafter your character can only wield weapons or equipment in his or her undamaged arm. Your character is still able to fight using his or her remaining arm. {{/rollBetween() roll95 96}} </td>
+				{{#rollBetween() roll 97 98}} <td class="template_value"> Nerve damage to both arms. Lose 1D6 DEX; though the legs are fine, neither arms nor hands can wield anything. Your character is unable to fight, unless using his or her legs or head butts. {{/rollBetween() roll 97 98}} </td>
+				{{#rollTotal() roll 99}} <td class="template_value"> Your character is mutilated with vicious wounds. Lose 1D3 points each from APP, DEX, and CON, and describe the results. Your character is unable to fight. {{/rollTotal() roll 99}} </td>
+				</tr>
+		</table>
+	</rolltemplate>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -26,8 +26,8 @@
             </div>
             <div class="sheet-col">
                 <label>Credits <input type="number" min="0" class="sheet-credits" name="attr_credits" /></label>
-                <label>Physical Description
-                <textarea rows="4" name="attr_Physical_Description"></textarea></label>
+                <label>Physical Description</label>
+                <textarea name="attr_Physical_Description" style="height:4em;" ></textarea>
             </div>
         </div>
     </div>
@@ -35,7 +35,7 @@
         <div class='sheet-3colrow'>
             <div class='sheet-col'>
                 <label class="sheet-areaLabel">Special Abilities</label>
-                <textarea name="attr_specialAbilities" style="width:230px;" rows="7"></textarea>
+                <textarea name="attr_specialAbilities" style="width:230px;height:9em;" ></textarea>
             </div>            
             <div class='sheet-col' >
                 <label>Move <input type="number" name="attr_move" class="sheet-smallshortnumber" min="0" value="10"/></label>
@@ -103,7 +103,7 @@
                         <button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
                           <input class="sheet-skilltext" type="text" name="attr_strskillname"/> 
                           <div class="sheet-right">
-							<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="0"/>D
+							<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
 							+<input type="number" name="attr_strskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                           </div>
                     </fieldset>			
@@ -119,8 +119,8 @@
                         <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
                           <input class="sheet-skilltext" type="text" name="attr_techskillname"/> 
                           <div class="sheet-right">
-                          <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
+                          <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+						  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                           </div>
                     </fieldset>
                 </td class="sheet-tdborder"> 
@@ -137,8 +137,8 @@
                         <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
                           <input class="sheet-skilltext" type="text" name="attr_dexskillname"/>
                           <div class="sheet-right">		
-                          <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/>
+                          <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+						  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
                           </div>
                     </fieldset>
                 </td>
@@ -153,8 +153,8 @@
                         <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
                           <input class="sheet-skilltext" type="text" name="attr_knowskillname"/> 
                           <div class="sheet-right">
-                          <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
+                          <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+						  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                           </div>
                     </fieldset>
                 </td> 
@@ -169,8 +169,8 @@
                         <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} +@{Force_ControlPain_ResistStun} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
                          <input class="sheet-skilltext" type="text" name="attr_mechskillname"/> 
                          <div class="sheet-right">
-                         <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1"/>D
-						 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2"/> 
+                         <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+						 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
                          </div>
                     </fieldset>
                 </td> 
@@ -302,7 +302,7 @@
 			<div class='sheet-col'>
 				<div><!-- Force Power list -->
 					<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
-					<textarea name="attr_forcePowers" rows="16"  style="width:220px"></textarea>
+					<textarea name="attr_forcePowers" style="width:260px;height:17em"></textarea>
 				</div>				
 			</div>		
 		</div>

--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -365,9 +365,9 @@
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
 								<span class="table-data center" style="min-width:80px">
 									<select name="attr_attackMod" class="modtype" title="Attack Modifier @{repeating_attack_X_attackMod}">           
-									  <option value="@{str|max}" >STR</option>
-									  <option value="@{dex|max}" >DEX</option>	
-									  <option value="@{cha|max}" >CHA</option>
+									  <option value="@{str|max}" data-i18n="str">STR</option>
+ 									  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
 								<span class="table-data center" style="min-width:50px">
@@ -399,11 +399,11 @@
 								<span class="table-data center" style="min-width:80px">	
 									<select name="attr_damageMod" class="modtype" title="Weapon Damage modifier @{repeating_attack_X_damageMod}">
 									  <option value="0" selected>None</option>                
-									  <option value="@{str|max}" >STR</option>
+									  <option value="@{str|max}" data-i18n="str">STR</option>
 									  <option value="[[@{str|max}*2]]">STRx2</option>
-									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="@{dex|max}" data-i18n="dex">DEX</option>
 									  <option value="[[@{dex|max}*2]]">DEXx2</option>
-									  <option value="@{cha|max}" >CHA</option>
+									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 									  <option value="[[@{cha|max}*2]]">CHAx2</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
@@ -479,12 +479,12 @@
 						<span class="table-data"><input type="number" name="attr_Acrobatics" value="@{AcrobaticsFormula}" disabled="true" title="Acrobatics Total @{Acrobatics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_AcrobaticsMod" class="modtype" title="Acrobatics Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat" title="Trained in Acrobatics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat_max" title="Focused in Acrobatics?" /></span> <!-- Skill Focus -->
@@ -522,12 +522,12 @@
 						<span class="table-data"><input type="number" name="attr_Climb" value="@{ClimbFormula}" disabled="true" title="Climb Total @{Climb}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_ClimbMod" class="modtype" title="Climb Mod (default STR)">
-							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str" selected>STR</option>
+							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat" title="Trained in Climb?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat_max" title="Focused in Climb?" /></span> <!-- Skill Focus -->
@@ -565,12 +565,12 @@
 						<span class="table-data"><input type="number" name="attr_Deception" value="@{DeceptionFormula}" disabled="true" title="Deception Total @{Deception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_DeceptionMod" class="modtype" title="Deception Mod (default CHA)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}"  selected>CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+							  <option value="@{con|max}" data-i18n="con">CON</option>
+							  <option value="@{int|max}" data-i18n="int">INT</option>
+							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat" title="Trained in Deception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat_max" title="Focused in Deception?" /></span> <!-- Skill Focus -->
@@ -608,12 +608,12 @@
 						<span class="table-data"><input type="number" name="attr_Endurance" value="@{EnduranceFormula}" disabled="true" title="Endurance Total @{Endurance}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_EnduranceMod" class="modtype" title="Endurance Mod (default CON)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}"  selected>CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con" selected>CON</option>
+ 						      <option value="@{int|max}" data-i18n="int">INT</option>
+ 						      <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat" title="Trained in Endurance?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat_max" title="Focused in Endurance?" /></span> <!-- Skill Focus -->
@@ -651,12 +651,12 @@
 						<span class="table-data"><input type="number" name="attr_GatherInformation" value="@{GatherInformationFormula}" disabled="true" title="Gather Information Total @{GatherInformation}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_GatherInformationMod" class="modtype" title="GatherInformation Mod (default CHA)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}"  selected>CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat" title="Trained in Gather Information?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat_max" title="Focused in Gather Information?" /></span> <!-- Skill Focus -->
@@ -694,12 +694,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -737,12 +737,12 @@
 						<span class="table-data"><input type="number" name="attr_Jump" value="@{JumpFormula}" disabled="true" title="Jump Total @{Jump}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_JumpMod" class="modtype" title="Jump Mod (default STR)">
-							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str" selected>STR</option>
+							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat" title="Trained in Jump?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat_max" title="Focused in Jump?" /></span> <!-- Skill Focus -->
@@ -782,12 +782,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Bureaucracy" value="@{Knowledge-BureaucracyFormula}" disabled="true" title="Knowledge (Bureaucracy) Total @{Knowledge-Bureaucracy}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-BureaucracyMod" class="modtype" title="Knowledge (Bureaucracy) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat" title="Trained in Knowledge (Bureaucracy)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat_max" title="Focused in Knowledge (Bureaucracy)?" /></span> <!-- Skill Focus -->
@@ -826,12 +826,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-GalacticLore" value="@{Knowledge-GalacticLoreFormula}" disabled="true" title="Knowledge (Galactic Lore) Total @{Knowledge-GalacticLore}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-GalacticLoreMod" class="modtype" title="Knowledge (Galactic Lore) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat" title="Trained in Knowledge (Galactic Lore)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat_max" title="Focused in Knowledge (Galactic Lore)?" /></span> <!-- Skill Focus -->
@@ -870,12 +870,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-LifeSciences" value="@{Knowledge-LifeSciencesFormula}" disabled="true" title="Knowledge (Life Sciences) Total @{Knowledge-LifeSciences}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-LifeSciencesMod" class="modtype" title="Knowledge (Life Sciences) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat" title="Trained in Knowledge (Life Sciences)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat_max" title="Focused in Knowledge (Life Sciences)?" /></span> <!-- Skill Focus -->
@@ -914,12 +914,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-PhysicalScience" value="@{Knowledge-PhysicalScienceFormula}" disabled="true" title="Knowledge (Physical Science) Total @{Knowledge-PhysicalScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-PhysicalScienceMod" class="modtype" title="Knowledge (Physical Science) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat" title="Trained in Knowledge (Physical Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat_max" title="Focused in Knowledge (Physical Science)?" /></span> <!-- Skill Focus -->
@@ -958,12 +958,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-SocialScience" value="@{Knowledge-SocialScienceFormula}" disabled="true" title="Knowledge (Social Science) Total @{Knowledge-SocialScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-SocialScienceMod" class="modtype" title="Knowledge (Social Science) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat" title="Trained in Knowledge (Social Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat_max" title="Focused in Knowledge (Social Science)?" /></span> <!-- Skill Focus -->
@@ -1002,12 +1002,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Tactics" value="@{Knowledge-TacticsFormula}" disabled="true" title="Knowledge (Tactics) Total @{Knowledge-Tactics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TacticsMod" class="modtype" title="Knowledge (Tactics) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat" title="Trained in Knowledge (Tactics)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat_max" title="Focused in Knowledge (Tactics)?" /></span> <!-- Skill Focus -->
@@ -1046,12 +1046,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Technology" value="@{Knowledge-TechnologyFormula}" disabled="true" title="Knowledge (Technology) Total @{Knowledge-Technology}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TechnologyMod" class="modtype" title="Knowledge (Technology) Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat" title="Trained in Knowledge (Technology)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat_max" title="Focused in Knowledge (Technology)?" /></span> <!-- Skill Focus -->
@@ -1090,12 +1090,12 @@
 						<span class="table-data"><input type="number" name="attr_Mechanics" value="@{MechanicsFormula}" disabled="true" title="Mechanics Total @{Mechanics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_MechanicsMod" class="modtype" title="Mechanics Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat" title="Trained in Mechanics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat_max" title="Focused in Mechanics?" /></span> <!-- Skill Focus -->
@@ -1133,12 +1133,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default WIS)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}"  selected>WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -1176,12 +1176,12 @@
 						<span class="table-data"><input type="number" name="attr_Persuasion" value="@{PersuasionFormula}" disabled="true" title="Persuasion Total @{Persuasion}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PersuasionMod" class="modtype" title="Persuasion Mod (default CHA)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}"  selected>CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat" title="Trained in Persuasion?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat_max" title="Focused in Persuasion?" /></span> <!-- Skill Focus -->
@@ -1219,12 +1219,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -1262,12 +1262,12 @@
 						<span class="table-data"><input type="number" name="attr_Ride" value="@{RideFormula}" disabled="true" title="Ride Total @{Ride}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_RideMod" class="modtype" title="Ride Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat" title="Trained in Ride?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat_max" title="Focused in Ride?" /></span> <!-- Skill Focus -->
@@ -1305,12 +1305,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
@@ -1349,12 +1349,12 @@
 						<span class="table-data"><input type="number" name="attr_Survival" value="@{SurvivalFormula}" disabled="true" title="Survival Total @{Survival}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SurvivalMod" class="modtype" title="Survival Mod (default WIS)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}"  selected>WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat" title="Trained in Survival?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat_max" title="Focused in Survival?" /></span> <!-- Skill Focus -->
@@ -1392,12 +1392,12 @@
 						<span class="table-data"><input type="number" name="attr_Swim" value="@{SwimFormula}" disabled="true" title="Swim Total @{Swim}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SwimMod" class="modtype" title="Swim Mod (default STR)">
-							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str" selected>STR</option>
+							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat" title="Trained in Swim?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat_max" title="Focused in Swim?" /></span> <!-- Skill Focus -->
@@ -1435,12 +1435,12 @@
 						<span class="table-data"><input type="number" name="attr_TreatInjury" value="@{TreatInjuryFormula}" disabled="true" title="Treat Injury Total @{TreatInjury}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_TreatInjuryMod" class="modtype" title="Treat Injury Mod (default WIS)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}"  selected>WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat" title="Trained in Treat Injury?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat_max" title="Focused in Treat Injury?" /></span> <!-- Skill Focus -->
@@ -1478,12 +1478,12 @@
 						<span class="table-data"><input type="number" name="attr_UseComputer" value="@{UseComputerFormula}" disabled="true" title="Use Computer Total @{UseComputer}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_UseComputerMod" class="modtype" title="Use Computer Mod (default INT)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}"  selected>INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat" title="Trained in Use Computer?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat_max" title="Focused in Use Computer?" /></span> <!-- Skill Focus -->
@@ -1521,12 +1521,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" >STR</option>
-						  <option value="@{dex|max}" >DEX</option>	
-						  <option value="@{con|max}" >CON</option>
-						  <option value="@{int|max}" >INT</option>
-						  <option value="@{wis|max}" >WIS</option>
-						  <option value="@{cha|max}"  selected>CHA</option>
+						  <option value="@{str|max}" data-i18n="str">STR</option>
+ 						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 						  <option value="@{con|max}" data-i18n="con">CON</option>
+ 						  <option value="@{int|max}" data-i18n="int">INT</option>
+ 						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->
@@ -1931,8 +1931,8 @@
 					<td><input type="number" name="attr_Grapple" value="@{BAB}[BAB]+@{GrpMod}[Mod]+@{GrappleSize}[Size]+@{GrpMod|max}[Misc]+@{CT}[CT]" disabled="true" title="Grapple @{Grapple}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier @{GrpMod}">
-					  <option value="@{str|max}" >STR</option>
-					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{str|max}" data-i18n="str">STR</option>
+ 					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
 					</select></td>				
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" value="0" name="attr_GrappleSize" class="hidden" />	<input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier @{GrpMod|max}" /></td>
@@ -2209,12 +2209,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default WIS)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -2252,12 +2252,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}" >DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}"  selected>WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -2295,12 +2295,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -2338,13 +2338,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" >STR</option>
-							  <option value="@{dex|max}"   selected>DEX</option>	
-							  <option value="@{con|max}" >CON</option>
-							  <option value="@{int|max}" >INT</option>
-							  <option value="@{wis|max}" >WIS</option>
-							  <option value="@{cha|max}" >CHA</option>
-							</select></span>
+							  <option value="@{str|max}" data-i18n="str">STR</option>
+ 							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
+ 							  <option value="@{con|max}" data-i18n="con">CON</option>
+ 							  <option value="@{int|max}" data-i18n="int">INT</option>
+ 							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
 						<span class="table-data"><input type="number" name="attr_StealthMisc" title="Stealth Miscellaneous Modifier" value="0" class="skills" /></span>
@@ -2381,12 +2380,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" >STR</option>
-						  <option value="@{dex|max}" >DEX</option>	
-						  <option value="@{con|max}" >CON</option>
-						  <option value="@{int|max}" >INT</option>
-						  <option value="@{wis|max}" >WIS</option>
-						  <option value="@{cha|max}"  selected>CHA</option>
+						  <option value="@{str|max}" data-i18n="str">STR</option>
+ 						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+ 						  <option value="@{con|max}" data-i18n="con">CON</option>
+ 						  <option value="@{int|max}" data-i18n="int">INT</option>
+ 						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+ 						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->

--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -5,43 +5,43 @@
 
 <div class="tab-content tab1">
     <div class="record"><img height="100px" width="300px" src="http://i.imgur.com/DzKBH23.png"/> <br />
-            	<span>Character Record Sheet</span></div> 
+            	<span data-i18n="character-sheet">Character Record Sheet</span></div>
     <div class="table left classHeader">
         <div class="table-row">
-			<span class="table-data long">	<label>Class:</label>		</span>
+			<span class="table-data long">	<label data-i18n="class">Class:</label>		</span>
 			<span class="table-data">		<input type="text" name="attr_rank" title="List of class levels @{rank}" style="width:100%" />	</span>	
 		</div>
 	</div>
 	<div class="table left classHeader">
 		<div class="table-row">
-			<span class="table-data long"><label>Level:</label>		</span>
+			<span class="table-data long"><label data-i18n="level">Level:</label>		</span>
 			<span class="table-data">	<input type="number" name="attr_level" title="Total number of Heroic levels @{level}" value="1" /> <input type="number" name="attr_level_max" value="[[(floor((@{level}+@{nonlevel})/2))]]"  title="Half Level @{level|max}" disabled="true" /></span>  <input type="hidden" name="attr_hlevel_max" value="[[(floor((@{level})/2))]]"  title="Half Heroic Level @{hlevel|max}" disabled="true" /></span>
 			<span class="table-data" style="width:15px"></span>	
-			<span class="table-data"><label><span>Background:</span></label>		</span>
+			<span class="table-data"><label><span data-i18n="background">Background:</span></label>		</span>
 			<span class="table-data">	<input type="text" name="attr_background" title="Background @{Background}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span>Species:</span></label>		</span>
+			<span class="table-data"><label><span data-i18n="species">Species:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_species" title="Species @{Species}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span>Destiny:</span></label>		</span>
+			<span class="table-data"><label><span data-i18n="destiny">Destiny:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_destiny" title="Destiny @{Destiny}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span>Gender:</span></label>		</span>
+			<span class="table-data"><label><span data-i18n="gender">Gender:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_gender" title="Gender @{Gender}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span>Size:</span></label>		</span>
+			<span class="table-data"><label><span data-i18n="size">Size:</span></label>		</span>
             <span class="table-data">	<select name="attr_Size" style="width:100%" title="Racial size. @{Size}">
-					<option value="Colossal">Colossal</option>                
-					<option value="Gargantuan">Gargantuan</option>
-					<option value="Huge">Huge</option>
-					<option value="Large">Large</option>
-					<option value="Medium" selected>Medium</option>
-					<option value="Small">Small</option>
-					<option value="Tiny">Tiny</option>
-					<option value="Diminutive">Diminutive</option>
-					<option value="Fine">Fine</option>
+					<option value="Colossal" data-i18n="size-colossal">Colossal</option>                
+					<option value="Gargantuan" data-i18n="size-gargantuan">Gargantuan</option>
+					<option value="Huge" data-i18n="size-huge">Huge</option>
+					<option value="Large" data-i18n="size-large">Large</option>
+					<option value="Medium" data-i18n="size-medium" selected>Medium</option>
+					<option value="Small" data-i18n="size-small">Small</option>
+					<option value="Tiny" data-i18n="size-tiny">Tiny</option>
+					<option value="Diminutive" data-i18n="size-diminutive">Diminutive</option>
+					<option value="Fine" data-i18n="size-fine">Fine</option>
 			</select>	</span> 
 			
 		</div>
@@ -51,39 +51,39 @@
 	<div class="3colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead"><span>Attributes</div>	</tr>
+				<tr><div class="textHead"><span data-i18n="attributes">Attributes</div>	</tr>
 				<tr>
-					<td class="col1">STR<br><div class="small"><span>Strength</span></div></td>
+					<td class="col1">STR<br><div class="small"><span data-i18n="strength">Strength</span></div></td>
 					<td><input type="number" name="attr_STR" value="8" title="Strength Score @{STR}" /></td>
 					<td><input type="number" name="attr_STR_max" value="[[floor(@{STR}/2-5)]]" disabled="true" title="Strength Modifier @{STR|max}" /></td>
 					<td><button type="roll" name="roll_STRCheck" value="&{template:skill} {{name=Strength}} {{skill=[[1d20+@{STR|max}[STR]+@{CT}[CT]]]}}" title="Roll Strength %{STRCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">DEX<br><div class="small"><span>Dexterity</span></div></td>
+					<td class="col1">DEX<br><div class="small"><span data-i18n="dexterity">Dexterity</span></div></td>
 					<td><input type="number" name="attr_DEX" value="8" title="Dexterity Score @{DEX}" /></td>
 					<td><input type="number" name="attr_DEX_max" value="[[floor(@{DEX}/2-5)]]" disabled="true" title="Dexterity Modifier @{DEX|max}" /></td>
 					<td><button type="roll" name="roll_DEXCheck" value="&{template:skill} {{name=Dexterity}} {{skill=[[1d20+@{Dex|max}[DEX]+@{CT}[CT]]]}}" title="Roll Dexterity  %{DEXCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CON<br><div class="small"><span>Constitution</span></div></td>
+					<td class="col1">CON<br><div class="small"><span data-i18n="constitution">Constitution</span></div></td>
 					<td><input type="number" name="attr_CON" value="8" title="Constitution Score @{CON}" /></td>
 					<td><input type="number" name="attr_CON_max" value="[[floor(@{CON}/2-5)]]" disabled="true" title="Constitution Modifier @{CON|max}" /></td>
 					<td><button type="roll" name="roll_CONCheck" value="&{template:skill} {{name=Constitution}} {{skill=[[ 1d20+@{Con|max}[CON]+@{CT}[CT]]]}}" title="Roll Constitution %{CONCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">INT<br><div class="small"><span>Intelligence</span></div></td>
+					<td class="col1">INT<br><div class="small"><span data-i18n="intelligence">Intelligence</span></div></td>
 					<td><input type="number" name="attr_INT" value="8" title="Intelligence Score @{INT}" /></td>
 					<td><input type="number" name="attr_INT_max" value="[[floor(@{INT}/2-5)]]" disabled="true" title="Intelligence Modifier @{INT|max}}" /></td>
 					<td><button type="roll" name="roll_INTCheck" value="&{template:skill} {{name=Intelligence}} {{skill=[[ 1d20+@{INT|max}[INT]+@{CT}[CT]]]}}" title="Roll Intelligence %{INTCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">WIS<br><div class="small"><span>Wisdom</span></div></td>
+					<td class="col1">WIS<br><div class="small"><span data-i18n="wisdom">Wisdom</span></div></td>
 					<td><input type="number" name="attr_WIS" value="8" title="Wisdom Score" /></td>
 					<td><input type="number" name="attr_WIS_max" value="[[floor(@{WIS}/2-5)]]" disabled="true" title="Wisdom Modifier" /></td>
 					<td><button type="roll" name="roll_WISCheck" value="&{template:skill} {{name=Wisdom}} {{skill=[[ 1d20+@{WIS|max}[WIS]+@{CT}[CT]]]}}" title="Roll Wisdom %{WISCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CHA<br><div class="small"><span>Charisma</span></div></td>
+					<td class="col1">CHA<br><div class="small"><span data-i18n="charisma">Charisma</span></div></td>
 					<td><input type="number" name="attr_CHA" value="8" title="Charisma Score @{CHA}" /></td>
 					<td><input type="number" name="attr_CHA_max" value="[[floor(@{CHA}/2-5)]]" disabled="true" title="Charisma Modifier @{CHA|max}" /></td>
 					<td><button type="roll" name="roll_CHACheck" value="&{template:skill} {{name=Charisma}} {{skill=[[ 1d20+@{CHA|max}[CHA]+@{CT}[CT]]]}}" title="Roll Charisma %{CHACheck}"></button></td>
@@ -92,50 +92,50 @@
 		</div>
 		<div class="col">
 			<table>		
-				<tr>	<td colspan="3"><div class="textHead"><span>Hit Points</span></div> </td>	
+				<tr>	<td colspan="3"><div class="textHead"><span data-i18n="hit-points">Hit Points</span></div> </td>	
 						<td></td> 	
 						<td width="15px" rowspan="7"></td>	
-						<td><div class="textHead"><span>Condition</span></div></td>	</tr>
+						<td><div class="textHead"><span data-i18n="condition">Condition</span></div></td>	</tr>
 				<tr><th>Current</th>		<th></th>	<th>Total</th>
 					<td></td>
 					<!-- rowspan placholder -->
 					<td rowspan="5" style="text-align:left">		
-						<input type="radio" value="0" name="attr_CT" checked="true" /> <span>Normal</span><br />
+						<input type="radio" value="0" name="attr_CT" checked="true" /> <span data-i18n="ct_normal">Normal</span><br />
 						<input type="radio" value="-1" name="attr_CT" /> -1<br />
 						<input type="radio" value="-2" name="attr_CT" /> -2<br />
 						<input type="radio" value="-5" name="attr_CT" /> -5<br />
 						<input type="radio" value="-10" name="attr_CT" /> -10<br />
-						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span>Helpless</span></td>		
+						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span data-i18n="ct_helpless">Helpless</span></td>		
 				</tr>
 				<tr>	
 					<td> <input type="number" name="attr_HP" value="0" title="Current HP @{HP}" /></td>
 					<td>&nbsp;/&nbsp;</td>
 					<td><input type="number" name="attr_HP_max" value="0" title="Max HP @{HP|max}" /></td>
 				</tr>
-				<tr>	<td colspan="4"><div class="textHead"><span>Threshold</span></div> </td>			</tr>
-				<tr>	<th><span>Total</span></th>	<th></th>	<th><span>Defense</span></th> 	<th><span>Misc</span></th>		</tr>
+				<tr>	<td colspan="4"><div class="textHead"><span data-i18n="threshold">Threshold</span></div> </td>			</tr>
+				<tr>	<th><span data-i18n="total">Total</span></th>	<th></th>	<th><span data-i18n="defense">Defense</span></th> 	<th><span data-i18n="misc">Misc</span></th>		</tr>
 				<tr>	
 					<td><input type="number" name="attr_DT" value="@{DamageThresholdDefense}+@{DamageThresholdSize}[Size]+@{DamageThresholdMisc}[Misc]"  disabled="true" title="Damage Threshold @{DT}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_DamageThresholdDefense" class="modtype" title="Damage Threshold Defense @{DamageThresholdDefense}">
-					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" selected>Fort</option>
-					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" >Will</option>
+					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" data-i18n="fortitude" selected>Fort</option>
+					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" data-i18n="will">Will</option>
 					</select></td>
 					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier @{DamageThresholdMisc}" />
 						<input type="number" value="0" name="attr_DamageThresholdSize" class="hidden" /></td>
 				</tr>
 			</table>
-			<p><span>Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
+			<p><span data-i18n="ignore_ct">Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
 			
-			<span class="displayInline-block"><label><span>Damage Reduction</span></label></span>
+			<span class="displayInline-block"><label><span data-i18n="damage_reduction">Damage Reduction</span></label></span>
 				<input type="checkbox" class="DRShow hideCheckbox" style="width:140px; margin-left:-156px;" value="1" name="attr_DR-Show" title="Show/Hide Damage Reduction" />	
 				<span class="DRBody not-sheet-show"><input type="number" name="attr_DR" value="0" title="Damage Reduction @{DR}" />	</span>
 			<br />
-			<span class="displayInline-block"><label><span>Shield Rating</span></label></span>
+			<span class="displayInline-block"><label><span data-i18n="shield_rating">Shield Rating</span></label></span>
 				<input type="checkbox" class="SRShow hideCheckbox" style="width:102px; margin-left:-118px;" value="1" name="attr_SR-Show" title="Show/Hide Shield Rating" />			
 					<span class="not-sheet-show SRBody"><input type="number" name="attr_SR" value="0" title="Current Shield Rating @{SR}" /> / <input type="number" name="attr_SR_max" value="0" title="Max Shield Rating @{SR|max}" /></span>
 			<br />
-			<span class="displayInline-block"><label><span>Immune</span></label></span>
+			<span class="displayInline-block"><label><span data-i18n="immune">Immune</span></label></span>
 				<input type="checkbox" class="immuneShow hideCheckbox" style="width:64px; margin-left:-80px;" value="1" name="attr_immune-Show"  title="Show/Hide Immunities"  />
 				<span class="not-sheet-show immuneBody"><input type="text" name="attr_Immune" value="" title="Immunities @{Immune}" style="width:75%" /> </span>
 			<span></span>	
@@ -146,8 +146,8 @@
 		<div class="col">				
 			<table class="spacing">
 				<tr>			
-					<td colspan="4"><div class="textHead"><span>Force Points</span></div></td>			
-					<td colspan="2"><div class="textHead"><span>Destiny Pts</span></div></td>
+					<td colspan="4"><div class="textHead"><span data-i18n="force_points">Force Points</span></div></td>			
+					<td colspan="2"><div class="textHead"><span data-i18n="destiny_points">Destiny Pts</span></div></td>
 				</tr>
 				<tr>
 					<td colspan="4"><input type="number" name="attr_FP" value="5" title="Current Force Points @{FP}" />  
@@ -156,9 +156,9 @@
 					<td colspan="2"><input type="number" name="attr_DP" value="0" title="Destiny Points" /></td>						
 				</tr>
 				<tr>						
-					<td colspan="2"><div class="textHead"><span>BAB</span></div></td>
-					<td colspan="2"><div class="textHead"><span>Speed</span></div></td>	
-					<td colspan="2"><div class="textHead"><span>Dark Side Pts</span></div></td>		
+					<td colspan="2"><div class="textHead"><span data-i18n="bab">BAB</span></div></td>
+					<td colspan="2"><div class="textHead"><span data-i18n="speed">Speed</span></div></td>	
+					<td colspan="2"><div class="textHead"><span data-i18n="dark_side_points">Dark Side Pts</span></div></td>		
 				</tr>
 				<tr>	
 					<td colspan="2"><input type="number" name="attr_BAB" value="0" title="Base Attack Bonus @{BAB}" /></td>
@@ -170,8 +170,8 @@
 			<div class="table left">			
 				<div class="table-row">
 					<span class="table-data">	
-					<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
-						<label><span>Perception</span></label>
+						<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
+						<label><span data-i18n="perception">Perception</span></label>
 						<input type="checkbox" class="PerceptionShow hideCheckbox" style="width:84px; margin-left:-100px;" value="1" name="attr_Perception-Show"  title="Show/Hide Perception Notes" />	
 						<br />
 						<input class="PerceptionBody" style="margin-left:50px" type="text" name="attr_Perception_max" placeholder="Senses Notes" title="Senses Notes @{Perception|max}" />	 	</span>
@@ -180,27 +180,27 @@
 				<div class="table-row">
 					<span class="table-data">	
 						<button type="roll" name="roll_InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Dex Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
-						<label><span>Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox" value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked />Dex Score as Decimal</span>
+						<label><span data-i18n="initiative">Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox"  value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked /><span data-i18n="init_dex_decimal" class="sheet-not-sheet-show">Dex Score as Decimal</span>
 					</span>
 				</div>
 			</div>
 			<table>
 				<tr>		
-					<td colspan="6"><div class="textHead"><span>Grapple</span></div></td>		
+					<td colspan="6"><div class="textHead"><span data-i18n="grapple">Grapple</span></div></td>		
 				</tr>
 				<tr>		
 					<th colspan="3"></th>
-					<th><span>Mod</span></th>		
+					<th><span data-i18n="mod">Mod</span></th>		
 					<th></th>
-					<th><span>Misc<span></th>
+					<th><span data-i18n="misc">Misc<span></th>
 				</tr>			
 				<tr>
 					<td><button type="roll" name="roll_GrappleCheck" value="&{template:skill} {{name=Grapple}} {{skill=[[1d20+@{Grapple}+?{Other Modifiers|0}[Other]]]}}" title="Roll Grapple %{GrappleCheck}"></button></td>		
 					<td><input type="number" name="attr_Grapple" value="@{BAB}[BAB]+@{GrpMod}[Mod]+@{GrappleSize}[Size]+@{GrpMod|max}[Misc]+@{CT}[CT]" disabled="true" title="Grapple @{Grapple}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier @{GrpMod}">
-					  <option value="@{str|max}" >STR</option>
-					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{str|max}" data-i18n="str">STR</option>
+					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
 					</select></td>				
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" value="0" name="attr_GrappleSize" class="hidden" />	<input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier @{GrpMod|max}" /></td>
@@ -213,38 +213,38 @@
 	<div class="2colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead2Col"><span>Defenses</span></div></tr>
+				<tr><div class="textHead2Col"><span data-i18n="defenses">Defenses</span></div></tr>
 				<thead>
 					<tr>
 						<th></th>
-						<th><span>Total</span></th>
+						<th><span data-i18n="total">Total</span></th>
 						<th></th>
-						<th style="min-width:50px">	<span><span>Level</span> /<br /><span>Armor</span></span>	</th>
-						<th><span>Class</span></th>					
-						<th><span>Mod</span></th>
-						<th><span>Misc</span></th>
+						<th style="min-width:50px">	<span><span data-i18n="level">Level</span> /<br /><span data-i18n="armor">Armor</span></span>	</th>
+						<th><span data-i18n="class">Class</span></th>					
+						<th><span data-i18n="mod">Mod</span></th>
+						<th><span data-i18n="misc">Misc</span></th>
 					</tr>
 				</thead>	
 			  <tbody>
 				<tr>
-					<td class="col1" rowspan="2"><span>Reflex</span></td>
+					<td class="col1" rowspan="2"><span data-i18n="reflex">Reflex</span></td>
 					<td><input type="number" name="attr_Reflex" value="10+@{RefMod}[Mod]+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex @{Reflex}" /></td> 
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_RefLevel" value="@{RefLevel|max}"  disabled="true" title="Reflex Level / Armor bonus @{RefLevel}"/>	<input type="text" name="attr_RefLevel_max" value="@{level}" title="Reflex Level Formula @{RefLevel|max}"  class="hidden" /></td>	
 					<td><input type="number" name="attr_RefClass" value="0" title="Reflex Class bonus @{RefClass}" /></td>
 					<td> <select name="attr_RefMod" class="modtype" title="Reflex Ability Modifier (default DEX) @{RefMod}">
-					  <option value="@{str|max}" >STR</option>
-					  <option value="@{dex|max}"  selected>DEX</option>					  
-					  <option value="@{ArmorDex}" >DEX (Max Armor)</option>
-					  <option value="@{con|max}" >CON</option>
-					  <option value="@{int|max}" >INT</option>
-					  <option value="@{wis|max}" >WIS</option>
-					  <option value="@{cha|max}" >CHA</option>
+					  <option value="@{str|max}" data-i18n="str">STR</option>
+					  <option value="@{dex|max}" data-i18n="dex" selected>DEX</option>					  
+					  <option value="@{ArmorDex}" data-i18n="dex_max">DEX (Max Armor)</option>
+					  <option value="@{con|max}" data-i18n="con">CON</option>
+					  <option value="@{int|max}" data-i18n="int">INT</option>
+					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_RefMisc" value="0" title="Reflex Miscellaneous Modifier @{RefMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><div class="small"><span>Flatfooted</span></div></td>
+					<td class="col1"><div class="small"><span data-i18n="flatfooted">Flatfooted</span></div></td>
 					<td><input type="number" name="attr_ReflexFlatFooted" value="10+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefFlatFootedMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex Flat Footed @{ReflexFlatFooted}" /></td>
 					<td></td>
 					<td colspan="2" align="right">
@@ -254,34 +254,34 @@
 				</tr>
 						
 				<tr>
-					<td class="col1"><span>Fortitude</span></td>
+					<td class="col1"><span data-i18n="fortitude">Fortitude</span></td>
 					<td><input type="number" name="attr_Fortitude" value="10+@{FortMod}[Mod]+@{FortLevel}[Level]+@{FortClass}[Class]+@{FortMisc}[Misc]+@{CT}[CT]" disabled="true" title="Fortitude  @{Fortitude}" />
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_FortLevel" value="@{FortLevel|max}"  disabled="true"  title="Fortitude Level / Armor bonus @{FortLevel}" />	<input type="text" name="attr_FortLevel_max" value="@{level}" title="Fortitude Level Formula @{FortLevel|max}" class="hidden" /></td>	
 					<td><input type="number" name="attr_FortClass" value="0" title="Fortitude Class bonus @{FortClass}" /></td>
 					<td> <select name="attr_FortMod" class="modtype " title="Fortitude Ability Modifier (default CON) @{FortMod}">
-					  <option value="@{str|max}" >STR</option>
-					  <option value="@{dex|max}" >DEX</option>	
-					  <option value="@{con|max}"  selected>CON</option>
-					  <option value="@{int|max}" >INT</option>
-					  <option value="@{wis|max}" >WIS</option>
-					  <option value="@{cha|max}" >CHA</option>
+					  <option value="@{str|max}" data-i18n="str">STR</option>
+					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{con|max}" data-i18n="con" selected>CON</option>
+					  <option value="@{int|max}" data-i18n="int">INT</option>
+					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
+					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_FortMisc" value="0" title="Fortitude Miscellaneous Modifier @{FortMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><span>Will</span></td>
+					<td class="col1"><span data-i18n="will">Will</span></td>
 					<td><input type="number" name="attr_Will" value="10+@{WillMod}[Mod]+@{WillLevel}[Level]+@{WillClass}[Class]+@{WillMisc}[Misc]+@{CT}[CT]" disabled="true" title="Will @{Will}" /></td>
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_WillLevel" value="@{level}"  disabled="true" title="Will Level / Armor bonus @{WillLevel}"/></td>		
 					<td><input type="number" name="attr_WillClass" value="0" title="Will Class bonus @{WillClass}" /></td>
 					<td> <select name="attr_WillMod" class="modtype" title="Will Ability Modifier (default WIS) @{WillMod}">
-					  <option value="@{str|max}" >STR</option>
-					  <option value="@{dex|max}" >DEX</option>	
-					  <option value="@{con|max}" >CON</option>
-					  <option value="@{int|max}" >INT</option>
-					  <option value="@{wis|max}"  selected>WIS</option>
-					  <option value="@{cha|max}" >CHA</option>
+					  <option value="@{str|max}" data-i18n="str">STR</option>
+					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{con|max}" data-i18n="con">CON</option>
+					  <option value="@{int|max}" data-i18n="int">INT</option>
+					  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
+					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_WillMisc" value="0" title="Will Miscellaneous Modifier @{WillMisc}" /></td>
 				</tr>
@@ -1927,16 +1927,16 @@
 					<th>Misc</th>	
 				</tr>
 				<tr>
-					<td><button type="roll" name="roll_NPC-GrappleCheck" value="&{template:skill} {{name=Grapple}} {{skill=[[1d20+@{NPC-Grapple}+?{Other Modifiers|0}[Other]]]}}" title="Roll Grapple"></button></td>
-					<td><input type="number" name="attr_NPC-Grapple" value="@{BAB} + @{GrpMod}[Mod] + @{GrpMod|max} + @{GrappleSize} +@{npc-ct}" disabled="true" title="Grapple" /></td>
+					<td><button type="roll" name="roll_GrappleCheck" value="&{template:skill} {{name=Grapple}} {{skill=[[1d20+@{Grapple}+?{Other Modifiers|0}[Other]]]}}" title="Roll Grapple %{GrappleCheck}"></button></td>		
+					<td><input type="number" name="attr_Grapple" value="@{BAB}[BAB]+@{GrpMod}[Mod]+@{GrappleSize}[Size]+@{GrpMod|max}[Misc]+@{CT}[CT]" disabled="true" title="Grapple @{Grapple}" /></td>
 					<td>&nbsp;=&nbsp;</td>
-					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier">
+					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier @{GrpMod}">
 					  <option value="@{str|max}" >STR</option>
 					  <option value="@{dex|max}" >DEX</option>	
-					</select></td>
+					</select></td>				
 					<td>&nbsp;+&nbsp;</td>
-					<td><input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier" /></td>
-				</tr>	
+					<td><input type="number" value="0" name="attr_GrappleSize" class="hidden" />	<input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier @{GrpMod|max}" /></td>
+				</tr>
 			</table>
 		</div>
 	</div>

--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -5,43 +5,43 @@
 
 <div class="tab-content tab1">
     <div class="record"><img height="100px" width="300px" src="http://i.imgur.com/DzKBH23.png"/> <br />
-            	<span data-i18n="character-sheet">Character Record Sheet</span></div>
+            	<span>Character Record Sheet</span></div> 
     <div class="table left classHeader">
         <div class="table-row">
-			<span class="table-data long">	<label data-i18n="class">Class:</label>		</span>
+			<span class="table-data long">	<label>Class:</label>		</span>
 			<span class="table-data">		<input type="text" name="attr_rank" title="List of class levels @{rank}" style="width:100%" />	</span>	
 		</div>
 	</div>
 	<div class="table left classHeader">
 		<div class="table-row">
-			<span class="table-data long"><label data-i18n="level">Level:</label>		</span>
-			<span class="table-data">	<input type="number" name="attr_level" title="Total number of Heroic levels @{level}" value="1" /> <input type="number" name="attr_level_max" value="[[(floor((@{level}+@{nonlevel})/2))]]"  title="Half Level @{level|max}" disabled="true" /></span>
+			<span class="table-data long"><label>Level:</label>		</span>
+			<span class="table-data">	<input type="number" name="attr_level" title="Total number of Heroic levels @{level}" value="1" /> <input type="number" name="attr_level_max" value="[[(floor((@{level}+@{nonlevel})/2))]]"  title="Half Level @{level|max}" disabled="true" /></span>  <input type="hidden" name="attr_hlevel_max" value="[[(floor((@{level})/2))]]"  title="Half Heroic Level @{hlevel|max}" disabled="true" /></span>
 			<span class="table-data" style="width:15px"></span>	
-			<span class="table-data"><label><span data-i18n="background">Background:</span></label>		</span>
+			<span class="table-data"><label><span>Background:</span></label>		</span>
 			<span class="table-data">	<input type="text" name="attr_background" title="Background @{Background}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span data-i18n="species">Species:</span></label>		</span>
+			<span class="table-data"><label><span>Species:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_species" title="Species @{Species}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span data-i18n="destiny">Destiny:</span></label>		</span>
+			<span class="table-data"><label><span>Destiny:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_destiny" title="Destiny @{Destiny}" class="header" /></span>
 		</div>
 		<div class="table-row">
-			<span class="table-data"><label><span data-i18n="gender">Gender:</span></label>		</span>
+			<span class="table-data"><label><span>Gender:</span></label>		</span>
             <span class="table-data">	<input type="text" name="attr_gender" title="Gender @{Gender}" class="header" /></span>
 			<span class="table-data"></span>
-			<span class="table-data"><label><span data-i18n="size">Size:</span></label>		</span>
+			<span class="table-data"><label><span>Size:</span></label>		</span>
             <span class="table-data">	<select name="attr_Size" style="width:100%" title="Racial size. @{Size}">
-					<option value="Colossal" data-i18n="size-colossal">Colossal</option>                
-					<option value="Gargantuan" data-i18n="size-gargantuan">Gargantuan</option>
-					<option value="Huge" data-i18n="size-huge">Huge</option>
-					<option value="Large" data-i18n="size-large">Large</option>
-					<option value="Medium" data-i18n="size-medium" selected>Medium</option>
-					<option value="Small" data-i18n="size-small">Small</option>
-					<option value="Tiny" data-i18n="size-tiny">Tiny</option>
-					<option value="Diminutive" data-i18n="size-diminutive">Diminutive</option>
-					<option value="Fine" data-i18n="size-fine">Fine</option>
+					<option value="Colossal">Colossal</option>                
+					<option value="Gargantuan">Gargantuan</option>
+					<option value="Huge">Huge</option>
+					<option value="Large">Large</option>
+					<option value="Medium" selected>Medium</option>
+					<option value="Small">Small</option>
+					<option value="Tiny">Tiny</option>
+					<option value="Diminutive">Diminutive</option>
+					<option value="Fine">Fine</option>
 			</select>	</span> 
 			
 		</div>
@@ -51,39 +51,39 @@
 	<div class="3colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead"><span data-i18n="attributes">Attributes</div>	</tr>
+				<tr><div class="textHead"><span>Attributes</div>	</tr>
 				<tr>
-					<td class="col1">STR<br><div class="small"><span data-i18n="strength">Strength</span></div></td>
+					<td class="col1">STR<br><div class="small"><span>Strength</span></div></td>
 					<td><input type="number" name="attr_STR" value="8" title="Strength Score @{STR}" /></td>
 					<td><input type="number" name="attr_STR_max" value="[[floor(@{STR}/2-5)]]" disabled="true" title="Strength Modifier @{STR|max}" /></td>
 					<td><button type="roll" name="roll_STRCheck" value="&{template:skill} {{name=Strength}} {{skill=[[1d20+@{STR|max}[STR]+@{CT}[CT]]]}}" title="Roll Strength %{STRCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">DEX<br><div class="small"><span data-i18n="dexterity">Dexterity</span></div></td>
+					<td class="col1">DEX<br><div class="small"><span>Dexterity</span></div></td>
 					<td><input type="number" name="attr_DEX" value="8" title="Dexterity Score @{DEX}" /></td>
 					<td><input type="number" name="attr_DEX_max" value="[[floor(@{DEX}/2-5)]]" disabled="true" title="Dexterity Modifier @{DEX|max}" /></td>
 					<td><button type="roll" name="roll_DEXCheck" value="&{template:skill} {{name=Dexterity}} {{skill=[[1d20+@{Dex|max}[DEX]+@{CT}[CT]]]}}" title="Roll Dexterity  %{DEXCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CON<br><div class="small"><span data-i18n="constitution">Constitution</span></div></td>
+					<td class="col1">CON<br><div class="small"><span>Constitution</span></div></td>
 					<td><input type="number" name="attr_CON" value="8" title="Constitution Score @{CON}" /></td>
 					<td><input type="number" name="attr_CON_max" value="[[floor(@{CON}/2-5)]]" disabled="true" title="Constitution Modifier @{CON|max}" /></td>
 					<td><button type="roll" name="roll_CONCheck" value="&{template:skill} {{name=Constitution}} {{skill=[[ 1d20+@{Con|max}[CON]+@{CT}[CT]]]}}" title="Roll Constitution %{CONCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">INT<br><div class="small"><span data-i18n="intelligence">Intelligence</span></div></td>
+					<td class="col1">INT<br><div class="small"><span>Intelligence</span></div></td>
 					<td><input type="number" name="attr_INT" value="8" title="Intelligence Score @{INT}" /></td>
 					<td><input type="number" name="attr_INT_max" value="[[floor(@{INT}/2-5)]]" disabled="true" title="Intelligence Modifier @{INT|max}}" /></td>
 					<td><button type="roll" name="roll_INTCheck" value="&{template:skill} {{name=Intelligence}} {{skill=[[ 1d20+@{INT|max}[INT]+@{CT}[CT]]]}}" title="Roll Intelligence %{INTCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">WIS<br><div class="small"><span data-i18n="wisdom">Wisdom</span></div></td>
+					<td class="col1">WIS<br><div class="small"><span>Wisdom</span></div></td>
 					<td><input type="number" name="attr_WIS" value="8" title="Wisdom Score" /></td>
 					<td><input type="number" name="attr_WIS_max" value="[[floor(@{WIS}/2-5)]]" disabled="true" title="Wisdom Modifier" /></td>
 					<td><button type="roll" name="roll_WISCheck" value="&{template:skill} {{name=Wisdom}} {{skill=[[ 1d20+@{WIS|max}[WIS]+@{CT}[CT]]]}}" title="Roll Wisdom %{WISCheck}"></button></td>
 				</tr>
 				<tr>
-					<td class="col1">CHA<br><div class="small"><span data-i18n="charisma">Charisma</span></div></td>
+					<td class="col1">CHA<br><div class="small"><span>Charisma</span></div></td>
 					<td><input type="number" name="attr_CHA" value="8" title="Charisma Score @{CHA}" /></td>
 					<td><input type="number" name="attr_CHA_max" value="[[floor(@{CHA}/2-5)]]" disabled="true" title="Charisma Modifier @{CHA|max}" /></td>
 					<td><button type="roll" name="roll_CHACheck" value="&{template:skill} {{name=Charisma}} {{skill=[[ 1d20+@{CHA|max}[CHA]+@{CT}[CT]]]}}" title="Roll Charisma %{CHACheck}"></button></td>
@@ -92,50 +92,50 @@
 		</div>
 		<div class="col">
 			<table>		
-				<tr>	<td colspan="3"><div class="textHead"><span data-i18n="hit-points">Hit Points</span></div> </td>	
+				<tr>	<td colspan="3"><div class="textHead"><span>Hit Points</span></div> </td>	
 						<td></td> 	
 						<td width="15px" rowspan="7"></td>	
-						<td><div class="textHead"><span data-i18n="condition">Condition</span></div></td>	</tr>
+						<td><div class="textHead"><span>Condition</span></div></td>	</tr>
 				<tr><th>Current</th>		<th></th>	<th>Total</th>
 					<td></td>
 					<!-- rowspan placholder -->
 					<td rowspan="5" style="text-align:left">		
-						<input type="radio" value="0" name="attr_CT" checked="true" /> <span data-i18n="ct_normal">Normal</span><br />
+						<input type="radio" value="0" name="attr_CT" checked="true" /> <span>Normal</span><br />
 						<input type="radio" value="-1" name="attr_CT" /> -1<br />
 						<input type="radio" value="-2" name="attr_CT" /> -2<br />
 						<input type="radio" value="-5" name="attr_CT" /> -5<br />
 						<input type="radio" value="-10" name="attr_CT" /> -10<br />
-						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span data-i18n="ct_helpless">Helpless</span></td>		
+						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span>Helpless</span></td>		
 				</tr>
 				<tr>	
 					<td> <input type="number" name="attr_HP" value="0" title="Current HP @{HP}" /></td>
 					<td>&nbsp;/&nbsp;</td>
 					<td><input type="number" name="attr_HP_max" value="0" title="Max HP @{HP|max}" /></td>
 				</tr>
-				<tr>	<td colspan="4"><div class="textHead"><span data-i18n="threshold">Threshold</span></div> </td>			</tr>
-				<tr>	<th><span data-i18n="total">Total</span></th>	<th></th>	<th><span data-i18n="defense">Defense</span></th> 	<th><span data-i18n="misc">Misc</span></th>		</tr>
+				<tr>	<td colspan="4"><div class="textHead"><span>Threshold</span></div> </td>			</tr>
+				<tr>	<th><span>Total</span></th>	<th></th>	<th><span>Defense</span></th> 	<th><span>Misc</span></th>		</tr>
 				<tr>	
 					<td><input type="number" name="attr_DT" value="@{DamageThresholdDefense}+@{DamageThresholdSize}[Size]+@{DamageThresholdMisc}[Misc]"  disabled="true" title="Damage Threshold @{DT}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_DamageThresholdDefense" class="modtype" title="Damage Threshold Defense @{DamageThresholdDefense}">
-					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" data-i18n="fortitude" selected>Fort</option>
-					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" data-i18n="will">Will</option>
+					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" selected>Fort</option>
+					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" >Will</option>
 					</select></td>
 					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier @{DamageThresholdMisc}" />
 						<input type="number" value="0" name="attr_DamageThresholdSize" class="hidden" /></td>
 				</tr>
 			</table>
-			<p><span data-i18n="ignore_ct">Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
+			<p><span>Ignore CT?</span> <input type="checkbox" value="[[@{CT}*-1]][CT Ignore]" name="attr_CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track? @{CTIgnoreDT}" /></p>
 			
-			<span class="displayInline-block"><label><span data-i18n="damage_reduction">Damage Reduction</span></label></span>
+			<span class="displayInline-block"><label><span>Damage Reduction</span></label></span>
 				<input type="checkbox" class="DRShow hideCheckbox" style="width:140px; margin-left:-156px;" value="1" name="attr_DR-Show" title="Show/Hide Damage Reduction" />	
 				<span class="DRBody not-sheet-show"><input type="number" name="attr_DR" value="0" title="Damage Reduction @{DR}" />	</span>
 			<br />
-			<span class="displayInline-block"><label><span data-i18n="shield_rating">Shield Rating</span></label></span>
+			<span class="displayInline-block"><label><span>Shield Rating</span></label></span>
 				<input type="checkbox" class="SRShow hideCheckbox" style="width:102px; margin-left:-118px;" value="1" name="attr_SR-Show" title="Show/Hide Shield Rating" />			
 					<span class="not-sheet-show SRBody"><input type="number" name="attr_SR" value="0" title="Current Shield Rating @{SR}" /> / <input type="number" name="attr_SR_max" value="0" title="Max Shield Rating @{SR|max}" /></span>
 			<br />
-			<span class="displayInline-block"><label><span data-i18n="immune">Immune</span></label></span>
+			<span class="displayInline-block"><label><span>Immune</span></label></span>
 				<input type="checkbox" class="immuneShow hideCheckbox" style="width:64px; margin-left:-80px;" value="1" name="attr_immune-Show"  title="Show/Hide Immunities"  />
 				<span class="not-sheet-show immuneBody"><input type="text" name="attr_Immune" value="" title="Immunities @{Immune}" style="width:75%" /> </span>
 			<span></span>	
@@ -146,8 +146,8 @@
 		<div class="col">				
 			<table class="spacing">
 				<tr>			
-					<td colspan="4"><div class="textHead"><span data-i18n="force_points">Force Points</span></div></td>			
-					<td colspan="2"><div class="textHead"><span data-i18n="destiny_points">Destiny Pts</span></div></td>
+					<td colspan="4"><div class="textHead"><span>Force Points</span></div></td>			
+					<td colspan="2"><div class="textHead"><span>Destiny Pts</span></div></td>
 				</tr>
 				<tr>
 					<td colspan="4"><input type="number" name="attr_FP" value="5" title="Current Force Points @{FP}" />  
@@ -156,9 +156,9 @@
 					<td colspan="2"><input type="number" name="attr_DP" value="0" title="Destiny Points" /></td>						
 				</tr>
 				<tr>						
-					<td colspan="2"><div class="textHead"><span data-i18n="bab">BAB</span></div></td>
-					<td colspan="2"><div class="textHead"><span data-i18n="speed">Speed</span></div></td>	
-					<td colspan="2"><div class="textHead"><span data-i18n="dark_side_points">Dark Side Pts</span></div></td>		
+					<td colspan="2"><div class="textHead"><span>BAB</span></div></td>
+					<td colspan="2"><div class="textHead"><span>Speed</span></div></td>	
+					<td colspan="2"><div class="textHead"><span>Dark Side Pts</span></div></td>		
 				</tr>
 				<tr>	
 					<td colspan="2"><input type="number" name="attr_BAB" value="0" title="Base Attack Bonus @{BAB}" /></td>
@@ -170,8 +170,8 @@
 			<div class="table left">			
 				<div class="table-row">
 					<span class="table-data">	
-						<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
-						<label><span data-i18n="perception">Perception</span></label>
+					<button type="roll" name="roll_PerceptionCheck" value="@{PerceptionFormula|max}" title="Roll Perception  %{PerceptionCheck} "></button>
+						<label><span>Perception</span></label>
 						<input type="checkbox" class="PerceptionShow hideCheckbox" style="width:84px; margin-left:-100px;" value="1" name="attr_Perception-Show"  title="Show/Hide Perception Notes" />	
 						<br />
 						<input class="PerceptionBody" style="margin-left:50px" type="text" name="attr_Perception_max" placeholder="Senses Notes" title="Senses Notes @{Perception|max}" />	 	</span>
@@ -180,27 +180,27 @@
 				<div class="table-row">
 					<span class="table-data">	
 						<button type="roll" name="roll_InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Dex Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
-						<label><span data-i18n="initiative">Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox"  value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked /><span data-i18n="init_dex_decimal" class="sheet-not-sheet-show">Dex Score as Decimal</span>
+						<label><span>Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox" value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked />Dex Score as Decimal</span>
 					</span>
 				</div>
 			</div>
 			<table>
 				<tr>		
-					<td colspan="6"><div class="textHead"><span data-i18n="grapple">Grapple</span></div></td>		
+					<td colspan="6"><div class="textHead"><span>Grapple</span></div></td>		
 				</tr>
 				<tr>		
 					<th colspan="3"></th>
-					<th><span data-i18n="mod">Mod</span></th>		
+					<th><span>Mod</span></th>		
 					<th></th>
-					<th><span data-i18n="misc">Misc<span></th>
+					<th><span>Misc<span></th>
 				</tr>			
 				<tr>
 					<td><button type="roll" name="roll_GrappleCheck" value="&{template:skill} {{name=Grapple}} {{skill=[[1d20+@{Grapple}+?{Other Modifiers|0}[Other]]]}}" title="Roll Grapple %{GrappleCheck}"></button></td>		
 					<td><input type="number" name="attr_Grapple" value="@{BAB}[BAB]+@{GrpMod}[Mod]+@{GrappleSize}[Size]+@{GrpMod|max}[Misc]+@{CT}[CT]" disabled="true" title="Grapple @{Grapple}" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier @{GrpMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
 					</select></td>				
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" value="0" name="attr_GrappleSize" class="hidden" />	<input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier @{GrpMod|max}" /></td>
@@ -213,38 +213,38 @@
 	<div class="2colrow">
 		<div class="col">
 			<table class="spacing">
-				<tr><div class="textHead2Col"><span data-i18n="defenses">Defenses</span></div></tr>
+				<tr><div class="textHead2Col"><span>Defenses</span></div></tr>
 				<thead>
 					<tr>
 						<th></th>
-						<th><span data-i18n="total">Total</span></th>
+						<th><span>Total</span></th>
 						<th></th>
-						<th style="min-width:50px">	<span><span data-i18n="level">Level</span> /<br /><span data-i18n="armor">Armor</span></span>	</th>
-						<th><span data-i18n="class">Class</span></th>					
-						<th><span data-i18n="mod">Mod</span></th>
-						<th><span data-i18n="misc">Misc</span></th>
+						<th style="min-width:50px">	<span><span>Level</span> /<br /><span>Armor</span></span>	</th>
+						<th><span>Class</span></th>					
+						<th><span>Mod</span></th>
+						<th><span>Misc</span></th>
 					</tr>
 				</thead>	
 			  <tbody>
 				<tr>
-					<td class="col1" rowspan="2"><span data-i18n="reflex">Reflex</span></td>
+					<td class="col1" rowspan="2"><span>Reflex</span></td>
 					<td><input type="number" name="attr_Reflex" value="10+@{RefMod}[Mod]+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex @{Reflex}" /></td> 
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_RefLevel" value="@{RefLevel|max}"  disabled="true" title="Reflex Level / Armor bonus @{RefLevel}"/>	<input type="text" name="attr_RefLevel_max" value="@{level}" title="Reflex Level Formula @{RefLevel|max}"  class="hidden" /></td>	
 					<td><input type="number" name="attr_RefClass" value="0" title="Reflex Class bonus @{RefClass}" /></td>
 					<td> <select name="attr_RefMod" class="modtype" title="Reflex Ability Modifier (default DEX) @{RefMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex" selected>DEX</option>					  
-					  <option value="@{ArmorDex}" data-i18n="dex_max">DEX (Max Armor)</option>
-					  <option value="@{con|max}" data-i18n="con">CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}"  selected>DEX</option>					  
+					  <option value="@{ArmorDex}" >DEX (Max Armor)</option>
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_RefMisc" value="0" title="Reflex Miscellaneous Modifier @{RefMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><div class="small"><span data-i18n="flatfooted">Flatfooted</span></div></td>
+					<td class="col1"><div class="small"><span>Flatfooted</span></div></td>
 					<td><input type="number" name="attr_ReflexFlatFooted" value="10+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefFlatFootedMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex Flat Footed @{ReflexFlatFooted}" /></td>
 					<td></td>
 					<td colspan="2" align="right">
@@ -254,34 +254,34 @@
 				</tr>
 						
 				<tr>
-					<td class="col1"><span data-i18n="fortitude">Fortitude</span></td>
+					<td class="col1"><span>Fortitude</span></td>
 					<td><input type="number" name="attr_Fortitude" value="10+@{FortMod}[Mod]+@{FortLevel}[Level]+@{FortClass}[Class]+@{FortMisc}[Misc]+@{CT}[CT]" disabled="true" title="Fortitude  @{Fortitude}" />
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_FortLevel" value="@{FortLevel|max}"  disabled="true"  title="Fortitude Level / Armor bonus @{FortLevel}" />	<input type="text" name="attr_FortLevel_max" value="@{level}" title="Fortitude Level Formula @{FortLevel|max}" class="hidden" /></td>	
 					<td><input type="number" name="attr_FortClass" value="0" title="Fortitude Class bonus @{FortClass}" /></td>
 					<td> <select name="attr_FortMod" class="modtype " title="Fortitude Ability Modifier (default CON) @{FortMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-					  <option value="@{con|max}" data-i18n="con" selected>CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}"  selected>CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_FortMisc" value="0" title="Fortitude Miscellaneous Modifier @{FortMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1"><span data-i18n="will">Will</span></td>
+					<td class="col1"><span>Will</span></td>
 					<td><input type="number" name="attr_Will" value="10+@{WillMod}[Mod]+@{WillLevel}[Level]+@{WillClass}[Class]+@{WillMisc}[Misc]+@{CT}[CT]" disabled="true" title="Will @{Will}" /></td>
 					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_WillLevel" value="@{level}"  disabled="true" title="Will Level / Armor bonus @{WillLevel}"/></td>		
 					<td><input type="number" name="attr_WillClass" value="0" title="Will Class bonus @{WillClass}" /></td>
 					<td> <select name="attr_WillMod" class="modtype" title="Will Ability Modifier (default WIS) @{WillMod}">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-					  <option value="@{con|max}" data-i18n="con">CON</option>
-					  <option value="@{int|max}" data-i18n="int">INT</option>
-					  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-					  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}"  selected>WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
 					</select></td>
 					<td><input type="number" name="attr_WillMisc" value="0" title="Will Miscellaneous Modifier @{WillMisc}" /></td>
 				</tr>
@@ -365,9 +365,9 @@
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
 								<span class="table-data center" style="min-width:80px">
 									<select name="attr_attackMod" class="modtype" title="Attack Modifier @{repeating_attack_X_attackMod}">           
-									  <option value="@{str|max}" data-i18n="str">STR</option>
-									  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+									  <option value="@{str|max}" >STR</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="@{cha|max}" >CHA</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
 								<span class="table-data center" style="min-width:50px">
@@ -399,11 +399,11 @@
 								<span class="table-data center" style="min-width:80px">	
 									<select name="attr_damageMod" class="modtype" title="Weapon Damage modifier @{repeating_attack_X_damageMod}">
 									  <option value="0" selected>None</option>                
-									  <option value="@{str|max}" data-i18n="str">STR</option>
+									  <option value="@{str|max}" >STR</option>
 									  <option value="[[@{str|max}*2]]">STRx2</option>
-									  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+									  <option value="@{dex|max}" >DEX</option>	
 									  <option value="[[@{dex|max}*2]]">DEXx2</option>
-									  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+									  <option value="@{cha|max}" >CHA</option>
 									  <option value="[[@{cha|max}*2]]">CHAx2</option>
 									</select>	</span>
 								<span class="table-data center">	&nbsp;+&nbsp;	</span>
@@ -416,7 +416,7 @@
 							<span class="table-data" style="width:44px">		</span> 
 							<span class="table-data atkFormula">	
 								<span class="small"><b>Damage Modifier Total Formula</b></span>	<br />						
-								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{level|max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
+								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{hlevel_max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
 								<span class="small"><b>Damage Roll Formula</b></span>	<br />					
 								<textarea type="text" name="attr_WeaponDamage" class="atkFormula" title="Damage formula @{repeating_attack_X_WeaponDamage}" >@{damage}[Damage] + @{DamageTotal}</textarea> 
 							</span>
@@ -479,12 +479,12 @@
 						<span class="table-data"><input type="number" name="attr_Acrobatics" value="@{AcrobaticsFormula}" disabled="true" title="Acrobatics Total @{Acrobatics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_AcrobaticsMod" class="modtype" title="Acrobatics Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat" title="Trained in Acrobatics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_AcrobaticsFeat_max" title="Focused in Acrobatics?" /></span> <!-- Skill Focus -->
@@ -523,11 +523,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_ClimbMod" class="modtype" title="Climb Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat" title="Trained in Climb?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_ClimbFeat_max" title="Focused in Climb?" /></span> <!-- Skill Focus -->
@@ -565,12 +565,12 @@
 						<span class="table-data"><input type="number" name="attr_Deception" value="@{DeceptionFormula}" disabled="true" title="Deception Total @{Deception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_DeceptionMod" class="modtype" title="Deception Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat" title="Trained in Deception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_DeceptionFeat_max" title="Focused in Deception?" /></span> <!-- Skill Focus -->
@@ -608,12 +608,12 @@
 						<span class="table-data"><input type="number" name="attr_Endurance" value="@{EnduranceFormula}" disabled="true" title="Endurance Total @{Endurance}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_EnduranceMod" class="modtype" title="Endurance Mod (default CON)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con" selected>CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}"  selected>CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat" title="Trained in Endurance?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_EnduranceFeat_max" title="Focused in Endurance?" /></span> <!-- Skill Focus -->
@@ -651,12 +651,12 @@
 						<span class="table-data"><input type="number" name="attr_GatherInformation" value="@{GatherInformationFormula}" disabled="true" title="Gather Information Total @{GatherInformation}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_GatherInformationMod" class="modtype" title="GatherInformation Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat" title="Trained in Gather Information?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_GatherInformationFeat_max" title="Focused in Gather Information?" /></span> <!-- Skill Focus -->
@@ -694,12 +694,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -738,11 +738,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_JumpMod" class="modtype" title="Jump Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat" title="Trained in Jump?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_JumpFeat_max" title="Focused in Jump?" /></span> <!-- Skill Focus -->
@@ -782,12 +782,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Bureaucracy" value="@{Knowledge-BureaucracyFormula}" disabled="true" title="Knowledge (Bureaucracy) Total @{Knowledge-Bureaucracy}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-BureaucracyMod" class="modtype" title="Knowledge (Bureaucracy) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat" title="Trained in Knowledge (Bureaucracy)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-BureaucracyFeat_max" title="Focused in Knowledge (Bureaucracy)?" /></span> <!-- Skill Focus -->
@@ -826,12 +826,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-GalacticLore" value="@{Knowledge-GalacticLoreFormula}" disabled="true" title="Knowledge (Galactic Lore) Total @{Knowledge-GalacticLore}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-GalacticLoreMod" class="modtype" title="Knowledge (Galactic Lore) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat" title="Trained in Knowledge (Galactic Lore)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-GalacticLoreFeat_max" title="Focused in Knowledge (Galactic Lore)?" /></span> <!-- Skill Focus -->
@@ -870,12 +870,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-LifeSciences" value="@{Knowledge-LifeSciencesFormula}" disabled="true" title="Knowledge (Life Sciences) Total @{Knowledge-LifeSciences}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-LifeSciencesMod" class="modtype" title="Knowledge (Life Sciences) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat" title="Trained in Knowledge (Life Sciences)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-LifeSciencesFeat_max" title="Focused in Knowledge (Life Sciences)?" /></span> <!-- Skill Focus -->
@@ -914,12 +914,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-PhysicalScience" value="@{Knowledge-PhysicalScienceFormula}" disabled="true" title="Knowledge (Physical Science) Total @{Knowledge-PhysicalScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-PhysicalScienceMod" class="modtype" title="Knowledge (Physical Science) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat" title="Trained in Knowledge (Physical Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-PhysicalScienceFeat_max" title="Focused in Knowledge (Physical Science)?" /></span> <!-- Skill Focus -->
@@ -958,12 +958,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-SocialScience" value="@{Knowledge-SocialScienceFormula}" disabled="true" title="Knowledge (Social Science) Total @{Knowledge-SocialScience}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-SocialScienceMod" class="modtype" title="Knowledge (Social Science) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat" title="Trained in Knowledge (Social Science)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-SocialScienceFeat_max" title="Focused in Knowledge (Social Science)?" /></span> <!-- Skill Focus -->
@@ -1002,12 +1002,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Tactics" value="@{Knowledge-TacticsFormula}" disabled="true" title="Knowledge (Tactics) Total @{Knowledge-Tactics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TacticsMod" class="modtype" title="Knowledge (Tactics) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat" title="Trained in Knowledge (Tactics)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TacticsFeat_max" title="Focused in Knowledge (Tactics)?" /></span> <!-- Skill Focus -->
@@ -1046,12 +1046,12 @@
 						<span class="table-data"><input type="number" name="attr_Knowledge-Technology" value="@{Knowledge-TechnologyFormula}" disabled="true" title="Knowledge (Technology) Total @{Knowledge-Technology}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_Knowledge-TechnologyMod" class="modtype" title="Knowledge (Technology) Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat" title="Trained in Knowledge (Technology)?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_Knowledge-TechnologyFeat_max" title="Focused in Knowledge (Technology)?" /></span> <!-- Skill Focus -->
@@ -1090,12 +1090,12 @@
 						<span class="table-data"><input type="number" name="attr_Mechanics" value="@{MechanicsFormula}" disabled="true" title="Mechanics Total @{Mechanics}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_MechanicsMod" class="modtype" title="Mechanics Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat" title="Trained in Mechanics?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_MechanicsFeat_max" title="Focused in Mechanics?" /></span> <!-- Skill Focus -->
@@ -1133,12 +1133,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -1176,12 +1176,12 @@
 						<span class="table-data"><input type="number" name="attr_Persuasion" value="@{PersuasionFormula}" disabled="true" title="Persuasion Total @{Persuasion}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PersuasionMod" class="modtype" title="Persuasion Mod (default CHA)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}"  selected>CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat" title="Trained in Persuasion?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PersuasionFeat_max" title="Focused in Persuasion?" /></span> <!-- Skill Focus -->
@@ -1219,12 +1219,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -1262,12 +1262,12 @@
 						<span class="table-data"><input type="number" name="attr_Ride" value="@{RideFormula}" disabled="true" title="Ride Total @{Ride}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_RideMod" class="modtype" title="Ride Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat" title="Trained in Ride?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_RideFeat_max" title="Focused in Ride?" /></span> <!-- Skill Focus -->
@@ -1305,12 +1305,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
@@ -1349,12 +1349,12 @@
 						<span class="table-data"><input type="number" name="attr_Survival" value="@{SurvivalFormula}" disabled="true" title="Survival Total @{Survival}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SurvivalMod" class="modtype" title="Survival Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat" title="Trained in Survival?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SurvivalFeat_max" title="Focused in Survival?" /></span> <!-- Skill Focus -->
@@ -1393,11 +1393,11 @@
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_SwimMod" class="modtype" title="Swim Mod (default STR)">
 							  <option value="@{str|max}" selected>STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat" title="Trained in Swim?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SwimFeat_max" title="Focused in Swim?" /></span> <!-- Skill Focus -->
@@ -1435,12 +1435,12 @@
 						<span class="table-data"><input type="number" name="attr_TreatInjury" value="@{TreatInjuryFormula}" disabled="true" title="Treat Injury Total @{TreatInjury}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_TreatInjuryMod" class="modtype" title="Treat Injury Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat" title="Trained in Treat Injury?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_TreatInjuryFeat_max" title="Focused in Treat Injury?" /></span> <!-- Skill Focus -->
@@ -1478,12 +1478,12 @@
 						<span class="table-data"><input type="number" name="attr_UseComputer" value="@{UseComputerFormula}" disabled="true" title="Use Computer Total @{UseComputer}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_UseComputerMod" class="modtype" title="Use Computer Mod (default INT)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int" selected>INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}"  selected>INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat" title="Trained in Use Computer?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UseComputerFeat_max" title="Focused in Use Computer?" /></span> <!-- Skill Focus -->
@@ -1521,12 +1521,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" data-i18n="str">STR</option>
-						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-						  <option value="@{con|max}" data-i18n="con">CON</option>
-						  <option value="@{int|max}" data-i18n="int">INT</option>
-						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+						  <option value="@{str|max}" >STR</option>
+						  <option value="@{dex|max}" >DEX</option>	
+						  <option value="@{con|max}" >CON</option>
+						  <option value="@{int|max}" >INT</option>
+						  <option value="@{wis|max}" >WIS</option>
+						  <option value="@{cha|max}"  selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->
@@ -1849,29 +1849,31 @@
 				<tr><th>Current</th>		<th></th>	<th>Total</th>	
 					<td colspan="3"></td>
 					<td rowspan="4" style="text-align:left">		
-						<input type="radio" value="0" name="attr_NPC-CT" checked="true" /> Normal<br />
-						<input type="radio" value="-1" name="attr_NPC-CT" /> -1<br />
-						<input type="radio" value="-2" name="attr_NPC-CT" /> -2<br />
-						<input type="radio" value="-5" name="attr_NPC-CT" /> -5<br />
-						<input type="radio" value="-10" name="attr_NPC-CT" /> -10<br />
-						<input type="radio" value="-10[Helpless]" name="attr_NPC-CT" /> Helpless</td>		
+                        <input type="radio" value="0" name="attr_CT" checked="true" /> <span>Normal</span><br />
+						<input type="radio" value="-1" name="attr_CT" /> -1<br />
+						<input type="radio" value="-2" name="attr_CT" /> -2<br />
+						<input type="radio" value="-5" name="attr_CT" /> -5<br />
+						<input type="radio" value="-10" name="attr_CT" /> -10<br />
+						<input type="radio" value="-10[Helpless]" name="attr_CT" /><span>Helpless</span></td>	
 				</tr>
 				<tr>	
 					<td> <input type="number" name="attr_HP" value="0" title="Current HP"/></td>
 					<td>&nbsp;/&nbsp;</td>
 					<td><input type="number" name="attr_HP_max" value="0" title="Max HP" /></td>
 				</tr>
-				<tr>	<td colspan="5"><div class="textHead">Threshold</div> </td>		<td width="15px"></td>	</tr>
-				<tr><th>Total</th>	<th></th>	<th>Defense</th> <th>Misc</th>		</tr>
+<tr>	<td colspan="4"><div class="textHead"><span>Threshold</span></div> </td>			</tr>
+				<tr>	<th><span>Total</span></th>	<th></th>	<th><span>Defense</span></th> 	<th><span>Misc</span></th>		</tr>
 				<tr>	
-					<td><input type="number" name="attr_NPC-DT" value="@{NPC-DamageThresholdDefense}+@{DamageThresholdMisc}[Misc]+@{DamageThresholdSize}[Size]+@{NPC-CTIgnoreDT}"  disabled="true" title="Damage Threshold" /></td>
+					<td><input type="number" name="attr_DT" value="@{DamageThresholdDefense}+@{DamageThresholdSize}[Size]+@{DamageThresholdMisc}[Misc]"  disabled="true" title="Damage Threshold @{DT}" /></td>
 					<td>&nbsp;=&nbsp;</td>
-					<td><select name="attr_NPC-DamageThresholdDefense" class="modtype" title="Damage Threshold Defense">
-					  <option value="@{NPC-Fortitude}" selected>Fort</option>
-					  <option value="@{NPC-Will}">Will</option>
+					<td> <select name="attr_DamageThresholdDefense" class="modtype" title="Damage Threshold Defense @{DamageThresholdDefense}">
+					  <option value="[[@{Fortitude}+@{CTIgnoreDT}]][Fortitude]" selected>Fort</option>
+					  <option value="[[@{Will}+@{CTIgnoreDT}]][Will]" >Will</option>
 					</select></td>
-					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier" /></td>
-				</tr>	
+					<td><input type="number" name="attr_DamageThresholdMisc" value="0"  title="Damage Threshold Miscellaneous Modifier @{DamageThresholdMisc}" />
+						<input type="number" value="0" name="attr_DamageThresholdSize" class="hidden" /></td>
+				</tr>				
+
 			</table>
 			<p>Ignore CT? <input type="checkbox" value="-@{npc-ct}" name="attr_NPC-CTIgnoreDT"  title="Does Damage Threshold ignore decrease from the Condition Track?" /></p>
 			
@@ -1929,8 +1931,8 @@
 					<td><input type="number" name="attr_NPC-Grapple" value="@{BAB} + @{GrpMod}[Mod] + @{GrpMod|max} + @{GrappleSize} +@{npc-ct}" disabled="true" title="Grapple" /></td>
 					<td>&nbsp;=&nbsp;</td>
 					<td> <select name="attr_GrpMod" class="modtype" title="Choose the highest modifier">
-					  <option value="@{str|max}" data-i18n="str">STR</option>
-					  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
 					</select></td>
 					<td>&nbsp;+&nbsp;</td>
 					<td><input type="number" name="attr_GrpMod_max" value="0" title="Miscellaneous Grapple Modifier" /></td>
@@ -1941,91 +1943,223 @@
 	 <br />
 	<div class="2colrow">
 		<div class="col">
-			<div class="textHead">Defenses</div>
 			<table class="spacing">
+				<tr><div class="textHead2Col"><span>Defenses</span></div></tr>
+				<thead>
+					<tr>
+						<th></th>
+						<th><span>Total</span></th>
+						<th></th>
+						<th style="min-width:50px">	<span><span>Level</span> /<br /><span>Armor</span></span>	</th>
+						<th><span>Class</span></th>					
+						<th><span>Mod</span></th>
+						<th><span>Misc</span></th>
+					</tr>
+				</thead>	
+			  <tbody>
 				<tr>
-					<th></th>
-					<th></th>
-					<th>Total <br> after CT</th>
-					<th>Total</th>
+					<td class="col1" rowspan="2"><span>Reflex</span></td>
+					<td><input type="number" name="attr_Reflex" value="10+@{RefMod}[Mod]+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex @{Reflex}" /></td> 
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_RefLevel" value="@{RefLevel|max}"  disabled="true" title="Reflex Level / Armor bonus @{RefLevel}"/>	<input type="text" name="attr_RefLevel_max" value="@{level}" title="Reflex Level Formula @{RefLevel|max}"  class="hidden" /></td>	
+					<td><input type="number" name="attr_RefClass" value="0" title="Reflex Class bonus @{RefClass}" /></td>
+					<td> <select name="attr_RefMod" class="modtype" title="Reflex Ability Modifier (default DEX) @{RefMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}"  selected>DEX</option>					  
+					  <option value="@{ArmorDex}" >DEX (Max Armor)</option>
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_RefMisc" value="0" title="Reflex Miscellaneous Modifier @{RefMisc}" /></td>
 				</tr>
 				<tr>
-					<td class="col1" rowspan="2">Reflex</td>
+					<td class="col1"><div class="small"><span>Flatfooted</span></div></td>
+					<td><input type="number" name="attr_ReflexFlatFooted" value="10+@{RefLevel}[Level]+@{RefClass}[Class]+@{RefFlatFootedMisc}[Misc]+@{RefSizeMod}[Size Mod]+@{CT}[CT]" disabled="true"  title="Reflex Flat Footed @{ReflexFlatFooted}" /></td>
 					<td></td>
-					<td><input type="number" name="attr_NPC-Reflex" value="@{RefTotal}+@{npc-ct}" disabled="true"  title="Reflex" /></td> 
-					<td><input type="text" name="attr_RefTotal" value="10+@{level}+@{Dex|max}+@{RefSizeMod}"  title="Reflex Total (You can use formulas, for example: 10+@{level|max}[Half Level]+@{Dex|max} or enter the total Defence Score)"/></td>
+					<td colspan="2" align="right">
+						<input type="number" value="0" name="attr_RefSizeMod" class="hidden" />
+					</td>
+					<td><input type="number" name="attr_RefFlatFootedMisc" value="0" title="Reflex Flat Footed Miscellaneous Modifier @{RefFlatFootedMisc}" /></td>
+				</tr>
+						
+				<tr>
+					<td class="col1"><span>Fortitude</span></td>
+					<td><input type="number" name="attr_Fortitude" value="10+@{FortMod}[Mod]+@{FortLevel}[Level]+@{FortClass}[Class]+@{FortMisc}[Misc]+@{CT}[CT]" disabled="true" title="Fortitude  @{Fortitude}" />
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_FortLevel" value="@{FortLevel|max}"  disabled="true"  title="Fortitude Level / Armor bonus @{FortLevel}" />	<input type="text" name="attr_FortLevel_max" value="@{level}" title="Fortitude Level Formula @{FortLevel|max}" class="hidden" /></td>	
+					<td><input type="number" name="attr_FortClass" value="0" title="Fortitude Class bonus @{FortClass}" /></td>
+					<td> <select name="attr_FortMod" class="modtype " title="Fortitude Ability Modifier (default CON) @{FortMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}"  selected>CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}" >WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_FortMisc" value="0" title="Fortitude Miscellaneous Modifier @{FortMisc}" /></td>
 				</tr>
 				<tr>
-					<!-- rowspan placeholder -->
-					<td class="col1"><div class="small">Flatfooted</div></td>
-					<td><input type="number" name="attr_NPC-ReflexFlatFooted" value="@{RefTotal|max}+@{npc-ct}" disabled="true"  title="Reflex Flat Footed" /></td>					 
-					<td><input type="text" name="attr_RefTotal_max" value="10+@{level}+@{RefSizeMod}"  title="FlatFooted Reflex Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+					<td class="col1"><span>Will</span></td>
+					<td><input type="number" name="attr_Will" value="10+@{WillMod}[Mod]+@{WillLevel}[Level]+@{WillClass}[Class]+@{WillMisc}[Misc]+@{CT}[CT]" disabled="true" title="Will @{Will}" /></td>
+					<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
+					<td><input type="number" name="attr_WillLevel" value="@{level}"  disabled="true" title="Will Level / Armor bonus @{WillLevel}"/></td>		
+					<td><input type="number" name="attr_WillClass" value="0" title="Will Class bonus @{WillClass}" /></td>
+					<td> <select name="attr_WillMod" class="modtype" title="Will Ability Modifier (default WIS) @{WillMod}">
+					  <option value="@{str|max}" >STR</option>
+					  <option value="@{dex|max}" >DEX</option>	
+					  <option value="@{con|max}" >CON</option>
+					  <option value="@{int|max}" >INT</option>
+					  <option value="@{wis|max}"  selected>WIS</option>
+					  <option value="@{cha|max}" >CHA</option>
+					</select></td>
+					<td><input type="number" name="attr_WillMisc" value="0" title="Will Miscellaneous Modifier @{WillMisc}" /></td>
+				</tr>
+			  </tbody>
+			</table>
+			<br />			
+			<input type="checkbox" class="sect-show hidden" value="1" name="attr_armor-show" /> 		
+			<table class="spacing sect table2col">
+				<tr colspan="7">	<div class="textHead2Col">Armor&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Armor Section" name="attr_armor-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span></div></tr>
+				<tr>	
+					<th width="50%" colspan="3">Armor Worn <input type="checkbox" value="1" name="attr_ArmorWornCheck" title="Armor equiped @{ArmorWornCheck}" /></th>		
+					<th class="small">Ref Def<br />Bonus</th>		
+					<th class="small">Fort Def<br />Bonus</th>		
+					<th class="small">Max Dex<br />Bonus</th>		
+					<th>Speed</th>		</tr>
+				<tr>
+					<td colspan="3"><input type="text" name="attr_ArmorWorn" style="width:100%" title="Armor Name @{ArmorWorn}" /></td>
+					<td><input type="number" name="attr_ArmorRef" value="0"  title="Armor Reflex Defense Bonus @{ArmorRef}" /></td>
+					<td><input type="number" name="attr_ArmorFort" value="0" title="Armor Fortitude Defense Bonus @{ArmorFort}"  /></td>
+					<td><input type="number" name="attr_ArmorDex" value="0"  title="Armor Max DEX @{ArmorDex}" /></td>
+					<td><input type="number" name="attr_Speed_max" value="0" title="Armor Max Speed @{Speed|max}"  /></td>
 				</tr>
 				<tr>
-					<td class="col1">Fortitude</td>
-					<td rowspan="2"></td>
-					<td><input type="number" name="attr_NPC-Fortitude" value="@{FortTotal}+@{npc-ct}" disabled="true" />					 
-					<td><input type="text" name="attr_FortTotal" value="10+@{level}+@{CON|max}"  title="Fortitude Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+					<th class="small">Proficiency<br /><input type="checkbox" value="1" name="attr_ArmorProf" title="Proficient in armor worn @{ArmorProf}" /></th>
+					<th class="small">Armor Def.<br /><input type="checkbox" value="1" name="attr_ArmorDefense" title="Armor Specialist: Armor Defense @{ArmorDefense}" /></th>				
+					<th class="small">Improved<br />Armor Def.<br /><input type="checkbox" value="1" name="attr_ImpArmorDefense" title="Armor Specialist: Improved Armor Defense @{ArmorDefense}" /></th>
+					<th class="small" colspan="2">Armor Type<br/>
+						<select name="attr_ArmorType" style="width:90px" title="Armor Type @{ArmorType}">           
+							  <option value="Light">Light</option>
+							  <option value="Medium">Medium</option>
+							  <option value="Heavy">Heavy</option>
+						</select>
+						<input type="number" name="attr_ArmorType_max" value="0" class="hidden" title="Armor Penalty @{ArmorType|max}"  /> </th>
+					<th class="small" colspan="2">Helmet Package<br/>
+						<select name="attr_ArmorPerception" style="width:90px" title="Helmet Package Perception bonus @{ArmorPerception}">           
+						  <option value="None" selected>None</option>
+						  <option value="Standard">Standard</option>
+						  <option value="Superior">Superior</option>
+					</select></th>
+				</tr>	
+				<tr>	
+					
 				</tr>
-				<tr>
-					<td class="col1">Will</td>					
-					<!-- rowspan placeholder -->
-					<td><input type="number" name="attr_NPC-Will" value="@{WillTotal}+@{npc-ct}" disabled="true" /></td>					 
-					<td><input type="text" name="attr_WillTotal" value="10+@{level}+@{Wis|max}"  title="Will Total (You can use formulas, for example: 10+@{level} or enter the total Defence Score)"/></td>
+				<tr>		
+					<td colspan="7"><textarea type="text" name="attr_ArmorNotes" class="atkNotes" title="Armor Notes @{ArmorNotes}"  placeholder="Armor Notes"></textarea></td>
 				</tr>
 			</table>
-		<div class="textHead2Col">Attacks</div>
-			<fieldset class="repeating_NPC-attack">	
+			<br />			
+			<div class="textHead2Col">Attacks</div>
+				<fieldset class="repeating_attack">	
 				<div class="table">	
 					<div class="table-row">
 						<div class="table">	
 							<div class="table-row">												
 								<span class="table-data">	<button  type="roll" name="roll_WeaponCheck" value="@{AttackFormula}" title="Attack Roll"> </button>	</span>
-								<span class="table-data" style="width:55%">	<input type="text" name="attr_WeaponName" placeholder="Weapon Name" style="width:100%"  title="Weapon Name @{repeating_npc-attack_X_WeaponName}" />	</span>
-								<span class="table-data">	<input type="text" name="attr_WeaponName_max" placeholder="Type" style="width:100%" title="Weapon Type @{repeating_npc-attack_X_WeaponName|max}" />	</span>
-							</div>
+								<span class="table-data" style="width:50%">	<input type="text" name="attr_WeaponName" placeholder="Weapon Name" style="width:100%"  title="Weapon Name @{repeating_attack_X_WeaponName}" />	</span>
+								<span class="table-data">	<input type="text" name="attr_WeaponName_max" placeholder="Type" style="width:100%" title="Weapon Type @{repeating_attack_X_WeaponName|max}" />	</span>
+								<span class="table-data" style="width:35px">		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sectAttack-show" title="Show/Hide Attack & Damage" name="attr_AttackDamage-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>
+							</div>							
 						</div>						
-					</div>				
+					</div>
+					<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>						
 					<div class="table-row">
 						<span class="table-data">	<div class="table">	
 							<div class="table-row">
 								<span class="table-header" style="min-width:44px"></span>
-								<span class="table-header" style="min-width:55px"></span>
-								<span class="table-header" style="min-width:130px">Total</span>
-								<span class="table-header"></span>
-								<span class="table-header">Mod</span>
-							</div>	
-							<div class="table-row">
-								<span class="table-data" style="min-width:44px">		</span>
-								<span class="table-data col1"  style="min-width:55px">	Attack	</span>
-								<span class="table-data center" style="min-width:130px">
-									<input type="number" name="attr_AttackTotal" value="@{Attack}+@{npc-ct}"  disabled="true" title="Attack Total Preview @{repeating_npc-attack_X_AttackTotal}" />	</span>
-								<span class="table-data center">	&nbsp;|&nbsp;</span>
-								<span class="table-data center">	<input type="text" name="attr_Attack" value="@{BAB}+@{STR|max}"  title="Attack Total (You can use formulas, for example: @{BAB}+@{STR|max} or enter the total attack modifier) @{repeating_npc-attack_X_attack}" style="width:100%" />	</span>
+								<span class="table-header" style="min-width:55px;"></span>
+							<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>	
+								<span class="table-header sectAttack not-sheet-show" style="min-width:130px">Total</span>
+								<span class="table-header sectAttack"></span>
+								<span class="table-header sectAttack" style="min-width:80px">Mod</span>					
+								<span class="table-header sectAttack"></span>
+								<span class="table-header sectAttack" style="min-width:50px">Misc</span>
 							</div>
-						</div>	</span>
-					</div>		
-					<div class="table-row">
-						<span class="table-data">	<div class="table">	
-							<div class="table-row">
+							<input type="checkbox" class="sectAttack-show hidden" name="attr_AttackDamage-show" value="1"/>		
+							<div class="table-row sectAttack">
 								<span class="table-data" style="min-width:44px">		</span>
-								<span class="table-data col1"  style="min-width:55px">	Damage	</span>
-								<span class="table-data" style="min-width:130px">	
-									<input type="text" name="attr_damage" placeholder="2d8"  style="width:60px" title="Weapon Damage @{repeating_npc-attack_X_damage}"/>
-									&nbsp;+&nbsp;	
-									<input type="number" name="attr_DamageTotal" value="@{damage|max}" disabled="true"  title="Damage Total @{repeating_npc-attack_X_DamageTotal}" />	</span>
+								<span class="table-data col1"  style="min-width:55px">	<span>Attack</span>	<input type="checkbox" class="sect-show skillsHideCheckbox" title="Show/Hide Attack Formula" name="attr_attack-show" value="1" style="width: 38px; margin-left: -41px;" />	</span>
+								<span class="table-data center" style="min-width:130px">
+									<input type="number" name="attr_AttackTotal_max" value="@{AttackTotal}" disabled="true"  title="Attack Total  @{repeating_attack_X_AttackTotal|max}" />	</span>
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
-								<span class="table-data center">	<input type="text" name="attr_damage_max" value="@{STR|max}+@{level|max}"  style="width:100%" title="Weapon Damage Bonus (You can use formulas, for example: (@{STR|max}*2)+@{level|max} or enter the entire Damage roll for example: 6) @{repeating_npc-attack_X_damage|max}"/>	</span>								
+								<span class="table-data center" style="min-width:80px">
+									<select name="attr_attackMod" class="modtype" title="Attack Modifier @{repeating_attack_X_attackMod}">           
+									  <option value="@{str|max}" >STR</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="@{cha|max}" >CHA</option>
+									</select>	</span>
+								<span class="table-data center">	&nbsp;+&nbsp;	</span>
+								<span class="table-data center" style="min-width:50px">
+									<input type="number" name="attr_attackModMisc" placeholder="Misc" value="0" style="width:40px"  title="Attack Miscellaneous Modifier @{repeating_attack_X_attackModMisc}" />	</span>
 							</div>
 						</div>	</span>
 					</div>
-					<div class="table-row">
+					<div style="width:100%">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_attack-show" />
+						<div class="table-row sect">
+							<span class="table-data" style="min-width:44px">		</span> 
+							<span class="table-data atkFormula">
+								<span class="small"><b>Attack Modifier Total Formula</b></span>	<br />
+								<textarea type="text" name="attr_AttackTotal" class="atkFormula" title="Attack Total formula @{repeating_attack_X_AttackTotal}" >@{BAB}[BAB] + @{attackMod}[Mod] + @{attackModMisc}[Misc] +@{CT}[CT] +@{ArmorType|max}[Armor Penalty] </textarea> 							
+								<span class="small"><b>Attack Roll Formula</b></span>	<br />
+								<textarea type="text" name="attr_WeaponAttack" class="atkFormula" title="Attack formula @{repeating_attack_X_WeaponAttack}" >1d20cs>@{WeaponCrit}[Critical Range] + @{attackTotal} + ?{Other Modifiers (Attack)|0}[Other]</textarea> 
+							</span>
+						</div>
+					</div>				
+					<div class="table-row sectAttack">
+						<span class="table-data">	<div class="table">	
+							<div class="table-row">
+								<span class="table-data" style="min-width:44px">		</span>
+								<span class="table-data col1"  style="min-width:55px">	<span>Damage</span>	<input type="checkbox" class="sect-show skillsHideCheckbox" title="Show/Hide Attack Formula" name="attr_damage-show" value="1" style="width: 50px; margin-left: -53px;" />	</span>
+								<span class="table-data" style="min-width:130px">	
+									<input type="text" name="attr_damage" placeholder="2d8" value="2d8"  style="width:60px" title="Weapon Damage @{repeating_attack_X_damage}"/>
+									&nbsp;+&nbsp;	
+									<input type="number" name="attr_DamageTotal_max" value="@{damageTotal}" disabled="true"  title="Damage Total  @{repeating_attack_X_DamageTotal|max}" />	</span>
+								<span class="table-data center">	&nbsp;|&nbsp;</span>
+								<span class="table-data center" style="min-width:80px">	
+									<select name="attr_damageMod" class="modtype" title="Weapon Damage modifier @{repeating_attack_X_damageMod}">
+									  <option value="0" selected>None</option>                
+									  <option value="@{str|max}" >STR</option>
+									  <option value="[[@{str|max}*2]]">STRx2</option>
+									  <option value="@{dex|max}" >DEX</option>	
+									  <option value="[[@{dex|max}*2]]">DEXx2</option>
+									  <option value="@{cha|max}" >CHA</option>
+									  <option value="[[@{cha|max}*2]]">CHAx2</option>
+									</select>	</span>
+								<span class="table-data center">	&nbsp;+&nbsp;	</span>
+								<span class="table-data center" style="min-width:50px">	<input type="number" name="attr_damageMisc" placeholder="Misc" value="0" style="width:40px" title="Weapon Damage Miscellaneous Modifier @{repeating_attack_X_damageMisc}"  />	</span>
+							</div>
+						</div>	</span>
+					</div>
+					<div style="width:100%">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_damage-show" />
+						<div class="table-row sect">
+							<span class="table-data" style="width:44px">		</span> 
+							<span class="table-data atkFormula">	
+								<span class="small"><b>Damage Modifier Total Formula</b></span>	<br />						
+								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{hlevel_max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
+								<span class="small"><b>Damage Roll Formula</b></span>	<br />					
+								<textarea type="text" name="attr_WeaponDamage" class="atkFormula" title="Damage formula @{repeating_attack_X_WeaponDamage}" >@{damage}[Damage] + @{DamageTotal}</textarea> 
+							</span>
+						</div>
+					</div>
+					<div class="table-row  sectAttack">
 						<span class="table-data">	<div class="table">	
 							<div class="table-row">
 								<span class="table-data" style="min-width:44px">		</span>
 								<span class="table-data" style="min-width:110px">	<b>Critical Info</b>	</span>
-								<span class="table-data">	<span class="small"><b>Range</b></span> 	<input type="number" name="attr_WeaponCrit" placeholder="Crit" value="20" title="Weapon Critical Starting Range ie.20 @{repeating_npc-attack_X_WeaponCrit}" />	</span>
-								<span class="table-data">		<span class="small"><b>Multiplier</b></span>	 <input type="number" name="attr_WeaponCrit_max" value="2" title="Weapon Crit Damage Multiplier @{repeating_npc-attack_X_WeaponCrit|max}" />		</span>
+								<span class="table-data">	<span class="small"><b>Range</b></span> 	<input type="number" name="attr_WeaponCrit" placeholder="Crit" value="20" title="Weapon Critical Starting Range ie.20 @{repeating_attack_X_WeaponCrit}" />	</span>
+								<span class="table-data">		<span class="small"><b>Multiplier</b></span>	 <input type="number" name="attr_WeaponCrit_max" value="2" title="Weapon Crit Damage Multiplier @{repeating_attack_X_WeaponCrit|max}" />		</span>
 								<span class="table-data">	<b>Template <br/>Formula</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Attack Template Formula" name="attr_AttackFormula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>
 							</div>
 						</div>	</span>
@@ -2036,7 +2170,7 @@
 							<span class="table-data" style="width:44px">		</span> 
 							<span class="table-data atkFormula">							
 								<span class="small"><b>Template Formula</b></span>	<br />						
-								<textarea type="text" name="attr_AttackFormula" class="atkFormula" title="Attack Template formula @{repeating_npc-attack_X_AttackFormula}" >&{template:attack} {{name=@{WeaponName}}} {{type=@{WeaponName|max}}} {{attack=[[1d20cs>@{WeaponCrit} + @{AttackTotal} + ?{Other Modifiers (Attack)|0}]]}} {{atkeffect=@{WeaponNotes|max}}} {{damage=[[@{damage}+@{damageTotal}]]}} {{dmgcrit=[[(@{damage}+@{damageTotal})*@{WeaponCrit|max}]]}}</textarea> 
+								<textarea type="text" name="attr_AttackFormula" class="atkFormula" title="Attack Template formula @{repeating_attack_X_AttackFormula}" >&{template:attack} {{name=@{WeaponName}}} {{type=@{WeaponName|max}}}  {{atkeffect=@{WeaponNotes|max}}} {{attack=[[@{WeaponAttack}]]}} {{damage=[[@{WeaponDamage}]]}} {{dmgcrit=[[(@{WeaponDamage})*@{WeaponCrit|max}[Critical Multiplier]]]}}</textarea> 
 							</span>
 						</div>	</span>
 					</div>
@@ -2045,14 +2179,14 @@
 							<div class="table-row">
 								<span class="table-data" style="width:44px">		</span> 
 								<span class="table-data">							
-									<textarea type="text" name="attr_WeaponNotes_max" placeholder="Attack Notes" class="atkNotes" title="Attack Notes: ie Devesating Attack, Rapid Strike, Point Blank Shot @{repeating_npc-attack_X_WeaponNotes|max}" ></textarea>
-									<textarea type="text" name="attr_WeaponNotes" placeholder="Weapon Notes" class="atkNotes" title="Weapon Notes @{repeating_npc-attack_X_WeaponNotes}"></textarea>
+									<textarea type="text" name="attr_WeaponNotes_max" placeholder="Attack Notes" class="atkNotes" title="Attack Notes: ie Devesating Attack, Rapid Strike, Point Blank Shot @{repeating_attack_X_WeaponNotes|max}" ></textarea>
+									<textarea type="text" name="attr_WeaponNotes" placeholder="Weapon Notes" class="atkNotes" title="Weapon Notes @{repeating_attack_X_WeaponNotes}"></textarea>
 								</span>
 							</div>
 						</div>	</span>
 					</div>
 				</div>
-			</fieldset>
+				</fieldset>
 		</div>	
 		<div class="col">
 			<div class="textHead2Col">Skills</div>
@@ -2075,12 +2209,12 @@
 						<span class="table-data"><input type="number" name="attr_Initiative" value="@{InitiativeFormula}" disabled="true" title="Initiative Total @{Initiative}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_InitiativeMod" class="modtype" title="Initiative Mod (default WIS)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat" title="Trained in Initiative?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_InitiativeFeat_max" title="Focused in Initiative?" /></span> <!-- Skill Focus -->
@@ -2118,12 +2252,12 @@
 						<span class="table-data"><input type="number" name="attr_Perception" value="@{PerceptionFormula}" disabled="true" title="Perception Total @{Perception}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PerceptionMod" class="modtype" title="Perception Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis" selected>WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}"  selected>WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat" title="Trained in Perception?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PerceptionFeat_max" title="Focused in Perception?" /></span> <!-- Skill Focus -->
@@ -2161,12 +2295,12 @@
 						<span class="table-data"><input type="number" name="attr_Pilot" value="@{PilotFormula}" disabled="true" title="Pilot Total @{Pilot}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_PilotMod" class="modtype" title="Pilot Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat" title="Trained in Pilot?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_PilotFeat_max" title="Focused in Pilot?" /></span> <!-- Skill Focus -->
@@ -2204,12 +2338,12 @@
 						<span class="table-data"><input type="number" name="attr_Stealth" value="@{StealthFormula}" disabled="true" title="Stealth Total @{Stealth}" class="skills" /></span> 
 						<span class="table-data">&nbsp;=&nbsp;</span>	
 						<span class="table-data"><select name="attr_StealthMod" class="modtype" title="Stealth Mod (default DEX)">
-							  <option value="@{str|max}" data-i18n="str">STR</option>
-							  <option value="@{dex|max}" data-i18n="dex"  selected>DEX</option>	
-							  <option value="@{con|max}" data-i18n="con">CON</option>
-							  <option value="@{int|max}" data-i18n="int">INT</option>
-							  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-							  <option value="@{cha|max}" data-i18n="cha">CHA</option>
+							  <option value="@{str|max}" >STR</option>
+							  <option value="@{dex|max}"   selected>DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
 							</select></span>
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat" title="Trained in Stealth?" /></span> <!-- Skill Training -->
 						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_StealthFeat_max" title="Focused in Stealth?" /></span> <!-- Skill Focus -->
@@ -2247,12 +2381,12 @@
 					<span class="table-data"><input type="number" class="skills" name="attr_UsetheForce" value="@{UsetheForceFormula}" disabled="true" title="Use the Force Total @{UsetheForce}" /></span> 
 					<span class="table-data">&nbsp;=&nbsp;</span>	
 					<span class="table-data"><select name="attr_UsetheForceMod" class="modtype" title="Use the Force  Mod (default CHA)">
-						  <option value="@{str|max}" data-i18n="str">STR</option>
-						  <option value="@{dex|max}" data-i18n="dex">DEX</option>	
-						  <option value="@{con|max}" data-i18n="con">CON</option>
-						  <option value="@{int|max}" data-i18n="int">INT</option>
-						  <option value="@{wis|max}" data-i18n="wis">WIS</option>
-						  <option value="@{cha|max}" data-i18n="cha" selected>CHA</option>
+						  <option value="@{str|max}" >STR</option>
+						  <option value="@{dex|max}" >DEX</option>	
+						  <option value="@{con|max}" >CON</option>
+						  <option value="@{int|max}" >INT</option>
+						  <option value="@{wis|max}" >WIS</option>
+						  <option value="@{cha|max}"  selected>CHA</option>
 						</select></span>
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat" title="Trained in Use the Force?" /></span> <!-- Skill Training -->
 					<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_UsetheForceFeat_max" title="Focused in Use the Force?" /></span> <!-- Skill Focus -->
@@ -2283,23 +2417,52 @@
 					</div>	</div>
 				</div>	</div>		
 			</div>
+			
 			<fieldset class="repeating_npc-skill">	
 				<table class="spacing">
-					<tr>
-						<td class="skillsCol1"><input type="text" name="attr_Skill" placeholder="Skill Name" title="Skill Name" /></td>
-						<td><button type="roll" name="roll_SkillCheck" value="@{formula}" title="Roll Skill"></button></td>
-						<td><input type="number" name="attr_SkillTotal" value="@{skill|max}+@{npc-ct}"  disabled="true" title="Skill Total Preview" /></td>
-						<td style="min-width:75px">	<b>Formulas & Notes</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Skill Template Formula" name="attr_Skill-Formula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</td>
-					</tr>
-					<tr>
-						<td colspan="4" align="left">	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Formula-show" />	<div class="sect">
-							<input type="text" name="attr_SkillNotes" placeholder="Skill Notes" title="Skill Notes" style="margin-left:10%; width:90%;" /> <br />
-							<span class="small" style="margin-left:10%;"><b>Skill Total Formula</b></span>	<br />
-							<input type="text" style="margin-left:10%; width:90%;" name="attr_skill_max" value="@{str|max}+@{level|max}[Half Level]" title="Skill Total (Can Include formula, for example: (@{str|max}+@{level|max}[Half Level]+5+5) or enter the total) " /> <br />
-							<span class="small" style="margin-left:10%;"><b>Skill Roll Formula</b></span>	<br />
-							<!-- Skill Formula -->	<textarea type="text" name="attr_Formula" class="atkFormula" style="margin-left:10%; width:90%;" title="Skill Template formula" >&{template:skill} {{name=@{Skill}}} {{skill=[[1d20+@{SkillTotal}+?{Other Modifiers|0}[Other]]]}}</textarea>	
-						</div>	</td>
-					</tr>
+				<div class="table-row"><div class="table">
+					<div class="table-row">
+						<Span class="skillsCol1"><input type="text" name="attr_SkillName" style="width:95%" placeholder="Skill Name" title="Skill Name" /></span> 
+						<span class="table-data"><button type="roll" name="roll_SkillCheck" value="@{SkillFormula|max}"></button></span>
+						<span class="table-data"><input type="number" name="attr_Skill" value="@{SkillFormula}" disabled="true" title="Skill Total @{Skill}" class="skills" /></span> 
+						<span class="table-data">&nbsp;=&nbsp;</span>	
+						<span class="table-data"><select name="attr_SkillMod" class="modtype" title="Skill Mod (default STR)">
+							  <option value="@{str|max}"   selected>STR</option>
+							  <option value="@{dex|max}" >DEX</option>	
+							  <option value="@{con|max}" >CON</option>
+							  <option value="@{int|max}" >INT</option>
+							  <option value="@{wis|max}" >WIS</option>
+							  <option value="@{cha|max}" >CHA</option>
+							</select></span>
+						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SkillFeat" title="Trained in Skill?" /></span> <!-- Skill Training -->
+						<span class="table-data skillsFeats"><input type="checkbox" value="5" name="attr_SkillFeat_max" title="Focused in Skill?" /></span> <!-- Skill Focus -->
+						<span class="table-data"><input type="number" name="attr_SkillMisc" title="Skill Miscellaneous Modifier" value="0" class="skills" /></span>
+					</div>
+				</div></div>
+				<div>		
+					<!-- Pilot Notes -->	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Skill-Show" />
+					<div class="table-row sect"><div class="table">
+						<div class="table-row">
+							<span class="table-data" style="min-width:50px">	</span>
+							<span class="table-data">	<input class="skillsNotes" type="text" name="attr_Skill_max" placeholder="Skill Notes" title="Skill Notes @{Pilot|max}" />	</span>
+							<span class="table-data" style="min-width:15px">	</span>
+							<span class="table-data">	<b>Formula</b>	 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" class="sect-show" title="Show/Hide Skill Template Formula_max" name="attr_Skill-Skill-Formula-show" value="1" style="opacity:0;width: 35px;height: 16px;position: relative;top: 5px;left: 6px;margin: -32px;cursor: pointer;z-index: 1;" /><span></span>	</span>							
+						</div>
+					</div>	</div>	
+					<!-- Pilot Formula -->	<input type="checkbox" class="sect-show hidden" value="1" name="attr_Skill-Skill-Formula-Show" />	
+					<div class="table-row sect">	<div class="table">
+						<div class="table-row">
+							<span class="table-data" style="min-width:50px">	</span>
+							<span class="table-data atkFormula">							
+								<span class="small"><b>Skill Modifier Total Formula</b></span>	<br />
+								<textarea type="text" name="attr_SkillFormula" class="atkFormula" title="Skill Total formula @{SkillFormula}" >@{level|max}[Half Level]+@{SkillMod}[Mod]+@{SkillFeat}[Training]+@{SkillFeat|max}[Focus]+@{SkillMisc}[Misc]+@{CT}[CT]</textarea> 
+								<span class="small"><b>Template Formula</b></span>	<br />
+								<textarea type="text" name="attr_SkillFormula_max" class="atkFormula" title="Skill Template formula @{SkillFormula|max}" >&{template:skill} {{name=@{SkillName}}} {{skill=[[1d20 + @{Skill} + ?{Other Modifiers|0}[Other]]]}}</textarea> 
+							</span>
+						</div>
+					</div>	</div>
+				</div>
+				<div>		
 				</table>
 			</fieldset>	
 			<br />			
@@ -3217,15 +3380,11 @@ For Help, please see the wiki page. <input type="text" name="attr_vehicle-Equipm
 // Github:   https://github.com/shdwjk/TheAaronSheet/blob/master/TheAaronSheet.js
 // By:       The Aaron, Arcane Scriptomancer
 // Contact:  https://app.roll20.net/users/104025/the-aaron
-
 var TAS = TAS || (function(){
     'use strict';
-
     var version = '0.2.0',
         lastUpdate = 1448523710,
-
 		queuedUpdates = {}, //< Used for delaying saves till the last momment.
-
 	log = function(){
         _.each(arguments,function(m){
             switch(typeof m){
@@ -3242,16 +3401,13 @@ var TAS = TAS || (function(){
             }
         });
 	},
-
     prepareUpdate = function( attribute, value ){
         queuedUpdates[attribute]=value;
     },
-
     applyQueuedUpdates = function() {
       setAttrs(queuedUpdates);
       queuedUpdates = {};
     },
-
 	namesFromArgs = function(args,base){
         return _.chain(args)
             .reduce(function(memo,attr){
@@ -3265,7 +3421,6 @@ var TAS = TAS || (function(){
             .uniq()
             .value();
 	},
-
 	addId = function(obj,value){
 		Object.defineProperty(obj,'id',{
 			value: value,
@@ -3273,13 +3428,11 @@ var TAS = TAS || (function(){
 			enumerable: false
 		});
 	},
-
 	addProp = function(obj,prop,value,fullname){
 		(function(){
             var pname=(_.contains(['S','F','I','D'],prop) ? '_'+prop : prop),
 			    full_pname = fullname || prop,
                 pvalue=value;
-
             _.each(['S','I','F'],function(p){
                 if( !_.has(obj,p)){
                     Object.defineProperty(obj, p, {
@@ -3303,8 +3456,6 @@ var TAS = TAS || (function(){
                     readonly: true
                 });
             }
-
-
             // Raw value
 			Object.defineProperty(obj, pname, {
                 enumerable: true,
@@ -3329,7 +3480,6 @@ var TAS = TAS || (function(){
 					return pvalue.toString();
 				}
 			});
-
             // int value
 			Object.defineProperty(obj.I, pname, {
                 enumerable: true,
@@ -3342,7 +3492,6 @@ var TAS = TAS || (function(){
 					return parseInt(pvalue,10) || 0;
 				}
 			});
-
             // float value
 			Object.defineProperty(obj.F, pname, {
                 enumerable: true,
@@ -3368,7 +3517,6 @@ var TAS = TAS || (function(){
                     }
                 });
             });
-
 		}());
 	},
 	
@@ -3428,7 +3576,6 @@ var TAS = TAS || (function(){
 					attrSet = {},
 					fieldIds = [],
 					fullFieldNames = [];
-
 				// call each operation per row.
 				// call each operation's final
 				getSectionIDs("repeating_"+sectionName,function(ids){
@@ -3444,7 +3591,6 @@ var TAS = TAS || (function(){
 								addProp(attrSet,aname,values[aname]);
 							}
 						});
-
 						rowSet = _.reduce(fieldIds,function(memo,id){
 							var r={};
 							addId(r,id);
@@ -3452,33 +3598,27 @@ var TAS = TAS || (function(){
 								var fn = 'repeating_'+sectionName+'_'+id+'_'+name;  
 								addProp(r,name,values[fn],fn);
 							});
-
 							memo[id]=r;
-
 							return memo;
 						},{});
-
                         _.each(operations,function(op){
                             var res;
                             switch(op.type){
                                 case 'tap':
                                     _.bind(op.final,op.context,rowSet,attrSet)();
                                     break;
-
                                 case 'each':
                                     _.each(rowSet,function(r){
                                         _.bind(op.func,op.context,r,attrSet,r.id,rowSet)();
                                     });
                                     _.bind(op.final,op.context,rowSet,attrSet)();
                                     break;
-
                                 case 'map':
                                     res = _.map(rowSet,function(r){
                                         return _.bind(op.func,op.context,r,attrSet,r.id,rowSet)();
                                     });
                                     _.bind(op.final,op.context,res,rowSet,attrSet)();
                                     break;
-
                                 case 'reduce':
                                     res = op.memo;
                                     _.each(rowSet,function(r){
@@ -3488,7 +3628,6 @@ var TAS = TAS || (function(){
                                     break;
                             }
                         });
-
                         // finalize attrs
                         applyQueuedUpdates();
 					});
@@ -3498,33 +3637,25 @@ var TAS = TAS || (function(){
 			return {
 				attrs: repAttrs,
 				attr: repAttrs,
-
 				column: repFields,
 				columns: repFields,
 				field: repFields,
 				fields: repFields,
-
 				reduce: repReduce,
 				inject: repReduce,
 				foldl: repReduce,
-
 				map: repMap,
 				collect: repMap,
-
 				each: repEach,
                 forEach: repEach,
-
                 tap: repTap,
                 'do': repTap,
-
 				execute: repExecute,
 				go: repExecute,
 				run: repExecute
 			};
 		}(section));
 	},
-
-
     repeatingSimpleSum = function(section, field, destination){
         repeating(section)
             .attr(destination)
@@ -3536,17 +3667,13 @@ var TAS = TAS || (function(){
             })
             .execute();
     };
-
     console.log('-=> TheAaronSheet v'+version+' <=-  ['+(new Date(lastUpdate*1000))+']');
-
     return {
         repeatingSimpleSum: repeatingSimpleSum,
 		repeating: repeating
     };
 }());
-
 /* ---- END: TheAaronSheet.js ---- */
-
 // ====== PC /NPC Sheet ====== \\
 on("change:level", function() {
 	ArmorUpdate();
@@ -3554,11 +3681,9 @@ on("change:level", function() {
 on("change:size", function() {
 	SizeUpdate();
 });
-
 on("change:dex", function() {
 	ArmorUpdate();
 });
-
 //Changes to Armor
 on("change:armorworncheck", function() {
 	ArmorUpdate();
@@ -3571,11 +3696,9 @@ on("change:armorperception", function() {
 	ArmorPerception();
 });
 // ====== Vehicle Sheet ====== \\
-
 on("change:vehicle-size", function() {
 	VehicleSizeUpdate();
 });
-
 // When something in inventory is changed...
 on("change:repeating_equipment remove:repeating_equipment",function(){
     //TAS.repeatingSimpleSum('equipment','equipmentwt','equipmentrunningtotal');	
@@ -3601,7 +3724,6 @@ on("change:repeating_equipment remove:repeating_equipment",function(){
         })
         .execute(); 
 });
-
 on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:str",function(){	
 	getAttrs(["ArmorWt","EquipmentWtRunningTotal", "STR", "ArmorCarry"], function(v) {
 		EquipmentCapacity = parseFloat(v["STR"]/2)*(v["STR"]/2).toFixed(1);
@@ -3638,8 +3760,6 @@ on("change:inventoryrunningsummary change:ArmorWorn",function(){
 		setAttrs({"inventory": summary});
 	});
 });
-
-
 // ====== Functions ====== \\
 var ArmorPerception = function() {
 	getAttrs(["ArmorWornCheck", "ArmorPerception","ArmorPerception_max", "PerceptionMisc"], function(v) {
@@ -3669,16 +3789,13 @@ var ArmorPerception = function() {
 		setAttrs({"PerceptionMisc": newPerception, "ArmorPerception_max": perception});
 	});
 };
-
 var ArmorUpdate = function() {
 	getAttrs(["ArmorWornCheck", "ArmorDefense", "ImpArmorDefense", "ArmorProf", "ArmorRef", "level", "ArmorType", "ArmorDex", "DEX", "RefMod"], function(v) {
-
 /*	console.log("ArmorWornCheck = " + v["ArmorWornCheck"] + '\n' +  
 				"ArmorDefense = " + v["ArmorDefense"]   + '\n' + 
 				"ImpArmorDefense = " + v["ImpArmorDefense"] + '\n' + 
 				"ArmorProf = " + v["ArmorProf"] + '\n' + 
 				"ArmorType = " + v["ArmorType"]	);		*/
-
 	//Defenses	
 	ImpArmorDefense = parseInt(v["level"]) + Math.floor(parseInt(v["ArmorRef"]/ 2))
 	if (v["ArmorProf"] == "0") {setAttrs({"ArmorDefense": "0", "ImpArmorDefense": "0" });}
@@ -3729,7 +3846,6 @@ var ArmorUpdate = function() {
 			armorFortitude = "@{level}"
 			setAttrs({"ArmorCarry": "0"}); //Armor is not Carried
 		}
-
 	console.log("armorReflex = " + armorReflex + '\n' + "armorFortitude = " + armorFortitude + '\narmorPenalty = ' + armorPenalty );
 		setAttrs({
 			"RefLevel_max": armorReflex,
@@ -3754,7 +3870,6 @@ var ArmorUpdate = function() {
 	else{console.log("== NO OPTIONS ==" + '\n' + "dexmod = " +dexMod + '\n' + "ArmorDex = " +v["ArmorDex"] + "\nRefMod = " + v["RefMod"]);}
 	}); //End 
 };
-
 var SizeUpdate = function() {
 	getAttrs(["Size"], function(v) {
 	console.log("Size = " + v["Size"])
@@ -3834,7 +3949,6 @@ var VehicleSizeUpdate = function() {
 		console.log("vehicle-sizeMod = " + sizeMod   + '\n' + 
 			"vehicle-GrpSize = " + grappleSize + '\n' + 
 			"vehicle-DTSizeMod = " + dtSize);
-
 		setAttrs({
 			"vehicle-sizeMod": sizeMod,
 			"vehicle-GrpSize": grappleSize,


### PR DESCRIPTION
•	Changed the NPC’s Defenses section to make it more like the PC’s
•	Added an Armor Section for the NPC sheet
•	Changed the NPC’s Attacks Section to make it more like the PC’s.
•	Changed the Repeating Skills Section on the NPC Sheet to be more like the PC skills.
•	Fixed NPC Sheet’s Damage Threshold 
•	Fix NPC Sheet’s Condition Tracker
•	Fix NPC Grapple and Skills
•	Fix PC and NPC Sheet’s Weapon Damage, it should not be counting Non-Heroic Levels for damage.
•	Changed the NPC Grapple to function more like the PC Grapple
