### PR TITLE
Update translation.json

### DIFF
--- a/L5R Fantasy Flight Games/translation.json
+++ b/L5R Fantasy Flight Games/translation.json
@@ -31,7 +31,7 @@
 	"smithing-u": "Smithing",
 	"artisan-skills-u": "Artisan Skills",
 	"martial-skills-u": "Martial Skills",
-	"fitness-u": "Fitness",
+	"fitness-u": "Fitness (Defense)",
 	"martial_arts_melee-u": "M.A. [Melee]",
 	"martial_arts_ranged-u": "M.A. [Ranged]",
 	"martial_arts_unarmed-u": "M.A. [Unarmed]",


### PR DESCRIPTION
Fixed the label on Fitness, to include (Defense) for campaigns where you break fitness out by subskills.