### PR TITLE
Remove attack entries for spells that aren't prepared

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -5986,12 +5986,20 @@
             return;
         }
         var repeating_source = eventinfo.sourceAttribute.substring(0, eventinfo.sourceAttribute.lastIndexOf('_'));
-        getAttrs([repeating_source + "_spellattackid", repeating_source + "_spelllevel"], function(v) {
+        getAttrs([repeating_source + "_spellattackid", repeating_source + "_spelllevel", repeating_source + "_spelloutput", repeating_source + "_spellprepared", "character_id"], function(v) {
             var spellid = repeating_source.slice(-20);
             var attackid = v[repeating_source + "_spellattackid"];
             var lvl = v[repeating_source + "_spelllevel"];
-            if(attackid && lvl && spellid) {
+            var spelloutput = v[repeating_source + "_spelloutput"];
+            var prepared = v[repeating_source + "_spellprepared"];
+            if(attackid && lvl && spellid && prepared) {
                 update_attack_from_spell(lvl, spellid, attackid)
+            }
+            if (attackid && attackid != "" && !prepared) {
+                remove_attack(attackid);
+            }
+            if (!attackid && spelloutput && spelloutput === "ATTACK" && prepared) {
+                create_attack_from_spell(lvl, spellid, v["character_id"]);
             }
         });
     });


### PR DESCRIPTION
UNTESTED. Please review. Not a pro user, I can't locally test.

Background/Repro: Started a 5e game with the 'official' sheet, entered spells on a character sheet with attack profiles and then unchecked 'prep', discovered that spells with attack profiles persisted on the front page even when the spell was set to unprepared.
Expected: Marking a spell as unprepared should remove associated attack profiles until the spell is prepared again.

Anticipated issues: 
1. Deleting an attack profile (the clickable attack macro button on the first page) may leave an attackid on the spell. If this is the case, then I don't see a good way to discover whether an attack currently exists or not when recreating the attack due to preparing the spell.
2. If the attackid is left behind when an attack is deleted, future updates may issue a delete command to an attackid without a corresponding attack. I think this is safe as I didn't see special handling elsewhere when attacks are deleted.
3. If attack information besides the form info sticks around while the attack is deleted (e.g. for use when creating the attack profile), then it'd be a bad idea to quash the update_attack_from_spell call while the spell is unprepared. But if update_attack_from_spell relies on the attack profile existing in order to update it, then it is right to not touch this call unless the spell is prepared and the associated attack should exist.
4. I may have missed places where attack profiles are added. I'd be fine as long as attacks vanish when the spell is next unprepared (prepare->unprepare cycle, 'try restarting') but as this is the official sheet I imagine you'd like to be better polished.

This looks like a new state (spell output = ATTACK but no attack profile), so problems may arise. Still, this will make wizards much cleaner to play. Next wishlist: Allow clicking on the red dot to be equivalent to the 'prep' checkbox...