### PR TITLE
Star Trek: Weapons & Stress fixed

### DIFF
--- a/Star Trek Adventures Official/STA_Style.css
+++ b/Star Trek Adventures Official/STA_Style.css
@@ -63,7 +63,7 @@ hr {
 }
 
 .sheet-label {
-    font-size:1.1rem;
+    font-size: 1.1rem;
 	color: rgb(150,118,169);
 }
 

--- a/Star Trek Adventures Official/STA_Style.css
+++ b/Star Trek Adventures Official/STA_Style.css
@@ -1023,7 +1023,7 @@ input.sheet-weapon_setting_toggle:checked ~ div.sheet-weapon_settings {
 
 .sheet-rolltemplate-header span {
 	color: rgb(163,64,113);
-	font-size: 20px;
+	font-size: 15px;
 	background: rgb(0,19,35);
 	padding: 0px 5px 0px 5px;
 	vertical-align: top;

--- a/Star Trek Adventures Official/Star Trek Adventures Official.html
+++ b/Star Trek Adventures Official/Star Trek Adventures Official.html
@@ -660,7 +660,7 @@
 						<div class="weapon-row">
 							<span data-i18n="name-type-s" class="label-capsule-weapon">NAME/TYPE</span>
 							<input type="text" class="weapon-name" name="attr_weapon_name" spellcheck="false" spellcheck="false"/>
-							<button class="weapon-button" type='roll' value="&{template:strek}@{damageRoll}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}@{damageRoll}" title="Scale + Security + Weapon Damage">
+							<button class="weapon-button" type='roll' value="&{template:strek}@{damageRoll}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}@{damageRoll}" title="Security + Weapon Damage">
 							<!--This URL will need to change-->
 								<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Star%20Trek%20Adventures%20Official/STA_starfleet_insignia_full.png" />
 							</button>
@@ -1464,11 +1464,10 @@ on("change:security", function() {
 
 	//Configure damage for ships
 on("change:repeating_ship:weapon_damage change:repeating_ship:weapon_name", function() {
-    getAttrs(["repeating_ship_weapon_damage", "ship_security", "ship_scale"], function(v){
+    getAttrs(["repeating_ship_weapon_damage", "ship_security"], function(v){
         var dmg = parseInt(v.repeating_ship_weapon_damage) || 0;
         var sec = parseInt(v.ship_security) || 0;
-        var sca = parseInt(v.ship_scale) || 0;
-        var tot = dmg + sec + sca;
+        var tot = dmg + sec;
         var template = [];
         for (i = 1; i <= tot; i++) {
             template.push("{{cdice".concat(i, "=[[1d6]]}}"));

--- a/Star Trek Adventures Official/Star Trek Adventures Official.html
+++ b/Star Trek Adventures Official/Star Trek Adventures Official.html
@@ -284,6 +284,7 @@
 						<input type="hidden" name="attr_stress_17_enabled" value="true"/>
 						<input type="radio" name="attr_stress" value="17" /><span></span>
 						<input type="hidden" name="attr_stress_18_enabled" value="true"/>
+						<input type="radio" name="attr_stress" value="18" /><span></span>
 						<input type="hidden" name="attr_stress_19_enabled" value="true"/>
 						<input type="radio" name="attr_stress" value="19" /><span></span>
 						<input type="hidden" name="attr_stress_20_enabled" value="true"/>
@@ -576,7 +577,7 @@
 							<span data-i18n="current" class="capsule-power">CURRENT</span><input type="number" class="capsule" name="attr_power" title="@{power}" />
 							<span data-i18n="max-p" class="capsule-power">MAX</span><div class="capsule"><span name="attr_power_max"></span></div>
 						</div>
-						<!-- Shields (The # of visible bubbles depends on the score of Structure and Security rating).-->
+						<!-- Shields (The # of visible bubbles depends on Structure and Security rating).-->
 						<div class='shields'>
 							<input type="radio" class="radio-header-shields" name="attr_shields" value="0" title="@{shields}" checked="checked" />
 							<div class="section-heading"><span data-i18n="shields">SHIELDS</span></div>


### PR DESCRIPTION
Weapons needed to be fixed to account for torpedoes not using scale. Scale was removed from the damage calculations. Stress 18 was also missing. Added that attribute in.