### PR TITLE
[Mutant Year Zero] Sheet Rolls, character race added

### DIFF
--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.css
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.css
@@ -10,6 +10,10 @@ div.sheet-tab-content {
    margin-top:2px;
 }
 
+input.sheet-textinput-skills.sheet-skill-input {
+    width:200px;
+}
+
 input.sheet-tab-character-sheet:checked ~ div.sheet-tab-character-sheet,
 input.sheet-tab-ark-sheet:checked ~ div.sheet-tab-ark-sheet,
 {                                 
@@ -322,6 +326,10 @@ Character Sheet
 
 .sheet-relationships {
    width: 620px;
+}
+
+.sheet-right-roll {
+    float:right;
 }
 
 /* ------

--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
@@ -1,3 +1,8 @@
+
+            <input type="radio" class="sheet-character-type sheet-character-type-mutant" name ="attr_CharacterType" text="Mutant" style="visibility:hidden;" value="Mutant" checked="true"/>    
+            <input type="radio" class="sheet-character-type sheet-character-type-animal" name ="attr_CharacterType" text="Animal" style="visibility:hidden;" value="Animal" />         
+            <input type="radio" class="sheet-character-type sheet-character-type-robot"  name ="attr_CharacterType" text="Robot"  style="visibility:hidden;" value="Robot" />          
+            <input type="radio" class="sheet-character-type sheet-character-type-human"  name ="attr_CharacterType" text="Human"  style="visibility:hidden;" value="Human" />   
        <form>
             <input checked="checked" class="sheet-tab sheet-tab-character-sheet sheet-player-sheet" name="attr_pcgm" style="float:left;" title="Character Sheet" type="radio" value="1"> 
             <input class="sheet-tab sheet-tab-ark-sheet sheet-player-sheet" name="attr_pcgm" style="float:left;" title="Ark Sheet" type="radio" value="2"> 
@@ -6,7 +11,32 @@
             <img alt="MUTANT YEAR ZERO" src="http://i.imgur.com/juUlixw.jpg">
         </div>
         <div class="sheet-character-wrapper sheet-tab-content sheet-tab-character-sheet">
-            <div class="sheet-meta1">
+            
+    		<input type="hidden" name="attr_endure_name"        value="Endure (Strength)"       />
+    		<input type="hidden" name="attr_force_name"         value="Force (Strength)"        />
+    		<input type="hidden" name="attr_fight_name"         value="Fight (Strength)"        />
+    		<input type="hidden" name="attr_sneak_name"         value="Sneak (Agility)"         />
+    		<input type="hidden" name="attr_move_name"          value="Move (Agility)"          />
+    		<input type="hidden" name="attr_shoot_name"         value="Shoot (Agility)"         />
+    		<input type="hidden" name="attr_scout_name"         value="Scout (Wits)"            />
+    		<input type="hidden" name="attr_comprehend_name"    value="Comprehend (Wits)"       />
+    		<input type="hidden" name="attr_know_the_zone_name" value="Know the Zone (Wits)"    />
+    		<input type="hidden" name="attr_sense_emotion_name" value="Sense Emotion (Empathy)" />
+    		<input type="hidden" name="attr_manipulate_name"    value="Manipulate (Empathy)"    />
+    		<input type="hidden" name="attr_heal_name"          value="Heal (Empathy)"          />
+		
+		
+             Character Type:
+            <input type="radio" class="sheet-character-type sheet-character-type-mutant" name ="attr_RaceType" text="Mutant"  value="Mutant" checked="true"/>    
+            <span>Mutant</span>
+            <input type="radio" class="sheet-character-type sheet-character-type-animal" name ="attr_RaceType" text="Animal"  value="Animal" />                  
+            <span>Animal</span>
+            <input type="radio" class="sheet-character-type sheet-character-type-robot"  name ="attr_RaceType" text="Robot"   value="Robot" />                  
+            <span>Robot</span>
+            <input type="radio" class="sheet-character-type sheet-character-type-human"  name ="attr_RaceType" text="Human"   value="Human" />                  
+            <span>Human</span>
+            
+            <div class="sheet-meta1" name="attr_RaceType">
                 <div class="sheet-singlecell-bottompadding">
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
@@ -16,58 +46,64 @@
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-table-noright sheet-text-stats">
-                                Strength
+                                <span name="attr_strength_name">Strength</span>
+                                
                             </td>
-                            <td align="center" class="sheet-table-noleft" width="42">
+                            <td align="center" class="sheet-table-noleft" width="86">
+							    <input class="sheet-value sheet-value-singledigit" name="attr_damage" type="number" value='0'> /
                                 <input class="sheet-value sheet-value-singledigit" name="attr_strength" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
-                                Damage
+                                <span name="attr_damage_name">Damage</span>
                             </td>
-                            <td align="center" class="sheet-table-noleft" width="86">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_damage" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_damage_max" type="number" value='0' readonly />
+                            <td align="center" class="sheet-table-noleft" width="42">
+                               <input class="sheet-value sheet-value-singledigit" name="attr_damage_total" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-table-noright sheet-text-stats">
-                                Agility
+                                <span name="attr_agility_name">Agility</span>
                             </td>
                             <td align="center" class="sheet-table-noleft">
+								<input class="sheet-value sheet-value-singledigit" name="attr_fatigue" type="number" value='0'> / 
                                 <input class="sheet-value sheet-value-singledigit" name="attr_agility" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
-                                Fatigue
+                                <span name="attr_fatigue_name">Fatigue</span>
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_fatigue" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_fatigue_max" type="number" value='0' readonly />
+                                
+								<input class="sheet-value sheet-value-singledigit" name="attr_fatigue_total" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-table-noright sheet-text-stats">
-                                Wits
+                                <span name="attr_wits_name">Wits</span>
                             </td>
                             <td align="center" class="sheet-table-noleft">
+								<input class="sheet-value sheet-value-singledigit" name="attr_confusion" type="number" value='0'> / 
                                 <input class="sheet-value sheet-value-singledigit" name="attr_wits" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
-                                Confusion
+                                <span name="attr_confusion_name">Confusion</span>
                             </td>
                             <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_confusion" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_confusion_max" type="number" value='0' readonly />
+                                
+								<input class="sheet-value sheet-value-singledigit" name="attr_confusion_total" type="number" value='0' readonly />
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-table-noright sheet-text-stats">
-                                Empathy
+                                <span name="attr_empathy_name">Empathy</span>
                             </td>
                             <td align="center" class="sheet-table-noleft">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_doubt" type="number" value='0'> /
                                 <input class="sheet-value sheet-value-singledigit" name="attr_empathy" type="number" value='0'>
                             </td>
                             <td class="sheet-table-noright sheet-text-stats">
-                                Doubt
+                                <span name="attr_doubt_name">Doubt</span>
                             </td>
-                            <td align="center" class="sheet-table-noleft">
-                                <input class="sheet-value sheet-value-singledigit" name="attr_doubt" type="number" value='0'> / <input class="sheet-value sheet-value-singledigit" name="attr_doubt_max" type="number" value='0' readonly />
+                            <td align="center" class="sheet-table-noleft"> <input class="sheet-value sheet-value-singledigit" name="attr_doubt_total" type="number" value='0' readonly />
                             </td>
                         </tr>
                     </table>
@@ -132,111 +168,163 @@
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
                             <td class="sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/GQdwWwj.jpg')">
-                                SKILLS
+                                <span name="attr_skill_name">Skills</span>
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Endure (Strength)
+                                <span name="attr_endure_name">Endure (Strength)</span>
                             </td>
                             <td align="center" width="42px">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_endure" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{endure_name}}} {{Base Dice = [[[[@{damage}]]d6>6]]}} {{Skill Dice = [[[[@{endure}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_endure'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Force (Strength)
+                                <span name="attr_force_name">Force (Strength)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_force" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{force_name}}} {{Base Dice = [[[[@{damage}]]d6>6]]}} {{Skill Dice = [[[[@{force}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_force'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Fight (Strength)
+                                <span name="attr_fight_name">Fight (Strength)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_fight" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{fight_name}}} {{Base Dice = [[[[@{damage}]]d6>6]]}} {{Skill Dice = [[[[@{fight}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_fight'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Sneak (Agility)
+                                <span name="attr_sneak_name">Sneak (Agility)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_sneak" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{sneak_name}}} {{Base Dice = [[[[@{fatigue}]]d6>6]]}} {{Skill Dice = [[[[@{sneak}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_sneak'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Move (Agility)
+                                <span name="attr_move_name">Move (Agility)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_move" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{move_name}}} {{Base Dice = [[[[@{fatigue}]]d6>6]]}} {{Skill Dice = [[[[@{move}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_move'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Shoot (Agility)
+                                <span name="attr_shoot_name">Shoot (Agility)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_shoot" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{shoot_name}}} {{Base Dice = [[[[@{fatigue}]]d6>6]]}} {{Skill Dice = [[[[@{shoot}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_shoot'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Scout (Wits)
+                                <span name="attr_scout_name">Scout (Wits)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_scout" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{scout_name}}} {{Base Dice = [[[[@{confusion}]]d6>6]]}} {{Skill Dice = [[[[@{scout}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_scout'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Comprehend (Wits)
+                                <span name="attr_comprehend_name">Comprehend (Wits)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_comprehend" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{comprehend_name}}} {{Base Dice = [[[[@{confusion}]]d6>6]]}} {{Skill Dice = [[[[@{comprehend}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_comprehend'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Know the Zone (Wits)
+                                <span name="attr_know_the_zone_name">Know the Zone (Wits)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_knowthezone" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{know_the_zone_name}}} {{Base Dice = [[[[@{confusion}}]]d6>6]]}}  {{Skill Dice = [[[[@{knowthezone}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_knowthezone'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Sense Emotion (Empathy)
+                                <span name="attr_sense_emotion_name">Sense Emotion (Empathy)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_senseemotion" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{sense_emotion_name}}} {{Base Dice = [[[[@{doubt}}]]d6>6]]}} {{Skill Dice = [[[[@{senseemotion}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_emotion'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Manipulate (Empathy)
+                                <span name="attr_manipulate_name">Manipulate (Empathy)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_manipulate" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{manipulate_name}}} {{Base Dice = [[[[@{doubt}}]]d6>6]]}} {{Skill Dice = [[[[@{manipulate}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_manipulate'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td class="sheet-text-stats">
-                                Heal (Empathy)
+                                <span name="attr_heal_name">Heal (Empathy)</span>
                             </td>
                             <td align="center">
                                 <input class="sheet-value sheet-value-singledigit" name="attr_heal" type="number">
                             </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name=@{heal_name}}} {{Base Dice = [[[[@{doubt}}]]d6>6]]}} {{Skill Dice = [[[[@{heal}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_heal'></button>
+                            </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-table-notop">
-                                <input class="sheet-textinput-skills" name="attr_custom-skill-name" type="text">
+                                <input class="sheet-textinput-skills sheet-skill-input" name="attr_custom-skill-name" type="text">
                             </td>
                             <td align="center" class="sheet-row-light sheet-table-notop">
                                 <input class="sheet-value-brighter sheet-value-singledigit" name="attr_custom-skill-value" type="number">
+                            </td>
+                            <td align="center">
+                                <button type='roll' value='&{template:default} {{name= @{custom-skill-name}}} {{Base Dice = [[?{Base Dice|0}d6>6]]}} {{Skill Dice = [[[[@{custom-skill-value}+0]]d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                name='roll_custom'></button>
                             </td>
                         </tr>
                     </table>
@@ -244,14 +332,91 @@
                         <table class="sheet-table-onecolumn sheet-table-notop">
                             <tr class="sheet-row-light sheet-table-notop">
                                 <td class="sheet-table-notop">
-                                    <input class="sheet-textinput-skills" name="attr_skill-name-repeating" type="text">
+                                    <input class="sheet-textinput-skills sheet-skill-input" name="attr_skill-name-repeating" type="text">
                                 </td>
                                 <td align="center" class="sheet-table-notop" width="42px">
                                     <input class="sheet-value-brighter sheet-value-singledigit" name="attr_skill-value-repeating" type="number">
                                 </td>
+                                <td align="center">
+                                    <button type='roll' value='&{template:default} {{name= @{skill-name-repeating}}} {{Base Dice = [[?{Base Dice|0}d6>6]]}} {{Skill Dice = [[?{Skill Dice|0}d6>6]]}} {{Gear Dice = [[?{Gear Dice|0}d6>6]]}}'
+                                    name='roll_custom_rep'></button>
+                                </td>
                             </tr>
                         </table>
                     </fieldset>
+                    <br/>
+                    <table class="sheet-table-onecolumn">
+                        <tr class="sheet-text-header">
+                            <td class="sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/NHDGp0U.jpg')">
+                                ADVANCED ROLL
+                            </td>
+                        </tr>
+                        <tr class="sheet-row-dark">
+                            <td class="sheet-table-noright sheet-text-stats">
+                                <span name="attr_strength_name">Base</span>
+                                
+                            </td>
+                            <td align="center" class="" width="42">
+							    <span class="sheet-text-header-smaller">Total</span>
+                            </td>
+                            <td align="center" class="" width="42">
+                                <span class="sheet-text-header-smaller">Successes</span>
+                            </td>
+                            <td align="center" class="" width="42">
+                                <span class="sheet-text-header-smaller">Fails</span>
+                            </td>
+                        </tr>
+                        <tr class="sheet-row-dark">
+                            <td class="sheet-table-noright sheet-text-stats">
+                                <span name="attr_strength_name">Base</span>
+                                
+                            </td>
+                            <td align="center" class="" width="42">
+							    <input class="sheet-value sheet-value-singledigit" name="attr_advroll_base_start" type="number" value='0'> 
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_base_success" type="number" value='0'>
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_base_fail" type="number" value='0'>
+                            </td>
+                        </tr>
+                        <tr class="sheet-row-dark">
+                            <td class="sheet-table-noright sheet-text-stats">
+                                <span name="attr_agility_name">Skill</span>
+                            </td>
+                            <td align="center" class="" width="42">
+							    <input class="sheet-value sheet-value-singledigit" name="attr_advroll_skill_start" type="number" value='0'> 
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_skill_success" type="number" value='0'>
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_skill_fail" type="number" value='0'>
+                            </td>
+                        </tr>
+                        <tr class="sheet-row-dark">
+                            <td class="sheet-table-noright sheet-text-stats">
+                                <span name="attr_wits_name">Gear</span>
+                            </td>
+                            <td align="center" class="" width="42">
+							    <input class="sheet-value sheet-value-singledigit" name="attr_advroll_gear_start" type="number" value='0'> 
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_gear_success" type="number" value='0'>
+                            </td>
+                            <td align="center" class="" width="42">
+                                <input class="sheet-value sheet-value-singledigit" name="attr_advroll_gear_fail" type="number" value='0'>
+                            </td>
+                        </tr>
+                        <tr class="sheet-row-dark">
+                            <td class="sheet-table-noright sheet-text-stats" colspan="4">
+                                <button type="roll"  name='roll_fight' class="sheet-right-roll"
+                                        value='&{template:default} {{name=Custom Roll}}  {{ Base Dice= [[[[@{advroll_base_success}+0]]d1cs1cf2>0+ [[@{advroll_base_fail}+0]]d1cs2cf1>6+ [[@{advroll_base_start}-@{advroll_base_success}-@{advroll_base_fail}+0]]d6>6]]}}  {{ Skill Dice= [[[[@{advroll_skill_success}+0]]d1cs1cf2>0+ [[@{advroll_skill_fail}+0]]d1cs2cf1>6+ [[@{advroll_skill_start}-@{advroll_skill_success}-@{advroll_skill_fail}+0]]d6>6]]}} {{ Gear Dice= [[[[@{advroll_gear_success}+0]]d1cs1cf2>0+ [[@{advroll_gear_fail}+0]]d1cs2cf1>6+ [[@{advroll_gear_start}-@{advroll_gear_success}-@{advroll_gear_fail}+0]]d6>6]]}}'
+                                ></button>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
                 <div class="sheet-singlecell-bottompadding">
                     <table class="sheet-table-onecolumn">
@@ -262,16 +427,16 @@
                         </tr>
                         <tr class="sheet-row-dark">
                             <td align="center" colspan="2">
-                                <input checked name="attr_rot" type="radio" value="0"> 
-								<input name="attr_rot" type="radio" value="1"> 
-								<input name="attr_rot" type="radio" value="2"> 
-								<input name="attr_rot" type="radio" value="3"> 
-								<input name="attr_rot" type="radio" value="4"> 
-								<input name="attr_rot" type="radio" value="5"> 
-								<input name="attr_rot" type="radio" value="6"> 
-								<input name="attr_rot" type="radio" value="7"> 
-								<input name="attr_rot" type="radio" value="8"> 
-								<input name="attr_rot" type="radio" value="9">
+                                <input checked name="attr_rot" type="radio" value="0" title="0"> 
+								<input name="attr_rot" type="radio" value="1" title="1"> 
+								<input name="attr_rot" type="radio" value="2" title="2"> 
+								<input name="attr_rot" type="radio" value="3" title="3"> 
+								<input name="attr_rot" type="radio" value="4" title="4"> 
+								<input name="attr_rot" type="radio" value="5" title="5"> 
+								<input name="attr_rot" type="radio" value="6" title="6"> 
+								<input name="attr_rot" type="radio" value="7" title="7"> 
+								<input name="attr_rot" type="radio" value="8" title="8"> 
+								<input name="attr_rot" type="radio" value="9" title="9">
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
@@ -293,16 +458,16 @@
                         </tr>
                         <tr class="sheet-row-dark">
                             <td align="center">
-                                <input checked name="attr_exp" type="radio" value="0"> 
-								<input name="attr_exp" type="radio" value="1"> 
-								<input name="attr_exp" type="radio" value="2"> 
-								<input name="attr_exp" type="radio" value="3"> 
-								<input name="attr_exp" type="radio" value="4"> 
-								<input name="attr_exp" type="radio" value="5"> 
-								<input name="attr_exp" type="radio" value="6"> 
-								<input name="attr_exp" type="radio" value="7"> 
-								<input name="attr_exp" type="radio" value="8"> 
-								<input name="attr_exp" type="radio" value="9">
+                                <input checked name="attr_exp" type="radio" value="0" title="0"> 
+								<input name="attr_exp" type="radio" value="1" title="1"> 
+								<input name="attr_exp" type="radio" value="2" title="2"> 
+								<input name="attr_exp" type="radio" value="3" title="3"> 
+								<input name="attr_exp" type="radio" value="4" title="4"> 
+								<input name="attr_exp" type="radio" value="5" title="5"> 
+								<input name="attr_exp" type="radio" value="6" title="6"> 
+								<input name="attr_exp" type="radio" value="7" title="7"> 
+								<input name="attr_exp" type="radio" value="8" title="8"> 
+								<input name="attr_exp" type="radio" value="9" title="9">
                             </td>
                         </tr>
                     </table>
@@ -324,6 +489,15 @@
                             <input class="sheet-textinput-role" name="attr_character-role" type="text">
                         </td>
                     </tr>
+                    <tr class="sheet-row-light">
+                        <td class="sheet-table-noright sheet-text-stats">
+                            <span name="attr_rank_name">Rank:</span>
+                        </td>
+                        <td class="sheet-table-noleftright" colspan="3">
+                            <input class="sheet-value sheet-value-singledigit" name="attr_character_rank" type="number">
+                        </td>
+                        
+                    </tr>
                 </table>
             </div>
             <div class="sheet-meta2">
@@ -331,26 +505,29 @@
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
                             <td class=" sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/69HoHMG.jpg')">
-                                APPEARANCE
+                                
+                            <span name="attr_appearance_name">APPEARANCE</span>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
-                                Face: 
+                                <span name="attr_face_name">Face</span>: 
                                 <textarea class="sheet-text-apperance" rows='2' name="attr_face">
                                 </textarea>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
-                                Body: 
+                                
+                                <span name="attr_body_name">Body</span>: 
                                 <textarea class="sheet-text-apperance" rows='2' name="attr_body">
                                 </textarea>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label">
-                                Clothing: 
+                                
+                                <span name="attr_clothing_name">Clothing</span>: 
                                 <textarea class="sheet-text-apperance" rows='2' name="attr_clothing">
                                 </textarea>
                             </td>
@@ -396,7 +573,8 @@
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
                             <td class="sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/Bbmh252.jpg')">
-                                TALENTS
+                                
+                                <span name="attr_talent_name">TALENTS</span>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
@@ -433,7 +611,8 @@
                     <table class="sheet-table-onecolumn sheet-table-notop">
                         <tr class="sheet-text-header sheet-table-notop">
                             <td class="sheet-text-header sheet-table-notop" colspan="4" style="background-image: url('http://i.imgur.com/l2BGBAz.jpg')">
-                                MUTATIONS
+                                
+                                <span name="attr_mutation_name">MUTATIONS</span>
                             </td>
                         </tr>
                         <tr class="sheet-row-light">
@@ -470,21 +649,22 @@
                     <table class="sheet-table-onecolumn">
                         <tr class="sheet-text-header">
                             <td class="sheet-text-header" colspan="4" style="background-image: url('http://i.imgur.com/g9dm9HR.jpg')">
-                                MUTATION POINTS
+                                
+                                <span name="attr_mutation_points_name">MUTATION POINTS</span>
                             </td>
                         </tr>
                         <tr class="sheet-row-dark">
                             <td align="center">
-                                <input checked name="attr_mutation" type="radio" value="0"> 
-								<input name="attr_mutation" type="radio" value="1"> 
-								<input name="attr_mutation" type="radio" value="2"> 
-								<input name="attr_mutation" type="radio" value="3"> 
-								<input name="attr_mutation" type="radio" value="4"> 
-								<input name="attr_mutation" type="radio" value="5"> 
-								<input name="attr_mutation" type="radio" value="6"> 
-								<input name="attr_mutation" type="radio" value="7"> 
-								<input name="attr_mutation" type="radio" value="8"> 
-								<input name="attr_mutation" type="radio" value="9">
+                                <input checked name="attr_mutation" type="radio" value="0" title="0"> 
+								<input name="attr_mutation" type="radio" value="1" title="1"> 
+								<input name="attr_mutation" type="radio" value="2" title="2"> 
+								<input name="attr_mutation" type="radio" value="3" title="3"> 
+								<input name="attr_mutation" type="radio" value="4" title="4"> 
+								<input name="attr_mutation" type="radio" value="5" title="5"> 
+								<input name="attr_mutation" type="radio" value="6" title="6"> 
+								<input name="attr_mutation" type="radio" value="7" title="7"> 
+								<input name="attr_mutation" type="radio" value="8" title="8"> 
+								<input name="attr_mutation" type="radio" value="9" title="9">
                             </td>
                         </tr>
                     </table>
@@ -990,6 +1170,183 @@
         </div>
 
         <script type="text/worker">
+            //object reference for Race specific attribute names
+            
+            //Upate sheet labels when RaceType attribute changes
+            on("change:RaceType", function(eventInfo) {
+                
+                var character_types = {
+                    "Mutant":{strength_name:"Strength",
+                    		agility_name: "Agility",
+                    		wits_name: "Wits",
+                    		empathy_name:"Empathy",
+                    		damage_name: "Damage",
+                    		fatigue_name: "Fatigue",
+                    		confusion_name: "Confusion",
+                    		doubt_name: "Doubt",
+                    		appearance_name: "Appearance",
+                    		face_name: "Face",
+                    		body_name: "Body",
+                    		clothing_name: "Clothing",
+                    		skill_name: "Skills",
+                    		mutation_name: "Mutations",
+                    		talent_name: "Talents",
+                    		mutation_points_name: "Mutation Points",
+                    		role_name:"Role",
+                    		rank_name: "Rank",
+                    		endure_name: "Endure (Strength)",
+                    		force_name: "Force (Strength)",
+                    		fight_name: "Fight (Strength)",
+                    		sneak_name: "Sneak (Agility)",
+                    		move_name: "Move (Agility)",
+                    		shoot_name: "Shoot (Agility)",
+                    		scout_name: "Scout (Wits)",
+                    		comprehend_name: "Comprehend (Wits)",
+                    		know_the_zone_name: "Know the Zone (Wits)",
+                    		sense_emotion_name:"Sense Emotion (Empathy)",
+                    		manipulate_name:"Manipulate (Empathy)",
+                    		heal_name:"Heal (Empathy)" },
+                    		
+                    "Animal":{strength_name:"Strength",
+                    		agility_name: "Agility",
+                    		wits_name: "Wits",
+                    		empathy_name:"Instinct",
+                    		damage_name: "Damage",
+                    		fatigue_name: "Fatigue",
+                    		confusion_name: "Confusion",
+                    		doubt_name: "Doubt",
+                    		appearance_name: "Appearance",
+                    		face_name: "Face",
+                    		body_name: "Body",
+                    		clothing_name: "Clothing",
+                    		skill_name: "Skills",
+                    		mutation_name: "Animal Powers",
+                    		talent_name: "Talents",
+                    		mutation_points_name: "Feral Points",
+                    		role_name:"Role",
+                    		rank_name: "Rank",
+                    		endure_name: "Endure (Strength)",
+                    		force_name: "Force (Strength)",
+                    		fight_name: "Fight (Strength)",
+                    		sneak_name: "Sneak (Agility)",
+                    		move_name: "Move (Agility)",
+                    		shoot_name: "Shoot (Agility)",
+                    		scout_name: "Scout (Wits)",
+                    		comprehend_name: "Comprehend (Wits)",
+                    		know_the_zone_name: "Know Nature (Wits)",
+                    		sense_emotion_name:"Sense Emotion (Instinct)",
+                    		manipulate_name:"Dominate (Instinct)",
+                    		heal_name:"Heal (Instinct)" },
+                     
+                    "Robot":{strength_name:"Servos",
+                    		agility_name: "Stability",
+                    		wits_name: "Processor",
+                    		empathy_name:"Network",
+                    		damage_name: "Damage",
+                    		fatigue_name: "Damage",
+                    		confusion_name: "Damage",
+                    		doubt_name: "Damage",
+                    		appearance_name: "Chassis Parts",
+                    		face_name: "Head",
+                    		body_name: "Torso",
+                    		clothing_name: "Undercarriage",
+                    		skill_name: "Programs",
+                    		mutation_name: "Modules",
+                    		talent_name: "Secondary Functions",
+                    		mutation_points_name: "Energy Points",
+                    		role_name:"Model",
+                    		rank_name: "Heirarchy",
+                    		endure_name: "Overload (Servos)",
+                    		force_name: "Force (Servos)",
+                    		fight_name: "Assault (Servos)",
+                    		sneak_name: "Infiltrate (Stability)",
+                    		move_name: "Move (Stability)",
+                    		shoot_name: "Shoot (Stability)",
+                    		scout_name: "Scan (Processor)",
+                    		comprehend_name: "Datamine (Processor)",
+                    		know_the_zone_name: "Analyze (Processor)",
+                    		sense_emotion_name:"Question (Network)",
+                    		manipulate_name:"Interact (Network)",
+                    		heal_name:"Repair (Network)" },
+                      
+                    "Human":{strength_name:"Strength",
+                    		agility_name: "Agility",
+                    		wits_name: "Wits",
+                    		empathy_name:"Empathy",
+                    		damage_name: "Damage",
+                    		fatigue_name: "Fatigue",
+                    		confusion_name: "Confusion",
+                    		doubt_name: "Doubt",
+                    		appearance_name: "Appearance",
+                    		face_name: "Face",
+                    		body_name: "Body",
+                    		clothing_name: "Clothing",
+                    		skill_name: "Skills",
+                    		mutation_name: "Abilities",
+                    		talent_name: "Talents",
+                    		mutation_points_name: "Power Points",
+                    		role_name:"Role",
+                    		rank_name: "Rank",
+                    		endure_name: "Endure (Strength)",
+                    		force_name: "Force (Strength)",
+                    		fight_name: "Fight (Strength)",
+                    		sneak_name: "Sneak (Agility)",
+                    		move_name: "Move (Agility)",
+                    		shoot_name: "Shoot (Agility)",
+                    		scout_name: "Scout (Wits)",
+                    		comprehend_name: "Comprehend (Wits)",
+                    		know_the_zone_name: "Know the Zone (Wits)",
+                    		sense_emotion_name:"Sense Emotion (Empathy)",
+                    		manipulate_name:"Manipulate (Empathy)",
+                    		heal_name:"Heal (Empathy)" },
+                };   
+                
+                getAttrs(["RaceType"], function(values) {
+                    
+					
+					
+        		    var race_att_names;
+                    if (_.has(character_types, values.RaceType) ) {
+                        race_att_names = character_types[values.RaceType];
+                        
+            		} 
+            		else {
+                        race_att_names = character_types["Mutant"];
+            		}
+			        setAttrs({strength_name: race_att_names.strength_name});
+			        setAttrs({agility_name: race_att_names.agility_name});
+			        setAttrs({wits_name: race_att_names.wits_name});
+			        setAttrs({empathy_name: race_att_names.empathy_name});
+			        
+			        
+		        	setAttrs({damage_name: race_att_names.damage_name});
+            		setAttrs({fatigue_name: race_att_names.fatigue_name});
+            		setAttrs({confusion_name: race_att_names.confusion_name});
+            		setAttrs({doubt_name: race_att_names.doubt_name});
+            		setAttrs({appearance_name: race_att_names.appearance_name});
+            		setAttrs({face_name: race_att_names.face_name});
+            		setAttrs({body_name: race_att_names.body_name});
+            		setAttrs({clothing_name: race_att_names.clothing_name});
+            		setAttrs({skill_name: race_att_names.skill_name});
+            		setAttrs({mutation_name: race_att_names.mutation_name});
+            		setAttrs({talent_name: race_att_names.talent_name});
+            		setAttrs({mutation_points_name: race_att_names.mutation_points_name});
+            		setAttrs({role_name: race_att_names.role_name});
+            		setAttrs({rank_name: race_att_names.rank_name});
+            		setAttrs({endure_name: race_att_names.endure_name});
+            		setAttrs({force_name: race_att_names.force_name});
+            		setAttrs({fight_name: race_att_names.fight_name});
+            		setAttrs({sneak_name: race_att_names.sneak_name});
+            		setAttrs({move_name: race_att_names.move_name});
+            		setAttrs({shoot_name: race_att_names.shoot_name});
+            		setAttrs({scout_name: race_att_names.scout_name});
+            		setAttrs({comprehend_name: race_att_names.comprehend_name});
+            		setAttrs({know_the_zone_name: race_att_names.know_the_zone_name});
+            		setAttrs({sense_emotion_name: race_att_names.sense_emotion_name});
+            		setAttrs({manipulate_name: race_att_names.manipulate_name});
+            		setAttrs({heal_name: race_att_names.heal_name});
+            	});
+            });
             //object reference matching core attribute with the associated trauma type
             var trauma = {
                 strength:"damage_max", 
@@ -997,21 +1354,55 @@
                 wits:"confusion_max", 
                 empathy:"doubt_max"
             };   
+            var trauma_calc = {
+                strength:{ stat_name: "strength", harm_value: "damage", harm_total: "damage_total" },
+                agility: { stat_name: "agility", harm_value: "fatigue", harm_total: "fatigue_total" },
+                wits:    { stat_name: "wits", harm_value: "confusion", harm_total: "confusion_total" },
+                empathy: { stat_name: "empathy", harm_value: "doubt", harm_total: "doubt_total" },
+                damage: { stat_name: "strength", harm_value: "damage", harm_total: "damage_total" },
+                fatigue: { stat_name: "agility", harm_value: "fatigue", harm_total: "fatigue_total" },
+                confusion: { stat_name: "wits", harm_value: "confusion", harm_total: "confusion_total" },
+                doubt: { stat_name: "empathy", harm_value: "doubt", harm_total: "doubt_total" }
+                
+            }
 
-            //Change max trauma when core attribute changes
-            on("change:strength change:agility change:wits change:empathy", function(eventInfo) {
-                var x = eventInfo.sourceAttribute;
-                getAttrs([x],function(values){
-                    var targetAttr = trauma[x];
-
-                    var attrHash = attrHash || {};  
-                    attrHash[targetAttr] = values[x];
-                    setAttrs(attrHash);
+            //Update current damage total when strength or damage changes
+            on("change:strength change:damage ", function(eventInfo) {
+                getAttrs(["strength", "damage"],function(values){
+                    setAttrs({
+                      damage_total: values["strength"] - values["damage"]
+                    });
                 });
-            });
+            })
+            //Update current fatigue total when agility or fatigue changes
+            on("change:agility change:fatigue ", function(eventInfo) {
+                getAttrs(["agility", "fatigue"],function(values){
+                    setAttrs({
+                      fatigue_total: values["agility"] - values["fatigue"]
+                    });
+                });
+            })
+            //Update current confusion total when wits or confusion changes
+            on("change:wits change:confusion ", function(eventInfo) {
+                getAttrs(["wits", "confusion"],function(values){
+                    setAttrs({
+                      confusion_total: values["wits"] - values["confusion"]
+                    });
+                });
+            })
+            //Update current doubt total when empathy or doubt changes
+            on("change:empathy change:doubt ", function(eventInfo) {
+                getAttrs(["empathy", "doubt"],function(values){
+                    setAttrs({
+                      doubt_total: values["empathy"] - values["doubt"]
+                    });
+                });
+            })
+
+
 
             //Ensure max trauma = core attribute when sheet is loaded
-            on("sheet:opened", function() {
+            on("sheet:opened", function() {			
                 //create array of attributes from trauma reference var
                 var fetchAttrs = _.keys(trauma).concat(_.values(trauma));
 

--- a/Mutant Year Zero Alternative/sheet.json
+++ b/Mutant Year Zero Alternative/sheet.json
@@ -1,8 +1,8 @@
 {
     "html": "MutantYearZeroAlternative.html",
     "css": "MutantYearZeroAlternative.css",
-    "authors": "Ludvig L.",
-    "roll20userid": "2709",
+    "authors": {"Ludvig L.", "John C."},
+    "roll20userid": {"2709", "3107550"},
     "preview": "MutantYearZeroPreview.png",
     "instructions": "A sheet for Mutant: Year Zero. This particular sheet features an updated look and a far more intuitive attribute naming convention."
 }


### PR DESCRIPTION
This adds a number of small and less small enhancements including 
-new rolling functionality
-character races and appropriate labeling of sheet features relative to race. 
-a new advanced roll template
-hover over text on values

No sheet values were removed or renamed. I've only added new functionality that enhances what was already there. I've play tested this with my group and contacted the rpg community in question to get feedback. I think this is ready for a wider audience.