### PR TITLE
DnD_5e Monster Compendium Support

### DIFF
--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -16612,7 +16612,45 @@
 			<hr/>
 		</div>
 	</div>
-	<div class="sheet-npc">
+	<div class="sheet-npc compendium-drop-target monsters">
+    <!-- COMPENDIUM DROP CATCHERS -->
+    <input type="hidden" name="attr_drop_category" accept="Category">
+    <input type="hidden" name="attr_drop_name" accept="Name">
+    <input type="hidden" name="attr_drop_weight" accept="Weight">
+    <input type="hidden" name="attr_drop_properties" accept="Properties">
+    <input type="hidden" name="attr_drop_modifiers" accept="Modifiers">
+    <input type="hidden" name="attr_drop_content" accept="Content">
+    <input type="hidden" name="attr_drop_itemtype" accept="Item Type">
+    <input type="hidden" name="attr_drop_damage" accept="Damage">
+    <input type="hidden" name="attr_drop_damagetype" accept="Damage Type">
+    <input type="hidden" name="attr_drop_range" accept="Range">
+    <input type="hidden" name="attr_drop_ac" accept="AC">
+
+    <input type="hidden" name="attr_drop_speed" accept="Speed">
+    <input type="hidden" name="attr_drop_str" accept="STR">
+    <input type="hidden" name="attr_drop_dex" accept="DEX">
+    <input type="hidden" name="attr_drop_con" accept="CON">
+    <input type="hidden" name="attr_drop_int" accept="INT">
+    <input type="hidden" name="attr_drop_wis" accept="WIS">
+    <input type="hidden" name="attr_drop_cha" accept="CHA">
+    <input type="hidden" name="attr_drop_vulnerabilities" accept="Vulnerabilities">
+    <input type="hidden" name="attr_drop_resistances" accept="Resistances">
+    <input type="hidden" name="attr_drop_immunities" accept="Immunities">
+    <input type="hidden" name="attr_drop_condition_immunities" accept="Condition Immunities">
+    <input type="hidden" name="attr_drop_languages" accept="Languages">
+    <input type="hidden" name="attr_drop_challenge_rating" accept="Challenge Rating">
+
+    <input type="hidden" name="attr_drop_size" accept="Size">
+    <input type="hidden" name="attr_drop_type" accept="Type">
+    <input type="hidden" name="attr_drop_alignment" accept="Alignment">
+    <input type="hidden" name="attr_drop_hp" accept="HP">
+    <input type="hidden" name="attr_drop_saving_throws" accept="Saving Throws">
+    <input type="hidden" name="attr_drop_senses" accept="Senses">
+    <input type="hidden" name="attr_drop_passive_perception" accept="Passive Perception">
+    <input type="hidden" name="attr_drop_skills" accept="Skills">
+    <input type="hidden" name="attr_drop_token_size" accept="Token Size">
+    <!-- END COMPENDIUM DROP CATCHERS -->
+    
 		<h4 class="sheet-center">NPC/Monster Sheet <span class="sheet-pictos">F</span></h4>
 		<p class="sheet-small-note">This page of the character sheet is intended for use by GM/DM's only. All the macros on this page send their output only to the GM via a private whisper/tell. GM/DM's should be sure to make sure any data entered into larger text fields is all on one line as any line breaks will break the output and some of it will be shown in public chat. There is no current workaround for this but the Roll20 devs are aware and reviewing the options. </p>
 		<div class="sheet-row sheet-npc-output-options sheet-checkbox-row sheet-margin-bottom">
@@ -18191,6 +18229,351 @@
 	<div class="sheet-row sheet-footer">
 		<div class="sheet-col-1 sheet-small-label sheet-center">Sheet help - https://wiki.roll20.net/DnD5e_Character_Sheet</div>
 	</div>
+  <script type="text/worker">
+
+    on("change:drop_category", function(eventinfo) {
+        if(eventinfo.newValue === "Monsters") {
+            handle_drop_monster(eventinfo.newValue);
+        }
+    });
+    
+    var handle_drop_monster = function(category, eventinfo) {
+        var callbacks = [];
+        var update = {};
+        var id = generateRowID();
+        
+        drop_attrs = ["drop_name","drop_weight","drop_properties",
+                      "drop_modifiers","drop_content","drop_itemtype",
+                      "drop_damage","drop_damagetype","drop_damage2",
+                      "drop_damagetype2","drop_range","drop_ac", 
+                      "drop_speed", "drop_str", "drop_dex", "drop_con", 
+                      "drop_int", "drop_wis", "drop_cha", 
+                      "drop_vulnerabilities", "drop_resistances", 
+                      "drop_immunities", "drop_condition_immunities", 
+                      "drop_languages", "drop_challenge_rating", "drop_size", 
+                      "drop_type", "drop_alignment", "drop_hp", 
+                      "drop_saving_throws", "drop_senses", 
+                      "drop_passive_perception", "drop_skills", 
+                      "drop_token_size", "character_id"]
+        getAttrs(drop_attrs, function(v) {
+            if(category === "Monsters") {
+                update["is_npc"] = "1";
+                if(v["drop_name"] && v["drop_name"] != "") {update["character_name"] = v["drop_name"]};
+                // core stats
+                update["npc_strength"]     = v["drop_str"] ? v["drop_str"] : "";
+                update["npc_dexterity"]    = v["drop_dex"] ? v["drop_dex"] : "";
+                update["npc_constitution"] = v["drop_con"] ? v["drop_con"] : "";
+                update["npc_intelligence"] = v["drop_int"] ? v["drop_int"] : "";
+                update["npc_wisdom"]       = v["drop_wis"] ? v["drop_wis"] : "";
+                update["npc_charisma"]     = v["drop_cha"] ? v["drop_cha"] : "";
+                update["npc_strength_save_mod"] = 0;
+                update["npc_dexterity_save_mod"] = 0;
+                update["npc_constitution_save_mod"] = 0;
+                update["npc_intelligence_save_mod"] = 0;
+                update["npc_wisdom_save_mod"] = 0;
+                update["npc_charisma_save_mod"] = 0;
+                if(v["drop_saving_throws"] && v["drop_saving_throws"] != "") {
+                    var savearray = v["drop_saving_throws"].split(", ");
+                    _.each(savearray, function(save) {
+                        kv = save.indexOf("-") > -1 ? save.split(" ") : save.split(" +");
+                        update["npc_" + kv[0].toLowerCase() + "_save_mod"] = parseInt(kv[1], 10);
+                    });
+                };
+                //right side of core stats, top to bottom
+                update["npc_size"]      = v["drop_size"] ? v["drop_size"] : "";
+                update["npc_type"]      = v["drop_type"] ? v["drop_type"] : "";
+                update["npc_alignment"] = v["drop_alignment"] ? v["drop_alignment"] : "";
+                 //AC handling
+                if(v["drop_ac"]) {
+                    if(v["drop_ac"].indexOf("(") > -1) {
+                        update["npc_ac"] = v["drop_ac"].split(" (")[0];
+                        update["npc_AC_note"] = v["drop_ac"].split(" (")[1].slice(0, -1);
+                    }
+                    else {
+                        update["npc_ac"] = v["drop_ac"];
+                        update["npc_AC_note"] = "";
+                    };
+                }
+                else {
+                    update["npc_ac"] = 10;
+                    update["npc_AC_note"] = "";
+                };
+                 //HP handling
+                if(v["drop_hp"]) {
+                    if(v["drop_hp"].indexOf("(") > -1) {
+                        update["npc_HP"] = v["drop_hp"].split(" (")[0];
+                        update["npc_HP_max"] = v["drop_hp"].split(" (")[0];
+                        //update["npc_HP_max"] = v["drop_hp"].split(" (")[1].slice(0, -1);
+                    }
+                    else {
+                        update["npc_HP"] = v["drop_hp"]
+                        update["npc_HP_max"] = v["drop_hp"]
+                        //update["npc_hpformula"] = ""
+                    };
+                }
+                else {
+                    update["npc_HP"] = 1
+                    update["npc_HP_max"] = 1
+                };
+                 //Speed handling
+                if(v["drop_speed"]) {
+                    speed = /\d+/i
+                    fly   = /fly \d+/i
+                    climb = /climb \d+/i
+                    swim  = /swim \d+/i
+                    speed_match = speed.exec(v["drop_speed"])
+                    fly_match   = fly.exec(v["drop_speed"])
+                    climb_match = climb.exec(v["drop_speed"])
+                    swim_match  = swim.exec(v["drop_speed"])
+                    if(speed_match) {
+                        speed_number = speed_match[0].split(" ")
+                        speed_number = parseInt(speed_number[0], 10)
+                        update["npc_speed"] = speed_number
+                    }
+                    if(fly_match) {
+                        speed_number = fly_match[0].split(" ")
+                        speed_number = parseInt(speed_number[1], 10)
+                        update["npc_speed_fly"] = speed_number
+                    }
+                    if(climb_match) {
+                        speed_number = climb_match[0].split(" ")
+                        speed_number = parseInt(speed_number[1], 10)
+                        update["npc_speed_climb"] = speed_number
+                    }
+                    if(swim_match) {
+                        speed_number = swim_match[0].split(" ")
+                        speed_number = parseInt(speed_number[1], 10)
+                        update["npc_speed_swim"] = speed_number
+                    }
+                }
+                //Challenge --> Languages
+                 //Challenge/XP handling
+                if(v["drop_challenge_rating"] && v["drop_challenge_rating"] != "") {
+                  update["npc_challenge"] = v["drop_challenge_rating"];                  
+                  var xp = 0;
+                  var pb = 0;
+                  switch(v["drop_challenge_rating"]) {
+                  case "0":
+                      xp = "10";
+                      pb = 2;
+                      break;
+                  case "1/8":
+                      xp = "25";
+                      pb = 2;
+                      break;
+                  case "1/4":
+                      xp = "50";
+                      pb = 2;
+                      break;
+                  case "1/2":
+                      xp = "100";
+                      pb = 2;
+                      break;
+                  case "1":
+                      xp = "200";
+                      pb = 2;
+                      break;
+                  case "2":
+                      xp = "450";
+                      pb = 2;
+                      break;
+                  case "3":
+                      xp = "700";
+                      pb = 2;
+                      break;
+                  case "4":
+                      xp = "1100";
+                      pb = 2;
+                      break;
+                  case "5":
+                      xp = "1800";
+                      pb = 3;
+                      break;
+                  case "6":
+                      xp = "2300";
+                      pb = 3;
+                      break;
+                  case "7":
+                      xp = "2900";
+                      pb = 3;
+                      break;
+                  case "8":
+                      xp = "3900";
+                      pb = 3;
+                      break;
+                  case "9":
+                      xp = "5000";
+                      pb = 4;
+                      break;
+                  case "10":
+                      xp = "5900";
+                      pb = 4;
+                      break;
+                  case "11":
+                      xp = "7200";
+                      pb = 4;
+                      break;
+                  case "12":
+                      xp = "8400";
+                      pb = 4;
+                      break;
+                  case "13":
+                      xp = "10000";
+                      pb = 5;
+                      break;
+                  case "14":
+                      xp = "11500";
+                      pb = 5;
+                      break;
+                  case "15":
+                      xp = "13000";
+                      pb = 5;
+                      break;
+                  case "16":
+                      xp = "15000";
+                      pb = 5;
+                      break;
+                  case "17":
+                      xp = "18000";
+                      pb = 6;
+                      break;
+                  case "18":
+                      xp = "20000";
+                      pb = 6;
+                      break;
+                  case "19":
+                      xp = "22000";
+                      pb = 6;
+                      break;
+                  case "20":
+                      xp = "25000";
+                      pb = 6;
+                      break;
+                  case "21":
+                      xp = "33000";
+                      pb = 7;
+                      break;
+                  case "22":
+                      xp = "41000";
+                      pb = 7;
+                      break;
+                  case "23":
+                      xp = "50000";
+                      pb = 7;
+                      break;
+                  case "24":
+                      xp = "62000";
+                      pb = 7;
+                      break;
+                  case "25":
+                      xp = "75000";
+                      pb = 8;
+                      break;
+                  case "26":
+                      xp = "90000";
+                      pb = 8;
+                      break;
+                  case "27":
+                      xp = "105000";
+                      pb = 8;
+                      break;
+                  case "28":
+                      xp = "120000";
+                      pb = 8;
+                      break;
+                  case "29":
+                      xp = "";
+                      pb = 9;
+                      break;
+                  case "30":
+                      xp = "155000";
+                      pb = 9;
+                      break;
+                  }
+                  update["npc_xp"] = xp;
+                }
+                update["npc_senses"] = v["drop_senses"] ? v["drop_senses"] : "";
+                update["npc_languages"] = v["drop_languages"] ? v["drop_languages"] : "";
+                //Traits/Background
+                update["npc_damage_resistance"] = v["drop_resistances"] ? v["drop_resistances"] : "";        
+                update["npc_damage_vulnerability"] = v["drop_vulnerabilities"] ? v["drop_vulnerabilities"] : "";
+                update["npc_damage_immunity"] = v["drop_immunities"] ? v["drop_immunities"] : "";
+                update["npc_condition_immunity"] = v["drop_condition_immunities"] ? v["drop_condition_immunities"] : "";
+                update["npc_traits"] = v["drop_content"] ? v["drop_content"] : "";
+                //Skills
+                update["npc_acrobatics_bonus"] = 0;
+                update["npc_animal_handling_bonus"] = 0;
+                update["npc_arcana_bonus"] = 0;
+                update["npc_athletics_bonus"] = 0;
+                update["npc_deception_bonus"] = 0;
+                update["npc_history_bonus"] = 0;
+                update["npc_insight_bonus"] = 0;
+                update["npc_intimidation_bonus"] = 0;
+                update["npc_investigation_bonus"] = 0;
+                update["npc_medicine_bonus"] = 0;
+                update["npc_nature_bonus"] = 0;
+                update["npc_perception_bonus"] = 0;
+                update["npc_performance_bonus"] = 0;
+                update["npc_persuasion_bonus"] = 0;
+                update["npc_religion_bonus"] = 0;
+                update["npc_sleight_of_hand_bonus"] = 0;
+                update["npc_stealth_bonus"] = 0;
+                update["npc_survival_bonus"] = 0;
+                if(v["drop_skills"] && v["drop_skills"] != "") {
+                    skillarray = v["drop_skills"].split(", ");
+                    _.each(skillarray, function(skill) {
+                        kv = skill.indexOf("-") > -1 ? skill.split(" ") : skill.split(" +");
+                        update["npc_" + kv[0].toLowerCase().replace(/ /g, '_') + "_bonus"] = parseInt(kv[1], 10);
+                    });
+                }
+            };
+
+            callbacks.push( function() {cleanup_drop_fields();} );
+            setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+        });
+
+
+    };
+    
+    var cleanup_drop_fields = function() {
+        var update = {};
+        update["drop_name"] = "";
+        update["drop_weight"] = "";
+        update["drop_properties"] = "";
+        update["drop_modifiers"] = "";
+        update["drop_content"] = "";
+        update["drop_itemtype"] = "";
+        update["drop_damage"] = "";
+        update["drop_damagetype"] = "";
+        update["drop_range"] = "";
+        update["drop_ac"] = "";
+        update["drop_category"] = "";
+        update["drop_speed"] = "";
+        update["drop_str"] = "";
+        update["drop_dex"] = "";
+        update["drop_con"] = "";
+        update["drop_int"] = "";
+        update["drop_wis"] = "";
+        update["drop_cha"] = "";
+        update["drop_vulnerabilities"] = "";
+        update["drop_resistances"] = "";
+        update["drop_immunities"] = "";
+        update["drop_condition_immunities"] = "";
+        update["drop_languages"] = "";
+        update["drop_challenge_rating"] = "";
+        update["drop_size"] = "";
+        update["drop_type"] = "";
+        update["drop_alignment"] = "";
+        update["drop_hp"] = "";
+        update["drop_saving_throws"] = "";
+        update["drop_senses"] = "";
+        update["drop_passive_perception"] = "";
+        update["drop_skills"] = "";
+        update["drop_token_size"] = "";
+        setAttrs(update, {silent: true});
+    };
+
+  </script>
 </div>
 <rolltemplate class="sheet-rolltemplate-5eDefault">
 	<div class="sheet-rt-card">

--- a/DnD_5e/ReadMe.md
+++ b/DnD_5e/ReadMe.md
@@ -4,6 +4,12 @@ This is a character sheet for use on Roll20.net with the latest (5th) edition of
 
 ### Changelog
 
+# v1.1.5 - 10th March 2018
+Partial 5e compendium support added for monsters by user:darmes
+
+# v1.1.4 - 18th May 2017
+Partial 5e compendium support added for spells by user:legendblade
+
 # v1.1.3 - 3rd Apr 2016
 Added default roll options pane (accessible through the gear at the top-right of the character sheet header) and a "Use Default" option to each roll configuration panel.
 

--- a/DnD_5e/sheet.json
+++ b/DnD_5e/sheet.json
@@ -4,5 +4,6 @@
 	"authors": "John Myles (Actoba on Roll20.net, @jmyles85 on Twitter)",
 	"roll20userid": "427494",
 	"preview": "DnD_5e.png",
+  "compendium": "dnd5e",
 	"instructions": "This sheet is designed for use with the full release of DnD 5th edition.  Where possible, it supports the 'rules as written' as listed in the Basic DnD PDF that's freely available for download, and the Players Handbook (PHB) that was released in August 2014.  Sheet help is available on the roll20 wiki - https://wiki.roll20.net/DnD5e_Character_Sheet "
 }


### PR DESCRIPTION
Adds partial support for drag-and-dropping monsters from the compendium onto the NPC sheet. Automatically populates most values, but doesn't set actions.