### PR TITLE
Dungeon World Official - Two small quality-of-life improvements

### DIFF
--- a/Dungeon_World_Official/Dungeon World.html
+++ b/Dungeon_World_Official/Dungeon World.html
@@ -382,6 +382,12 @@
 								<input type="number" name="attr_gmod_ongoing_mod" value="0" />
 							</span>
 						</div>
+                        <div class="flex-row flex-left">
+							<input class="enable-mod" type="checkbox" name="attr_barbdice_on" value="1" />
+							<span>
+								<span class="label">Roll 1d6+1d8 for Moves </span>
+							</span>
+						</div>
 						<div class="flex-row flex-left">
 							<input class="enable-mod" type="checkbox" name="attr_dmg_on" value="1" />
 							<span>
@@ -487,7 +493,7 @@
 			<span class="label" data-i18n="gear-u">GEAR</span>
 			<span class="weight-counter">
 				<span class="label" data-i18n="load-u">LOAD</span>
-				<input type="number" class="load-count" name="attr_load" value="@{calc_load}" disabled="true" /> <span class="label">/</span>
+				<input type="number" class="load-count" name="attr_load2" value="0" /> <span class="label">/</span>
 				<input type="number" class="load-count" name="attr_load_max" value="0" />
 			</span>
 		</div>
@@ -2709,6 +2715,23 @@ on("change:repeating_gmods:enable_modifier change:repeating_gmods:ongoing_on cha
 		}
 	});
 });
+// Set 1d6+1d8 (barbarian dice)     
+on("change:repeating_gmods:enable_modifier change:repeating_gmods:barbdice_on change:repeating_gmods:gmod_rolltype", function() {
+	getAttrs(["repeating_gmods_enable_modifier", "repeating_gmods_barbdice_on", "repeating_gmods_gmod_rolltype", "rolltype"], function(v) {
+		if (v.repeating_gmods_barbdice_on > 0 && v.repeating_gmods_enable_modifier > 0) {
+			var rolltype = "1d6+1d8";
+			if (rolltype === undefined || rolltype == "") mod = "2d6";
+			setAttrs({rolltype: rolltype});
+		} else {
+			setAttrs({rolltype: "2d6"});
+		}
+
+		if (!v.repeating_gmods_enable_modifier > 0) {
+			setAttrs({rolltype: "2d6"});
+		}
+	});
+});
+
 
 // Set Damage Mod
 on("change:repeating_gmods:enable_modifier change:repeating_gmods:dmg_on change:repeating_gmods:gmod_dmg_diecount change:repeating_gmods:gmod_dmg_die change:repeating_gmods:gmod_dmg_mod", function() {


### PR DESCRIPTION
Here are two small tweaks:

- Makes the Load input manual instead of auto-calculated. While not as smart, the auto-calculation doesn't seem to be working at the moment so manual entry would be preferable. 
- Add an option under "global modifiers" to let a character roll 1d6+1d8 instead of 2d6; this is crucial for moves like the barbarian's Herculean Appetites. 
  