### PR TITLE
A Series of Minor Changes to the BRP Sheet

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -84,7 +84,7 @@
 						<td><p>STR</p></td>
 						<td><input type="number" name="attr_STR" /></td>	
 							<td >
-							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|5}]] Effort Roll" >Effort</button>	
+							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Effort Roll" >Effort</button>	
 						</td>
 						<td><p>Dmg. Bonus</p></td>
 						<td colspan="3">	
@@ -95,7 +95,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>CON</p></td>
 						<td><input type="number" name="attr_CON" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|5}]] Stamina Roll" >Stamina</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Stamina Roll" >Stamina</button></td>
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank"><p >Siz SR</p></div>
@@ -135,7 +135,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>INT</p></td>
 						<td><input type="number" name="attr_INT" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|5}]] Idea Roll" >Idea</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Idea Roll" >Idea</button></td>
 						<td><p>MOV</p></td><td><input type="number" name="attr_mov" /></td>		
 						<td></td>
 						<td></td>						
@@ -145,7 +145,7 @@
 						<td ><input type="checkbox" name="att_power-check" /><td>
 						<td><p>POW</p></td>
 						<td><input class="sheet-plain" type="number" name="attr_POW" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|5}]] Luck Roll" >&nbsp;Luck</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Luck Roll" >&nbsp;Luck</button></td>
 						<td><p>Hit Pts.</p></td>
 						<td><input type="number" name="attr_cur_hp" />
 						<td>/</td>
@@ -156,7 +156,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>DEX</p></td>
 						<td><input type="number" name="attr_DEX" /></td>	
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|5}]] Agility Roll" >Agility</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Agility Roll" >Agility</button></td>
 						<td><p>Power Pts.</p></td>
 						<td><input type="number" name="attr_cur_mp" />
 						<td>/</td>
@@ -167,7 +167,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>APP</p></td>
 						<td><input type="number" name="attr_APP" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Mulitplier|5}]] Charisma Roll" >Charisma</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Charisma Roll" >Charisma</button></td>
 							
 							<div class="sheet-hpbl">
 								<td>
@@ -221,229 +221,235 @@
 <hr/>
 <!-- ********************************************************************************************************************* -->
 <!-- Start of alpahbetical skills-->
-<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic"  style="display: none">
+<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic" checked="checked"  style="display: none">
 <div class="sheet-skills-alphabetical" />
-<h3 class="sheet-skills-header">Skills</h3>
-<div class='sheet-3colrow'>
-	<div class='sheet-col'>
-		<!-- Col 1 -->                
-		<table style="width: 100%">
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-				<td class="sheet-skillname">Appraise (15%)</td>
-				<td><input type="number" name="attr_Appraise"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Appraise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
-			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Art(05):</td>
-			</tr>
-		</table>				
-		<fieldset class='repeating_artskills'>
-			<table style="width: 100%;">	
-				<tr>
-				<td><input type="checkbox" name="attr_artSuccess"  /></td>
-				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-				<td><input type="number" name="attr_artScore" /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{artScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-				</tr>
-			</table>
-		</fieldset>	
-		<table style="width: 100%">
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
-				<td class="sheet-skillname">Bargain (05%)</td>
-				<td><input type="number" name="attr_Bargain"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Bargain}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Climb"  /></td>
-				<td class="sheet-skillname">Climb (40%)</td>
-				<td><input type="number" name="attr_Climb"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Climb}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Command"  /></td>
-				<td class="sheet-skillname">Command (05)</td>
-				<td><input type="number" name="attr_Command"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multipler|1}+?{Mods|0})/5)+1]]}}  {{success=[[ceil(@{Command}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
-			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Craft(05):</td>
-			</tr>	
-		</table>
-		<fieldset class='repeating_craftskills'>
-			<table style="width: 100%">	
-				<td><input type="checkbox" name="attr_craftSuccess"  /></td>
-				<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
-				<td><input type="number" name="attr_craftScore" /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{craftScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
-			</table>	
-		</fieldset>
-		<table style="width: 100%">
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-				<td class="sheet-skillname">Demolition (01%)</td>
-				<td><input type="number" name="attr_Demolition"  /></td>
-				<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Demolition}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>				
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-				<td class="sheet-skillname">Disguise (01)</td>
-				<td><input type="number" name="attr_Disguise"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multipler|1}+?{Mods|0})/5)+1]]}}    {{success=[[ceil(@{Disguise}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-				<td class="sheet-skillname">Dodge (DEX x02%)</td>
-				<td><input type="number" name="attr_Dodge"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Dodge}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
-			</tr>				
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Drive(Varies):</td>
-			</tr>	
-		</table>
-		<fieldset class='repeating_DriveSkills'>
-			<input type="checkbox" name="attr_DriveSucess"  />
-			<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-			<input type="number" name="attr_DriveScore" />
-			<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{DriveScore}*?{Multipler|1})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{Drive Skill}}}"/>
-		</fieldset>	
-		<table style="width: 100%">	
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-				<td class="sheet-skillname">Etiquette (05)</td>
-				<td><input type="number" name="attr_Etiquette"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Etiquette}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
-				<td class="sheet-skillname">Fast Talk (05%)</td>
-				<td><input type="number" name="attr_FastTalk" /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FastTalk}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
-			</tr>					
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-				<td class="sheet-skillname">Fine Manipulation (05%)</td>
-				<td><input type="number" name="attr_FineManipulation" /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{FineManipulation}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-				<td class="sheet-skillname">First Aid (30% or INT x1)</td>
-				<td><input type="number" name="attr_FirstAid"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{FirstAid}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-				<td class="sheet-skillname">Gaming (INT+POW)</td>
-				<td><input type="number" name="attr_Gaming"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Gaming}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
-			</tr>		
+<p>
+    <h3 class="sheet-skills-header">Skills</h3> 
+    <div class='sheet-3colrow'>
+        <div class='sheet-col'>
+				<!-- Col 1 -->                
+				<table style="width: 100%">
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+						<td class="sheet-skillname">Appraise (15%)</td>
+						<td><input type="number" style="width:105%" value="15" name="attr_Appraise"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+(@{Appraise}*?{Multiplier|Normal - x1, 1|Easy - x2, 2|Difficult -x1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+@{Mods})/20))]]}} {{crit=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}        {{success=[[ceil(@{Appraise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+					</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Art(05):</td>
+					</tr>
+				</table>				
+				<fieldset class='repeating_artskills'>
+					<table style="width: 100%;">	
+						<tr>
+						<td><input type="checkbox" name="attr_artSuccess"  /></td>
+						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+						<td><input type="number" style="width:105%" value="5" name="attr_artScore" /></td>
+					   <td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+(@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[ceil(@{artScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+					   </tr>
+					</table>
+				</fieldset>	
+				<table style="width: 100%">
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Bargain"  /></td>
+						<td class="sheet-skillname">Bargain (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Bargain"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{success=[[ceil(@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil((@{Bargain}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Climb"  /></td>
+						<td class="sheet-skillname">Climb (40%)</td>
+						<td><input type="number" style="width:105%" value="40" name="attr_Climb"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}    {{name=@{Name}}} {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+(@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Climb}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Command"  /></td>
+						<td class="sheet-skillname">Command (05)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Command"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Command}}} {{fumble=[[ceil(95+(@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Command}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>											
+					</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Craft(05):</td>
+					</tr>	
+				</table>
+				<fieldset class='repeating_craftskills'>
+					<table style="width: 100%">	
+						<td><input type="checkbox" name="attr_craftSuccess"  /></td>
+						<td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
+						<td><input type="number" style="width:105%" value="5" style="width:105%" value="5" name="attr_craftScore" /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+(@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{craftScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+					</table>	
+				</fieldset>
+				<table style="width: 100%">
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+						<td class="sheet-skillname">Demolition (01%)</td>
+						<td><input type="number" style="width:105%" value="1" name="attr_Demolition"  /></td>
+						<td><button type="roll" value="&{template:skillRoll} {{name=@{Name}}} {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+(@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Demolition}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+						<td class="sheet-skillname">Disguise (01)</td>
+						<td><input type="number" style="width:105%" value="1"  name="attr_Disguise"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+(@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Disguise}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>										
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+						<td class="sheet-skillname">Dodge (DEX x02%)</td>
+						<td><input type="number" style="width:105%"  name="attr_Dodge"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Dodge}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+					</tr>				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Drive(Varies):</td>
+					</tr>	
+				</table>
+				<fieldset class='repeating_DriveSkills'>
+					<table style="width: 100%">	
+					<td><input type="checkbox" name="attr_DriveSucess"  /></td>
+					 <td><input type="text" name="attr_DriveSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_DriveScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+(@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{DriveScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20})+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Drive}}"/></td>																																																	 				 				 				 					 					 					 					 					 					
+				</fieldset>	
+				<table style="width: 100%">	
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+						<td class="sheet-skillname">Etiquette (05)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Etiquette"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+(@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Etiquette}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>															
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
+						<td class="sheet-skillname">Fast Talk (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_FastTalk" /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FastTalk}}}  {{fumble=[[ceil(95+(@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{FastTalk}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
+					</tr>					
+					<tr>
+						<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+						<td class="sheet-skillname">Fine Manipulation (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_FineManipulation" /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+(@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{FineManipulation}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+					</tr>
 
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Heavy Machine (01%):</td>
-			</tr>	
-		</table>
-		
-		<fieldset class='repeating_hMachineSkills'>
-			<input type="checkbox" name="attr_hMachineSuccess"  />
-			<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-			<input type="number" name="attr_hMachineScore" />
-			<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{hMachineScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
-		</fieldset>					
-		<table style="width: 100%">		
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Hide"  /></td>
-				<td class="sheet-skillname">Hide (10%)</td>
-				<td><input type="number" name="attr_Hide"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[ceil(@{Hide}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
-			</tr>
-			<tr>
-				<td><input type="checkbox" name="attr_Success-Insight"  /></td>
-				<td class="sheet-skillname">Insight (05%)</td>
-				<td><input type="number" name="attr_Insight"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Insight}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
-			</tr>
-		</table>
-		<!-- End of Col 1 -->	
-	</div> <!-- col 1 close -->     
-	<div class='sheet-col'><!-- col 2 start --> 
-	<!-- Start of Col 2 -->									
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
+                    <td><input type="number" style="width:105%" value="30"  name="attr_FirstAid"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[ceil(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+                    <td class="sheet-skillname">Gaming (INT+POW)</td>
+                    <td><input type="number" style="width:105%" name="attr_Gaming"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+(@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Gaming}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+                </tr>		
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Heavy Machine (01%):</td>
+				</tr>	
+				</table>
+				<fieldset class='repeating_hMachineSkills'>
+					<table style="width: 100%">					    
+						 <td><input type="checkbox" name="attr_hMachineSuccess"  /></td>
+						 <td><input type="text" name="attr_hMachineSkills" class="sheet-skillname"/></td>
+						 <td><input type="number" style="width:105%" value="1" name="attr_hMachineScore" /></td>
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+(@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{hMachineScore}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+				</fieldset>					
+				<table style="width: 100%">		
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Hide"  /></td>
+						<td class="sheet-skillname">Hide (10%)</td>
+						<td><input type="number" style="width:105%" value="10" name="attr_Hide"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+(@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Hide}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Insight"  /></td>
+						<td class="sheet-skillname">Insight (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Insight"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+(@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Insight}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+					</tr>
+				</table>
+				<!-- End of Col 1 -->	
+		</div> <!-- col 1 close -->     
+        <div class='sheet-col'><!-- col 2 start --> 
+        <!-- Start of Col 2 -->					
 		<table style="width: 100%">				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Jump"  /></td>
 				<td class="sheet-skillname">Jump (25%)</td>
-				<td><input type="number" name="attr_Jump"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Jump}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Jump"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+(@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Jump}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
 			</tr>
-			<tr>
-				<td class="sheet-chkfiller"></td>
-				<td>Knowledge (Varies):</td>
-			</tr>	
+
+				<tr>
+					<td class="sheet-chkfiller"></td>
+					<td>Knowledge (Varies):</td>
+				</tr>	
 		</table>
 			<fieldset class='repeating_KnowSkills'>
-				<input type="checkbox" name="attr_KnowSucess"  />
-				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_KnowScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{KnowScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
+				<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
+					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+
 			</fieldset>	
 			<table style="width: 100%">					
 				<tr>
 					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
 					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
-					<td><input type="number" name="attr_ownLang"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{ownLang}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>
+					<td><input type="number"  style="width:105%"  name="attr_ownLang"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+(@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{ownLang}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
 				</tr>			
 			</table>
 			<fieldset class='repeating_Langskills'>
-				<tr>
-					<input type="checkbox" name="attr_LangSuccess"  />
-					<input type="text" name="attr_LangSkillname" class="sheet-skillname" />
-					<input type="number" name="attr_LangScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{LangScore}*?{Multipler|1}+?{Mods|0})]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
-				</tr>		
+				<table style="width: 100%;">			
+					 <td><input type="checkbox" name="attr_LangSuccess"  /></td>
+					 <td><input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" /></td>
+					 <td><input type="number"  style="width:105%" name="attr_LangScore" /></td></td>
+				 	 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+(@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[@{LangScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/></td>
 			</fieldset>
+			</table>				
 			<table style="width: 100%">								
-				<tr>
+				 <tr>
 					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
 					<td class="sheet-skillname">Listen (25%)</td>
-					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|1}+?{Mods|0})/5)+1]]}}   {{success=[[ceil(@{Listen}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
-				</tr>			
+					<td><input type="number"  style="width:105%" value="25" name="attr_Listen"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+(@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Listen}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+				 </tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Literacy (Varies):</td>
 				</tr>	
 			</table>
 			<fieldset class='repeating_LitSkills'>
-				<input type="checkbox" name="attr_LitSucess"  />
-				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_LitScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{LitScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>
+					<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_LitSucess"  /></td>
+					 <td><input type="text" name="attr_LitSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_LitScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
 			</fieldset>				
 			<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-					<td class="sheet-skillname">Martial Arts (01%)</td>
-					<td><input type="number" name="attr_MartialArts"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{MartialArts}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-					<td class="sheet-skillname">Medicine (05%)</td>
-					<td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Medicine}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>
-				</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+						<td class="sheet-skillname">Martial Arts (01%)</td>
+						<td><input type="number" style="width:105%" value="1" name="attr_MartialArts"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+(@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{MartialArts}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>																																																							
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+						<td class="sheet-skillname">Medicine (05%)</td>
+						<td><input type="number" style="width:105%" value="5" name="attr_Medicine"  /></td>
+						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+(@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Medicine}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+					</tr>
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
 					<td class="sheet-skillname">Navigate (10%)</td>
-					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Navigate}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
+					<td><input type="number" style="width:105%" value="10" name="attr_Navigate"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+(@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Navigate}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Navigate}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -451,17 +457,18 @@
 				</tr>								
 			</table>
 			<fieldset class='repeating_PerformSkills'>
-				<input type="checkbox" name="attr_Success-Perform"  />
-				<input type="text" name="attr_PerformSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_Perform" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{Perform}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/>
+					<table style="width: 100%">				    
+					 <td><input type="checkbox" name="attr_Success-Perform"  /></td>
+					 <td><input type="text" name="attr_PerformSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="5" name="attr_Perform" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+(@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Perform}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Perform}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PerformSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
-			<table style="width: 100%;">
+				<table style="width: 100%;">	
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
 					<td class="sheet-skillname">Persuade (15%)</td>
-					<td><input type="number" name="attr_Persuade"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Persuade}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
+					<td><input type="number" style="width:105%" value="15" name="attr_Persuade"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+(@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Persuade}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Persuade}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>																														
 				</tr>			
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -469,41 +476,42 @@
 				</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-				<input type="checkbox" name="attr_PilotSucess"  />
-				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PilotScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{PilotScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_PilotSucess"  /></td>
+					 <td><input type="text" name="attr_PilotSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_PilotScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
 				<table style="width: 100%;">				
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
+					<td class="sheet-skillname">Projection(DEX x02%)</td>
+					<td><input type="number" style="width:105%" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Projection}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																														
+				</tr>
+				<tr>
+					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+					<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
+					<td><input type="number" style="width:105%" value="0" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																														
+				</tr>								
 					<tr>
-						<td><input type="checkbox" name="attr_Success-Projection"  /></td>
-						<td class="sheet-skillname">Projection(DEX x02%)</td>
-						<td><input type="number" name="attr_Projection"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+(@{Projection}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Projection}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Projection}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>
-					</tr>
-					<tr>
-						<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-						<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
-						<td><input type="number" name="attr_Psychotherapy"  /></td>
-						<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Psychotherapy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
-					</tr>								
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td class="sheet-skillname">Repair (15%)</td>
+					    <td class="sheet-chkfiller"></td>
+					    <td class="sheet-skillname">Repair (15%)</td>
 					</tr>
 				</table>
 				<fieldset class='repeating_repairSkills'>
-					<input type="checkbox" name="attr_repairSuccess"  />
-					<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-					<input type="number" name="attr_repairScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{repairScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/>
+						 <input type="checkbox" name="attr_repairSuccess"  />
+						 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
+						 <input type="number" name="attr_repairScore" />
+						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
 				</fieldset>				
 				<table style="width: 100%;">				
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Research"  /></td>
 					<td class="sheet-skillname">Research (25%)</td>
-					<td><input type="number" name="attr_Research"  /></td>
-					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|1}+?{Mods|0})/5)+1]]}}       {{success=[[ceil(@{Research}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
+					<td><input type="number" style="width:105%" value="25" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Research}}} {{fumble=[[ceil(95+(@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Research}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																														
 				</tr>						
 					<tr>
 						<td class="sheet-chkfiller"></td>
@@ -511,112 +519,116 @@
 					</tr>	
 				</table>
 				<fieldset class='repeating_RideSkills'>
-					<input type="checkbox" name="attr_RideSucess"  />
-					<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_RideScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{RideScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_RideSucess"  /></td>
+							 <td><input type="text" name="attr_RideSkill" class="sheet-skillname"/></td>
+							 <td><input type="number" style="width:105%" value="1" name="attr_RideScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20 }+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}       {{success=[[ceil(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 				</fieldset>				 
 				<table style="width: 100%;">				
-					<tr>
-						<td class="sheet-chkfiller"></td>
-						<td>Science (01%)</td>
-					</tr>
+						<tr>
+							<td class="sheet-chkfiller"></td>
+							<td>Science (01%)</td>
+						</tr>	
 				</table>
 				<fieldset class='repeating_ScienceSkills'>
-					<input type="checkbox" name="attr_ScienceSucess"  />
-					<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_ScienceScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ScienceScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
+					<table style="width: 100%">	
+						 <td><input type="checkbox" name="attr_ScienceSucess"  /></td>
+						 <td><input type="text" name="attr_ScienceSkill" class="sheet-skillname"/></td>
+						 <td><input type="number" style="width:105%" value="1" name="attr_ScienceScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+(@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{ScienceScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
 				</fieldset>	
-			
-		</div><!-- col 2 close --> 
-		<div class="sheet-col">			
+        </div><!-- col 2 close --> 
+        <div class="sheet-col">
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Sense"  /></td>
 				<td class="sheet-skillname">Sense (10%)</td>
-				<td><input type="number" name="attr_Sense"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Sense}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Sense"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+(@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{Sense}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
 				<td class="sheet-skillname">Sleight of Hand (05%)</td>
-				<td><input type="number" name="attr_SleightofHandScore"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{SleightofHandScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_SleightofHandScore"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+(@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{SleightofHandScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Spot"  /></td>
 				<td class="sheet-skillname">Spot (25%)</td>
-				<td><input type="number" name="attr_Spot"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Spot}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Spot"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+(@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Spot}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
 			</tr>				
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Status"  /></td>
 				<td class="sheet-skillname">Status (05%)</td>
-				<td><input type="number" name="attr_Status"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Status}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_Status"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Status}}} {{fumble=[[ceil(95+(@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Status}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>																																			
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
 				<td class="sheet-skillname">Stealth (10%)</td>
-				<td><input type="number" name="attr_Stealth"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|1}+?{Mods|0})/5)+1]]}}     {{success=[[ceil(@{Stealth}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Stealth"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+(@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[ceil(@{Stealth}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
 			</tr>
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
 				<td class="sheet-skillname">Strategy (01%)</td>
-				<td><input type="number" name="attr_Strategy"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Strategy}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>
+				<td><input type="number" style="width:105%" value="1" style="width:105%" value="1" name="attr_Strategy"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+(@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Strategy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
 			</tr>		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Swim"  /></td>
 				<td class="sheet-skillname">Swim (25%)</td>
-				<td><input type="number" name="attr_Swim"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Swim}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_Swim"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+(@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Swim}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
 			</tr>	
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Teach"  /></td>
 				<td class="sheet-skillname">Teach (10%)</td>
-				<td><input type="number" name="attr_Teach"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|1}+?{Mods|0})/5)+1]]}}          {{success=[[@{Teach}*?{Multipler|1}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Teach"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+(@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[@{Teach}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>																																								
 			</tr>	
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Technical Skill(Varies):</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Technical Skill(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_TechSkills'>
-				<input type="checkbox" name="attr_TechSucess"  />
-				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_TechScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{TechScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
+					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
 			<table style="width: 100%;">		
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Throw"  /></td>
 				<td class="sheet-skillname">Throw (25%)</td>
-				<td><input type="number" name="attr_throw"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{throw}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
+				<td><input type="number" style="width:105%" value="25" name="attr_throw"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{throw}}} {{fumble=[[ceil(95+(@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{throw}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
 			</tr>			
 			<tr>
 				<td><input type="checkbox" name="attr_Success-Track "  /></td>
 				<td class="sheet-skillname">Track (10%)</td>
-				<td><input type="number" name="attr_Track"  /></td>
-				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{Track}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
+				<td><input type="number" style="width:105%" value="10" name="attr_Track"  /></td>
+				<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Track}}} {{fumble=[[ceil(95+(@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Track}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
 			</tr>					
 			</table>		
 			<br />
 			<table style="width: 100%;">					
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td><strong>Other Skills</strong></td>
-				</tr>					
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td><strong>Other Skills</strong></td>
+					</tr>					
 			</table>
 			<fieldset class='repeating_OtherSkills'>
-				<input type="checkbox" name="attr_OtherSucess"  />
-				<input type="text" name="attr_OtherSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_OtherScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{OtherScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/>
+					<table style="width: 100%">	
+					 <td><input type="checkbox" name="attr_OtherSucess"  /></td>
+					 <td><input type="text" name="attr_OtherSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_OtherScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{OtherScore}}} {{fumble=[[ceil(95+(@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{OtherScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{OtherSkill}}}"/></td>
 			</fieldset>	
 			<br />
 				<table style="width: 100%;">					
@@ -631,12 +643,13 @@
 						<td>Melee (Physical)</td>
 					</tr>	
 				</table>	
-
+				
 				<fieldset class='repeating_meleeSkills'>
-					<input type="checkbox" name="attr_meleeSucess"  />
-					<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_meleeScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}        {{success=[[ceil(@{meleeScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_meleeSucess"  /></td>
+							 <td><input type="text" name="attr_meleeSkill" class="sheet-skillname"/></td>
+							 <td><input type="number" style="width:105%" name="attr_meleeScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+(@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{meleeScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
 				</fieldset>				
 
 				<table style="width: 100%;">
@@ -646,28 +659,32 @@
 				</tr>	
 				</table>
 				<fieldset class='repeating_rangedSkills'>
-					<input type="checkbox" name="attr_rangedSucess"  />
-					<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-					<input type="number" name="attr_rangedScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{rangedScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/>
+					<table style="width: 100%">	
+							 <td><input type="checkbox" name="attr_rangedSucess"  /></td>
+							 <td><input type="text" name="attr_rangedSkill" class="sheet-skillname"/></td>
+							 <td><input type="number"  style="width:105%" name="attr_rangedScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+(@{rangedScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{rangedScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 				</fieldset>
 				
 				<table style="width: 100%;">
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Artillery (Manip.)</td>
+                    <td>Artillery (Manip.)</td>
 				</tr>	
 				</table>
 				<fieldset class='repeating_artillerySkills'>
-					<input type="checkbox" name="attr_ArtillerySucess"  />
-					<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-					<input type="number" name="attr_ArtilleryScore" />
-					<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})/5)+1]]}}         {{success=[[ceil(@{ArtilleryScore}*?{Multipler|1}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/>
-				</fieldset>				
+					<table style="width: 100%">	
+
+							 <td><input type="checkbox" name="attr_ArtillerySucess"  /></td>
+							 <td><input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/></td>
+							 <td><input type="number"  style="width:105%" name="attr_ArtilleryScore" /></td>
+							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+(@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{ArtilleryScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>	
 				<br />					
-			<br>
-		</div>
-	</div>
+            <br>
+        </div>
+    </div>
+</p>
 </div>
 <!--End of alabetical skills-->
 <!-- ********************************************************************************************************************* -->
@@ -683,88 +700,84 @@
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Communication</b></td>
-					<td><input type="number" name="attr_Communication" value="0"/></td>
+					<td><input type="number" name="attr_Communication" value="0"  /></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Bargain"/></td>
-					<td class="sheet-skillname">Bargain (5%)</td>
-					<td><input type="number" name="attr_Bargain"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Bargain}}} {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Command"  /></td>
-					<td class="sheet-skillname">Command (5%)</td>
-					<td><input type="number" name="attr_Command"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Command}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Command}}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Disguise"  /></td>
-					<td class="sheet-skillname">Disguise (1%)</td>
-					<td><input type="number" name="attr_Disguise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Disguise}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Disguise}}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
-					<td class="sheet-skillname">Etiquette (5%)</td>
-					<td><input type="number" name="attr_Etiquette"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Etiquette}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Etiquette}}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FastTalk" /></td>
-					<td class="sheet-skillname">Fast Talk (5%)</td>
-					<td><input type="number" name="attr_FastTalk" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FastTalk}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FastTalk}}} {{roll=[[1d100]]}} {{skillname=Fast Talk}}"/></td>
-				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-ownLang"  /></td>
-					<td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
-					<td><input type="number" name="attr_ownLang"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ownLang}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ownLang}}} {{roll=[[1d100]]}} {{skillname=ownLang}}"/></td>
-				</tr>
-			</table>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Bargain"  /></td>
+                    <td class="sheet-skillname">Bargain (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Bargain"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}  {{fumble=[[ceil(95+((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{1/2success=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{success=[[ceil((@{Bargain}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20})+?{Mods|0}]]}}  {{skillvalue=@{Bargain}}}  {{roll=[[1d100]]}} {{skillname=Bargain}}"/></td> 
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Command"  /></td>
+                    <td class="sheet-skillname">Command (05)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Command"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Command}}} {{fumble=[[ceil(95+((@{Command}+@{Communication})*?{Multiplier|1}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil(((@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[(@{Command}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Command}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Disguise"  /></td>
+                    <td class="sheet-skillname">Disguise (01)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Disguise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}    {{skillvalue=@{Disguise}}} {{fumble=[[ceil(95+((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Disguise}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Disguise}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Etiquette"  /></td>
+                    <td class="sheet-skillname">Etiquette (05)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Etiquette"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Etiquette}}}  {{fumble=[[ceil(95+((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Etiquette}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Etiquette}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-ownLang"  /></td>
+                    <td class="sheet-skillname">Language, Own (INT/EDUx5%)</td>
+                    <td><input type="number" style="width:105%" name="attr_ownLang"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ownLang}}}  {{fumble=[[ceil(95+((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{ownLang}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Own Language}}"/></td>																				
+                </tr>
+		    </table>
+			
 			<fieldset class='repeating_Langskills'>
-				<input type="checkbox" name="attr_LangSuccess"  />
-				<input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" />
-				<input type="number" name="attr_LangScore" /></td>
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LangScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LangScore}}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/>
-			</fieldset>		
-			<table style="width:100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Perform"  /></td>
-					<td class="sheet-skillname">Perform (5%)</td>
-					<td><input type="number" name="attr_Perform"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Perform}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Perform}}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>
-				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Persuade"  /></td>
-					<td class="sheet-skillname">Persuade (15%)</td>
-					<td><input type="number" name="attr_Persuade"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Persuade}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Persuade}}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Status"  /></td>
-					<td class="sheet-skillname">Status (15%)</td>
-					<td><input type="number" name="attr_Status"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Status}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Status}}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Teach"  /></td>
-					<td class="sheet-skillname">Teach (10%)</td>
-					<td><input type="number" name="attr_Teach"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Teach}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Teach}}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
-				</tr>
-			</table>	
-			<fieldset class='repeating_commskills'>
-				<table style="width: 100%;">	
-					<tr>
-						<td><input type="checkbox" name="attr_ComSuccess"  /></td>
-						<td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td>
-						<td><input type="number" name="attr_ComScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ComScore}+@{Communication})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ComScore}}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
-					</tr>
-				</table>
+				<table style="width: 100%;">			
+					 <td><input type="checkbox" name="attr_LangSuccess"  /></td>
+					 <td><input type="text" name="attr_LangSkillname" class="sheet-repeat-skillname" /></td>
+					 <td><input type="number"  style="width:105%" name="attr_LangScore" /></td></td>
+				 	 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{LangScore}}} {{fumble=[[ceil(95+((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{LangScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LangSkillname}}}"/></td>
 			</fieldset>
-			<!-- Manipulation -->
+			</table>			
+			<table style="width:100%;">	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Perform"  /></td>
+                    <td class="sheet-skillname">Perform (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Perform"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Perform}}} {{fumble=[[ceil(95+((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Perform}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Perform}}"/></td>
+                </tr>				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Persuade"  /></td>
+                    <td class="sheet-skillname">Persuade (15%)</td>
+                    <td><input type="number" style="width:105%" value="15" name="attr_Persuade"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Persuade}}} {{fumble=[[ceil(95+((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Persuade}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Persuade}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Status"  /></td>
+                    <td class="sheet-skillname">Status (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Status"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Status}}} {{fumble=[[ceil(95+((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Status}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Status}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Teach"  /></td>
+                    <td class="sheet-skillname">Teach (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Teach"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Teach}}} {{fumble=[[ceil(95+((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{Teach}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Teach}}"/></td>
+                </tr>				
+		  </table>	
+		<fieldset class='repeating_commskills'>
+			<table style="width: 100%;">	
+			<tr>
+				 <td><input type="checkbox" name="attr_ComSuccess"  /></td>
+				 <td><input type="text" name="attr_ComSkillname" class="sheet-skillname" /></td> 
+				 <td><input type="number" style="width:105%" name="attr_ComScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ComScore}}} {{fumble=[[ceil(95+((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{ComScore}+@{Communication})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ComSkillname}}}"/></td>
+			</tr>		
+			</table>			
+		</fieldset>
 			<table style="width: 100%;">
 				<tr>
 					<td class="sheet-chkfiller"></td>
@@ -773,89 +786,93 @@
 				</tr>					
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Art(5%):</td>
+					<td>Art(05):</td>
 				</tr>			
 			</table>
-			<fieldset class='repeating_artskills'>
-				<table style="width: 100%;">	
-					<tr>
-						<td><input type="checkbox" name="attr_artSuccess"  /></td>
-						<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
-						<td><input type="number" name="attr_artScore" /></td>
-						<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{artScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{artScore}}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
-					</tr>
-				</table>
-			</fieldset>
-			<table style="width: 100%;">				
+		<fieldset class='repeating_artskills'>
+			<table style="width: 100%;">	
+				<tr>
+				<td><input type="checkbox" name="attr_artSuccess"  /></td>
+				<td><input  type="text" name="attr_artSkillname" class="sheet-skillname" /></td>
+				<td><input type="number" style="width:105%" value="5" name="attr_artScore" /></td>
+			   <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{artScore}}} {{fumble=[[ceil(95+((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{artScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{artSkillname}}}"/></td>
+			   </tr>
+			</table>
+		</fieldset>			
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Craft(5%):</td>
+					<td>Craft(05):</td>
 				</tr>	
-			</table>
-			<fieldset class='repeating_craftskills'>
-				<input type="checkbox" name="attr_craftSuccess"  />
-				<input type="text" name="attr_craftSkillname" class="sheet-skillname"/>
-				<input type="number" name="attr_craftScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{craftScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{craftScore}}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>
-			</fieldset>				
+		</table>
+		<fieldset class='repeating_craftskills'>
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Demolition"  /></td>
-					<td class="sheet-skillname">Demolition (1%)</td>
-					<td><input type="number" name="attr_Demolition"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Demolition}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Demolition}}} {{roll=[[1d100]]}} {{skillname=Demolition}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
-					<td class="sheet-skillname">Fine Manipulation (5%)</td>
-					<td><input type="number" name="attr_FineManipulation" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FineManipulation}}} {{roll=[[1d100]]}} {{skillname=Fine Manipulation}"/></td>
-				</tr>
-			</table>
+
+				 <td><input type="checkbox" name="attr_craftSuccess"  /></td>
+				 <td><input type="text" name="attr_craftSkillname" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="5" name="attr_craftScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{craftScore}}} {{fumble=[[ceil(95+((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{craftScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{craftSkillname}}}"/></td>																																																	 				 
+		</fieldset>				
 			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Demolition"  /></td>
+                    <td class="sheet-skillname">Demolition (01%)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Demolition"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Demolition}}} {{fumble=[[ceil(95+((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Demolition}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Demolition}}"/></td>																																			
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FineManipulation" /></td>
+                    <td class="sheet-skillname">Fine Manipulation (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_FineManipulation" /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{FineManipulation}}}  {{fumble=[[ceil(95+((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{FineManipulation}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Fine Manip.}}"/></td>
+                </tr>
+			</table>
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
-					<td>Heavy Machine (1%):</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_hMachineSkills'>
-				<input type="checkbox" name="attr_hMachineSuccess"  />
-				<input type="text" name="attr_hMachineSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_hMachineScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{hMachineScore}}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">				
+					<td>Heavy Machine (01%):</td>
+				</tr>	
+		</table>
+		<fieldset class='repeating_hMachineSkills'>
+			<table style="width: 100%;">
+				 <td><input type="checkbox" name="attr_hMachineSuccess"  /></td>
+				 <td><input type="text" name="attr_hMachineSkills" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="1" name="attr_hMachineScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{hMachineScore}}} {{fumble=[[ceil(95+((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{hMachineScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{hMachineSkills}}}"/></td>																																																	 				 				 
+		</fieldset>				
+		<table style="width: 100%;">				
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td class="sheet-skillname">Repair (15%)</td>
 				</tr>	
-			</table>
-			<fieldset class='repeating_repairSkills'>
-				<input type="checkbox" name="attr_repairSuccess"  />
-				<input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_repairScore" />
-				<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{repairScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{repairScore}}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>
-			</fieldset>				
+		</table>
+		<fieldset class='repeating_repairSkills'>
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
-					<td class="sheet-skillname">Sleight of Hand (5%)</td>
-					<td><input type="number" name="attr_SleightofHandScore"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{SleightofHandScore}}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>
-				</tr>
-			</table>
-			<fieldset class='repeating_manipkills'>	
-				<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_manipSuccess"  /></td>
-					<td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
-					<td><input type="number" name="attr_manipScore" /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{manipScore}+@{Manipulation})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{manipScore}}} {{roll=[[1d100]]}} {{skillname=@{{manipSkillname}}}"/></td>
-				</tr>		
-				</table>			
-			</fieldset>
-		</div>
-		<!-- Mental -->
+				 <td><input type="checkbox" name="attr_repairSuccess"  /></td>
+				 <td><input type="text" name="attr_repairSkills" class="sheet-skillname"/></td>
+				 <td><input type="number" style="width:105%" value="15" name="attr_repairScore" /></td>
+				 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{repairScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
+		</fieldset>				
+			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_SleightofHandSuccess"  /></td>
+                    <td class="sheet-skillname">Sleight of Hand (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_SleightofHandScore"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{SleightofHandScore}}} {{fumble=[[ceil(95+((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{SleightofHandScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sleight of Hand}}"/></td>																																								
+                </tr>
+            </table>
+		<fieldset class='repeating_manipkills'>
+			<table style="width: 100%;">	
+			<tr>
+				 <td><input type="checkbox" name="attr_manipSuccess"  /></td>
+				 <td><input type="text" name="attr_manipSkillname" class="sheet-skillname" /></td> 
+				 <td><input type="number" style="width:105%" name="attr_manipScore" /></td>
+				<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{manipScore}}} {{fumble=[[ceil(95+((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{manipScore}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{manipSkillname}}}"/></td>
+			</tr>		
+			</table>			
+		</fieldset>			
+        </div>
+  		<!-- Mental -->      
 		<div class='sheet-col'>
 			<table style="width: 100%;">
 				<tr>
@@ -863,94 +880,99 @@
 					<td><b class="sheet-cat_header">Mental</b></td>
 					<td><input type="number" name="attr_Mental" value="0"/></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Appraise"  /></td>
-					<td class="sheet-skillname">Appraise (15%)</td>
-					<td><input type="number" name="attr_Appraise"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Appraise}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Appraise}}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
-					<td class="sheet-skillname">First Aid (30%)</td>
-					<td><input type="number" name="attr_FirstAid"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FirstAid}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{FirstAid}}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Gaming"  /></td>
-					<td class="sheet-skillname">Gaming (INT+POW)</td>
-					<td><input type="number" name="attr_Gaming"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Gaming}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Gaming}}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>
-				</tr>              
-			</table>
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Knowledge (varies):</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_KnowSkills'>
-				<input type="checkbox" name="attr_KnowSucess"  />
-				<input type="text" name="attr_KnowSkills" class="sheet-skillname"/>
-				<input type="number" name="attr_KnowScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{KnowScore}}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Literacy (varies):</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_LitSkills'>
-				<input type="checkbox" name="attr_LitSucess"  />
-				<input type="text" name="attr_LitSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_LitScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LitScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{LitScore}}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/>
-			</fieldset>					
-			<table style="width: 100%;">	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Medicine"  /></td>
-					<td class="sheet-skillname">Medicine (5%)</td>
-					<td><input type="number" name="attr_Medicine"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Medicine}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Medicine}}} {{roll=[[1d100]]}} {{skillname=Medicine}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
-					<td class="sheet-skillname">Psychotherapy (varies)</td>
-					<td><input type="number" name="attr_Psychotherapy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Psychotherapy}}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>
-				</tr>
-			</table>
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Science (1%)</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_ScienceSkills'>
-				<input type="checkbox" name="attr_ScienceSucess"  />
-				<input type="text" name="attr_ScienceSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_ScienceScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ScienceScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ScienceScore}}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/>
-			</fieldset>				
-			<table style="width: 100%;">				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Strategy"  /></td>
-					<td class="sheet-skillname">Strategy (1%)</td>
-					<td><input type="number" name="attr_Strategy"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Strategy}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Strategy}}} {{roll=[[1d100]]}} {{skillname=Strategy}"/></td>
-				</tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Appraise"  /></td>
+                    <td class="sheet-skillname">Appraise (15%)</td>
+                    <td><input type="number" style="width:105%" value="15" name="attr_Appraise"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Appraise}}} {{fumble=[[ceil(95+((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Appraise}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Appraise}}"/></td>																																								
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
+                    <td class="sheet-skillname">First Aid (30% or INT x1)</td>
+                    <td><input type="number" style="width:105%" value="30" name="attr_FirstAid"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{FirstAid}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Gaming"  /></td>
+                    <td class="sheet-skillname">Gaming (INT+POW)</td>
+                    <td><input type="number" style="width:105%" name="attr_Gaming"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Gaming}}} {{fumble=[[ceil(95+((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Gaming}+@{Manipulation})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Gaming}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Gaming}}"/></td>																																																		
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
+                    <td class="sheet-skillname">Psychotherapy (00 or 01)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Psychotherapy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|1Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Psychotherapy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																																																		
+                </tr>                
 			</table>	
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Technical Skill (varies):</td>
-				</tr>
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Knowledge (Varies):</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_knowSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
+					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
+			</fieldset>				
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Literacy (Varies):</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_LitSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_LitSucess"  /></td>
+					 <td><input type="text" name="attr_LitSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_LitScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{LitScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
+			</fieldset>				
+			<table style="width: 100%;">	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Medicine"  /></td>
+                    <td class="sheet-skillname">Medicine (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Medicine"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Medicine}}} {{fumble=[[ceil(95+((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Medicine}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Medicine}}"/></td>																																																							
+                </tr>
+			</table>
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Science (01%)</td>
+					</tr>	
+			</table>
+			<fieldset class='repeating_ScienceSkills'>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_ScienceSucess"  /></td>
+					 <td><input type="text" name="attr_ScienceSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_ScienceScore" /></td>
+    					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ScienceScore}}} {{fumble=[[ceil(95+((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}      {{success=[[(@{ScienceScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ScienceSkill}}}"/></td>																																																	 				 				 				 					 					 					 
+			</fieldset>				
+			<table style="width: 100%;">				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Strategy"  /></td>
+                    <td class="sheet-skillname">Strategy (01%)</td>
+                    <td><input type="number" style="width:105%" value="1" name="attr_Strategy"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Strategy}}} {{fumble=[[ceil(95+((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{success=[[(@{Strategy}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Strategy}}"/></td>																																																												
+                </tr>
+			</table>	
+			
+			<table style="width: 100%;">				
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Technical Skill(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_TechSkills'>
-				<input type="checkbox" name="attr_TechSucess"  />
-				<input type="text" name="attr_TechSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_TechScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{TechScore}}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
+					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>
 			<!-- Perception -->
 			<table style="width: 100%;">								
@@ -959,215 +981,216 @@
 					<td class="sheet-skillname"><b class="sheet-cat_header">Perception</b></td>
 					<td><input type="number" name="attr_Perception" value="0" /></td>
 				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Insight"  /></td>
-					<td class="sheet-skillname">Insight (5%)</td>
-					<td><input type="number" name="attr_Insight"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Insight}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Insight}}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Listen"  /></td>
-					<td class="sheet-skillname">Listen (25%)</td>
-					<td><input type="number" name="attr_Listen"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Listen}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Listen}}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Navigate"  /></td>
-					<td class="sheet-skillname">Navigate (10%)</td>
-					<td><input type="number" name="attr_Navigate"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Navigate}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Navigate}}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Research"  /></td>
-					<td class="sheet-skillname">Research (25%)</td>
-					<td><input type="number" name="attr_Research"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Research}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Research}}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>
-				</tr>                
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Sense"  /></td>
-					<td class="sheet-skillname">Sense (10%)</td>
-					<td><input type="number" name="attr_Sense"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Sense}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Sense}}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Spot"  /></td>
-					<td class="sheet-skillname">Spot (25%)</td>
-					<td><input type="number" name="attr_Spot"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Spot}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Spot}}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>
-				</tr>				
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Track "  /></td>
-					<td class="sheet-skillname">Track (10%)</td>
-					<td><input type="number" name="attr_Track"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Track}+@{Perception})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Track}}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>
-				</tr>
-			</table>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Insight"  /></td>
+                    <td class="sheet-skillname">Insight (05%)</td>
+                    <td><input type="number" style="width:105%" value="5" name="attr_Insight"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Insight}}} {{fumble=[[ceil(95+((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Insight}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Insight}}"/></td>																																																																						
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Listen"  /></td>
+                    <td class="sheet-skillname">Listen (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Listen"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Listen}}} {{fumble=[[ceil(95+((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[(@{Listen}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Listen}}"/></td>																																																																											
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Navigate"  /></td>
+                    <td class="sheet-skillname">Navigate (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Navigate"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Navigate}}} {{fumble=[[ceil(95+((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Navigate}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Navigate}}"/></td>																																																																																
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Research"  /></td>
+                    <td class="sheet-skillname">Research (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Research"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Research}}} {{fumble=[[ceil(95+((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Research}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Research}}"/></td>																																																																																
+                </tr>                
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Sense"  /></td>
+                    <td class="sheet-skillname">Sense (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Sense"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Sense}}} {{fumble=[[ceil(95+((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Sense}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Sense}}"/></td>																																																																																					
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Spot"  /></td>
+                    <td class="sheet-skillname">Spot (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Spot"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Spot}}} {{fumble=[[ceil(95+((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Spot}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spot}}"/></td>																																																																																										
+                </tr>				
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Track "  /></td>
+                    <td class="sheet-skillname">Track (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Track"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Track}}} {{fumble=[[ceil(95+((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Track}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Track}}"/></td>																																																																																															
+                </tr>					
+            </table>
 			<fieldset class='repeating_PercepSkills'>
-				<input type="checkbox" name="attr_PercepSucess"  />
-				<input type="text" name="attr_PercepSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PercepScore" />
-				<button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+(@{PercepScore}+@{Perception}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PercepScore}+@{Perception}+?{Mods|0})/5)+1]]}}        {{success=[[@{PercepScore}+@{Perception}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>
+			<table style="width: 100%;">
+					 <td><input type="checkbox" name="attr_PercepSucess"  /></td>
+					 <td><input type="text" name="attr_PercepSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PercepScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PercepScore}}} {{fumble=[[ceil(95+((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PercepScore}+@{Perception})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PercepSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
-		</div>
-		<div class="sheet-col">
-			<!-- Physical -->
+        </div>
+        <div class="sheet-col">
+            <!-- Physical -->
 			<table style="width: 100%;">
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Physical</b></td>
 					<td><input type="number" name="attr_Physical" value="0" /></td>
 				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Climb"  /></td>
-					<td class="sheet-skillname">Climb (40%)</td>
-					<td><input type="number" name="attr_Climb"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Climb}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Climb}}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Dodge"  /></td>
-					<td class="sheet-skillname">Dodge (DEX x2%)</td>
-					<td><input type="number" name="attr_Dodge"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Dodge}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Dodge}}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>
-				</tr>
-			</table>		
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Climb"  /></td>
+                    <td class="sheet-skillname">Climb (40%)</td>
+                    <td><input type="number" style="width:105%" value="40" name="attr_Climb"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Climb}}} {{fumble=[[ceil(95+((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}       {{success=[[(@{Climb}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Climb}}"/></td>
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Dodge"  /></td>
+                    <td class="sheet-skillname">Dodge (DEX x02%)</td>
+                    <td><input type="number" style="width:105%" name="attr_Dodge"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}        {{success=[[(@{Dodge}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+                </tr>
+		</table>		
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Drive (varies)</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Drive(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_DriveSkills'>
-				<input type="checkbox" name="attr_DriveSucess"  />
-				<input type="text" name="attr_DriveSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_DriveScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{DriveScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{DriveScore}}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/>
-			</fieldset>				
-
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Hide"  /></td>
-					<td class="sheet-skillname">Hide (10%)</td>
-					<td><input type="number" name="attr_Hide"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Hide}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Hide}}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Jump"  /></td>
-					<td class="sheet-skillname">Jump (25%)</td>
-					<td><input type="number" name="attr_Jump"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Jump}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Jump}}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>
-				</tr>
-			</table>		
+					 <td><input type="checkbox" name="attr_DriveSucess"  /></td>
+					 <td><input type="text" name="attr_DriveSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_DriveScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{DriveScore}}} {{fumble=[[ceil(95+((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}}  {{1/2success=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{special=[[ceil(((@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}        {{success=[[(@{DriveScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{DriveSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 
+			</fieldset>				
+		<table style="width: 100%;">
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Hide"  /></td>
+                    <td class="sheet-skillname">Hide (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Hide"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Hide}}} {{fumble=[[ceil(95+((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Hide}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Hide}}"/></td>																																																																																																														
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Jump"  /></td>
+                    <td class="sheet-skillname">Jump (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Jump"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Jump}}} {{fumble=[[ceil(95+((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Jump}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Jump}}"/></td>																																																																																																																			
+                </tr>
+		</table>		
 			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Pilot (varies)</td>
-				</tr>	
+					<tr>
+						<td class="sheet-chkfiller"></td>
+						<td>Pilot(Varies):</td>
+					</tr>	
 			</table>
 			<fieldset class='repeating_PilotSkills'>
-				<input type="checkbox" name="attr_PilotSucess"  />
-				<input type="text" name="attr_PilotSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PilotScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PilotScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PilotScore}}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/>
-			</fieldset>				
 			<table style="width: 100%;">
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Projection"  /></td>
-					<td class="sheet-skillname">Projection (DEX x2%)</td>
-					<td><input type="number" name="attr_Projection"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Projection}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Projection}}} {{roll=[[1d100]]}} {{skillname=Projection}}"/>
-				</tr>
-			</table>		
-
-			<table style="width: 100%;">				
-				<tr>
-					<td class="sheet-chkfiller"></td>
-					<td>Ride (varies)</td>
-				</tr>	
-			</table>
-			<fieldset class='repeating_RideSkills'>
-				<input type="checkbox" name="attr_RideSucess"  />
-				<input type="text" name="attr_RideSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_RideScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{RideScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{RideScore}}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/>
+					 <td><input type="checkbox" name="attr_PilotSucess"  /></td>
+					 <td><input type="text" name="attr_PilotSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PilotScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PilotScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>				
-
-			<table style="width: 100%;">		
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Stealth"  /></td>
-					<td class="sheet-skillname">Stealth (10%)</td>
-					<td><input type="number" name="attr_Stealth"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Stealth}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Stealth}}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>
-				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Swim"  /></td>
-					<td class="sheet-skillname">Swim (25%)</td>
-					<td><input type="number" name="attr_Swim"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Swim}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{Swim}}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>
-				</tr>	
-				<tr>
-					<td><input type="checkbox" name="attr_Success-Throw"  /></td>
-					<td class="sheet-skillname">Throw (25%)</td>
-					<td><input type="number" name="attr_throw"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{throw}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{throw}}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>
-				</tr>
-			</table>
-			<fieldset class='repeating_PhysicalSkills'>
-				<input type="checkbox" name="attr_PhysicalSucess"  />
-				<input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_PhysicalScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{PhysicalScore}}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>
-			</fieldset>	
-			<!-- Combat -->
+		<table style="width: 100%;">
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Projection"  /></td>
+                    <td class="sheet-skillname">Projection (DEX x02%)</td>
+                    <td><input type="number" style="width:105%" name="attr_Projection"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Projection}}} {{fumble=[[ceil(95+((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{Projection}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Projection}}"/></td>																																																																																																																																							
+                </tr>			
+		</table>		
+		<table style="width: 100%;">				
+			<tr>
+				<td class="sheet-chkfiller"></td>
+				<td>Ride(Varies):</td>
+			</tr>	
+		</table>
+		<fieldset class='repeating_RideSkills'>
+			<table style="width: 100%;">				
+					 <td><input type="checkbox" name="attr_RideSucess"  /></td>
+					 <td><input type="text" name="attr_RideSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_RideScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{RideScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+		</fieldset>				
+		<table style="width: 100%;">		
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Stealth"  /></td>
+                    <td class="sheet-skillname">Stealth (10%)</td>
+                    <td><input type="number" style="width:105%" value="10" name="attr_Stealth"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Stealth}}} {{fumble=[[ceil(95+((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{success=[[(@{Stealth}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Stealth}}"/></td>																																																																																																																													
+                </tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Swim"  /></td>
+                    <td class="sheet-skillname">Swim (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_Swim"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{Swim}}} {{fumble=[[ceil(95+((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{Swim}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Swim}}"/></td>																																																																																																																																		
+                </tr>	
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-Throw"  /></td>
+                    <td class="sheet-skillname">Throw (25%)</td>
+                    <td><input type="number" style="width:105%" value="25" name="attr_throw"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{throw}}} {{fumble=[[ceil(95+((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{throw}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Throw}}"/></td>																																																																																																																																							
+                </tr>	
+		</table>
+		<fieldset class='repeating_PhysicalSkills'>
+			<table style="width: 100%;">	
+					 <td><input type="checkbox" name="attr_PhysicalSucess"  /></td>
+					 <td><input type="text" name="attr_PhysicalSkill" class="sheet-skillname"/></td>
+					 <td><input type="number" style="width:105%" name="attr_PhysicalScore" /></td>
+					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{PhysicalScore}}} {{fumble=[[ceil(95+((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{PhysicalScore}+@{Physical})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{PhysicalSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
+		</fieldset>	
+        <!-- Combat -->
 			<table style="width: 100%;">					
 				<tr>
 					<td style="width:20px"></td>
 					<td><b class="sheet-cat_header">Combat</b></td>
 					<td><input type="number" name="attr_Combat" value="0"/></td>
 				</tr>
-				<tr>
-					<td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
-					<td class="sheet-skillname">Martial Arts (1%)</td>
-					<td><input type="number" name="attr_MartialArts"  /></td>
-					<td><button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{MartialArts}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{MartialArts}}} {{roll=[[1d100]]}} {{skillname=Martial Arts}}"/></td>
-				</tr>
+                <tr>
+                    <td><input type="checkbox" name="attr_Success-MartialArts"  /></td>
+                    <td class="sheet-skillname">Martial Arts (1%)</td>
+                    <td><input type="number" name="attr_MartialArts"  /></td>
+					<td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{MartialArts}}} {{fumble=[[ceil(95+((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{MartialArts}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=MartialArts}}"/></td>																																																																																																																																							
+                </tr>				
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Melee</td>
-				</tr>
-			</table>
-			<fieldset class='repeating_meleeSkills'>
-				<input type="checkbox" name="attr_meleeSucess"  />
-				<input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_meleeScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{meleeScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{meleeScore}}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
-			</fieldset>				
-			<table style="width: 100%;">					
+				</tr>	
+		        </table>	
+				<fieldset class='repeating_meleeSkills'>
+							 <input type="checkbox" name="attr_meleeSucess"  />
+							 <input type="text" name="attr_meleeSkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_meleeScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{meleeScore}}} {{fumble=[[ceil(95+((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{meleeScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{meleeSkill}}}"/></td>
+				</fieldset>				
+	        	<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td>
 					<td>Ranged</td>
-				</tr>
-			</table>			
-			<fieldset class='repeating_rangedSkills'>
-				<input type="checkbox" name="attr_rangedSucess"  />
-				<input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
-				<input type="number" name="attr_rangedScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{rangedScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{rangedScore}}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"
-				/></td>
-			</fieldset>
-			<table style="width: 100%;">					
+				</tr	>	
+		        </table>			
+				<fieldset class='repeating_rangedSkills'>
+							 <input type="checkbox" name="attr_rangedSucess"  />
+							 <input type="text" name="attr_rangedSkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_rangedScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{rangedScore}}} {{fumble=[[ceil(95+((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{rangedScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{rangedSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>
+		<table style="width: 100%;">					
 				<tr>
 					<td class="sheet-chkfiller"></td> 
 					<td>Artillery</td>
-				</tr>
-			</table>	
-			<fieldset class='repeating_artillerySkills'>
-				<input type="checkbox" name="attr_ArtillerySucess"  />
-				<input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
-				<input type="number" name="attr_ArtilleryScore" />
-				<button type="roll" value="&{template:skillRoll} {{success=[[ceil((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})]]}} {{fumble=[[ceil((95+((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20))]]}} {{crit=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multipler|1}+?{Mods|0})/5)+1]]}} {{skillvalue=@{ArtilleryScore}}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>
-			</fieldset>
-		</div>
-	</div>
+				</tr>	
+		</table>	
+				<fieldset class='repeating_artillerySkills'>
+							 <input type="checkbox" name="attr_ArtillerySucess"  />
+							 <input type="text" name="attr_ArtillerySkill" class="sheet-skillname"/>
+							 <input type="number" name="attr_ArtilleryScore" />
+							 <button type="roll" value="&{template:skillRoll}   {{skillvalue=@{ArtilleryScore}}} {{fumble=[[ceil(95+((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil(((@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{ArtilleryScore}+@{Combat})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{ArtillerySkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
+				</fieldset>					
+       </div>
+    </div>
 </p>
 </div>
 <!--End of Skills by category-->
@@ -1208,27 +1231,27 @@
 					</td>
 					<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_length">
-							<option value="">S</option>
-							<option value="">M</option>
-							<option value="">M/L</option>
-							<option value="">L</option>								
-							<option value="">ALL</option>								
+								<option value=""selected>S</option>
+								<option value="">M</option>
+								<option value="">M/L</option>
+								<option value="">L</option>								
+								<option value="">ALL</option>									
 						</select>
 					</td>
 					
-					<td ><input style="width:50px" type="number" name="attr_Brawl" /></td>
+						<td ><input style="width:50px" value="25" type="number" name="attr_Brawl" /></td>
 					<td >
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Brawl_spcl">
-							<option value="Bl">Bl</option>
-							<option value="Im">Im</option>
-							<option value="Cr">Cr</option>
-							<option value="En">En</option>								
+								<option value="Bl">Bl</option>
+								<option value="Im">Im</option>
+								<option value="Cr"selected>Cr</option>
+								<option value="En">En</option>								
 						</select>
 					</td>	
 					<td ><input type="text" name="attr_Brawl-Damage" style="width: 60px" /></td>
 					<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
 					<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
 				</tr>
 				
 				<tr>
@@ -1242,28 +1265,28 @@
 						</td>
 					<td>
 						<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_length">
-							<option value="">S</option>
-							<option value="">M</option>
-							<option value="">M/L</option>
-							<option value="">L</option>								
-							<option value="">ALL</option>								
+								<option value=""selected>S</option>
+								<option value="">M</option>
+								<option value="">M/L</option>
+								<option value="">L</option>								
+								<option value="">ALL</option>								
 						</select>
 					</td>						
 					
 					
-					<td><input  style="width:50px" type="number" name="attr_Grapple" /></td>
+						<td><input  style="width:50px" value="25" type="number" name="attr_Grapple" /></td>
 					<td>
 					<select style="font-size: 9px; margin-bottom: 0px; width:49px" name="attr_Grapple_spcl">
-							<option value="Bl">Bl</option>
-							<option value="Im">Im</option>
-							<option value="Cr">Cr</option>
-							<option value="En">En</option>								
+								<option value="Bl">Bl</option>
+								<option value="Im">Im</option>
+								<option value="Cr">Cr</option>
+								<option value="En"Selected>En</option>							
 					</select>
 					</td>
 					<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
 					<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
 					<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Grapple}}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
 				</tr>
 				
 			</tbody>
@@ -1297,7 +1320,7 @@
 					<td><input style="width:62px" type="text" name="attr_Damagex"  /></td>
 					<td><input style="width:36px; margin-right:3px" type="number" name="attr_Attacks-Round" /></td>
 					<td><input  style="width:40px" type="text" name="attr_HP" /></td>
-					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
+					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
 				</tr>
 			</table>
 		</fieldset>
@@ -1331,7 +1354,7 @@
 						<option value="0.5">Yes</option>
 					</select>
 					</td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage1}+(ceil(@{Damage_Bonus}*@{weapon_type1}))]]}} {{success=[[ceil(@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score1}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score1}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm1}}}" /></td>						
 				</tr>				
 			</tbody>
 		</table>
@@ -1352,7 +1375,7 @@
 						<option value="0.5">Yes</option>
 					</select>						
 					</td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|1}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|1}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|1}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
 				</tr>
 			</table>
 		</fieldset>
@@ -1566,9 +1589,9 @@
 		</button>
 	</div>
 	<div style="display: inline">Hit Pts.
-		<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_max_hp" />
-		<p style="display:inline">/</p>
-		<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_cur_hp" />
+				<input style="border: none; width:42px" class="sheet-section-header" type="number" name="attr_cur_hp" />
+				<p style="display:inline">/</p>
+				<input style="border: none; width:42pxpx" class="sheet-section-header" type="number" name="attr_max_hp" />
 	</div> 		
 </div>
 
@@ -1735,40 +1758,41 @@
 			 
 			{{#rollBetween() roll fumble 100}} 
 				<td class="template_value">Fumble</td>
-			{{/rollBetween() roll fumble 100}} 
+		{{/rollBetween() roll fumble 100}} 
+		
+		{{#^rollBetween() roll fumble 100}}
+		
+			{{#rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
+					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
+				{{/^rollLess() roll crit}}
+
+			{{/rollGreater() success 99}}
 			
-			{{#^rollBetween() roll fumble 100}}
-			
-				{{#rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-	
-				{{/rollGreater() success 99}}
-				
-				{{#^rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}
-							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-							{{#^rollBetween() roll special success}}
-								{{#rollLess() roll fumble}}
-									<td class="template_value">Failure</td>
-								{{/rollLess() roll fumble}}
-								{{#^rollLess() roll fumble}}
-									<td class="template_value">fumble</td>
-								{{/^rollLess() roll fumble}}							
-							{{/^rollBetween() roll special success}}											
-						{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-				{{/^rollGreater() success 99}}
-			{{/^rollBetween() roll fumble 100}}
-			
-			
-			{{#rollLess() roll success}}
+						{{#^rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					{{#^rollLess() roll special}}
+						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+						{{#^rollBetween() roll special success}}
+							{{#rollLess() roll fumble}}
+								<td class="template_value">Failure</td>
+							{{/rollLess() roll fumble}}
+							{{#^rollLess() roll fumble}}
+								<td class="template_value">fumble</td>
+							{{/^rollLess() roll fumble}}							
+						{{/^rollBetween() roll special success}}											
+					{{/^rollLess() roll special}}
+				{{/^rollLess() roll crit}}
+			{{/^rollGreater() success 99}}
+		{{/^rollBetween() roll fumble 100}}
+		
+		
+		{{#rollLess() roll success}}
 				<tr>
 					<td class="template_label"><b>Damage:</b></td>
 					<td style="text-align: right"; class="template_value">{{tot}}<td>
@@ -1830,40 +1854,44 @@
 	
 			{{#rollBetween() roll fumble 100}} 
 					<td class="template_value">Fumble</td>
-			{{/rollBetween() roll fumble 100}} 
+		{{/rollBetween() roll fumble 100}} 
+		
+		{{#^rollBetween() roll fumble 100}}
+		
+			{{#rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
+					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
+				{{/^rollLess() roll crit}}
+
+			{{/rollGreater() success 99}}
 			
-			{{#^rollBetween() roll fumble 100}}
+			{{#^rollGreater() success 99}}
+				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+				{{#^rollLess() roll crit}}
+					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+					{{#^rollLess() roll special}}
+						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+						{{#^rollBetween() roll special success}}
+							{{#rollLess() roll fumble}}
+								<td class="template_value">Failure</td>
+							{{/rollLess() roll fumble}}
+							{{#^rollLess() roll fumble}}
+								<td class="template_value">fumble</td>
+							{{/^rollLess() roll fumble}}							
+						{{/^rollBetween() roll special success}}						
+					
+					{{/^rollLess() roll special}}
+				{{/^rollLess() roll crit}}
 			
-				{{#rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-	
-				{{/rollGreater() success 99}}
-				
-				{{#^rollGreater() success 99}}
-					{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-					{{#^rollLess() roll crit}}
-						{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-						{{#^rollLess() roll special}}
-							{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-							{{#^rollBetween() roll special success}}
-								{{#rollLess() roll fumble}}
-									<td class="template_value">Failure</td>
-								{{/rollLess() roll fumble}}
-								{{#^rollLess() roll fumble}}
-									<td class="template_value">fumble</td>
-								{{/^rollLess() roll fumble}}							
-							{{/^rollBetween() roll special success}}						
-						
-						{{/^rollLess() roll special}}
-					{{/^rollLess() roll crit}}
-				
-				{{/^rollGreater() success 99}}
-	
-			{{/^rollBetween() roll fumble 100}}
+			
+			
+			{{/^rollGreater() success 99}}
+
+			
+		{{/^rollBetween() roll fumble 100}}
 			</tr>
 		</table>
 	</rolltemplate>


### PR DESCRIPTION
•	Added a drop down menu for attribute rolls
•	Swapped the HP Counter on the bottom of the sheet. It was putting the Max HP value on the top instead of the bottom.
•	Added a “Roll Under Half” Section for Skill Roll Template. Due to there being some rules for them.
•	Increased the size of the number box in order to handle triple digit skills in alphabetical skills.
•	Created a drop down menu for the multiplier input when rolling in alphabetical and categorical skills.
•	Added a default value for skills in alphabetical and categorical skills
•	Made the number box bigger to take 3-digit numbers
•	Added drop down menu for the multiplier input in hand-to-hand weapons and ranged weapons
•	Added Default skill values, weapon length and attack type for Brawl and Grapple Attacks