### PR TITLE
Item modifiers skills minor fix

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -7121,7 +7121,7 @@
             if(mod.indexOf("wisdom save") > -1) {update_save("wisdom");} else if(mod.indexOf("wisdom") > -1) {update_attr("wisdom");};
             if(mod.indexOf("charisma save") > -1) {update_save("charisma");} else if(mod.indexOf("charisma") > -1) {update_attr("charisma");};
             if(mod.indexOf("acrobatics") > -1) {update_skills(["acrobatics"]);};
-            if(mod.indexOf("animal handling") > -1) {update_skills(["animal_handling"]);};
+            if(mod.indexOf("animal_handling") > -1) {update_skills(["animal_handling"]);};
             if(mod.indexOf("arcana") > -1) {update_skills(["arcana"]);};
             if(mod.indexOf("athletics") > -1) {update_skills(["athletics"]);};
             if(mod.indexOf("deception") > -1) {update_skills(["deception"]);};
@@ -7135,7 +7135,7 @@
             if(mod.indexOf("performance") > -1) {update_skills(["performance"]);};
             if(mod.indexOf("persuasion") > -1) {update_skills(["persuasion"]);};
             if(mod.indexOf("religion") > -1) {update_skills(["religion"]);};
-            if(mod.indexOf("sleight of hand") > -1) {update_skills(["sleight_of_hand"]);};
+            if(mod.indexOf("sleight_of_hand") > -1) {update_skills(["sleight_of_hand"]);};
             if(mod.indexOf("stealth") > -1) {update_skills(["stealth"]);};
             if(mod.indexOf("survival") > -1) {update_skills(["survival"]);};
         });


### PR DESCRIPTION
Previously item modifiers for animal handling and sleight of hand did not properly apply skill bonuses. The expected string to trigger the changed used spaces whereas determining the value of the bonus was looking for the name of the skill to have underscores. This meant that it was impossible to use the item modifiers for this field.

This change will require the underscores between words for these skills so that the correct bonus can be applied.