### PR TITLE
[Open Legend] Quick Fix to Might 0 Speed Calc

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -772,7 +772,11 @@
             if(values.item_18_heavy === "heavy") {  heavy_total += 1;   }
             if(values.item_19_heavy === "heavy") {  heavy_total += 1;   }
             if(values.item_20_heavy === "heavy") {  heavy_total += 1;   }
-            if(heavy_total == score) {  heavy_speed = Math.ceil(heavy_speed/2); }
+            if(heavy_total == score) {
+                if(score != 0) {
+                    heavy_speed = Math.ceil(heavy_speed/2);
+                }
+            }
             if(heavy_total > score) {   heavy_speed = 0;    }
             setAttrs({
                 "item_heavy_result": heavy_speed

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,10 @@
 
 ### Changelog
 
+### 1.8.9.98a on 2018 March 10th
+* Fixed Speed Calculations if Mighty is 0
+    - Was halving speed even if no heavy items
+
 ### 1.8.9.98 on 2018 March 4th
 * Fixed a new character sheet not auto calculating Feat & Attribute Point Totals
 * Fixed Speed changes based on Max Heavy amount


### PR DESCRIPTION
### 1.8.9.98a on 2018 March 10th
* Fixed Speed Calculations if Mighty is 0
    - Was halving speed even if no heavy items