### PR TITLE
Housecleaning and Additions

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -84,7 +84,7 @@
 						<td><p>STR</p></td>
 						<td><input type="number" name="attr_STR" /></td>	
 							<td >
-							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{STR}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Effort Roll" >Effort</button>	
+							<button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[ceil(@{STR}*?{Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1})]] Effort Roll" >Effort</button>	
 						</td>
 						<td><p>Dmg. Bonus</p></td>
 						<td colspan="3">	
@@ -95,7 +95,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>CON</p></td>
 						<td><input type="number" name="attr_CON" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{CON}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Stamina Roll" >Stamina</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[ceil(@{CON}*?{Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1})]] Stamina Roll" >Stamina</button></td>
 						<td>
 							<input type="checkbox" class="sheet-showstrike-rank" name="attr_showstrike-rank" checked="checked" style="display: none">
 							<div class="sheet-strike-rank"><p >Siz SR</p></div>
@@ -135,7 +135,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>INT</p></td>
 						<td><input type="number" name="attr_INT" /></td>
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{INT}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Idea Roll" >Idea</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[ceil(@{INT}*?{Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1})]] Idea Roll" >Idea</button></td>
 						<td><p>MOV</p></td><td><input type="number" name="attr_mov" /></td>		
 						<td></td>
 						<td></td>						
@@ -145,7 +145,7 @@
 						<td ><input type="checkbox" name="att_power-check" /><td>
 						<td><p>POW</p></td>
 						<td><input class="sheet-plain" type="number" name="attr_POW" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{POW}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Luck Roll" >&nbsp;Luck</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[ceil(@{POW}*?{Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1})]] Luck Roll" >&nbsp;Luck</button></td>
 						<td><p>Hit Pts.</p></td>
 						<td><input type="number" name="attr_cur_hp" />
 						<td>/</td>
@@ -156,7 +156,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>DEX</p></td>
 						<td><input type="number" name="attr_DEX" /></td>	
-						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{DEX}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Agility Roll" >Agility</button></td>
+						<td ><button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[ceil(@{DEX}*?{Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1})]] Agility Roll" >Agility</button></td>
 						<td><p>Power Pts.</p></td>
 						<td><input type="number" name="attr_cur_mp" />
 						<td>/</td>
@@ -167,7 +167,7 @@
 						<td class=".sheet-chkfiller"><td>
 						<td><p>APP</p></td>
 						<td><input type="number" name="attr_APP" /></td>
-						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[@{APP}*?{Multiplier|Normal - x5, 5|x4, 4|Hard - x3, 3|x2, 2|x1, 1}]] Charisma Roll" >Charisma</button></td>
+						<td ><button class="sheet-characteristic-roll sheet-plain"  type="roll" value="/roll 1d100<[[ceil(@{APP}*?{Multiplier|Normal - x5, 5|Easy - x10, 10|x4, 4|x3, 3|Difficult - x3/2, 3/2|x2, 2|x1, 1})]] Charisma Roll" >Charisma</button></td>
 							
 							<div class="sheet-hpbl">
 								<td>
@@ -201,7 +201,7 @@
 						<td >
 							<input type="checkbox" class="sheet-showedufld" name="attr_showedufld" checked="checked" style="display: none">
 							<div class="sheet-edufld">
-							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{EDU}*?{Multiplier|5}]] Know Roll">Know</button>
+							<button  class="sheet-characteristic-roll sheet-plain" type="roll" value="/roll 1d100<[[@{EDU}*?{Multiplier|Multiplier|Normal, 5|Easy, 10|Difficult, 5/2|x4, 4|x3, 3|x2, 2|x1, 1}]] Know Roll">Know</button>
 							</div>
 						</td>
 						
@@ -221,7 +221,7 @@
 <hr/>
 <!-- ********************************************************************************************************************* -->
 <!-- Start of alpahbetical skills-->
-<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic" checked="checked"  style="display: none">
+<input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic"  style="display: none">
 <div class="sheet-skills-alphabetical" />
 <p>
     <h3 class="sheet-skills-header">Skills</h3> 
@@ -337,7 +337,7 @@
                 <tr>
                     <td><input type="checkbox" name="attr_Success-FirstAid"  /></td>
                     <td class="sheet-skillname">First Aid (30% or INT x1)</td>
-                    <td><input type="number" style="width:105%" value="30"  name="attr_FirstAid"  /></td>
+                    <td><input type="number" style="width:105%"  name="attr_FirstAid"  /></td>
 					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{FirstAid}}} {{fumble=[[ceil(95+(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}   {{success=[[ceil(@{FirstAid}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=First Aid}}"/></td>																																													
                 </tr>
                 <tr>
@@ -393,7 +393,7 @@
 				<table style="width: 100%">				    
 					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
 					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><input type="number" style="width:105%" name="attr_KnowScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{KnowScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
 
 			</fieldset>	
@@ -429,7 +429,7 @@
 					<table style="width: 100%">				    
 					 <td><input type="checkbox" name="attr_LitSucess"  /></td>
 					 <td><input type="text" name="attr_LitSkill" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_LitScore" /></td>
+					 <td><input type="number" style="width:105%" name="attr_LitScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{LitScore}}} {{fumble=[[ceil(95+(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{LitScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{LitSkill}}}"/></td>																																																	 				 				 				 					 					 
 			</fieldset>				
 			<table style="width: 100%;">	
@@ -479,7 +479,7 @@
 					<table style="width: 100%">	
 					 <td><input type="checkbox" name="attr_PilotSucess"  /></td>
 					 <td><input type="text" name="attr_PilotSkill" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_PilotScore" /></td>
+					 <td><input type="number" style="width:105%" name="attr_PilotScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{PilotScore}}} {{fumble=[[ceil(95+(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil((@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{PilotScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{PilotSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 
 			</fieldset>	
 				<table style="width: 100%;">				
@@ -492,7 +492,7 @@
 				<tr>
 					<td><input type="checkbox" name="attr_Success-Psychotherapy"  /></td>
 					<td class="sheet-skillname">Psychotherapy(00% or 01%)</td>
-					<td><input type="number" style="width:105%" value="0" name="attr_Psychotherapy"  /></td>
+					<td><input type="number" style="width:105%" name="attr_Psychotherapy"  /></td>
 					<td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Psychotherapy}}} {{fumble=[[ceil(95+(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[ceil(@{Psychotherapy}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=Psychotherapy}}"/></td>																														
 				</tr>								
 					<tr>
@@ -503,7 +503,7 @@
 				<fieldset class='repeating_repairSkills'>
 						 <input type="checkbox" name="attr_repairSuccess"  />
 						 <input type="text" name="attr_repairSkills" class="sheet-skillname"/>
-						 <input type="number" name="attr_repairScore" />
+						 <input type="number" style="width:105%" value="15" name="attr_repairScore" />
 						 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{repairScore}}} {{fumble=[[ceil(95+(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}    {{1/2success=[[ceil((@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{repairScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{repairSkills}}}"/></td>																																																	 				 				 				 
 				</fieldset>				
 				<table style="width: 100%;">				
@@ -522,7 +522,7 @@
 					<table style="width: 100%">	
 							 <td><input type="checkbox" name="attr_RideSucess"  /></td>
 							 <td><input type="text" name="attr_RideSkill" class="sheet-skillname"/></td>
-							 <td><input type="number" style="width:105%" value="1" name="attr_RideScore" /></td>
+							 <td><input type="number" style="width:105%" name="attr_RideScore" /></td>
 							 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{RideScore}}} {{fumble=[[ceil(95+(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20 }+?{Mods|0})/20))]]}} {{crit=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}       {{success=[[ceil(@{RideScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{RideSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 					 					 					 
 				</fieldset>				 
 				<table style="width: 100%;">				
@@ -599,7 +599,7 @@
 					<table style="width: 100%">	
 					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
 					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><input type="number" style="width:105%" name="attr_TechScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil((@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[ceil(@{TechScore}*?{Multipler|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>	
 			<table style="width: 100%;">		
@@ -921,7 +921,7 @@
 			<table style="width: 100%;">
 					 <td><input type="checkbox" name="attr_KnowSucess"  /></td>
 					 <td><input type="text" name="attr_KnowSkills" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_KnowScore" /></td>
+					 <td><input type="number" style="width:105%"  name="attr_KnowScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{KnowScore}}} {{fumble=[[ceil(95+((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}     {{1/2success=[[ceil(((@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}    {{success=[[(@{KnowScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{KnowSkills}}}"/></td>																																																	 				 				 				 					 
 			</fieldset>				
 			<table style="width: 100%;">				
@@ -977,7 +977,7 @@
 			<table style="width: 100%;">
 					 <td><input type="checkbox" name="attr_TechSucess"  /></td>
 					 <td><input type="text" name="attr_TechSkill" class="sheet-skillname"/></td>
-					 <td><input type="number" style="width:105%" value="1" name="attr_TechScore" /></td>
+					 <td><input type="number" style="width:105%" name="attr_TechScore" /></td>
 					 <td><button type="roll" value="&{template:skillRoll}   {{skillvalue=@{TechScore}}} {{fumble=[[ceil(95+((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)]]}} {{crit=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}   {{1/2success=[[ceil(((@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}     {{success=[[(@{TechScore}+@{Mental})*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=@{TechSkill}}}"/></td>																																																	 				 				 				 					 					 					 					 
 			</fieldset>
 			<!-- Perception -->
@@ -1491,7 +1491,7 @@
 				</tr>
 			</table>
 		</fieldset>
-				
+			
 		<div style="width: 100%;font-size:0.8em">
 			<div style="display: inline">
 				<input type="checkbox" name="attr_shield_success" />
@@ -1519,36 +1519,7 @@
 			</div>
 		</div>
 
-		<fieldset class="repeating_ shields">
-			<table>
-			<div style="width: 100%;font-size:0.8em">
-				<div style="display: inline">
-					<input type="checkbox" name="attr_shield_success" />
-					<button type="roll"style="Width: 55px;font-size:0.8em;"value="&{template:melee-roll} {{tot=[[@{shield_damage}+@{Damage_Bonus}]]}} {{success=[[@{shield_skill}+?{Mods|0}]]}} {{fumble=[[ceil(95+(@{shield_skill}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{shield_skill}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{shield_skill}+?{Mods|0})/5)+1]]}}  {{skillvalue=@{shield_skill}}}  {{roll=[[1d100]]}} {{skillname=Shield}}" class="sheet-plain" >Shield</button>
-					<input type="number" name="attr_shield_skill" />
-					%&nbsp;
-				</div>
-				<div style="display:inline; float:right">
-					Attack Damage
-					<input style="width: 55px" type="text" name="attr_shield_damage" />
-				</div>
-			</div>
-			<div style="font-size:0.8em">
-				<div style="display:inline">
-					<input type="radio" name="attr_shield_type" value="H" />&nbsp;H
-					<input type="radio" name="attr_shield_type" value="S" />&nbsp;S
-					<input type="radio" name="attr_shield_type" value="F" />&nbsp;F
-					<input type="radio" name="attr_shield_type" value="L" />&nbsp;L
-				
-					Base Chance
-					<input type="number" name="attr_shield_base_chance" />
-				</div>
-				<div style="display: inline; float: right">
-					HP<input type="number" name="attr_shield_hp" />
-				</div>
-			</div>
-			</table>
-		</fieldset>
+
 			
 		</div >				
 		<div  style=" color: #FFF; background-color: #000;width: 100%" >
@@ -1761,44 +1732,43 @@
 			</tr>
 			<tr>
 				<td class="template_label"><b>Result:</b></td>
-			 
-			{{#rollBetween() roll fumble 100}} 
-				<td class="template_value">Fumble</td>
-		{{/rollBetween() roll fumble 100}} 
-		
-		{{#^rollBetween() roll fumble 100}}
-		
-			{{#rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
-					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
-				{{/^rollLess() roll crit}}
-
-			{{/rollGreater() success 99}}
-			
-						{{#^rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}
-						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-						{{#^rollBetween() roll special success}}
-							{{#rollLess() roll fumble}}
-								<td class="template_value">Failure</td>
-							{{/rollLess() roll fumble}}
-							{{#^rollLess() roll fumble}}
-								<td class="template_value">fumble</td>
-							{{/^rollLess() roll fumble}}							
-						{{/^rollBetween() roll special success}}											
-					{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-			{{/^rollGreater() success 99}}
-		{{/^rollBetween() roll fumble 100}}
-		
-		
-		{{#rollLess() roll success}}
+ 		 
+ 		{{#rollBetween() roll fumble 100}} 
+ 				<td class="template_value">Fumble</td>
+ 		{{/rollBetween() roll fumble 100}} 
+ 		
+ 		{{#^rollBetween() roll fumble 100}}
+ 		
+ 			{{#rollGreater() success 99}}
+ 				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+ 				{{#^rollLess() roll crit}}
+ 					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+ 					{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
+ 				{{/^rollLess() roll crit}}
+ 
+ 			{{/rollGreater() success 99}}
+ 			
+ 			{{#^rollGreater() success 99}}
+ 				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+ 				{{#^rollLess() roll crit}}
+ 					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+ 					{{#^rollLess() roll special}}
+ 						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+ 						{{#^rollBetween() roll special success}}
+ 							{{#rollLess() roll fumble}}
+ 								<td class="template_value">Failure</td>
+ 							{{/rollLess() roll fumble}}
+ 							{{#^rollLess() roll fumble}}
+ 								<td class="template_value">fumble</td>
+ 							{{/^rollLess() roll fumble}}							
+ 						{{/^rollBetween() roll special success}}											
+ 					{{/^rollLess() roll special}}
+ 				{{/^rollLess() roll crit}}
+ 			{{/^rollGreater() success 99}}
+ 		{{/^rollBetween() roll fumble 100}}
+ 		
+ 		
+ 		{{#rollLess() roll success}}
 				<tr>
 					<td class="template_label"><b>Damage:</b></td>
 					<td style="text-align: right"; class="template_value">{{tot}}<td>
@@ -1841,7 +1811,7 @@
 		</table>
 	</rolltemplate>
 	
-	<rolltemplate class="sheet-rolltemplate-skillRoll">
+		<rolltemplate class="sheet-rolltemplate-skillRoll">
 		<table class="skillRoll" style="width: 100%; border: 1px solid black;">
 			<tr><th colspan="2">{{name}}</th></tr>
 			<tr><th colspan="2">Skill Roll</th></tr>
@@ -1857,47 +1827,49 @@
 			</tr>
 			<tr>
 			 <td class="template_label"><b>Result:</b></td>
-	
-			{{#rollBetween() roll fumble 100}} 
-					<td class="template_value">Fumble</td>
-		{{/rollBetween() roll fumble 100}} 
-		
-		{{#^rollBetween() roll fumble 100}}
-		
-			{{#rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					    {{#rollBetween() roll special 1/2success}}<td class="template_value">Under 1/2 </td>{{/rollBetween() roll special 1/2success}}
-					{{#^rollLess() roll 1/2success}}<td class="template_value">Success</td>{{/^rollLess() roll 1/2success}}
-				{{/^rollLess() roll crit}}
-
-			{{/rollGreater() success 99}}
-			
-			{{#^rollGreater() success 99}}
-				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
-				{{#^rollLess() roll crit}}
-					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
-					{{#^rollLess() roll special}}
-						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
-						{{#^rollBetween() roll special success}}
-							{{#rollLess() roll fumble}}
-								<td class="template_value">Failure</td>
-							{{/rollLess() roll fumble}}
-							{{#^rollLess() roll fumble}}
-								<td class="template_value">fumble</td>
-							{{/^rollLess() roll fumble}}							
-						{{/^rollBetween() roll special success}}						
-					
-					{{/^rollLess() roll special}}
-				{{/^rollLess() roll crit}}
-			
-			
-			
-			{{/^rollGreater() success 99}}
-
-			
-		{{/^rollBetween() roll fumble 100}}
+ 
+ 		{{#rollBetween() roll fumble 100}} 
+ 				<td class="template_value">Fumble</td>
+ 		{{/rollBetween() roll fumble 100}} 
+ 		
+ 		{{#^rollBetween() roll fumble 100}}
+ 		
+ 			{{#rollGreater() success 99}}
+ 				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+ 				{{#^rollLess() roll crit}}
+ 					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+ 					{{#^rollLess() roll special}}<td class="template_value">Success</td>{{/^rollLess() roll special}}
+ 				{{/^rollLess() roll crit}}
+ 
+ 			{{/rollGreater() success 99}}
+ 			
+ 			{{#^rollGreater() success 99}}
+ 				{{#rollLess() roll crit}}<td class="template_value">Critical!!!!!!</td>{{/rollLess() roll crit}}
+ 				{{#^rollLess() roll crit}}
+ 					{{#rollLess() roll special}}<td class="template_value">Special!!!</td>{{/rollLess() roll special}}
+ 					{{#^rollLess() roll special}}
+ 						{{#rollBetween() roll special success}}<td class="template_value">Success</td>{{/rollBetween() roll special success}}
+ 						{{#^rollBetween() roll special success}}
+ 							{{#rollLess() roll fumble}}
+ 								<td class="template_value">Failure</td>
+ 							{{/rollLess() roll fumble}}
+ 							{{#^rollLess() roll fumble}}
+ 								<td class="template_value">fumble</td>
+ 							{{/^rollLess() roll fumble}}							
+ 						{{/^rollBetween() roll special success}}						
+ 					
+ 					{{/^rollLess() roll special}}
+ 				
+ 				
+ 				
+ 				{{/^rollLess() roll crit}}
+ 			
+ 			
+ 			
+ 			{{/^rollGreater() success 99}}
+ 
+ 			
+ 		{{/^rollBetween() roll fumble 100}}
 			</tr>
 		</table>
 	</rolltemplate>
@@ -2004,7 +1976,6 @@
 	</rolltemplate>
 <!-- SHEET WORKERS -->
 <script type="text/worker">
-
 on("change:str change:siz", function() {  // stat names must use lower case here
 	    getAttrs(["STR", "SIZ"], function(pvalue) {  // from here on, use the actual case of the stat names. 
 		    var curStrength = parseInt(pvalue.STR);


### PR DESCRIPTION
•	Removed the “Rolled Under 1/2” Sections of the Roll Template.
•	Change Attribute Rolls to Easy (x10), Normal (x5) and Hard (x5/2)
o	Normal-x5,Easy-x10,Difficult-x5/2,x4, x3, x2, x1
•	Remove number from First Aid, Knowledge, Literacy, Pilot, Psychotherapy, Ride, and Technical Skill on Alphabetical Skills as they have variable base numbers.
•	Add Default Number to Repair (15%) on Alphabetical Skills
•	Remove number from Knowledge and Technical Skill on Categorical Skills as they have variable base numbers.
•	Removed Repeating Shields due to problems when Repeating Armor is deleted. Will be re-added in another update.
•	Accidentally left Alphabetical Skills checked when it should have been unchecked, this caused the Alphabetical Skills to only appear when unchecked. My Apologizes for that mistake.