### PR TITLE
Fixed roll buttons on statistics

### DIFF
--- a/Impulse_Drive/Impulse Drive.html
+++ b/Impulse_Drive/Impulse Drive.html
@@ -59,14 +59,14 @@
                     <div class="sheet-attr-box odd">
                         <label class="sheet-volatile sheet-label-bold">Volatile</label>
                         <input type="number" name="attr_Volatile" value="0" />
-                        <button type="roll" name="roll_vol"
-                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Volatile}} {{roll_mod=@{vol}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{vol}]]}} {{resulta=[[@{Advantage} + @{vol}]]}} {{resultd=[[@{Disadvantage} + @{vol}]]}}"></button>
+                        <button type="roll" name="roll_volatile"
+                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Volatile}} {{roll_mod=@{volatile}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{volatile}]]}} {{resulta=[[@{Advantage} + @{volatile}]]}} {{resultd=[[@{Disadvantage} + @{volatile}]]}}"></button>
                     </div>
                     <div class="sheet-attr-box">
                         <label class="sheet-calculating sheet-label-bold">Calculating</label>
                         <input type="number" name="attr_Calculating" value="0" />
-                        <button type="roll" name="roll_calc"
-                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Calculating}} {{roll_mod=@{calc}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{calc}]]}} {{resulta=[[@{Advantage} + @{calc}]]}} {{resultd=[[@{Disadvantage} + @{calc}]]}}"></button>
+                        <button type="roll" name="roll_calculating"
+                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Calculating}} {{roll_mod=@{calculating}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{calculating}]]}} {{resulta=[[@{Advantage} + @{calculating}]]}} {{resultd=[[@{Disadvantage} + @{calculating}]]}}"></button>
                     </div>
                     <div class="sheet-attr-box odd">
                         <label class="sheet-slick sheet-label-bold">Slick</label>
@@ -77,8 +77,8 @@
                     <div class="sheet-attr-box">
                         <label class="sheet-stalwart sheet-label-bold">Stalwart</label>
                         <input type="number" name="attr_Stalwart" value="0" />
-                        <button type="roll" name="roll_stal"
-                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Stalwart}} {{roll_mod=@{stal}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{stal}]]}} {{resulta=[[@{Advantage} + @{stal}]]}} {{resultd=[[@{Disadvantage} + @{stal}]]}}"></button>
+                        <button type="roll" name="roll_stalwart"
+                                value="&{template:id} {{name=@{character_name}}} {{roll_name=Stalwart}} {{roll_mod=@{stalwart}}} {{roll_type=[[@{rolltype_query}]]}} {{resultn=[[@{Normal} + @{stalwart}]]}} {{resulta=[[@{Advantage} + @{stalwart}]]}} {{resultd=[[@{Disadvantage} + @{stalwart}]]}}"></button>
                     </div>
                     <div class="sheet-attr-box odd">
                         <label class="sheet-alien sheet-label-bold">Alien</label>


### PR DESCRIPTION
Fixed roll button errors for primary stats: Volatile, Calculating, Stalwart. Output now references the stats correctly.