### PR TITLE
Elite Dangerous RPG - Bug Fixes for attributes linked and not saving

### DIFF
--- a/Elite Dangerous Role Playing Game/EDRPG.html
+++ b/Elite Dangerous Role Playing Game/EDRPG.html
@@ -171,11 +171,11 @@ on("change:clearallchecks", function(eventInfo) {
 		<br><br>
 		<h2>Ranged Weapons</h2>
 		<fieldset class="repeating_rangedwep">
-		    <input type="text" placeholder="Weapon"name="attr_rangedweapons"> To Hit <input type="number" name="rangedweaponstohit"> Short <input type="number"name="attr_rangedweaponsshortdist">m <input type="number"name="attr_rangedweaponsshort"> Medium <input type="number"name="attr_rangedweaponsmediumdistance">m <input type="number" name="attr_rangedweaponsmedium"> Long <input type="number" name="attr_rangedweaponslongdistance">m <input type="number"name="attr_rangedweaponslong"><br>Damage <input type="text" name="attr_rangedweaponsdamage"> Ammo <input type="number"name="attr_rangedweaponsammo"> Notes <textarea name="attr_rangedweaponsnotes"></textarea>
+		    <input type="text" placeholder="Weapon"name="attr_rangedweapons"> To Hit <input type="number" name="attr_rangedweaponstohit"> Short <input type="number"name="attr_rangedweaponsshortdist">m <input type="number"name="attr_rangedweaponsshort"> Medium <input type="number"name="attr_rangedweaponsmediumdistance">m <input type="number" name="attr_rangedweaponsmedium"> Long <input type="number" name="attr_rangedweaponslongdistance">m <input type="number"name="attr_rangedweaponslong"><br>Damage <input type="text" name="attr_rangedweaponsdamage"> Ammo <input type="number"name="attr_rangedweaponsammo"> Notes <textarea name="attr_rangedweaponsnotes"></textarea>
 		</fieldset>
 
 		<h2>Close Combat</h2>
-		<input type="text" value="Fighting"> To Hit <input type="number"> Finesse <input type="number" value="5"> Damage <input type="text" value="d10 Halved"> Notes <textarea name="attr_basemelenotes"></textarea>
+		<input type="text" value="Fighting"> To Hit <input type="number" name="attr_fightingweaponstohit"> Finesse <input type="number" value="5"> Damage <input type="text" value="d10 Halved"> Notes <textarea name="attr_basemelenotes"></textarea>
 		<fieldset class="repeating_closewep">
 		    <input type="text" name="attr_ccweapons" placeholder="Weapon"> To Hit <input type="number" name="attr_ccweaponstohit"> Finesse <input type="number" name="attr_ccweaponsfinesse"> Damage <input type="text" name="attr_ccweaponsdamage"> Notes <textarea name="attr_ccweaponsnotes"></textarea>
 		</fieldset>
@@ -211,7 +211,7 @@ on("change:clearallchecks", function(eventInfo) {
 		    <div>
 		        <h2>Clothing</h2>
 		            <fieldset class="repeating_clothing">
-		            Item <input type="text"name="attr_clothingitem"> Worn <input type="text"name="clothingwornstatus"><br>
+		            Item <input type="text"name="attr_clothingitem"> Worn <input type="text"name="attr_clothingwornstatus"><br>
 		            Description <textarea name="attr_clothingdescription"></textarea>
 		            </fieldset>
 		    </div>
@@ -273,27 +273,27 @@ on("change:clearallchecks", function(eventInfo) {
 		<h2>Weapons</h2>
 		<fieldset class="repeating_shipwep">
 				<input type="text" placeholder="Name"name="attr_shipweapons"> Size <input type="text" name="attr_shipweaponsize"> Strength <input type="text" name="attr_shipweaponstrength"><br>
-				Power <input type="text" name="attr_shipweaponstrength"> Accuracy <input type="number" name="shipweaponsaccuracy"> To Hit (accuracy + SPC wep bonus) <input type="number" name="shipweaponstohit"><br>
+				Power <input type="text" name="attr_shipweaponpower"> Accuracy <input type="number" name="attr_shipweaponsaccuracy"> To Hit (accuracy + SPC wep bonus) <input type="number" name="attr_shipweaponstohit"><br>
 				Damage <input type="text" name="attr_shipweapondamage"> Ammo <input type="number"name="attr_shipweaponammo"><br>
 				Notes <textarea name="attr_shipweaponnotes"></textarea>
 		</fieldset>
 		<h2>Utility Mounts</h2>
 		<fieldset class="repeating_shiputility">
 				<input type="text" placeholder="Name"name="attr_shiputility"> Size <input type="text" name="attr_shiputilitysize"> Strength <input type="text" name="attr_utilitystrength"><br>
-				Power <input type="text" name="attr_shipweaponpower"> Model <input type="text" name="attr_shiputiliitymodel"> Description <input type="text" name="attr_shiputilitydescription"><br>
+				Power <input type="text" name="attr_shiputilitypower"> Model <input type="text" name="attr_shiputiliitymodel"> Description <input type="text" name="attr_shiputilitydescription"><br>
 				Notes <textarea name="attr_shiputilitynotes"></textarea>
 		</fieldset>
 		<h2>Fixed Components</h2>
 		Bulkhead, PowerPlant, Thrusters, Frame Shift Drive, Life Support, Power Distributer, Sensors, Cargo Hatch
 		<fieldset class="repeating_shipfixedcomp">
 				<input type="text" placeholder="Name"name="attr_shipfixedcomp"> Size <input type="text" name="attr_shipfixedcompsize"> Strength <input type="text" name="attr_shipfixedcompstrength"><br>
-				Power <input type="text" name="attr_shipfixedcompstrength"> Model <input type="text" name="attr_shipfixedcompmodel"> Description <input type="text" name="attr_shipfixedcompdescription"><br>
+				Power <input type="text" name="attr_shipfixedcomppower"> Model <input type="text" name="attr_shipfixedcompmodel"> Description <input type="text" name="attr_shipfixedcompdescription"><br>
 				Notes <textarea name="attr_shipfixedcompnotes"></textarea>
 		</fieldset>
 		<h2>Internal Components</h2>
 		<fieldset class="repeating_shipinternalcomp">
 				<input type="text" placeholder="Name"name="attr_shipinternalcomp"> Size <input type="text" name="attr_shipinternalcompsize"> Strength <input type="text" name="attr_shipinternalstrength"><br>
-				Power <input type="text" name="attr_shipinternalpstrength"> Model <input type="text" name="attr_shipinternalcompmodel"> Description <input type="text" name="attr_shipinternaldescription"><br>
+				Power <input type="text" name="attr_shipinternalpower"> Model <input type="text" name="attr_shipinternalcompmodel"> Description <input type="text" name="attr_shipinternaldescription"><br>
 				Notes <textarea name="attr_shipfixedcompnotes"></textarea>
 		</fieldset>
 		<h2>Total power</h2>
@@ -312,7 +312,7 @@ on("change:clearallchecks", function(eventInfo) {
 		<strong>Sheilds Recharge</strong> <input type="number" name="attr_vehicshieldrecharge"><br><br>
 		<h2>Weapons</h2>
 		<fieldset class="repeating_vehicwep">
-				<input type="text" placeholder="Name"name="attr_vehicweapons"> Accuracy <input type="number" name="vehicweaponsaccuracy"> To Hit (accuracy + VHC wep bonus) <input type="number" name="vehicweaponstohit"><br>
+				<input type="text" placeholder="Name"name="attr_vehicweapons"> Accuracy <input type="number" name="attr_vehicweaponsaccuracy"> To Hit (accuracy + VHC wep bonus) <input type="number" name="attr_vehicweaponstohit"><br>
 				Damage <input type="text" name="attr_vehicweapondamage"> Ammo <input type="number"name="attr_vehicweaponammo"><br>
 				Notes <textarea name="attr_vehicweaponnotes"></textarea>
 		</fieldset>


### PR DESCRIPTION
Fixed a bug where in repeating sections two different values were saving to the same atribute.
- This occured 3 times

Fixed 1 misnamed attribute which was pulling an incorrect value from somewhere else on the sheet.

Fixed 5 attributes which were not properly tagged as attributes and not saving their values.

This affected ranged weapons to hit values, a fighting weapon to hit value, a field for where clothing is being worn,  strength and power values in  ship weapons, utilities, fixed components and internal components and vehicle weapon accuracy and to hit.