### PR TITLE
[Pokemon Tabletop Adventures] Bug fixes

### DIFF
--- a/PokemonTabletopAdventures/PTA.html
+++ b/PokemonTabletopAdventures/PTA.html
@@ -247,7 +247,7 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label><input type="number" name='attr_Pokemon_HP1' class='sheet-short'><br />
+        <label>Current</label><input type="number" name='attr_pokemon_HP1' class='sheet-short'><br />
         <label>Max</label><input type="number" name="attr_pokemon_HP1_max" value="(@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_level1})" disabled="true"><br />
       </div>
 </div>
@@ -259,19 +259,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1a" value='&{template:Attack} {{name=@{movename1a}}} {{subtags=@{movetype1a}, @{movefreq1a}, @{moverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1a}}} {{damage=[[[[@{movedmgdieamount1a}]]d[[@{movedmgdie1a}]]+[[@{attr_movedmgbonus1a}]]+[[@{movestab1a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1a}]]]]}} {{effect=@{moveeffect1a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1a" value='&{template:Attack} {{name=@{movename1a}}} {{subtags=@{movetype1a}, @{movefreq1a}, @{moverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1a}}} {{damage=[[[[@{movedmgdieamount1a}]]d[[@{movedmgdie1a}]]+[[@{movedmgbonus1a}]]+[[@{movestab1a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1a}]]]]}} {{effect=@{moveeffect1a}}}'></button>
                 <input type="text" name="attr_movename1a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1b" value='&{template:Attack} {{name=@{movename1b}}} {{subtags=@{movetype1b}, @{movefreq1b}, @{moverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1b}}} {{damage=[[[[@{movedmgdieamount1b}]]d[[@{movedmgdie1b}]]+[[@{attr_movedmgbonus1b}]]+[[@{movestab1b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1b}]]]]}} {{effect=@{moveeffect1b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1b" value='&{template:Attack} {{name=@{movename1b}}} {{subtags=@{movetype1b}, @{movefreq1b}, @{moverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1b}}} {{damage=[[[[@{movedmgdieamount1b}]]d[[@{movedmgdie1b}]]+[[@{movedmgbonus1b}]]+[[@{movestab1b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1b}]]]]}} {{effect=@{moveeffect1b}}}'></button>
                 <input type="text" name="attr_movename1b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1c" value='&{template:Attack} {{name=@{movename1c}}} {{subtags=@{movetype1c}, @{movefreq1c}, @{moverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1c}}} {{damage=[[[[@{movedmgdieamount1c}]]d[[@{movedmgdie1c}]]+[[@{attr_movedmgbonus1c}]]+[[@{movestab1c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1c}]]]]}} {{effect=@{moveeffect1c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1c" value='&{template:Attack} {{name=@{movename1c}}} {{subtags=@{movetype1c}, @{movefreq1c}, @{moverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1c}}} {{damage=[[[[@{movedmgdieamount1c}]]d[[@{movedmgdie1c}]]+[[@{movedmgbonus1c}]]+[[@{movestab1c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1c}]]]]}} {{effect=@{moveeffect1c}}}'></button>
                 <input type="text" name="attr_movename1c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1d" value='&{template:Attack} {{name=@{movename1d}}} {{subtags=@{movetype1d}, @{movefreq1d}, @{moverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1d}}} {{damage=[[[[@{movedmgdieamount1d}]]d[[@{movedmgdie1d}]]+[[@{attr_movedmgbonus1d}]]+[[@{movestab1d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1d}]]]]}} {{effect=@{moveeffect1d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1d" value='&{template:Attack} {{name=@{movename1d}}} {{subtags=@{movetype1d}, @{movefreq1d}, @{moverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1d}}} {{damage=[[[[@{movedmgdieamount1d}]]d[[@{movedmgdie1d}]]+[[@{movedmgbonus1d}]]+[[@{movestab1d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1d}]]]]}} {{effect=@{moveeffect1d}}}'></button>
                 <input type="text" name="attr_movename1d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1e" value='&{template:Attack} {{name=@{movename1e}}} {{subtags=@{movetype1e}, @{movefreq1e}, @{moverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1e}}} {{damage=[[[[@{movedmgdieamount1e}]]d[[@{movedmgdie1e}]]+[[@{attr_movedmgbonus1e}]]+[[@{movestab1e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1e}]]]]}} {{effect=@{moveeffect1e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move1e" value='&{template:Attack} {{name=@{movename1e}}} {{subtags=@{movetype1e}, @{movefreq1e}, @{moverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1e}}} {{damage=[[[[@{movedmgdieamount1e}]]d[[@{movedmgdie1e}]]+[[@{movedmgbonus1e}]]+[[@{movestab1e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1e}]]]]}} {{effect=@{moveeffect1e}}}'></button>    
                 <input type="text" name="attr_movename1e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1f" value='&{template:Attack} {{name=@{movename1f}}} {{subtags=@{movetype1f}, @{movefreq1f}, @{moverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1f}}} {{damage=[[[[@{movedmgdieamount1f}]]d[[@{movedmgdie1f}]]+[[@{attr_movedmgbonus1f}]]+[[@{movestab1f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1f}]]]]}} {{effect=@{moveeffect1f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1f" value='&{template:Attack} {{name=@{movename1f}}} {{subtags=@{movetype1f}, @{movefreq1f}, @{moverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1f}}} {{damage=[[[[@{movedmgdieamount1f}]]d[[@{movedmgdie1f}]]+[[@{movedmgbonus1f}]]+[[@{movestab1f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1f}]]]]}} {{effect=@{moveeffect1f}}}'></button>
                 <input type="text" name="attr_movename1f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1g" value='&{template:Attack} {{name=@{movename1g}}} {{subtags=@{movetype1g}, @{movefreq1g}, @{moverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1g}}} {{damage=[[[[@{movedmgdieamount1g}]]d[[@{movedmgdie1g}]]+[[@{attr_movedmgbonus1g}]]+[[@{movestab1g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1g}]]]]}} {{effect=@{moveeffect1g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1g" value='&{template:Attack} {{name=@{movename1g}}} {{subtags=@{movetype1g}, @{movefreq1g}, @{moverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1g}}} {{damage=[[[[@{movedmgdieamount1g}]]d[[@{movedmgdie1g}]]+[[@{movedmgbonus1g}]]+[[@{movestab1g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1g}]]]]}} {{effect=@{moveeffect1g}}}'></button>
                 <input type="text" name="attr_movename1g" class="sheet-med2"><br>
         </div>
         
@@ -902,8 +902,8 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label><input type="number" name='attr_Pokemon_HP2' class='sheet-short'><br />
-		<label>Max</label><input type="number" name="attr_pokemon_HP2max" value="(@{pokemon_hpstat2c}+@{pokemon_hpstat2c}+@{pokemon_hpstat2c}+@{pokemon_level2})" disabled="true"><br />
+        <label>Current</label><input type="number" name='attr_pokemon_HP2' class='sheet-short'><br />
+		<label>Max</label><input type="number" name="attr_pokemon_HP2_max" value="(@{pokemon_hpstat2c}+@{pokemon_hpstat2c}+@{pokemon_hpstat2c}+@{pokemon_level2})" disabled="true"><br />
     </div>
 </div>
 
@@ -914,19 +914,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2a" value='&{template:Attack} {{name=@{movename2a}}} {{subtags=@{movetype2a}, @{movefreq2a}, @{moverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2a}}} {{damage=[[[[@{movedmgdieamount2a}]]d[[@{movedmgdie2a}]]+[[@{attr_movedmgbonus2a}]]+[[@{movestab2a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2a}]]]]}} {{effect=@{moveeffect2a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2a" value='&{template:Attack} {{name=@{movename2a}}} {{subtags=@{movetype2a}, @{movefreq2a}, @{moverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2a}}} {{damage=[[[[@{movedmgdieamount2a}]]d[[@{movedmgdie2a}]]+[[@{movedmgbonus2a}]]+[[@{movestab2a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2a}]]]]}} {{effect=@{moveeffect2a}}}'></button>
                 <input type="text" name="attr_movename2a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2b" value='&{template:Attack} {{name=@{movename2b}}} {{subtags=@{movetype2b}, @{movefreq2b}, @{moverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2b}}} {{damage=[[[[@{movedmgdieamount2b}]]d[[@{movedmgdie2b}]]+[[@{attr_movedmgbonus2b}]]+[[@{movestab2b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2b}]]]]}} {{effect=@{moveeffect2b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2b" value='&{template:Attack} {{name=@{movename2b}}} {{subtags=@{movetype2b}, @{movefreq2b}, @{moverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2b}}} {{damage=[[[[@{movedmgdieamount2b}]]d[[@{movedmgdie2b}]]+[[@{movedmgbonus2b}]]+[[@{movestab2b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2b}]]]]}} {{effect=@{moveeffect2b}}}'></button>
                 <input type="text" name="attr_movename2b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2c" value='&{template:Attack} {{name=@{movename2c}}} {{subtags=@{movetype2c}, @{movefreq2c}, @{moverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2c}}} {{damage=[[[[@{movedmgdieamount2c}]]d[[@{movedmgdie2c}]]+[[@{attr_movedmgbonus2c}]]+[[@{movestab2c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2c}]]]]}} {{effect=@{moveeffect2c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2c" value='&{template:Attack} {{name=@{movename2c}}} {{subtags=@{movetype2c}, @{movefreq2c}, @{moverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2c}}} {{damage=[[[[@{movedmgdieamount2c}]]d[[@{movedmgdie2c}]]+[[@{movedmgbonus2c}]]+[[@{movestab2c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2c}]]]]}} {{effect=@{moveeffect2c}}}'></button>
                 <input type="text" name="attr_movename2c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2d" value='&{template:Attack} {{name=@{movename2d}}} {{subtags=@{movetype2d}, @{movefreq2d}, @{moverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2d}}} {{damage=[[[[@{movedmgdieamount2d}]]d[[@{movedmgdie2d}]]+[[@{attr_movedmgbonus2d}]]+[[@{movestab2d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2d}]]]]}} {{effect=@{moveeffect2d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2d" value='&{template:Attack} {{name=@{movename2d}}} {{subtags=@{movetype2d}, @{movefreq2d}, @{moverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2d}}} {{damage=[[[[@{movedmgdieamount2d}]]d[[@{movedmgdie2d}]]+[[@{movedmgbonus2d}]]+[[@{movestab2d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2d}]]]]}} {{effect=@{moveeffect2d}}}'></button>
                 <input type="text" name="attr_movename2d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2e" value='&{template:Attack} {{name=@{movename2e}}} {{subtags=@{movetype2e}, @{movefreq2e}, @{moverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2e}}} {{damage=[[[[@{movedmgdieamount2e}]]d[[@{movedmgdie2e}]]+[[@{attr_movedmgbonus2e}]]+[[@{movestab2e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2e}]]]]}} {{effect=@{moveeffect2e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move2e" value='&{template:Attack} {{name=@{movename2e}}} {{subtags=@{movetype2e}, @{movefreq2e}, @{moverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2e}}} {{damage=[[[[@{movedmgdieamount2e}]]d[[@{movedmgdie2e}]]+[[@{movedmgbonus2e}]]+[[@{movestab2e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2e}]]]]}} {{effect=@{moveeffect2e}}}'></button>    
                 <input type="text" name="attr_movename2e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2f" value='&{template:Attack} {{name=@{movename2f}}} {{subtags=@{movetype2f}, @{movefreq2f}, @{moverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2f}}} {{damage=[[[[@{movedmgdieamount2f}]]d[[@{movedmgdie2f}]]+[[@{attr_movedmgbonus2f}]]+[[@{movestab2f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2f}]]]]}} {{effect=@{moveeffect2f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2f" value='&{template:Attack} {{name=@{movename2f}}} {{subtags=@{movetype2f}, @{movefreq2f}, @{moverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2f}}} {{damage=[[[[@{movedmgdieamount2f}]]d[[@{movedmgdie2f}]]+[[@{movedmgbonus2f}]]+[[@{movestab2f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2f}]]]]}} {{effect=@{moveeffect2f}}}'></button>
                 <input type="text" name="attr_movename2f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2g" value='&{template:Attack} {{name=@{movename2g}}} {{subtags=@{movetype2g}, @{movefreq2g}, @{moverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2g}}} {{damage=[[[[@{movedmgdieamount2g}]]d[[@{movedmgdie2g}]]+[[@{attr_movedmgbonus2g}]]+[[@{movestab2g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2g}]]]]}} {{effect=@{moveeffect2g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2g" value='&{template:Attack} {{name=@{movename2g}}} {{subtags=@{movetype2g}, @{movefreq2g}, @{moverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2g}}} {{damage=[[[[@{movedmgdieamount2g}]]d[[@{movedmgdie2g}]]+[[@{movedmgbonus2g}]]+[[@{movestab2g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2g}]]]]}} {{effect=@{moveeffect2g}}}'></button>
                 <input type="text" name="attr_movename2g" class="sheet-med2"><br>
         </div>
         
@@ -1560,8 +1560,8 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label></strong></strong><input type="number" name='attr_Pokemon_HP3' class='sheet-short'><br />
-		<label>Max</label><input type="number" name="attr_pokemon_HP3max" value="(@{pokemon_hpstat3c}+@{pokemon_hpstat3c}+@{pokemon_hpstat3c}+@{pokemon_level3})" disabled="true"><br />
+        <label>Current</label></strong></strong><input type="number" name='attr_pokemon_HP3' class='sheet-short'><br />
+		<label>Max</label><input type="number" name="attr_pokemon_HP3_max" value="(@{pokemon_hpstat3c}+@{pokemon_hpstat3c}+@{pokemon_hpstat3c}+@{pokemon_level3})" disabled="true"><br />
     </div>
 </div>
 
@@ -1572,19 +1572,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3a" value='&{template:Attack} {{name=@{movename3a}}} {{subtags=@{movetype3a}, @{movefreq3a}, @{moverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3a}}} {{damage=[[[[@{movedmgdieamount3a}]]d[[@{movedmgdie3a}]]+[[@{attr_movedmgbonus3a}]]+[[@{movestab3a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3a}]]]]}} {{effect=@{moveeffect3a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3a" value='&{template:Attack} {{name=@{movename3a}}} {{subtags=@{movetype3a}, @{movefreq3a}, @{moverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3a}}} {{damage=[[[[@{movedmgdieamount3a}]]d[[@{movedmgdie3a}]]+[[@{movedmgbonus3a}]]+[[@{movestab3a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3a}]]]]}} {{effect=@{moveeffect3a}}}'></button>
                 <input type="text" name="attr_movename3a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3b" value='&{template:Attack} {{name=@{movename3b}}} {{subtags=@{movetype3b}, @{movefreq3b}, @{moverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3b}}} {{damage=[[[[@{movedmgdieamount3b}]]d[[@{movedmgdie3b}]]+[[@{attr_movedmgbonus3b}]]+[[@{movestab3b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3b}]]]]}} {{effect=@{moveeffect3b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3b" value='&{template:Attack} {{name=@{movename3b}}} {{subtags=@{movetype3b}, @{movefreq3b}, @{moverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3b}}} {{damage=[[[[@{movedmgdieamount3b}]]d[[@{movedmgdie3b}]]+[[@{movedmgbonus3b}]]+[[@{movestab3b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3b}]]]]}} {{effect=@{moveeffect3b}}}'></button>
                 <input type="text" name="attr_movename3b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3c" value='&{template:Attack} {{name=@{movename3c}}} {{subtags=@{movetype3c}, @{movefreq3c}, @{moverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3c}}} {{damage=[[[[@{movedmgdieamount3c}]]d[[@{movedmgdie3c}]]+[[@{attr_movedmgbonus3c}]]+[[@{movestab3c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3c}]]]]}} {{effect=@{moveeffect3c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3c" value='&{template:Attack} {{name=@{movename3c}}} {{subtags=@{movetype3c}, @{movefreq3c}, @{moverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3c}}} {{damage=[[[[@{movedmgdieamount3c}]]d[[@{movedmgdie3c}]]+[[@{movedmgbonus3c}]]+[[@{movestab3c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3c}]]]]}} {{effect=@{moveeffect3c}}}'></button>
                 <input type="text" name="attr_movename3c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3d" value='&{template:Attack} {{name=@{movename3d}}} {{subtags=@{movetype3d}, @{movefreq3d}, @{moverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3d}}} {{damage=[[[[@{movedmgdieamount3d}]]d[[@{movedmgdie3d}]]+[[@{attr_movedmgbonus3d}]]+[[@{movestab3d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3d}]]]]}} {{effect=@{moveeffect3d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3d" value='&{template:Attack} {{name=@{movename3d}}} {{subtags=@{movetype3d}, @{movefreq3d}, @{moverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3d}}} {{damage=[[[[@{movedmgdieamount3d}]]d[[@{movedmgdie3d}]]+[[@{movedmgbonus3d}]]+[[@{movestab3d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3d}]]]]}} {{effect=@{moveeffect3d}}}'></button>
                 <input type="text" name="attr_movename3d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3e" value='&{template:Attack} {{name=@{movename3e}}} {{subtags=@{movetype3e}, @{movefreq3e}, @{moverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3e}}} {{damage=[[[[@{movedmgdieamount3e}]]d[[@{movedmgdie3e}]]+[[@{attr_movedmgbonus3e}]]+[[@{movestab3e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3e}]]]]}} {{effect=@{moveeffect3e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move3e" value='&{template:Attack} {{name=@{movename3e}}} {{subtags=@{movetype3e}, @{movefreq3e}, @{moverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3e}}} {{damage=[[[[@{movedmgdieamount3e}]]d[[@{movedmgdie3e}]]+[[@{movedmgbonus3e}]]+[[@{movestab3e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3e}]]]]}} {{effect=@{moveeffect3e}}}'></button>    
                 <input type="text" name="attr_movename3e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3f" value='&{template:Attack} {{name=@{movename3f}}} {{subtags=@{movetype3f}, @{movefreq3f}, @{moverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3f}}} {{damage=[[[[@{movedmgdieamount3f}]]d[[@{movedmgdie3f}]]+[[@{attr_movedmgbonus3f}]]+[[@{movestab3f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3f}]]]]}} {{effect=@{moveeffect3f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3f" value='&{template:Attack} {{name=@{movename3f}}} {{subtags=@{movetype3f}, @{movefreq3f}, @{moverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3f}}} {{damage=[[[[@{movedmgdieamount3f}]]d[[@{movedmgdie3f}]]+[[@{movedmgbonus3f}]]+[[@{movestab3f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3f}]]]]}} {{effect=@{moveeffect3f}}}'></button>
                 <input type="text" name="attr_movename3f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3g" value='&{template:Attack} {{name=@{movename3g}}} {{subtags=@{movetype3g}, @{movefreq3g}, @{moverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3g}}} {{damage=[[[[@{movedmgdieamount3g}]]d[[@{movedmgdie3g}]]+[[@{attr_movedmgbonus3g}]]+[[@{movestab3g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3g}]]]]}} {{effect=@{moveeffect3g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3g" value='&{template:Attack} {{name=@{movename3g}}} {{subtags=@{movetype3g}, @{movefreq3g}, @{moverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3g}}} {{damage=[[[[@{movedmgdieamount3g}]]d[[@{movedmgdie3g}]]+[[@{movedmgbonus3g}]]+[[@{movestab3g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3g}]]]]}} {{effect=@{moveeffect3g}}}'></button>
                 <input type="text" name="attr_movename3g" class="sheet-med2"><br>
         </div>
         
@@ -2216,8 +2216,8 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label><input type="number" name='attr_Pokemon_HP4' class='sheet-short'><br />
-		<label>Max</label><input type="number" name="attr_pokemon_HP4max" value="@{pokemon_hpstat4c}+@{pokemon_hpstat4c}+@{pokemon_hpstat4c}+@{pokemon_level4}" disabled="true"><br />
+        <label>Current</label><input type="number" name='attr_pokemon_HP4' class='sheet-short'><br />
+		<label>Max</label><input type="number" name="attr_pokemon_HP4_max" value="@{pokemon_hpstat4c}+@{pokemon_hpstat4c}+@{pokemon_hpstat4c}+@{pokemon_level4}" disabled="true"><br />
     </div>
 </div>
 
@@ -2228,19 +2228,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4a" value='&{template:Attack} {{name=@{movename4a}}} {{subtags=@{movetype4a}, @{movefreq4a}, @{moverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4a}}} {{damage=[[[[@{movedmgdieamount4a}]]d[[@{movedmgdie4a}]]+[[@{attr_movedmgbonus4a}]]+[[@{movestab4a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4a}]]]]}} {{effect=@{moveeffect4a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4a" value='&{template:Attack} {{name=@{movename4a}}} {{subtags=@{movetype4a}, @{movefreq4a}, @{moverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4a}}} {{damage=[[[[@{movedmgdieamount4a}]]d[[@{movedmgdie4a}]]+[[@{movedmgbonus4a}]]+[[@{movestab4a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4a}]]]]}} {{effect=@{moveeffect4a}}}'></button>
                 <input type="text" name="attr_movename4a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4b" value='&{template:Attack} {{name=@{movename4b}}} {{subtags=@{movetype4b}, @{movefreq4b}, @{moverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4b}}} {{damage=[[[[@{movedmgdieamount4b}]]d[[@{movedmgdie4b}]]+[[@{attr_movedmgbonus4b}]]+[[@{movestab4b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4b}]]]]}} {{effect=@{moveeffect4b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4b" value='&{template:Attack} {{name=@{movename4b}}} {{subtags=@{movetype4b}, @{movefreq4b}, @{moverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4b}}} {{damage=[[[[@{movedmgdieamount4b}]]d[[@{movedmgdie4b}]]+[[@{movedmgbonus4b}]]+[[@{movestab4b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4b}]]]]}} {{effect=@{moveeffect4b}}}'></button>
                 <input type="text" name="attr_movename4b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4c" value='&{template:Attack} {{name=@{movename4c}}} {{subtags=@{movetype4c}, @{movefreq4c}, @{moverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4c}}} {{damage=[[[[@{movedmgdieamount4c}]]d[[@{movedmgdie4c}]]+[[@{attr_movedmgbonus4c}]]+[[@{movestab4c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4c}]]]]}} {{effect=@{moveeffect4c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4c" value='&{template:Attack} {{name=@{movename4c}}} {{subtags=@{movetype4c}, @{movefreq4c}, @{moverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4c}}} {{damage=[[[[@{movedmgdieamount4c}]]d[[@{movedmgdie4c}]]+[[@{movedmgbonus4c}]]+[[@{movestab4c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4c}]]]]}} {{effect=@{moveeffect4c}}}'></button>
                 <input type="text" name="attr_movename4c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4d" value='&{template:Attack} {{name=@{movename4d}}} {{subtags=@{movetype4d}, @{movefreq4d}, @{moverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4d}}} {{damage=[[[[@{movedmgdieamount4d}]]d[[@{movedmgdie4d}]]+[[@{attr_movedmgbonus4d}]]+[[@{movestab4d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4d}]]]]}} {{effect=@{moveeffect4d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4d" value='&{template:Attack} {{name=@{movename4d}}} {{subtags=@{movetype4d}, @{movefreq4d}, @{moverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4d}}} {{damage=[[[[@{movedmgdieamount4d}]]d[[@{movedmgdie4d}]]+[[@{movedmgbonus4d}]]+[[@{movestab4d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4d}]]]]}} {{effect=@{moveeffect4d}}}'></button>
                 <input type="text" name="attr_movename4d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4e" value='&{template:Attack} {{name=@{movename4e}}} {{subtags=@{movetype4e}, @{movefreq4e}, @{moverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4e}}} {{damage=[[[[@{movedmgdieamount4e}]]d[[@{movedmgdie4e}]]+[[@{attr_movedmgbonus4e}]]+[[@{movestab4e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4e}]]]]}} {{effect=@{moveeffect4e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move4e" value='&{template:Attack} {{name=@{movename4e}}} {{subtags=@{movetype4e}, @{movefreq4e}, @{moverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4e}}} {{damage=[[[[@{movedmgdieamount4e}]]d[[@{movedmgdie4e}]]+[[@{movedmgbonus4e}]]+[[@{movestab4e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4e}]]]]}} {{effect=@{moveeffect4e}}}'></button>    
                 <input type="text" name="attr_movename4e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4f" value='&{template:Attack} {{name=@{movename4f}}} {{subtags=@{movetype4f}, @{movefreq4f}, @{moverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4f}}} {{damage=[[[[@{movedmgdieamount4f}]]d[[@{movedmgdie4f}]]+[[@{attr_movedmgbonus4f}]]+[[@{movestab4f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4f}]]]]}} {{effect=@{moveeffect4f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4f" value='&{template:Attack} {{name=@{movename4f}}} {{subtags=@{movetype4f}, @{movefreq4f}, @{moverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4f}}} {{damage=[[[[@{movedmgdieamount4f}]]d[[@{movedmgdie4f}]]+[[@{movedmgbonus4f}]]+[[@{movestab4f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4f}]]]]}} {{effect=@{moveeffect4f}}}'></button>
                 <input type="text" name="attr_movename4f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4g" value='&{template:Attack} {{name=@{movename4g}}} {{subtags=@{movetype4g}, @{movefreq4g}, @{moverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4g}}} {{damage=[[[[@{movedmgdieamount4g}]]d[[@{movedmgdie4g}]]+[[@{attr_movedmgbonus4g}]]+[[@{movestab4g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4g}]]]]}} {{effect=@{moveeffect4g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4g" value='&{template:Attack} {{name=@{movename4g}}} {{subtags=@{movetype4g}, @{movefreq4g}, @{moverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4g}}} {{damage=[[[[@{movedmgdieamount4g}]]d[[@{movedmgdie4g}]]+[[@{movedmgbonus4g}]]+[[@{movestab4g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4g}]]]]}} {{effect=@{moveeffect4g}}}'></button>
                 <input type="text" name="attr_movename4g" class="sheet-med2"><br>
         </div>
         
@@ -2873,8 +2873,8 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label><input type="number" name='attr_Pokemon_HP5' class='sheet-short'><br />
-		<label>Max</label><input type="number" name="attr_pokemon_HP5max" value="@{pokemon_hpstat5c}+@{pokemon_hpstat5c}+@{pokemon_hpstat5c}+@{pokemon_level5}" disabled="true"><br />
+        <label>Current</label><input type="number" name='attr_pokemon_HP5' class='sheet-short'><br />
+		<label>Max</label><input type="number" name="attr_pokemon_HP5_max" value="@{pokemon_hpstat5c}+@{pokemon_hpstat5c}+@{pokemon_hpstat5c}+@{pokemon_level5}" disabled="true"><br />
     </div>
 </div>
 
@@ -2885,19 +2885,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5a" value='&{template:Attack} {{name=@{movename5a}}} {{subtags=@{movetype5a}, @{movefreq5a}, @{moverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5a}}} {{damage=[[[[@{movedmgdieamount5a}]]d[[@{movedmgdie5a}]]+[[@{attr_movedmgbonus5a}]]+[[@{movestab5a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5a}]]]]}} {{effect=@{moveeffect5a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5a" value='&{template:Attack} {{name=@{movename5a}}} {{subtags=@{movetype5a}, @{movefreq5a}, @{moverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5a}}} {{damage=[[[[@{movedmgdieamount5a}]]d[[@{movedmgdie5a}]]+[[@{movedmgbonus5a}]]+[[@{movestab5a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5a}]]]]}} {{effect=@{moveeffect5a}}}'></button>
                 <input type="text" name="attr_movename5a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5b" value='&{template:Attack} {{name=@{movename5b}}} {{subtags=@{movetype5b}, @{movefreq5b}, @{moverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5b}}} {{damage=[[[[@{movedmgdieamount5b}]]d[[@{movedmgdie5b}]]+[[@{attr_movedmgbonus5b}]]+[[@{movestab5b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5b}]]]]}} {{effect=@{moveeffect5b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5b" value='&{template:Attack} {{name=@{movename5b}}} {{subtags=@{movetype5b}, @{movefreq5b}, @{moverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5b}}} {{damage=[[[[@{movedmgdieamount5b}]]d[[@{movedmgdie5b}]]+[[@{movedmgbonus5b}]]+[[@{movestab5b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5b}]]]]}} {{effect=@{moveeffect5b}}}'></button>
                 <input type="text" name="attr_movename5b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5c" value='&{template:Attack} {{name=@{movename5c}}} {{subtags=@{movetype5c}, @{movefreq5c}, @{moverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5c}}} {{damage=[[[[@{movedmgdieamount5c}]]d[[@{movedmgdie5c}]]+[[@{attr_movedmgbonus5c}]]+[[@{movestab5c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5c}]]]]}} {{effect=@{moveeffect5c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5c" value='&{template:Attack} {{name=@{movename5c}}} {{subtags=@{movetype5c}, @{movefreq5c}, @{moverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5c}}} {{damage=[[[[@{movedmgdieamount5c}]]d[[@{movedmgdie5c}]]+[[@{movedmgbonus5c}]]+[[@{movestab5c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5c}]]]]}} {{effect=@{moveeffect5c}}}'></button>
                 <input type="text" name="attr_movename5c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5d" value='&{template:Attack} {{name=@{movename5d}}} {{subtags=@{movetype5d}, @{movefreq5d}, @{moverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5d}}} {{damage=[[[[@{movedmgdieamount5d}]]d[[@{movedmgdie5d}]]+[[@{attr_movedmgbonus5d}]]+[[@{movestab5d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5d}]]]]}} {{effect=@{moveeffect5d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5d" value='&{template:Attack} {{name=@{movename5d}}} {{subtags=@{movetype5d}, @{movefreq5d}, @{moverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5d}}} {{damage=[[[[@{movedmgdieamount5d}]]d[[@{movedmgdie5d}]]+[[@{movedmgbonus5d}]]+[[@{movestab5d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5d}]]]]}} {{effect=@{moveeffect5d}}}'></button>
                 <input type="text" name="attr_movename5d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5e" value='&{template:Attack} {{name=@{movename5e}}} {{subtags=@{movetype5e}, @{movefreq5e}, @{moverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5e}}} {{damage=[[[[@{movedmgdieamount5e}]]d[[@{movedmgdie5e}]]+[[@{attr_movedmgbonus5e}]]+[[@{movestab5e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5e}]]]]}} {{effect=@{moveeffect5e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move5e" value='&{template:Attack} {{name=@{movename5e}}} {{subtags=@{movetype5e}, @{movefreq5e}, @{moverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5e}}} {{damage=[[[[@{movedmgdieamount5e}]]d[[@{movedmgdie5e}]]+[[@{movedmgbonus5e}]]+[[@{movestab5e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5e}]]]]}} {{effect=@{moveeffect5e}}}'></button>    
                 <input type="text" name="attr_movename5e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5f" value='&{template:Attack} {{name=@{movename5f}}} {{subtags=@{movetype5f}, @{movefreq5f}, @{moverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5f}}} {{damage=[[[[@{movedmgdieamount5f}]]d[[@{movedmgdie5f}]]+[[@{attr_movedmgbonus5f}]]+[[@{movestab5f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5f}]]]]}} {{effect=@{moveeffect5f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5f" value='&{template:Attack} {{name=@{movename5f}}} {{subtags=@{movetype5f}, @{movefreq5f}, @{moverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5f}}} {{damage=[[[[@{movedmgdieamount5f}]]d[[@{movedmgdie5f}]]+[[@{movedmgbonus5f}]]+[[@{movestab5f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5f}]]]]}} {{effect=@{moveeffect5f}}}'></button>
                 <input type="text" name="attr_movename5f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5g" value='&{template:Attack} {{name=@{movename5g}}} {{subtags=@{movetype5g}, @{movefreq5g}, @{moverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5g}}} {{damage=[[[[@{movedmgdieamount5g}]]d[[@{movedmgdie5g}]]+[[@{attr_movedmgbonus5g}]]+[[@{movestab5g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5g}]]]]}} {{effect=@{moveeffect5g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5g" value='&{template:Attack} {{name=@{movename5g}}} {{subtags=@{movetype5g}, @{movefreq5g}, @{moverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5g}}} {{damage=[[[[@{movedmgdieamount5g}]]d[[@{movedmgdie5g}]]+[[@{movedmgbonus5g}]]+[[@{movestab5g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5g}]]]]}} {{effect=@{moveeffect5g}}}'></button>
                 <input type="text" name="attr_movename5g" class="sheet-med2"><br>
         </div>
         
@@ -3528,8 +3528,8 @@
     <div class="sheet-col">
         <h3 style="margin-bottom: 10px;">HP</h3>
         
-        <label>Current</label><input type="number" name='attr_Pokemon_HP6' class='sheet-short'><br />
-		<label>Max</label><input type="number" name="attr_pokemon_HP6max" value="@{pokemon_hpstat6c}+@{pokemon_hpstat6c}+@{pokemon_hpstat6c}+@{pokemon_level6}" disabled="true"><br />
+        <label>Current</label><input type="number" name='attr_pokemon_HP6' class='sheet-short'><br />
+		<label>Max</label><input type="number" name="attr_pokemon_HP6_max" value="@{pokemon_hpstat6c}+@{pokemon_hpstat6c}+@{pokemon_hpstat6c}+@{pokemon_level6}" disabled="true"><br />
     </div>
 </div>
 
@@ -3540,19 +3540,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6a" value='&{template:Attack} {{name=@{movename6a}}} {{subtags=@{movetype6a}, @{movefreq6a}, @{moverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6a}}} {{damage=[[[[@{movedmgdieamount6a}]]d[[@{movedmgdie6a}]]+[[@{attr_movedmgbonus6a}]]+[[@{movestab6a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6a}]]]]}} {{effect=@{moveeffect6a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6a" value='&{template:Attack} {{name=@{movename6a}}} {{subtags=@{movetype6a}, @{movefreq6a}, @{moverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6a}}} {{damage=[[[[@{movedmgdieamount6a}]]d[[@{movedmgdie6a}]]+[[@{movedmgbonus6a}]]+[[@{movestab6a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6a}]]]]}} {{effect=@{moveeffect6a}}}'></button>
                 <input type="text" name="attr_movename6a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6b" value='&{template:Attack} {{name=@{movename6b}}} {{subtags=@{movetype6b}, @{movefreq6b}, @{moverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6b}}} {{damage=[[[[@{movedmgdieamount6b}]]d[[@{movedmgdie6b}]]+[[@{attr_movedmgbonus6b}]]+[[@{movestab6b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6b}]]]]}} {{effect=@{moveeffect6b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6b" value='&{template:Attack} {{name=@{movename6b}}} {{subtags=@{movetype6b}, @{movefreq6b}, @{moverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6b}}} {{damage=[[[[@{movedmgdieamount6b}]]d[[@{movedmgdie6b}]]+[[@{movedmgbonus6b}]]+[[@{movestab6b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6b}]]]]}} {{effect=@{moveeffect6b}}}'></button>
                 <input type="text" name="attr_movename6b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6c" value='&{template:Attack} {{name=@{movename6c}}} {{subtags=@{movetype6c}, @{movefreq6c}, @{moverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6c}}} {{damage=[[[[@{movedmgdieamount6c}]]d[[@{movedmgdie6c}]]+[[@{attr_movedmgbonus6c}]]+[[@{movestab6c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6c}]]]]}} {{effect=@{moveeffect6c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6c" value='&{template:Attack} {{name=@{movename6c}}} {{subtags=@{movetype6c}, @{movefreq6c}, @{moverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6c}}} {{damage=[[[[@{movedmgdieamount6c}]]d[[@{movedmgdie6c}]]+[[@{movedmgbonus6c}]]+[[@{movestab6c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6c}]]]]}} {{effect=@{moveeffect6c}}}'></button>
                 <input type="text" name="attr_movename6c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6d" value='&{template:Attack} {{name=@{movename6d}}} {{subtags=@{movetype6d}, @{movefreq6d}, @{moverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6d}}} {{damage=[[[[@{movedmgdieamount6d}]]d[[@{movedmgdie6d}]]+[[@{attr_movedmgbonus6d}]]+[[@{movestab6d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6d}]]]]}} {{effect=@{moveeffect6d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6d" value='&{template:Attack} {{name=@{movename6d}}} {{subtags=@{movetype6d}, @{movefreq6d}, @{moverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6d}}} {{damage=[[[[@{movedmgdieamount6d}]]d[[@{movedmgdie6d}]]+[[@{movedmgbonus6d}]]+[[@{movestab6d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6d}]]]]}} {{effect=@{moveeffect6d}}}'></button>
                 <input type="text" name="attr_movename6d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6e" value='&{template:Attack} {{name=@{movename6e}}} {{subtags=@{movetype6e}, @{movefreq6e}, @{moverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6e}}} {{damage=[[[[@{movedmgdieamount6e}]]d[[@{movedmgdie6e}]]+[[@{attr_movedmgbonus6e}]]+[[@{movestab6e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6e}]]]]}} {{effect=@{moveeffect6e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move6e" value='&{template:Attack} {{name=@{movename6e}}} {{subtags=@{movetype6e}, @{movefreq6e}, @{moverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6e}}} {{damage=[[[[@{movedmgdieamount6e}]]d[[@{movedmgdie6e}]]+[[@{movedmgbonus6e}]]+[[@{movestab6e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6e}]]]]}} {{effect=@{moveeffect6e}}}'></button>    
                 <input type="text" name="attr_movename6e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6f" value='&{template:Attack} {{name=@{movename6f}}} {{subtags=@{movetype6f}, @{movefreq6f}, @{moverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6f}}} {{damage=[[[[@{movedmgdieamount6f}]]d[[@{movedmgdie6f}]]+[[@{attr_movedmgbonus6f}]]+[[@{movestab6f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6f}]]]]}} {{effect=@{moveeffect6f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6f" value='&{template:Attack} {{name=@{movename6f}}} {{subtags=@{movetype6f}, @{movefreq6f}, @{moverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6f}}} {{damage=[[[[@{movedmgdieamount6f}]]d[[@{movedmgdie6f}]]+[[@{movedmgbonus6f}]]+[[@{movestab6f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6f}]]]]}} {{effect=@{moveeffect6f}}}'></button>
                 <input type="text" name="attr_movename6f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6g" value='&{template:Attack} {{name=@{movename6g}}} {{subtags=@{movetype6g}, @{movefreq6g}, @{moverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6g}}} {{damage=[[[[@{movedmgdieamount6g}]]d[[@{movedmgdie6g}]]+[[@{attr_movedmgbonus6g}]]+[[@{movestab6g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6g}]]]]}} {{effect=@{moveeffect6g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6g" value='&{template:Attack} {{name=@{movename6g}}} {{subtags=@{movetype6g}, @{movefreq6g}, @{moverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6g}}} {{damage=[[[[@{movedmgdieamount6g}]]d[[@{movedmgdie6g}]]+[[@{movedmgbonus6g}]]+[[@{movestab6g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6g}]]]]}} {{effect=@{moveeffect6g}}}'></button>
                 <input type="text" name="attr_movename6g" class="sheet-med2"><br>
         </div>
         

--- a/PokemonTabletopAdventures/PTA.html
+++ b/PokemonTabletopAdventures/PTA.html
@@ -150,7 +150,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species1" class='sheet-long' /> <br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea1" class='sheet-type' /><input type="text" name="attr_pokemon_typeb1" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature1" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -159,7 +159,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -248,7 +248,7 @@
         <h3 style="margin-bottom: 10px;">HP</h3>
         
         <label>Current</label><input type="number" name='attr_Pokemon_HP1' class='sheet-short'><br />
-        <label>Max</label><input type="number" name="attr_pokemon_HP1max" value="(@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_level1})" disabled="true"><br />
+        <label>Max</label><input type="number" name="attr_pokemon_HP1_max" value="(@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_hpstat1c}+@{pokemon_level1})" disabled="true"><br />
       </div>
 </div>
 
@@ -259,19 +259,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1a" value='&{template:Attack} {{name=@{movename1a}}} {{subtags=@{movetype1a}, @{movefreq1a}, @{moverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1a}}} {{damage=[[[[@{movedmgdieamount1a}]]d[[@{movedmgdie1a}]]+[[@{movestab1a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1a}]]]]}} {{effect=@{moveeffect1a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1a" value='&{template:Attack} {{name=@{movename1a}}} {{subtags=@{movetype1a}, @{movefreq1a}, @{moverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1a}}} {{damage=[[[[@{movedmgdieamount1a}]]d[[@{movedmgdie1a}]]+[[@{attr_movedmgbonus1a}]]+[[@{movestab1a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1a}]]]]}} {{effect=@{moveeffect1a}}}'></button>
                 <input type="text" name="attr_movename1a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1b" value='&{template:Attack} {{name=@{movename1b}}} {{subtags=@{movetype1b}, @{movefreq1b}, @{moverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1b}}} {{damage=[[[[@{movedmgdieamount1b}]]d[[@{movedmgdie1b}]]+[[@{movestab1b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1b}]]]]}} {{effect=@{moveeffect1b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1b" value='&{template:Attack} {{name=@{movename1b}}} {{subtags=@{movetype1b}, @{movefreq1b}, @{moverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1b}}} {{damage=[[[[@{movedmgdieamount1b}]]d[[@{movedmgdie1b}]]+[[@{attr_movedmgbonus1b}]]+[[@{movestab1b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1b}]]]]}} {{effect=@{moveeffect1b}}}'></button>
                 <input type="text" name="attr_movename1b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1c" value='&{template:Attack} {{name=@{movename1c}}} {{subtags=@{movetype1c}, @{movefreq1c}, @{moverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1c}}} {{damage=[[[[@{movedmgdieamount1c}]]d[[@{movedmgdie1c}]]+[[@{movestab1c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1c}]]]]}} {{effect=@{moveeffect1c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1c" value='&{template:Attack} {{name=@{movename1c}}} {{subtags=@{movetype1c}, @{movefreq1c}, @{moverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1c}}} {{damage=[[[[@{movedmgdieamount1c}]]d[[@{movedmgdie1c}]]+[[@{attr_movedmgbonus1c}]]+[[@{movestab1c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1c}]]]]}} {{effect=@{moveeffect1c}}}'></button>
                 <input type="text" name="attr_movename1c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1d" value='&{template:Attack} {{name=@{movename1d}}} {{subtags=@{movetype1d}, @{movefreq1d}, @{moverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1d}}} {{damage=[[[[@{movedmgdieamount1d}]]d[[@{movedmgdie1d}]]+[[@{movestab1d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1d}]]]]}} {{effect=@{moveeffect1d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1d" value='&{template:Attack} {{name=@{movename1d}}} {{subtags=@{movetype1d}, @{movefreq1d}, @{moverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1d}}} {{damage=[[[[@{movedmgdieamount1d}]]d[[@{movedmgdie1d}]]+[[@{attr_movedmgbonus1d}]]+[[@{movestab1d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1d}]]]]}} {{effect=@{moveeffect1d}}}'></button>
                 <input type="text" name="attr_movename1d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1e" value='&{template:Attack} {{name=@{movename1e}}} {{subtags=@{movetype1e}, @{movefreq1e}, @{moverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1e}}} {{damage=[[[[@{movedmgdieamount1e}]]d[[@{movedmgdie1e}]]+[[@{movestab1e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1e}]]]]}} {{effect=@{moveeffect1e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move1e" value='&{template:Attack} {{name=@{movename1e}}} {{subtags=@{movetype1e}, @{movefreq1e}, @{moverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1e}}} {{damage=[[[[@{movedmgdieamount1e}]]d[[@{movedmgdie1e}]]+[[@{attr_movedmgbonus1e}]]+[[@{movestab1e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1e}]]]]}} {{effect=@{moveeffect1e}}}'></button>    
                 <input type="text" name="attr_movename1e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1f" value='&{template:Attack} {{name=@{movename1f}}} {{subtags=@{movetype1f}, @{movefreq1f}, @{moverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1f}}} {{damage=[[[[@{movedmgdieamount1f}]]d[[@{movedmgdie1f}]]+[[@{movestab1f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1f}]]]]}} {{effect=@{moveeffect1f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1f" value='&{template:Attack} {{name=@{movename1f}}} {{subtags=@{movetype1f}, @{movefreq1f}, @{moverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1f}}} {{damage=[[[[@{movedmgdieamount1f}]]d[[@{movedmgdie1f}]]+[[@{attr_movedmgbonus1f}]]+[[@{movestab1f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1f}]]]]}} {{effect=@{moveeffect1f}}}'></button>
                 <input type="text" name="attr_movename1f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move1g" value='&{template:Attack} {{name=@{movename1g}}} {{subtags=@{movetype1g}, @{movefreq1g}, @{moverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1g}}} {{damage=[[[[@{movedmgdieamount1g}]]d[[@{movedmgdie1g}]]+[[@{movestab1g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1g}]]]]}} {{effect=@{moveeffect1g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move1g" value='&{template:Attack} {{name=@{movename1g}}} {{subtags=@{movetype1g}, @{movefreq1g}, @{moverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac1g}}} {{damage=[[[[@{movedmgdieamount1g}]]d[[@{movedmgdie1g}]]+[[@{attr_movedmgbonus1g}]]+[[@{movestab1g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat1g}]]]]}} {{effect=@{moveeffect1g}}}'></button>
                 <input type="text" name="attr_movename1g" class="sheet-med2"><br>
         </div>
         
@@ -404,30 +404,37 @@
             <select name="attr_movedmgstat1a" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1b" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1c" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1d" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1e" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1f" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat1g" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -483,19 +490,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1a" value='&{template:Attack} {{name=@{tmovename1a}}} {{subtags=@{tmovetype1a}, @{tmovefreq1a}, @{tmoverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1a}}} {{damage=[[[[@{tmovedmgdieamount1a}]]d[[@{tmovedmgdie1a}]]+[[@{tmovestab1a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1a}]]]]}} {{effect=@{tmoveeffect1a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1a" value='&{template:Attack} {{name=@{tmovename1a}}} {{subtags=@{tmovetype1a}, @{tmovefreq1a}, @{tmoverange1a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1a}}} {{damage=[[[[@{tmovedmgdieamount1a}]]d[[@{tmovedmgdie1a}]]+[[@{attr_tmovedmgbonus1a}]]+[[@{tmovestab1a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1a}]]]]}} {{effect=@{tmoveeffect1a}}}'></button>
                 <input type="text" name="attr_tmovename1a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1b" value='&{template:Attack} {{name=@{tmovename1b}}} {{subtags=@{tmovetype1b}, @{tmovefreq1b}, @{tmoverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1b}}} {{damage=[[[[@{tmovedmgdieamount1b}]]d[[@{tmovedmgdie1b}]]+[[@{tmovestab1b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1b}]]]]}} {{effect=@{tmoveeffect1b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1b" value='&{template:Attack} {{name=@{tmovename1b}}} {{subtags=@{tmovetype1b}, @{tmovefreq1b}, @{tmoverange1b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1b}}} {{damage=[[[[@{tmovedmgdieamount1b}]]d[[@{tmovedmgdie1b}]]+[[@{attr_tmovedmgbonus1b}]]+[[@{tmovestab1b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1b}]]]]}} {{effect=@{tmoveeffect1b}}}'></button>
                 <input type="text" name="attr_tmovename1b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1c" value='&{template:Attack} {{name=@{tmovename1c}}} {{subtags=@{tmovetype1c}, @{tmovefreq1c}, @{tmoverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1c}}} {{damage=[[[[@{tmovedmgdieamount1c}]]d[[@{tmovedmgdie1c}]]+[[@{tmovestab1c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1c}]]]]}} {{effect=@{tmoveeffect1c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1c" value='&{template:Attack} {{name=@{tmovename1c}}} {{subtags=@{tmovetype1c}, @{tmovefreq1c}, @{tmoverange1c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1c}}} {{damage=[[[[@{tmovedmgdieamount1c}]]d[[@{tmovedmgdie1c}]]+[[@{attr_tmovedmgbonus1c}]]+[[@{tmovestab1c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1c}]]]]}} {{effect=@{tmoveeffect1c}}}'></button>
                 <input type="text" name="attr_tmovename1c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1d" value='&{template:Attack} {{name=@{tmovename1d}}} {{subtags=@{tmovetype1d}, @{tmovefreq1d}, @{tmoverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1d}}} {{damage=[[[[@{tmovedmgdieamount1d}]]d[[@{tmovedmgdie1d}]]+[[@{tmovestab1d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1d}]]]]}} {{effect=@{tmoveeffect1d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1d" value='&{template:Attack} {{name=@{tmovename1d}}} {{subtags=@{tmovetype1d}, @{tmovefreq1d}, @{tmoverange1d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1d}}} {{damage=[[[[@{tmovedmgdieamount1d}]]d[[@{tmovedmgdie1d}]]+[[@{attr_tmovedmgbonus1d}]]+[[@{tmovestab1d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1d}]]]]}} {{effect=@{tmoveeffect1d}}}'></button>
                 <input type="text" name="attr_tmovename1d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1e" value='&{template:Attack} {{name=@{tmovename1e}}} {{subtags=@{tmovetype1e}, @{tmovefreq1e}, @{tmoverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1e}}} {{damage=[[[[@{tmovedmgdieamount1e}]]d[[@{tmovedmgdie1e}]]+[[@{tmovestab1e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1e}]]]]}} {{effect=@{tmoveeffect1e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove1e" value='&{template:Attack} {{name=@{tmovename1e}}} {{subtags=@{tmovetype1e}, @{tmovefreq1e}, @{tmoverange1e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1e}}} {{damage=[[[[@{tmovedmgdieamount1e}]]d[[@{tmovedmgdie1e}]]+[[@{attr_tmovedmgbonus1e}]]+[[@{tmovestab1e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1e}]]]]}} {{effect=@{tmoveeffect1e}}}'></button>    
                 <input type="text" name="attr_tmovename1e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1f" value='&{template:Attack} {{name=@{tmovename1f}}} {{subtags=@{tmovetype1f}, @{tmovefreq1f}, @{tmoverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1f}}} {{damage=[[[[@{tmovedmgdieamount1f}]]d[[@{tmovedmgdie1f}]]+[[@{tmovestab1f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1f}]]]]}} {{effect=@{tmoveeffect1f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1f" value='&{template:Attack} {{name=@{tmovename1f}}} {{subtags=@{tmovetype1f}, @{tmovefreq1f}, @{tmoverange1f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1f}}} {{damage=[[[[@{tmovedmgdieamount1f}]]d[[@{tmovedmgdie1f}]]+[[@{attr_tmovedmgbonus1f}]]+[[@{tmovestab1f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1f}]]]]}} {{effect=@{tmoveeffect1f}}}'></button>
                 <input type="text" name="attr_tmovename1f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove1g" value='&{template:Attack} {{name=@{tmovename1g}}} {{subtags=@{tmovetype1g}, @{tmovefreq1g}, @{tmoverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1g}}} {{damage=[[[[@{tmovedmgdieamount1g}]]d[[@{tmovedmgdie1g}]]+[[@{tmovestab1g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1g}]]]]}} {{effect=@{tmoveeffect1g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove1g" value='&{template:Attack} {{name=@{tmovename1g}}} {{subtags=@{tmovetype1g}, @{tmovefreq1g}, @{tmoverange1g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac1g}}} {{damage=[[[[@{tmovedmgdieamount1g}]]d[[@{tmovedmgdie1g}]]+[[@{attr_tmovedmgbonus1g}]]+[[@{tmovestab1g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat1g}]]]]}} {{effect=@{tmoveeffect1g}}}'></button>
                 <input type="text" name="attr_tmovename1g" class="sheet-med2"><br>
         </div>
         
@@ -628,30 +635,37 @@
             <select name="attr_tmovedmgstat1a" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1b" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1c" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1d" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1e" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1f" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat1g" class="sheet-short2">                
                 <option value="(@{pokemon_atk1a}+@{pokemon_atk1b})">ATK</option>
                 <option value="(@{pokemon_satk1a}+@{pokemon_satk1b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -790,7 +804,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species2" class='sheet-long' /><br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea2" class='sheet-type' /><input type="text" name="attr_pokemon_typeb2" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature2" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -799,7 +813,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -900,19 +914,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2a" value='&{template:Attack} {{name=@{movename2a}}} {{subtags=@{movetype2a}, @{movefreq2a}, @{moverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2a}}} {{damage=[[[[@{movedmgdieamount2a}]]d[[@{movedmgdie2a}]]+[[@{movestab2a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2a}]]]]}} {{effect=@{moveeffect2a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2a" value='&{template:Attack} {{name=@{movename2a}}} {{subtags=@{movetype2a}, @{movefreq2a}, @{moverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2a}}} {{damage=[[[[@{movedmgdieamount2a}]]d[[@{movedmgdie2a}]]+[[@{attr_movedmgbonus2a}]]+[[@{movestab2a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2a}]]]]}} {{effect=@{moveeffect2a}}}'></button>
                 <input type="text" name="attr_movename2a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2b" value='&{template:Attack} {{name=@{movename2b}}} {{subtags=@{movetype2b}, @{movefreq2b}, @{moverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2b}}} {{damage=[[[[@{movedmgdieamount2b}]]d[[@{movedmgdie2b}]]+[[@{movestab2b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2b}]]]]}} {{effect=@{moveeffect2b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2b" value='&{template:Attack} {{name=@{movename2b}}} {{subtags=@{movetype2b}, @{movefreq2b}, @{moverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2b}}} {{damage=[[[[@{movedmgdieamount2b}]]d[[@{movedmgdie2b}]]+[[@{attr_movedmgbonus2b}]]+[[@{movestab2b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2b}]]]]}} {{effect=@{moveeffect2b}}}'></button>
                 <input type="text" name="attr_movename2b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2c" value='&{template:Attack} {{name=@{movename2c}}} {{subtags=@{movetype2c}, @{movefreq2c}, @{moverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2c}}} {{damage=[[[[@{movedmgdieamount2c}]]d[[@{movedmgdie2c}]]+[[@{movestab2c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2c}]]]]}} {{effect=@{moveeffect2c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2c" value='&{template:Attack} {{name=@{movename2c}}} {{subtags=@{movetype2c}, @{movefreq2c}, @{moverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2c}}} {{damage=[[[[@{movedmgdieamount2c}]]d[[@{movedmgdie2c}]]+[[@{attr_movedmgbonus2c}]]+[[@{movestab2c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2c}]]]]}} {{effect=@{moveeffect2c}}}'></button>
                 <input type="text" name="attr_movename2c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2d" value='&{template:Attack} {{name=@{movename2d}}} {{subtags=@{movetype2d}, @{movefreq2d}, @{moverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2d}}} {{damage=[[[[@{movedmgdieamount2d}]]d[[@{movedmgdie2d}]]+[[@{movestab2d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2d}]]]]}} {{effect=@{moveeffect2d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2d" value='&{template:Attack} {{name=@{movename2d}}} {{subtags=@{movetype2d}, @{movefreq2d}, @{moverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2d}}} {{damage=[[[[@{movedmgdieamount2d}]]d[[@{movedmgdie2d}]]+[[@{attr_movedmgbonus2d}]]+[[@{movestab2d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2d}]]]]}} {{effect=@{moveeffect2d}}}'></button>
                 <input type="text" name="attr_movename2d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2e" value='&{template:Attack} {{name=@{movename2e}}} {{subtags=@{movetype2e}, @{movefreq2e}, @{moverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2e}}} {{damage=[[[[@{movedmgdieamount2e}]]d[[@{movedmgdie2e}]]+[[@{movestab2e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2e}]]]]}} {{effect=@{moveeffect2e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move2e" value='&{template:Attack} {{name=@{movename2e}}} {{subtags=@{movetype2e}, @{movefreq2e}, @{moverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2e}}} {{damage=[[[[@{movedmgdieamount2e}]]d[[@{movedmgdie2e}]]+[[@{attr_movedmgbonus2e}]]+[[@{movestab2e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2e}]]]]}} {{effect=@{moveeffect2e}}}'></button>    
                 <input type="text" name="attr_movename2e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2f" value='&{template:Attack} {{name=@{movename2f}}} {{subtags=@{movetype2f}, @{movefreq2f}, @{moverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2f}}} {{damage=[[[[@{movedmgdieamount2f}]]d[[@{movedmgdie2f}]]+[[@{movestab2f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2f}]]]]}} {{effect=@{moveeffect2f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2f" value='&{template:Attack} {{name=@{movename2f}}} {{subtags=@{movetype2f}, @{movefreq2f}, @{moverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2f}}} {{damage=[[[[@{movedmgdieamount2f}]]d[[@{movedmgdie2f}]]+[[@{attr_movedmgbonus2f}]]+[[@{movestab2f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2f}]]]]}} {{effect=@{moveeffect2f}}}'></button>
                 <input type="text" name="attr_movename2f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move2g" value='&{template:Attack} {{name=@{movename2g}}} {{subtags=@{movetype2g}, @{movefreq2g}, @{moverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2g}}} {{damage=[[[[@{movedmgdieamount2g}]]d[[@{movedmgdie2g}]]+[[@{movestab2g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2g}]]]]}} {{effect=@{moveeffect2g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move2g" value='&{template:Attack} {{name=@{movename2g}}} {{subtags=@{movetype2g}, @{movefreq2g}, @{moverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac2g}}} {{damage=[[[[@{movedmgdieamount2g}]]d[[@{movedmgdie2g}]]+[[@{attr_movedmgbonus2g}]]+[[@{movestab2g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat2g}]]]]}} {{effect=@{moveeffect2g}}}'></button>
                 <input type="text" name="attr_movename2g" class="sheet-med2"><br>
         </div>
         
@@ -1045,30 +1059,37 @@
             <select name="attr_movedmgstat2a" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2b" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2c" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2d" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2e" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2f" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat2g" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -1124,19 +1145,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2a" value='&{template:Attack} {{name=@{tmovename2a}}} {{subtags=@{tmovetype2a}, @{tmovefreq2a}, @{tmoverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2a}}} {{damage=[[[[@{tmovedmgdieamount2a}]]d[[@{tmovedmgdie2a}]]+[[@{tmovestab2a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2a}]]]]}} {{effect=@{tmoveeffect2a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2a" value='&{template:Attack} {{name=@{tmovename2a}}} {{subtags=@{tmovetype2a}, @{tmovefreq2a}, @{tmoverange2a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2a}}} {{damage=[[[[@{tmovedmgdieamount2a}]]d[[@{tmovedmgdie2a}]]+[[@{attr_tmovedmgbonus2a}]]+[[@{tmovestab2a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2a}]]]]}} {{effect=@{tmoveeffect2a}}}'></button>
                 <input type="text" name="attr_tmovename2a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2b" value='&{template:Attack} {{name=@{tmovename2b}}} {{subtags=@{tmovetype2b}, @{tmovefreq2b}, @{tmoverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2b}}} {{damage=[[[[@{tmovedmgdieamount2b}]]d[[@{tmovedmgdie2b}]]+[[@{tmovestab2b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2b}]]]]}} {{effect=@{tmoveeffect2b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2b" value='&{template:Attack} {{name=@{tmovename2b}}} {{subtags=@{tmovetype2b}, @{tmovefreq2b}, @{tmoverange2b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2b}}} {{damage=[[[[@{tmovedmgdieamount2b}]]d[[@{tmovedmgdie2b}]]+[[@{attr_tmovedmgbonus2b}]]+[[@{tmovestab2b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2b}]]]]}} {{effect=@{tmoveeffect2b}}}'></button>
                 <input type="text" name="attr_tmovename2b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2c" value='&{template:Attack} {{name=@{tmovename2c}}} {{subtags=@{tmovetype2c}, @{tmovefreq2c}, @{tmoverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2c}}} {{damage=[[[[@{tmovedmgdieamount2c}]]d[[@{tmovedmgdie2c}]]+[[@{tmovestab2c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2c}]]]]}} {{effect=@{tmoveeffect2c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2c" value='&{template:Attack} {{name=@{tmovename2c}}} {{subtags=@{tmovetype2c}, @{tmovefreq2c}, @{tmoverange2c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2c}}} {{damage=[[[[@{tmovedmgdieamount2c}]]d[[@{tmovedmgdie2c}]]+[[@{attr_tmovedmgbonus2c}]]+[[@{tmovestab2c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2c}]]]]}} {{effect=@{tmoveeffect2c}}}'></button>
                 <input type="text" name="attr_tmovename2c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2d" value='&{template:Attack} {{name=@{tmovename2d}}} {{subtags=@{tmovetype2d}, @{tmovefreq2d}, @{tmoverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2d}}} {{damage=[[[[@{tmovedmgdieamount2d}]]d[[@{tmovedmgdie2d}]]+[[@{tmovestab2d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2d}]]]]}} {{effect=@{tmoveeffect2d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2d" value='&{template:Attack} {{name=@{tmovename2d}}} {{subtags=@{tmovetype2d}, @{tmovefreq2d}, @{tmoverange2d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2d}}} {{damage=[[[[@{tmovedmgdieamount2d}]]d[[@{tmovedmgdie2d}]]+[[@{attr_tmovedmgbonus2d}]]+[[@{tmovestab2d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2d}]]]]}} {{effect=@{tmoveeffect2d}}}'></button>
                 <input type="text" name="attr_tmovename2d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2e" value='&{template:Attack} {{name=@{tmovename2e}}} {{subtags=@{tmovetype2e}, @{tmovefreq2e}, @{tmoverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2e}}} {{damage=[[[[@{tmovedmgdieamount2e}]]d[[@{tmovedmgdie2e}]]+[[@{tmovestab2e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2e}]]]]}} {{effect=@{tmoveeffect2e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove2e" value='&{template:Attack} {{name=@{tmovename2e}}} {{subtags=@{tmovetype2e}, @{tmovefreq2e}, @{tmoverange2e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2e}}} {{damage=[[[[@{tmovedmgdieamount2e}]]d[[@{tmovedmgdie2e}]]+[[@{attr_tmovedmgbonus2e}]]+[[@{tmovestab2e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2e}]]]]}} {{effect=@{tmoveeffect2e}}}'></button>    
                 <input type="text" name="attr_tmovename2e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2f" value='&{template:Attack} {{name=@{tmovename2f}}} {{subtags=@{tmovetype2f}, @{tmovefreq2f}, @{tmoverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2f}}} {{damage=[[[[@{tmovedmgdieamount2f}]]d[[@{tmovedmgdie2f}]]+[[@{tmovestab2f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2f}]]]]}} {{effect=@{tmoveeffect2f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2f" value='&{template:Attack} {{name=@{tmovename2f}}} {{subtags=@{tmovetype2f}, @{tmovefreq2f}, @{tmoverange2f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2f}}} {{damage=[[[[@{tmovedmgdieamount2f}]]d[[@{tmovedmgdie2f}]]+[[@{attr_tmovedmgbonus2f}]]+[[@{tmovestab2f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2f}]]]]}} {{effect=@{tmoveeffect2f}}}'></button>
                 <input type="text" name="attr_tmovename2f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove2g" value='&{template:Attack} {{name=@{tmovename2g}}} {{subtags=@{tmovetype2g}, @{tmovefreq2g}, @{tmoverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2g}}} {{damage=[[[[@{tmovedmgdieamount2g}]]d[[@{tmovedmgdie2g}]]+[[@{tmovestab2g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2g}]]]]}} {{effect=@{tmoveeffect2g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove2g" value='&{template:Attack} {{name=@{tmovename2g}}} {{subtags=@{tmovetype2g}, @{tmovefreq2g}, @{tmoverange2g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac2g}}} {{damage=[[[[@{tmovedmgdieamount2g}]]d[[@{tmovedmgdie2g}]]+[[@{attr_tmovedmgbonus2g}]]+[[@{tmovestab2g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat2g}]]]]}} {{effect=@{tmoveeffect2g}}}'></button>
                 <input type="text" name="attr_tmovename2g" class="sheet-med2"><br>
         </div>
         
@@ -1269,30 +1290,37 @@
             <select name="attr_tmovedmgstat2a" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2b" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2c" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2d" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2e" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2f" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat2g" class="sheet-short2">                
                 <option value="(@{pokemon_atk2a}+@{pokemon_atk2b})">ATK</option>
                 <option value="(@{pokemon_satk2a}+@{pokemon_satk2b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -1434,7 +1462,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species3" class='sheet-long' /><br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea3" class='sheet-type' /><input type="text" name="attr_pokemon_typeb3" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature3" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -1443,7 +1471,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -1544,19 +1572,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3a" value='&{template:Attack} {{name=@{movename3a}}} {{subtags=@{movetype3a}, @{movefreq3a}, @{moverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3a}}} {{damage=[[[[@{movedmgdieamount3a}]]d[[@{movedmgdie3a}]]+[[@{movestab3a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3a}]]]]}} {{effect=@{moveeffect3a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3a" value='&{template:Attack} {{name=@{movename3a}}} {{subtags=@{movetype3a}, @{movefreq3a}, @{moverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3a}}} {{damage=[[[[@{movedmgdieamount3a}]]d[[@{movedmgdie3a}]]+[[@{attr_movedmgbonus3a}]]+[[@{movestab3a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3a}]]]]}} {{effect=@{moveeffect3a}}}'></button>
                 <input type="text" name="attr_movename3a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3b" value='&{template:Attack} {{name=@{movename3b}}} {{subtags=@{movetype3b}, @{movefreq3b}, @{moverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3b}}} {{damage=[[[[@{movedmgdieamount3b}]]d[[@{movedmgdie3b}]]+[[@{movestab3b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3b}]]]]}} {{effect=@{moveeffect3b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3b" value='&{template:Attack} {{name=@{movename3b}}} {{subtags=@{movetype3b}, @{movefreq3b}, @{moverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3b}}} {{damage=[[[[@{movedmgdieamount3b}]]d[[@{movedmgdie3b}]]+[[@{attr_movedmgbonus3b}]]+[[@{movestab3b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3b}]]]]}} {{effect=@{moveeffect3b}}}'></button>
                 <input type="text" name="attr_movename3b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3c" value='&{template:Attack} {{name=@{movename3c}}} {{subtags=@{movetype3c}, @{movefreq3c}, @{moverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3c}}} {{damage=[[[[@{movedmgdieamount3c}]]d[[@{movedmgdie3c}]]+[[@{movestab3c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3c}]]]]}} {{effect=@{moveeffect3c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3c" value='&{template:Attack} {{name=@{movename3c}}} {{subtags=@{movetype3c}, @{movefreq3c}, @{moverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3c}}} {{damage=[[[[@{movedmgdieamount3c}]]d[[@{movedmgdie3c}]]+[[@{attr_movedmgbonus3c}]]+[[@{movestab3c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3c}]]]]}} {{effect=@{moveeffect3c}}}'></button>
                 <input type="text" name="attr_movename3c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3d" value='&{template:Attack} {{name=@{movename3d}}} {{subtags=@{movetype3d}, @{movefreq3d}, @{moverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3d}}} {{damage=[[[[@{movedmgdieamount3d}]]d[[@{movedmgdie3d}]]+[[@{movestab3d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3d}]]]]}} {{effect=@{moveeffect3d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3d" value='&{template:Attack} {{name=@{movename3d}}} {{subtags=@{movetype3d}, @{movefreq3d}, @{moverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3d}}} {{damage=[[[[@{movedmgdieamount3d}]]d[[@{movedmgdie3d}]]+[[@{attr_movedmgbonus3d}]]+[[@{movestab3d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3d}]]]]}} {{effect=@{moveeffect3d}}}'></button>
                 <input type="text" name="attr_movename3d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3e" value='&{template:Attack} {{name=@{movename3e}}} {{subtags=@{movetype3e}, @{movefreq3e}, @{moverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3e}}} {{damage=[[[[@{movedmgdieamount3e}]]d[[@{movedmgdie3e}]]+[[@{movestab3e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3e}]]]]}} {{effect=@{moveeffect3e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move3e" value='&{template:Attack} {{name=@{movename3e}}} {{subtags=@{movetype3e}, @{movefreq3e}, @{moverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3e}}} {{damage=[[[[@{movedmgdieamount3e}]]d[[@{movedmgdie3e}]]+[[@{attr_movedmgbonus3e}]]+[[@{movestab3e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3e}]]]]}} {{effect=@{moveeffect3e}}}'></button>    
                 <input type="text" name="attr_movename3e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3f" value='&{template:Attack} {{name=@{movename3f}}} {{subtags=@{movetype3f}, @{movefreq3f}, @{moverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3f}}} {{damage=[[[[@{movedmgdieamount3f}]]d[[@{movedmgdie3f}]]+[[@{movestab3f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3f}]]]]}} {{effect=@{moveeffect3f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3f" value='&{template:Attack} {{name=@{movename3f}}} {{subtags=@{movetype3f}, @{movefreq3f}, @{moverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3f}}} {{damage=[[[[@{movedmgdieamount3f}]]d[[@{movedmgdie3f}]]+[[@{attr_movedmgbonus3f}]]+[[@{movestab3f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3f}]]]]}} {{effect=@{moveeffect3f}}}'></button>
                 <input type="text" name="attr_movename3f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move3g" value='&{template:Attack} {{name=@{movename3g}}} {{subtags=@{movetype3g}, @{movefreq3g}, @{moverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3g}}} {{damage=[[[[@{movedmgdieamount3g}]]d[[@{movedmgdie3g}]]+[[@{movestab3g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3g}]]]]}} {{effect=@{moveeffect3g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move3g" value='&{template:Attack} {{name=@{movename3g}}} {{subtags=@{movetype3g}, @{movefreq3g}, @{moverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac3g}}} {{damage=[[[[@{movedmgdieamount3g}]]d[[@{movedmgdie3g}]]+[[@{attr_movedmgbonus3g}]]+[[@{movestab3g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat3g}]]]]}} {{effect=@{moveeffect3g}}}'></button>
                 <input type="text" name="attr_movename3g" class="sheet-med2"><br>
         </div>
         
@@ -1689,30 +1717,37 @@
             <select name="attr_movedmgstat3a" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3b" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3c" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3d" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3e" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3f" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat3g" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -1768,19 +1803,19 @@
     <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3a" value='&{template:Attack} {{name=@{tmovename3a}}} {{subtags=@{tmovetype3a}, @{tmovefreq3a}, @{tmoverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3a}}} {{damage=[[[[@{tmovedmgdieamount3a}]]d[[@{tmovedmgdie3a}]]+[[@{tmovestab3a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3a}]]]]}} {{effect=@{tmoveeffect3a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3a" value='&{template:Attack} {{name=@{tmovename3a}}} {{subtags=@{tmovetype3a}, @{tmovefreq3a}, @{tmoverange3a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3a}}} {{damage=[[[[@{tmovedmgdieamount3a}]]d[[@{tmovedmgdie3a}]]+[[@{attr_tmovedmgbonus3a}]]+[[@{tmovestab3a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3a}]]]]}} {{effect=@{tmoveeffect3a}}}'></button>
                 <input type="text" name="attr_tmovename3a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3b" value='&{template:Attack} {{name=@{tmovename3b}}} {{subtags=@{tmovetype3b}, @{tmovefreq3b}, @{tmoverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3b}}} {{damage=[[[[@{tmovedmgdieamount3b}]]d[[@{tmovedmgdie3b}]]+[[@{tmovestab3b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3b}]]]]}} {{effect=@{tmoveeffect3b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3b" value='&{template:Attack} {{name=@{tmovename3b}}} {{subtags=@{tmovetype3b}, @{tmovefreq3b}, @{tmoverange3b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3b}}} {{damage=[[[[@{tmovedmgdieamount3b}]]d[[@{tmovedmgdie3b}]]+[[@{attr_tmovedmgbonus3b}]]+[[@{tmovestab3b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3b}]]]]}} {{effect=@{tmoveeffect3b}}}'></button>
                 <input type="text" name="attr_tmovename3b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3c" value='&{template:Attack} {{name=@{tmovename3c}}} {{subtags=@{tmovetype3c}, @{tmovefreq3c}, @{tmoverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3c}}} {{damage=[[[[@{tmovedmgdieamount3c}]]d[[@{tmovedmgdie3c}]]+[[@{tmovestab3c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3c}]]]]}} {{effect=@{tmoveeffect3c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3c" value='&{template:Attack} {{name=@{tmovename3c}}} {{subtags=@{tmovetype3c}, @{tmovefreq3c}, @{tmoverange3c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3c}}} {{damage=[[[[@{tmovedmgdieamount3c}]]d[[@{tmovedmgdie3c}]]+[[@{attr_tmovedmgbonus3c}]]+[[@{tmovestab3c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3c}]]]]}} {{effect=@{tmoveeffect3c}}}'></button>
                 <input type="text" name="attr_tmovename3c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3d" value='&{template:Attack} {{name=@{tmovename3d}}} {{subtags=@{tmovetype3d}, @{tmovefreq3d}, @{tmoverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3d}}} {{damage=[[[[@{tmovedmgdieamount3d}]]d[[@{tmovedmgdie3d}]]+[[@{tmovestab3d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3d}]]]]}} {{effect=@{tmoveeffect3d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3d" value='&{template:Attack} {{name=@{tmovename3d}}} {{subtags=@{tmovetype3d}, @{tmovefreq3d}, @{tmoverange3d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3d}}} {{damage=[[[[@{tmovedmgdieamount3d}]]d[[@{tmovedmgdie3d}]]+[[@{attr_tmovedmgbonus3d}]]+[[@{tmovestab3d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3d}]]]]}} {{effect=@{tmoveeffect3d}}}'></button>
                 <input type="text" name="attr_tmovename3d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3e" value='&{template:Attack} {{name=@{tmovename3e}}} {{subtags=@{tmovetype3e}, @{tmovefreq3e}, @{tmoverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3e}}} {{damage=[[[[@{tmovedmgdieamount3e}]]d[[@{tmovedmgdie3e}]]+[[@{tmovestab3e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3e}]]]]}} {{effect=@{tmoveeffect3e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove3e" value='&{template:Attack} {{name=@{tmovename3e}}} {{subtags=@{tmovetype3e}, @{tmovefreq3e}, @{tmoverange3e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3e}}} {{damage=[[[[@{tmovedmgdieamount3e}]]d[[@{tmovedmgdie3e}]]+[[@{attr_tmovedmgbonus3e}]]+[[@{tmovestab3e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3e}]]]]}} {{effect=@{tmoveeffect3e}}}'></button>    
                 <input type="text" name="attr_tmovename3e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3f" value='&{template:Attack} {{name=@{tmovename3f}}} {{subtags=@{tmovetype3f}, @{tmovefreq3f}, @{tmoverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3f}}} {{damage=[[[[@{tmovedmgdieamount3f}]]d[[@{tmovedmgdie3f}]]+[[@{tmovestab3f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3f}]]]]}} {{effect=@{tmoveeffect3f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3f" value='&{template:Attack} {{name=@{tmovename3f}}} {{subtags=@{tmovetype3f}, @{tmovefreq3f}, @{tmoverange3f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3f}}} {{damage=[[[[@{tmovedmgdieamount3f}]]d[[@{tmovedmgdie3f}]]+[[@{attr_tmovedmgbonus3f}]]+[[@{tmovestab3f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3f}]]]]}} {{effect=@{tmoveeffect3f}}}'></button>
                 <input type="text" name="attr_tmovename3f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove3g" value='&{template:Attack} {{name=@{tmovename3g}}} {{subtags=@{tmovetype3g}, @{tmovefreq3g}, @{tmoverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3g}}} {{damage=[[[[@{tmovedmgdieamount3g}]]d[[@{tmovedmgdie3g}]]+[[@{tmovestab3g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3g}]]]]}} {{effect=@{tmoveeffect3g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove3g" value='&{template:Attack} {{name=@{tmovename3g}}} {{subtags=@{tmovetype3g}, @{tmovefreq3g}, @{tmoverange3g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac3g}}} {{damage=[[[[@{tmovedmgdieamount3g}]]d[[@{tmovedmgdie3g}]]+[[@{attr_tmovedmgbonus3g}]]+[[@{tmovestab3g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat3g}]]]]}} {{effect=@{tmoveeffect3g}}}'></button>
                 <input type="text" name="attr_tmovename3g" class="sheet-med2"><br>
         </div>
         
@@ -1913,30 +1948,37 @@
             <select name="attr_tmovedmgstat3a" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3b" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3c" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3d" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3e" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3f" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat3g" class="sheet-short2">                
                 <option value="(@{pokemon_atk3a}+@{pokemon_atk3b})">ATK</option>
                 <option value="(@{pokemon_satk3a}+@{pokemon_satk3b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -2076,7 +2118,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species4" class='sheet-long' /><br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea4" class='sheet-type' /><input type="text" name="attr_pokemon_typeb4" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature4" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -2085,7 +2127,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -2186,19 +2228,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4a" value='&{template:Attack} {{name=@{movename4a}}} {{subtags=@{movetype4a}, @{movefreq4a}, @{moverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4a}}} {{damage=[[[[@{movedmgdieamount4a}]]d[[@{movedmgdie4a}]]+[[@{movestab4a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4a}]]]]}} {{effect=@{moveeffect4a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4a" value='&{template:Attack} {{name=@{movename4a}}} {{subtags=@{movetype4a}, @{movefreq4a}, @{moverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4a}}} {{damage=[[[[@{movedmgdieamount4a}]]d[[@{movedmgdie4a}]]+[[@{attr_movedmgbonus4a}]]+[[@{movestab4a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4a}]]]]}} {{effect=@{moveeffect4a}}}'></button>
                 <input type="text" name="attr_movename4a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4b" value='&{template:Attack} {{name=@{movename4b}}} {{subtags=@{movetype4b}, @{movefreq4b}, @{moverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4b}}} {{damage=[[[[@{movedmgdieamount4b}]]d[[@{movedmgdie4b}]]+[[@{movestab4b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4b}]]]]}} {{effect=@{moveeffect4b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4b" value='&{template:Attack} {{name=@{movename4b}}} {{subtags=@{movetype4b}, @{movefreq4b}, @{moverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4b}}} {{damage=[[[[@{movedmgdieamount4b}]]d[[@{movedmgdie4b}]]+[[@{attr_movedmgbonus4b}]]+[[@{movestab4b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4b}]]]]}} {{effect=@{moveeffect4b}}}'></button>
                 <input type="text" name="attr_movename4b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4c" value='&{template:Attack} {{name=@{movename4c}}} {{subtags=@{movetype4c}, @{movefreq4c}, @{moverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4c}}} {{damage=[[[[@{movedmgdieamount4c}]]d[[@{movedmgdie4c}]]+[[@{movestab4c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4c}]]]]}} {{effect=@{moveeffect4c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4c" value='&{template:Attack} {{name=@{movename4c}}} {{subtags=@{movetype4c}, @{movefreq4c}, @{moverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4c}}} {{damage=[[[[@{movedmgdieamount4c}]]d[[@{movedmgdie4c}]]+[[@{attr_movedmgbonus4c}]]+[[@{movestab4c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4c}]]]]}} {{effect=@{moveeffect4c}}}'></button>
                 <input type="text" name="attr_movename4c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4d" value='&{template:Attack} {{name=@{movename4d}}} {{subtags=@{movetype4d}, @{movefreq4d}, @{moverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4d}}} {{damage=[[[[@{movedmgdieamount4d}]]d[[@{movedmgdie4d}]]+[[@{movestab4d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4d}]]]]}} {{effect=@{moveeffect4d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4d" value='&{template:Attack} {{name=@{movename4d}}} {{subtags=@{movetype4d}, @{movefreq4d}, @{moverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4d}}} {{damage=[[[[@{movedmgdieamount4d}]]d[[@{movedmgdie4d}]]+[[@{attr_movedmgbonus4d}]]+[[@{movestab4d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4d}]]]]}} {{effect=@{moveeffect4d}}}'></button>
                 <input type="text" name="attr_movename4d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4e" value='&{template:Attack} {{name=@{movename4e}}} {{subtags=@{movetype4e}, @{movefreq4e}, @{moverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4e}}} {{damage=[[[[@{movedmgdieamount4e}]]d[[@{movedmgdie4e}]]+[[@{movestab4e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4e}]]]]}} {{effect=@{moveeffect4e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move4e" value='&{template:Attack} {{name=@{movename4e}}} {{subtags=@{movetype4e}, @{movefreq4e}, @{moverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4e}}} {{damage=[[[[@{movedmgdieamount4e}]]d[[@{movedmgdie4e}]]+[[@{attr_movedmgbonus4e}]]+[[@{movestab4e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4e}]]]]}} {{effect=@{moveeffect4e}}}'></button>    
                 <input type="text" name="attr_movename4e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4f" value='&{template:Attack} {{name=@{movename4f}}} {{subtags=@{movetype4f}, @{movefreq4f}, @{moverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4f}}} {{damage=[[[[@{movedmgdieamount4f}]]d[[@{movedmgdie4f}]]+[[@{movestab4f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4f}]]]]}} {{effect=@{moveeffect4f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4f" value='&{template:Attack} {{name=@{movename4f}}} {{subtags=@{movetype4f}, @{movefreq4f}, @{moverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4f}}} {{damage=[[[[@{movedmgdieamount4f}]]d[[@{movedmgdie4f}]]+[[@{attr_movedmgbonus4f}]]+[[@{movestab4f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4f}]]]]}} {{effect=@{moveeffect4f}}}'></button>
                 <input type="text" name="attr_movename4f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move4g" value='&{template:Attack} {{name=@{movename4g}}} {{subtags=@{movetype4g}, @{movefreq4g}, @{moverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4g}}} {{damage=[[[[@{movedmgdieamount4g}]]d[[@{movedmgdie4g}]]+[[@{movestab4g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4g}]]]]}} {{effect=@{moveeffect4g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move4g" value='&{template:Attack} {{name=@{movename4g}}} {{subtags=@{movetype4g}, @{movefreq4g}, @{moverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac4g}}} {{damage=[[[[@{movedmgdieamount4g}]]d[[@{movedmgdie4g}]]+[[@{attr_movedmgbonus4g}]]+[[@{movestab4g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat4g}]]]]}} {{effect=@{moveeffect4g}}}'></button>
                 <input type="text" name="attr_movename4g" class="sheet-med2"><br>
         </div>
         
@@ -2331,30 +2373,37 @@
             <select name="attr_movedmgstat4a" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4b" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4c" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4d" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4e" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4f" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat4g" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -2410,19 +2459,19 @@
     <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4a" value='&{template:Attack} {{name=@{tmovename4a}}} {{subtags=@{tmovetype4a}, @{tmovefreq4a}, @{tmoverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4a}}} {{damage=[[[[@{tmovedmgdieamount4a}]]d[[@{tmovedmgdie4a}]]+[[@{tmovestab4a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4a}]]]]}} {{effect=@{tmoveeffect4a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4a" value='&{template:Attack} {{name=@{tmovename4a}}} {{subtags=@{tmovetype4a}, @{tmovefreq4a}, @{tmoverange4a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4a}}} {{damage=[[[[@{tmovedmgdieamount4a}]]d[[@{tmovedmgdie4a}]]+[[@{attr_tmovedmgbonus4a}]]+[[@{tmovestab4a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4a}]]]]}} {{effect=@{tmoveeffect4a}}}'></button>
                 <input type="text" name="attr_tmovename4a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4b" value='&{template:Attack} {{name=@{tmovename4b}}} {{subtags=@{tmovetype4b}, @{tmovefreq4b}, @{tmoverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4b}}} {{damage=[[[[@{tmovedmgdieamount4b}]]d[[@{tmovedmgdie4b}]]+[[@{tmovestab4b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4b}]]]]}} {{effect=@{tmoveeffect4b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4b" value='&{template:Attack} {{name=@{tmovename4b}}} {{subtags=@{tmovetype4b}, @{tmovefreq4b}, @{tmoverange4b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4b}}} {{damage=[[[[@{tmovedmgdieamount4b}]]d[[@{tmovedmgdie4b}]]+[[@{attr_tmovedmgbonus4b}]]+[[@{tmovestab4b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4b}]]]]}} {{effect=@{tmoveeffect4b}}}'></button>
                 <input type="text" name="attr_tmovename4b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4c" value='&{template:Attack} {{name=@{tmovename4c}}} {{subtags=@{tmovetype4c}, @{tmovefreq4c}, @{tmoverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4c}}} {{damage=[[[[@{tmovedmgdieamount4c}]]d[[@{tmovedmgdie4c}]]+[[@{tmovestab4c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4c}]]]]}} {{effect=@{tmoveeffect4c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4c" value='&{template:Attack} {{name=@{tmovename4c}}} {{subtags=@{tmovetype4c}, @{tmovefreq4c}, @{tmoverange4c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4c}}} {{damage=[[[[@{tmovedmgdieamount4c}]]d[[@{tmovedmgdie4c}]]+[[@{attr_tmovedmgbonus4c}]]+[[@{tmovestab4c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4c}]]]]}} {{effect=@{tmoveeffect4c}}}'></button>
                 <input type="text" name="attr_tmovename4c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4d" value='&{template:Attack} {{name=@{tmovename4d}}} {{subtags=@{tmovetype4d}, @{tmovefreq4d}, @{tmoverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4d}}} {{damage=[[[[@{tmovedmgdieamount4d}]]d[[@{tmovedmgdie4d}]]+[[@{tmovestab4d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4d}]]]]}} {{effect=@{tmoveeffect4d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4d" value='&{template:Attack} {{name=@{tmovename4d}}} {{subtags=@{tmovetype4d}, @{tmovefreq4d}, @{tmoverange4d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4d}}} {{damage=[[[[@{tmovedmgdieamount4d}]]d[[@{tmovedmgdie4d}]]+[[@{attr_tmovedmgbonus4d}]]+[[@{tmovestab4d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4d}]]]]}} {{effect=@{tmoveeffect4d}}}'></button>
                 <input type="text" name="attr_tmovename4d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4e" value='&{template:Attack} {{name=@{tmovename4e}}} {{subtags=@{tmovetype4e}, @{tmovefreq4e}, @{tmoverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4e}}} {{damage=[[[[@{tmovedmgdieamount4e}]]d[[@{tmovedmgdie4e}]]+[[@{tmovestab4e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4e}]]]]}} {{effect=@{tmoveeffect4e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove4e" value='&{template:Attack} {{name=@{tmovename4e}}} {{subtags=@{tmovetype4e}, @{tmovefreq4e}, @{tmoverange4e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4e}}} {{damage=[[[[@{tmovedmgdieamount4e}]]d[[@{tmovedmgdie4e}]]+[[@{attr_tmovedmgbonus4e}]]+[[@{tmovestab4e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4e}]]]]}} {{effect=@{tmoveeffect4e}}}'></button>    
                 <input type="text" name="attr_tmovename4e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4f" value='&{template:Attack} {{name=@{tmovename4f}}} {{subtags=@{tmovetype4f}, @{tmovefreq4f}, @{tmoverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4f}}} {{damage=[[[[@{tmovedmgdieamount4f}]]d[[@{tmovedmgdie4f}]]+[[@{tmovestab4f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4f}]]]]}} {{effect=@{tmoveeffect4f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4f" value='&{template:Attack} {{name=@{tmovename4f}}} {{subtags=@{tmovetype4f}, @{tmovefreq4f}, @{tmoverange4f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4f}}} {{damage=[[[[@{tmovedmgdieamount4f}]]d[[@{tmovedmgdie4f}]]+[[@{attr_tmovedmgbonus4f}]]+[[@{tmovestab4f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4f}]]]]}} {{effect=@{tmoveeffect4f}}}'></button>
                 <input type="text" name="attr_tmovename4f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove4g" value='&{template:Attack} {{name=@{tmovename4g}}} {{subtags=@{tmovetype4g}, @{tmovefreq4g}, @{tmoverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4g}}} {{damage=[[[[@{tmovedmgdieamount4g}]]d[[@{tmovedmgdie4g}]]+[[@{tmovestab4g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4g}]]]]}} {{effect=@{tmoveeffect4g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove4g" value='&{template:Attack} {{name=@{tmovename4g}}} {{subtags=@{tmovetype4g}, @{tmovefreq4g}, @{tmoverange4g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac4g}}} {{damage=[[[[@{tmovedmgdieamount4g}]]d[[@{tmovedmgdie4g}]]+[[@{attr_tmovedmgbonus4g}]]+[[@{tmovestab4g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat4g}]]]]}} {{effect=@{tmoveeffect4g}}}'></button>
                 <input type="text" name="attr_tmovename4g" class="sheet-med2"><br>
         </div>
         
@@ -2555,30 +2604,37 @@
             <select name="attr_tmovedmgstat4a" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4b" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4c" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4d" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4e" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4f" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat4g" class="sheet-short2">                
                 <option value="(@{pokemon_atk4a}+@{pokemon_atk4b})">ATK</option>
                 <option value="(@{pokemon_satk4a}+@{pokemon_satk4b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -2719,7 +2775,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species5" class='sheet-long' /><br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea5" class='sheet-type' /><input type="text" name="attr_pokemon_typeb5" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature5" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -2728,7 +2784,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -2829,19 +2885,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5a" value='&{template:Attack} {{name=@{movename5a}}} {{subtags=@{movetype5a}, @{movefreq5a}, @{moverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5a}}} {{damage=[[[[@{movedmgdieamount5a}]]d[[@{movedmgdie5a}]]+[[@{movestab5a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5a}]]]]}} {{effect=@{moveeffect5a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5a" value='&{template:Attack} {{name=@{movename5a}}} {{subtags=@{movetype5a}, @{movefreq5a}, @{moverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5a}}} {{damage=[[[[@{movedmgdieamount5a}]]d[[@{movedmgdie5a}]]+[[@{attr_movedmgbonus5a}]]+[[@{movestab5a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5a}]]]]}} {{effect=@{moveeffect5a}}}'></button>
                 <input type="text" name="attr_movename5a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5b" value='&{template:Attack} {{name=@{movename5b}}} {{subtags=@{movetype5b}, @{movefreq5b}, @{moverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5b}}} {{damage=[[[[@{movedmgdieamount5b}]]d[[@{movedmgdie5b}]]+[[@{movestab5b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5b}]]]]}} {{effect=@{moveeffect5b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5b" value='&{template:Attack} {{name=@{movename5b}}} {{subtags=@{movetype5b}, @{movefreq5b}, @{moverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5b}}} {{damage=[[[[@{movedmgdieamount5b}]]d[[@{movedmgdie5b}]]+[[@{attr_movedmgbonus5b}]]+[[@{movestab5b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5b}]]]]}} {{effect=@{moveeffect5b}}}'></button>
                 <input type="text" name="attr_movename5b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5c" value='&{template:Attack} {{name=@{movename5c}}} {{subtags=@{movetype5c}, @{movefreq5c}, @{moverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5c}}} {{damage=[[[[@{movedmgdieamount5c}]]d[[@{movedmgdie5c}]]+[[@{movestab5c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5c}]]]]}} {{effect=@{moveeffect5c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5c" value='&{template:Attack} {{name=@{movename5c}}} {{subtags=@{movetype5c}, @{movefreq5c}, @{moverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5c}}} {{damage=[[[[@{movedmgdieamount5c}]]d[[@{movedmgdie5c}]]+[[@{attr_movedmgbonus5c}]]+[[@{movestab5c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5c}]]]]}} {{effect=@{moveeffect5c}}}'></button>
                 <input type="text" name="attr_movename5c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5d" value='&{template:Attack} {{name=@{movename5d}}} {{subtags=@{movetype5d}, @{movefreq5d}, @{moverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5d}}} {{damage=[[[[@{movedmgdieamount5d}]]d[[@{movedmgdie5d}]]+[[@{movestab5d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5d}]]]]}} {{effect=@{moveeffect5d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5d" value='&{template:Attack} {{name=@{movename5d}}} {{subtags=@{movetype5d}, @{movefreq5d}, @{moverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5d}}} {{damage=[[[[@{movedmgdieamount5d}]]d[[@{movedmgdie5d}]]+[[@{attr_movedmgbonus5d}]]+[[@{movestab5d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5d}]]]]}} {{effect=@{moveeffect5d}}}'></button>
                 <input type="text" name="attr_movename5d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5e" value='&{template:Attack} {{name=@{movename5e}}} {{subtags=@{movetype5e}, @{movefreq5e}, @{moverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5e}}} {{damage=[[[[@{movedmgdieamount5e}]]d[[@{movedmgdie5e}]]+[[@{movestab5e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5e}]]]]}} {{effect=@{moveeffect5e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move5e" value='&{template:Attack} {{name=@{movename5e}}} {{subtags=@{movetype5e}, @{movefreq5e}, @{moverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5e}}} {{damage=[[[[@{movedmgdieamount5e}]]d[[@{movedmgdie5e}]]+[[@{attr_movedmgbonus5e}]]+[[@{movestab5e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5e}]]]]}} {{effect=@{moveeffect5e}}}'></button>    
                 <input type="text" name="attr_movename5e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5f" value='&{template:Attack} {{name=@{movename5f}}} {{subtags=@{movetype5f}, @{movefreq5f}, @{moverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5f}}} {{damage=[[[[@{movedmgdieamount5f}]]d[[@{movedmgdie5f}]]+[[@{movestab5f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5f}]]]]}} {{effect=@{moveeffect5f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5f" value='&{template:Attack} {{name=@{movename5f}}} {{subtags=@{movetype5f}, @{movefreq5f}, @{moverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5f}}} {{damage=[[[[@{movedmgdieamount5f}]]d[[@{movedmgdie5f}]]+[[@{attr_movedmgbonus5f}]]+[[@{movestab5f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5f}]]]]}} {{effect=@{moveeffect5f}}}'></button>
                 <input type="text" name="attr_movename5f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move5g" value='&{template:Attack} {{name=@{movename5g}}} {{subtags=@{movetype5g}, @{movefreq5g}, @{moverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5g}}} {{damage=[[[[@{movedmgdieamount5g}]]d[[@{movedmgdie5g}]]+[[@{movestab5g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5g}]]]]}} {{effect=@{moveeffect5g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move5g" value='&{template:Attack} {{name=@{movename5g}}} {{subtags=@{movetype5g}, @{movefreq5g}, @{moverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac5g}}} {{damage=[[[[@{movedmgdieamount5g}]]d[[@{movedmgdie5g}]]+[[@{attr_movedmgbonus5g}]]+[[@{movestab5g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat5g}]]]]}} {{effect=@{moveeffect5g}}}'></button>
                 <input type="text" name="attr_movename5g" class="sheet-med2"><br>
         </div>
         
@@ -2974,30 +3030,37 @@
             <select name="attr_movedmgstat5a" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5b" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5c" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5d" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5e" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5f" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat5g" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -3053,19 +3116,19 @@
     <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5a" value='&{template:Attack} {{name=@{tmovename5a}}} {{subtags=@{tmovetype5a}, @{tmovefreq5a}, @{tmoverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5a}}} {{damage=[[[[@{tmovedmgdieamount5a}]]d[[@{tmovedmgdie5a}]]+[[@{tmovestab5a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5a}]]]]}} {{effect=@{tmoveeffect5a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5a" value='&{template:Attack} {{name=@{tmovename5a}}} {{subtags=@{tmovetype5a}, @{tmovefreq5a}, @{tmoverange5a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5a}}} {{damage=[[[[@{tmovedmgdieamount5a}]]d[[@{tmovedmgdie5a}]]+[[@{attr_tmovedmgbonus5a}]]+[[@{tmovestab5a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5a}]]]]}} {{effect=@{tmoveeffect5a}}}'></button>
                 <input type="text" name="attr_tmovename5a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5b" value='&{template:Attack} {{name=@{tmovename5b}}} {{subtags=@{tmovetype5b}, @{tmovefreq5b}, @{tmoverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5b}}} {{damage=[[[[@{tmovedmgdieamount5b}]]d[[@{tmovedmgdie5b}]]+[[@{tmovestab5b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5b}]]]]}} {{effect=@{tmoveeffect5b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5b" value='&{template:Attack} {{name=@{tmovename5b}}} {{subtags=@{tmovetype5b}, @{tmovefreq5b}, @{tmoverange5b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5b}}} {{damage=[[[[@{tmovedmgdieamount5b}]]d[[@{tmovedmgdie5b}]]+[[@{attr_tmovedmgbonus5b}]]+[[@{tmovestab5b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5b}]]]]}} {{effect=@{tmoveeffect5b}}}'></button>
                 <input type="text" name="attr_tmovename5b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5c" value='&{template:Attack} {{name=@{tmovename5c}}} {{subtags=@{tmovetype5c}, @{tmovefreq5c}, @{tmoverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5c}}} {{damage=[[[[@{tmovedmgdieamount5c}]]d[[@{tmovedmgdie5c}]]+[[@{tmovestab5c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5c}]]]]}} {{effect=@{tmoveeffect5c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5c" value='&{template:Attack} {{name=@{tmovename5c}}} {{subtags=@{tmovetype5c}, @{tmovefreq5c}, @{tmoverange5c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5c}}} {{damage=[[[[@{tmovedmgdieamount5c}]]d[[@{tmovedmgdie5c}]]+[[@{attr_tmovedmgbonus5c}]]+[[@{tmovestab5c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5c}]]]]}} {{effect=@{tmoveeffect5c}}}'></button>
                 <input type="text" name="attr_tmovename5c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5d" value='&{template:Attack} {{name=@{tmovename5d}}} {{subtags=@{tmovetype5d}, @{tmovefreq5d}, @{tmoverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5d}}} {{damage=[[[[@{tmovedmgdieamount5d}]]d[[@{tmovedmgdie5d}]]+[[@{tmovestab5d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5d}]]]]}} {{effect=@{tmoveeffect5d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5d" value='&{template:Attack} {{name=@{tmovename5d}}} {{subtags=@{tmovetype5d}, @{tmovefreq5d}, @{tmoverange5d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5d}}} {{damage=[[[[@{tmovedmgdieamount5d}]]d[[@{tmovedmgdie5d}]]+[[@{attr_tmovedmgbonus5d}]]+[[@{tmovestab5d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5d}]]]]}} {{effect=@{tmoveeffect5d}}}'></button>
                 <input type="text" name="attr_tmovename5d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5e" value='&{template:Attack} {{name=@{tmovename5e}}} {{subtags=@{tmovetype5e}, @{tmovefreq5e}, @{tmoverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5e}}} {{damage=[[[[@{tmovedmgdieamount5e}]]d[[@{tmovedmgdie5e}]]+[[@{tmovestab5e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5e}]]]]}} {{effect=@{tmoveeffect5e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove5e" value='&{template:Attack} {{name=@{tmovename5e}}} {{subtags=@{tmovetype5e}, @{tmovefreq5e}, @{tmoverange5e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5e}}} {{damage=[[[[@{tmovedmgdieamount5e}]]d[[@{tmovedmgdie5e}]]+[[@{attr_tmovedmgbonus5e}]]+[[@{tmovestab5e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5e}]]]]}} {{effect=@{tmoveeffect5e}}}'></button>    
                 <input type="text" name="attr_tmovename5e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5f" value='&{template:Attack} {{name=@{tmovename5f}}} {{subtags=@{tmovetype5f}, @{tmovefreq5f}, @{tmoverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5f}}} {{damage=[[[[@{tmovedmgdieamount5f}]]d[[@{tmovedmgdie5f}]]+[[@{tmovestab5f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5f}]]]]}} {{effect=@{tmoveeffect5f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5f" value='&{template:Attack} {{name=@{tmovename5f}}} {{subtags=@{tmovetype5f}, @{tmovefreq5f}, @{tmoverange5f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5f}}} {{damage=[[[[@{tmovedmgdieamount5f}]]d[[@{tmovedmgdie5f}]]+[[@{attr_tmovedmgbonus5f}]]+[[@{tmovestab5f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5f}]]]]}} {{effect=@{tmoveeffect5f}}}'></button>
                 <input type="text" name="attr_tmovename5f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove5g" value='&{template:Attack} {{name=@{tmovename5g}}} {{subtags=@{tmovetype5g}, @{tmovefreq5g}, @{tmoverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5g}}} {{damage=[[[[@{tmovedmgdieamount5g}]]d[[@{tmovedmgdie5g}]]+[[@{tmovestab5g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5g}]]]]}} {{effect=@{tmoveeffect5g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove5g" value='&{template:Attack} {{name=@{tmovename5g}}} {{subtags=@{tmovetype5g}, @{tmovefreq5g}, @{tmoverange5g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac5g}}} {{damage=[[[[@{tmovedmgdieamount5g}]]d[[@{tmovedmgdie5g}]]+[[@{attr_tmovedmgbonus5g}]]+[[@{tmovestab5g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat5g}]]]]}} {{effect=@{tmoveeffect5g}}}'></button>
                 <input type="text" name="attr_tmovename5g" class="sheet-med2"><br>
         </div>
         
@@ -3198,30 +3261,37 @@
             <select name="attr_tmovedmgstat5a" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5b" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5c" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5d" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5e" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5f" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat5g" class="sheet-short2">                
                 <option value="(@{pokemon_atk5a}+@{pokemon_atk5b})">ATK</option>
                 <option value="(@{pokemon_satk5a}+@{pokemon_satk5b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -3360,7 +3430,7 @@
      <label>Species:</label><input type="text" name="attr_pokemon_species6" class='sheet-long' /><br>
      <label>Type:</label><input type="text" name="attr_pokemon_typea6" class='sheet-type' /><input type="text" name="attr_pokemon_typeb6" class='sheet-type' /><br>
      <label>Nature:</label><input type="text" name="attr_pokemon_nature6" class='sheet-long' /><br>
-     <label>+2:</label><select class="sheet-short" />
+     <label>+2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -3369,7 +3439,7 @@
           <option value="SDEF">SDEF</option>
           <option value="SPD">SPD</option>
      </select>
-     <label>-2:</label><select class="sheet-short" />
+     <label>-2:</label><select class="sheet-short">
           <option value="N/A">N/A</option>
           <option value="HP">HP</option>
           <option value="ATK">ATK</option>
@@ -3470,19 +3540,19 @@
 <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6a" value='&{template:Attack} {{name=@{movename6a}}} {{subtags=@{movetype6a}, @{movefreq6a}, @{moverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6a}}} {{damage=[[[[@{movedmgdieamount6a}]]d[[@{movedmgdie6a}]]+[[@{movestab6a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6a}]]]]}} {{effect=@{moveeffect6a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6a" value='&{template:Attack} {{name=@{movename6a}}} {{subtags=@{movetype6a}, @{movefreq6a}, @{moverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6a}}} {{damage=[[[[@{movedmgdieamount6a}]]d[[@{movedmgdie6a}]]+[[@{attr_movedmgbonus6a}]]+[[@{movestab6a}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6a}]]]]}} {{effect=@{moveeffect6a}}}'></button>
                 <input type="text" name="attr_movename6a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6b" value='&{template:Attack} {{name=@{movename6b}}} {{subtags=@{movetype6b}, @{movefreq6b}, @{moverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6b}}} {{damage=[[[[@{movedmgdieamount6b}]]d[[@{movedmgdie6b}]]+[[@{movestab6b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6b}]]]]}} {{effect=@{moveeffect6b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6b" value='&{template:Attack} {{name=@{movename6b}}} {{subtags=@{movetype6b}, @{movefreq6b}, @{moverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6b}}} {{damage=[[[[@{movedmgdieamount6b}]]d[[@{movedmgdie6b}]]+[[@{attr_movedmgbonus6b}]]+[[@{movestab6b}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6b}]]]]}} {{effect=@{moveeffect6b}}}'></button>
                 <input type="text" name="attr_movename6b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6c" value='&{template:Attack} {{name=@{movename6c}}} {{subtags=@{movetype6c}, @{movefreq6c}, @{moverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6c}}} {{damage=[[[[@{movedmgdieamount6c}]]d[[@{movedmgdie6c}]]+[[@{movestab6c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6c}]]]]}} {{effect=@{moveeffect6c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6c" value='&{template:Attack} {{name=@{movename6c}}} {{subtags=@{movetype6c}, @{movefreq6c}, @{moverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6c}}} {{damage=[[[[@{movedmgdieamount6c}]]d[[@{movedmgdie6c}]]+[[@{attr_movedmgbonus6c}]]+[[@{movestab6c}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6c}]]]]}} {{effect=@{moveeffect6c}}}'></button>
                 <input type="text" name="attr_movename6c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6d" value='&{template:Attack} {{name=@{movename6d}}} {{subtags=@{movetype6d}, @{movefreq6d}, @{moverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6d}}} {{damage=[[[[@{movedmgdieamount6d}]]d[[@{movedmgdie6d}]]+[[@{movestab6d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6d}]]]]}} {{effect=@{moveeffect6d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6d" value='&{template:Attack} {{name=@{movename6d}}} {{subtags=@{movetype6d}, @{movefreq6d}, @{moverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6d}}} {{damage=[[[[@{movedmgdieamount6d}]]d[[@{movedmgdie6d}]]+[[@{attr_movedmgbonus6d}]]+[[@{movestab6d}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6d}]]]]}} {{effect=@{moveeffect6d}}}'></button>
                 <input type="text" name="attr_movename6d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6e" value='&{template:Attack} {{name=@{movename6e}}} {{subtags=@{movetype6e}, @{movefreq6e}, @{moverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6e}}} {{damage=[[[[@{movedmgdieamount6e}]]d[[@{movedmgdie6e}]]+[[@{movestab6e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6e}]]]]}} {{effect=@{moveeffect6e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Move6e" value='&{template:Attack} {{name=@{movename6e}}} {{subtags=@{movetype6e}, @{movefreq6e}, @{moverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6e}}} {{damage=[[[[@{movedmgdieamount6e}]]d[[@{movedmgdie6e}]]+[[@{attr_movedmgbonus6e}]]+[[@{movestab6e}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6e}]]]]}} {{effect=@{moveeffect6e}}}'></button>    
                 <input type="text" name="attr_movename6e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6f" value='&{template:Attack} {{name=@{movename6f}}} {{subtags=@{movetype6f}, @{movefreq6f}, @{moverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6f}}} {{damage=[[[[@{movedmgdieamount6f}]]d[[@{movedmgdie6f}]]+[[@{movestab6f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6f}]]]]}} {{effect=@{moveeffect6f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6f" value='&{template:Attack} {{name=@{movename6f}}} {{subtags=@{movetype6f}, @{movefreq6f}, @{moverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6f}}} {{damage=[[[[@{movedmgdieamount6f}]]d[[@{movedmgdie6f}]]+[[@{attr_movedmgbonus6f}]]+[[@{movestab6f}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6f}]]]]}} {{effect=@{moveeffect6f}}}'></button>
                 <input type="text" name="attr_movename6f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Move6g" value='&{template:Attack} {{name=@{movename6g}}} {{subtags=@{movetype6g}, @{movefreq6g}, @{moverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6g}}} {{damage=[[[[@{movedmgdieamount6g}]]d[[@{movedmgdie6g}]]+[[@{movestab6g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6g}]]]]}} {{effect=@{moveeffect6g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Move6g" value='&{template:Attack} {{name=@{movename6g}}} {{subtags=@{movetype6g}, @{movefreq6g}, @{moverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{moveac6g}}} {{damage=[[[[@{movedmgdieamount6g}]]d[[@{movedmgdie6g}]]+[[@{attr_movedmgbonus6g}]]+[[@{movestab6g}*floor(@{pokemon_level1}/5)]]+[[@{movedmgstat6g}]]]]}} {{effect=@{moveeffect6g}}}'></button>
                 <input type="text" name="attr_movename6g" class="sheet-med2"><br>
         </div>
         
@@ -3615,30 +3685,37 @@
             <select name="attr_movedmgstat6a" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6b" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6c" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6d" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6e" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6f" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_movedmgstat6g" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         
@@ -3694,19 +3771,19 @@
     <div class='sheet-9colrow'>
         <div class='sheet-col'>
             <h4>&nbsp; &nbsp; &nbsp; &nbsp; Name</h4><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6a" value='&{template:Attack} {{name=@{tmovename6a}}} {{subtags=@{tmovetype6a}, @{tmovefreq6a}, @{tmoverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6a}}} {{damage=[[[[@{tmovedmgdieamount6a}]]d[[@{tmovedmgdie6a}]]+[[@{tmovestab6a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6a}]]]]}} {{effect=@{tmoveeffect6a}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6a" value='&{template:Attack} {{name=@{tmovename6a}}} {{subtags=@{tmovetype6a}, @{tmovefreq6a}, @{tmoverange6a}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6a}}} {{damage=[[[[@{tmovedmgdieamount6a}]]d[[@{tmovedmgdie6a}]]+[[@{attr_tmovedmgbonus6a}]]+[[@{tmovestab6a}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6a}]]]]}} {{effect=@{tmoveeffect6a}}}'></button>
                 <input type="text" name="attr_tmovename6a" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6b" value='&{template:Attack} {{name=@{tmovename6b}}} {{subtags=@{tmovetype6b}, @{tmovefreq6b}, @{tmoverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6b}}} {{damage=[[[[@{tmovedmgdieamount6b}]]d[[@{tmovedmgdie6b}]]+[[@{tmovestab6b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6b}]]]]}} {{effect=@{tmoveeffect6b}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6b" value='&{template:Attack} {{name=@{tmovename6b}}} {{subtags=@{tmovetype6b}, @{tmovefreq6b}, @{tmoverange6b}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6b}}} {{damage=[[[[@{tmovedmgdieamount6b}]]d[[@{tmovedmgdie6b}]]+[[@{attr_tmovedmgbonus6b}]]+[[@{tmovestab6b}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6b}]]]]}} {{effect=@{tmoveeffect6b}}}'></button>
                 <input type="text" name="attr_tmovename6b" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6c" value='&{template:Attack} {{name=@{tmovename6c}}} {{subtags=@{tmovetype6c}, @{tmovefreq6c}, @{tmoverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6c}}} {{damage=[[[[@{tmovedmgdieamount6c}]]d[[@{tmovedmgdie6c}]]+[[@{tmovestab6c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6c}]]]]}} {{effect=@{tmoveeffect6c}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6c" value='&{template:Attack} {{name=@{tmovename6c}}} {{subtags=@{tmovetype6c}, @{tmovefreq6c}, @{tmoverange6c}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6c}}} {{damage=[[[[@{tmovedmgdieamount6c}]]d[[@{tmovedmgdie6c}]]+[[@{attr_tmovedmgbonus6c}]]+[[@{tmovestab6c}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6c}]]]]}} {{effect=@{tmoveeffect6c}}}'></button>
                 <input type="text" name="attr_tmovename6c" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6d" value='&{template:Attack} {{name=@{tmovename6d}}} {{subtags=@{tmovetype6d}, @{tmovefreq6d}, @{tmoverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6d}}} {{damage=[[[[@{tmovedmgdieamount6d}]]d[[@{tmovedmgdie6d}]]+[[@{tmovestab6d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6d}]]]]}} {{effect=@{tmoveeffect6d}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6d" value='&{template:Attack} {{name=@{tmovename6d}}} {{subtags=@{tmovetype6d}, @{tmovefreq6d}, @{tmoverange6d}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6d}}} {{damage=[[[[@{tmovedmgdieamount6d}]]d[[@{tmovedmgdie6d}]]+[[@{attr_tmovedmgbonus6d}]]+[[@{tmovestab6d}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6d}]]]]}} {{effect=@{tmoveeffect6d}}}'></button>
                 <input type="text" name="attr_tmovename6d" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6e" value='&{template:Attack} {{name=@{tmovename6e}}} {{subtags=@{tmovetype6e}, @{tmovefreq6e}, @{tmoverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6e}}} {{damage=[[[[@{tmovedmgdieamount6e}]]d[[@{tmovedmgdie6e}]]+[[@{tmovestab6e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6e}]]]]}} {{effect=@{tmoveeffect6e}}}'></button>    
+            <button type="roll" class="sheet-violence" name="roll_Tmove6e" value='&{template:Attack} {{name=@{tmovename6e}}} {{subtags=@{tmovetype6e}, @{tmovefreq6e}, @{tmoverange6e}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6e}}} {{damage=[[[[@{tmovedmgdieamount6e}]]d[[@{tmovedmgdie6e}]]+[[@{attr_tmovedmgbonus6e}]]+[[@{tmovestab6e}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6e}]]]]}} {{effect=@{tmoveeffect6e}}}'></button>    
                 <input type="text" name="attr_tmovename6e" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6f" value='&{template:Attack} {{name=@{tmovename6f}}} {{subtags=@{tmovetype6f}, @{tmovefreq6f}, @{tmoverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6f}}} {{damage=[[[[@{tmovedmgdieamount6f}]]d[[@{tmovedmgdie6f}]]+[[@{tmovestab6f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6f}]]]]}} {{effect=@{tmoveeffect6f}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6f" value='&{template:Attack} {{name=@{tmovename6f}}} {{subtags=@{tmovetype6f}, @{tmovefreq6f}, @{tmoverange6f}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6f}}} {{damage=[[[[@{tmovedmgdieamount6f}]]d[[@{tmovedmgdie6f}]]+[[@{attr_tmovedmgbonus6f}]]+[[@{tmovestab6f}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6f}]]]]}} {{effect=@{tmoveeffect6f}}}'></button>
                 <input type="text" name="attr_tmovename6f" class="sheet-med2"><br>
-            <button type="roll" class="sheet-violence" name="roll_Tmove6g" value='&{template:Attack} {{name=@{tmovename6g}}} {{subtags=@{tmovetype6g}, @{tmovefreq6g}, @{tmoverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6g}}} {{damage=[[[[@{tmovedmgdieamount6g}]]d[[@{tmovedmgdie6g}]]+[[@{tmovestab6g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6g}]]]]}} {{effect=@{tmoveeffect6g}}}'></button>
+            <button type="roll" class="sheet-violence" name="roll_Tmove6g" value='&{template:Attack} {{name=@{tmovename6g}}} {{subtags=@{tmovetype6g}, @{tmovefreq6g}, @{tmoverange6g}}} {{attack=[[1d20+?{Misc. Attack Bonus}]]}} {{AC=@{tmoveac6g}}} {{damage=[[[[@{tmovedmgdieamount6g}]]d[[@{tmovedmgdie6g}]]+[[@{attr_tmovedmgbonus6g}]]+[[@{tmovestab6g}*floor(@{pokemon_level1}/5)]]+[[@{tmovedmgstat6g}]]]]}} {{effect=@{tmoveeffect6g}}}'></button>
                 <input type="text" name="attr_tmovename6g" class="sheet-med2"><br>
         </div>
         
@@ -3839,30 +3916,37 @@
             <select name="attr_tmovedmgstat6a" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6b" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6c" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6d" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6e" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6f" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
             <select name="attr_tmovedmgstat6g" class="sheet-short2">                
                 <option value="(@{pokemon_atk6a}+@{pokemon_atk6b})">ATK</option>
                 <option value="(@{pokemon_satk6a}+@{pokemon_satk6b})">SATK</option>
+                <option value="0">N/A</option>
             </select><br>
         </div>
         


### PR DESCRIPTION
Minor bug fixes & changes:
 - Changed the name of "attr_pokemon_HPXmax" to "attr_pokemon_HPX_max" for consistency
 - Changed the name of "attr_Pokemon_HPX" to "attr_pokemon_HPX" for consistency
 - Corrected a bug where nature-related stat where not kept inbetween sheet openings
 - Corrected the roll for damage to include the specificated damage bonus (movedmgbonusXX)
 - Added the "N/A" option in the damage move stat, for non-damaging moves