### PR TITLE
City of Mist character sheet repeating Power and Weakness tags.

### DIFF
--- a/City-of-Mist/city-of-mist.css
+++ b/City-of-Mist/city-of-mist.css
@@ -127,6 +127,25 @@ textarea {
     margin-bottom: 5px;
 }
 
+.sheet-weakness-tag {
+    display: inline-block;
+    margin: 5px 0;
+}
+
+.sheet-weakness-tag input[type=text] {
+    margin-bottom: 5px;
+}
+
+.sheet-weakness-tag input[type=checkbox] {
+    margin-bottom: 5px;
+    margin-right: 0px;
+}
+
+.sheet-burn_spacer {
+    width: calc(23% + 10px + 20px);
+    margin-right: 30px;
+}
+
 .sheet-clr {
     clear: both;
     padding: 0 !important;

--- a/City-of-Mist/city-of-mist.html
+++ b/City-of-Mist/city-of-mist.html
@@ -1,37 +1,37 @@
 <div class="com_sheet">
-    
+
     <div class="header">
-        
+
         <div class="quarter_grid">
             <div class="logo"></div>
         </div>
-        
+
         <div class="quarter_grid">
             <label class="label">Character Name:</label>
             <input type="text" name="attr_character_name"/>
         </div>
-        
+
         <div class="half_grid">
              <div class="third_grid">
                 <label class="label label_small">+ Positive Status</label><input type="number" name="attr_plusmod" value="0">
              </div>
-             
+
              <div class="third_grid">
                 <label class="label label_small">- Negative Status</label><input type="number" name="attr_minusmod" value ="0">
              </div>
-             
+
              <div class="third_grid total_power">
-                <label>Total Power</label><input type="number" name="attr_power" value='[[ @{tag_1} + @{tag_2} + @{tag_3} + @{tag_4} + @{tag_5} + @{tag_6} + @{tag_7} + @{tag_8} + @{tag_9} + @{tag_10} + @{tag_11} + @{tag_12} + @{plusmod} - @{weak_1} - @{weak_2} - @{weak_3} - @{weak_0} - @{minusmod} ]]' disabled/>
+                 <label>Total Power</label><span name="attr_power" value='0'>0</span>
             </div>
-            
+
         </div>
-        
+
     </div>
-    
+
     <div class="full_grid overall_move_grid">
-        
+
         <label class="label move_label">Moves</label>
-        
+
         <div class="move_grid">
             <label class="label label_small"><br>Investigate</label>
             <button type='roll' value='&{template:com} {{char=@{character_name}}} {{move=Investigate}} {{showroll=[[1]]}} {{total_power=@{power}}} {{check=[[2d6 + @{power}]]}} {{success=@{investigatesuccess}}} {{partial=@{investigatepartial}}} {{miss=@{investigatemiss}}}' name='roll_investigate'></button>
@@ -60,7 +60,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="move_grid">
             <label class="label label_small"><br>Convince</label>
             <button type='roll' value='&{template:com} {{char=@{character_name}}} {{move=Convince}} {{showroll=[[1]]}} {{total_power=@{power}}} {{check=[[2d6 + @{power}]]}} {{success=@{convince_success}}} {{partial=@{convince_partial}}} {{miss=@{convince_miss}}}' name='roll_convince'></button>
@@ -233,7 +233,7 @@
         </div>
         <div class="move_grid">
             <label class="label label_small">Take<br> A Risk</label>
-            <button type='roll' value='&{template:com} {{char=@{character_name}}} {{move=Take A Risk}} {{showroll=[[1]]}} {{total_power=@{power}}} {{check=[[2d6 + @{power}]]}} {{success=@{takearisk_success}}} {{partial=@{takearisk_partial}}} {{miss=@{takearis_kmiss}}}' name='roll_takearisk'></button>
+            <button type='roll' value='&{template:com} {{char=@{character_name}}} {{move=Take A Risk}} {{showroll=[[1]]}} {{total_power=@{power}}} {{check=[[2d6 + @{power}]]}} {{success=@{takearisk_success}}} {{partial=@{takearisk_partial}}} {{miss=@{takearisk_miss}}}' name='roll_takearisk'></button>
             <div class="hidden">
                 <div class="sheet-action">
                     <span class="sheet-action">Result 10+ : </span>
@@ -257,20 +257,20 @@
         <div class="theme quarter_grid theme_1">
             <div class="clr">
                 <label class="label">Theme Name:</label>
-                <input type="text" name="attr_theme_name_1"/> 
+                <input type="text" name="attr_theme_name_1"/>
             </div>
             <div class="adv">
                 <div class="half_grid">
                     <label class="label label_small ">Attention</label>
                     <input type="checkbox" name="attr_att_1"/>
                     <input type="checkbox" name="attr_att_2"/>
-                    <input type="checkbox" name="attr_att_3"/>  
+                    <input type="checkbox" name="attr_att_3"/>
                 </div>
                 <div class="half_grid">
                     <label class="label label_small ">Fade / Crack</label>
                     <input type="checkbox" name="attr_fade_1"/>
                     <input type="checkbox" name="attr_fade_2"/>
-                    <input type="checkbox" name="attr_fade_3"/> 
+                    <input type="checkbox" name="attr_fade_3"/>
                 </div>
             </div>
             <div class="clr">
@@ -285,57 +285,84 @@
                     <input type="checkbox" class="quarter_grid burn_1" name="attr_tag_1_burn"/>
                     <div class="sheet-burned_1">
                         <label class="label label_small label_1 quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_1" name="attr_tag_1" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_1" name="attr_roll_tag_1" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_2"/>
                     <label class="label label_small quarter_grid">Burn</label>
                     <input type="checkbox" class="quarter_grid burn_2" name="attr_tag_2_burn"/>
-                    <div class="sheet-burned_2">    
+                    <div class="sheet-burned_2">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_2" name="attr_tag_2" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_2" name="attr_roll_tag_2" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_3"/>
                     <label class="label label_small quarter_grid">Burn</label>
-                    <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_3_burn"/> 
+                    <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_3_burn"/>
                     <div class="sheet-burned_3">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_3" name="attr_tag_3" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_tag_3" value="1" />
                     </div>
                 </div>
+                <fieldset class="repeating_powertag-extra-1">
+                    <div class="power-tag">
+                        <input type="text" name="attr_tag_name_extra_1"/>
+                        <label class="label label_small quarter_grid">Burn</label>
+                        <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_extra_burn_1"/>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_tag_extra_1" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
             <div class="clr weakness">
                 <label class="label">Weakness Tags:</label>
-                <input type="checkbox" class="" name="attr_weak_1" value="1" /> 
-                <textarea name="attr_weak_1_name"></textarea> 
+                <div class="weakness-tag">
+                    <input type="text" name="attr_weak_1_name" />
+                    <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                    <div class="sheet-burned_3">
+                        <label class="label label_small quarter_grid">Roll</label>
+                        <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_1" value="1" />
+                    </div>
+                </div>
+                <fieldset class="repeating_weaknesstag-extra-1">
+                    <div class="weakness-tag">
+                        <input type="text" name="attr_weak_extra_name_1" />
+                        <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_extra_1" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
         </div>
 
         <div class="theme quarter_grid theme_2">
             <div class="clr">
                 <label class="label">Theme Name:</label>
-                <input type="text" name="attr_theme_nam_2"/> 
+                <input type="text" name="attr_theme_nam_2"/>
             </div>
             <div class="adv">
                 <div class="half_grid">
                     <label class="label label_small ">Attention</label>
                     <input type="checkbox" name="attr_att_4"/>
                     <input type="checkbox" name="attr_att_5"/>
-                    <input type="checkbox" name="attr_att_6"/>  
+                    <input type="checkbox" name="attr_att_6"/>
                 </div>
                 <div class="half_grid">
                     <label class="label label_small ">Fade / Crack</label>
                     <input type="checkbox" name="attr_fade_4"/>
                     <input type="checkbox" name="attr_fade_5"/>
-                    <input type="checkbox" name="attr_fade_6"/> 
+                    <input type="checkbox" name="attr_fade_6"/>
                 </div>
             </div>
             <div class="clr">
                 <label class="label">Mystery / Identity:</label>
-                <textarea name="attr_mystery_name_2"></textarea>  
+                <textarea name="attr_mystery_name_2"></textarea>
             </div>
             <div class="power_tag clr">
                 <label class="label">Power Tags:</label>
@@ -345,57 +372,84 @@
                     <input type="checkbox" class="quarter_grid burn_4" name="attr_tag_4_burn"/>
                     <div class="sheet-burned_4">
                         <label class="label label_small label_4 quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_4" name="attr_tag_4" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_4" name="attr_roll_tag_4" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_5"/>
                     <label class="label label_small quarter_grid">Burn</label>
                     <input type="checkbox" class="quarter_grid burn_5" name="attr_tag_5_burn"/>
-                    <div class="sheet-burned_5">    
+                    <div class="sheet-burned_5">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_5" name="attr_tag_5" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_5" name="attr_roll_tag_5" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_6"/>
                     <label class="label label_small quarter_grid">Burn</label>
-                    <input type="checkbox" class="quarter_grid burn_6" name="attr_tag_6_burn"/> 
+                    <input type="checkbox" class="quarter_grid burn_6" name="attr_tag_6_burn"/>
                     <div class="sheet-burned_6">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_6" name="attr_tag_6" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_6" name="attr_roll_tag_6" value="1" />
                     </div>
                 </div>
+                <fieldset class="repeating_powertag-extra-2">
+                    <div class="power-tag">
+                        <input type="text" name="attr_tag_name_extra_2"/>
+                        <label class="label label_small quarter_grid">Burn</label>
+                        <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_extra_burn_2"/>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_tag_extra_2" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
             <div class="clr weakness">
                 <label class="label">Weakness Tags:</label>
-                <input type="checkbox" class="" name="attr_weak_2" value="1" />
-                <textarea name="attr_weak_2_name"></textarea> 
+                <div class="weakness-tag">
+                    <input type="text" name="attr_weak_2_name" />
+                    <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                    <div class="sheet-burned_3">
+                        <label class="label label_small quarter_grid">Roll</label>
+                        <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_2" value="1" />
+                    </div>
+                </div>
+                <fieldset class="repeating_weaknesstag-extra-2">
+                    <div class="weakness-tag">
+                        <input type="text" name="attr_weak_extra_name_2" />
+                        <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_extra_2" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
         </div>
 
         <div class="theme quarter_grid theme_3">
             <div class="clr">
                 <label class="label">Theme Name:</label>
-                <input type="text" name="attr_theme_name_3"/> 
+                <input type="text" name="attr_theme_name_3"/>
             </div>
             <div class="adv">
                 <div class="half_grid">
                     <label class="label label_small ">Attention</label>
                     <input type="checkbox" name="attr_att_7"/>
                     <input type="checkbox" name="attr_att_8"/>
-                    <input type="checkbox" name="attr_att_9"/>  
+                    <input type="checkbox" name="attr_att_9"/>
                 </div>
                 <div class="half_grid">
                     <label class="label label_small ">Fade / Crack</label>
                     <input type="checkbox" name="attr_fade_7"/>
                     <input type="checkbox" name="attr_fade_8"/>
-                    <input type="checkbox" name="attr_fade_9"/> 
+                    <input type="checkbox" name="attr_fade_9"/>
                 </div>
             </div>
             <div class="clr">
                 <label class="label">Mystery / Identity:</label>
-                <textarea name="attr_mystery_name_3"></textarea>  
+                <textarea name="attr_mystery_name_3"></textarea>
             </div>
             <div class="power_tag clr">
                 <label class="label">Power Tags:</label>
@@ -405,57 +459,84 @@
                     <input type="checkbox" class="quarter_grid burn_7" name="attr_tag_7_burn"/>
                     <div class="sheet-burned_7">
                         <label class="label label_small label_7 quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_7" name="attr_tag_7" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_7" name="attr_roll_tag_7" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_8"/>
                     <label class="label label_small quarter_grid">Burn</label>
                     <input type="checkbox" class="quarter_grid burn_8" name="attr_tag_8_burn"/>
-                    <div class="sheet-burned_8">    
+                    <div class="sheet-burned_8">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_8" name="attr_tag_8" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_8" name="attr_roll_tag_8" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_9"/>
                     <label class="label label_small quarter_grid">Burn</label>
-                    <input type="checkbox" class="quarter_grid burn_9" name="attr_tag_9_burn"/> 
+                    <input type="checkbox" class="quarter_grid burn_9" name="attr_tag_9_burn"/>
                     <div class="sheet-burned_9">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_9" name="attr_tag_9" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_9" name="attr_roll_tag_9" value="1" />
                     </div>
                 </div>
+                <fieldset class="repeating_powertag-extra-3">
+                    <div class="power-tag">
+                        <input type="text" name="attr_tag_name_extra_3"/>
+                        <label class="label label_small quarter_grid">Burn</label>
+                        <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_extra_burn_3"/>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_tag_extra_3" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
             <div class="clr weakness">
                 <label class="label">Weakness Tags:</label>
-                <input type="checkbox" class="" name="attr_weak_3" value="1" />
-                <textarea name="attr_weak_3_name"></textarea> 
+                <div class="weakness-tag">
+                    <input type="text" name="attr_weak_3_name" />
+                    <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                    <div class="sheet-burned_3">
+                        <label class="label label_small quarter_grid">Roll</label>
+                        <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_3" value="1" />
+                    </div>
+                </div>
+                <fieldset class="repeating_weaknesstag-extra-3">
+                    <div class="weakness-tag">
+                        <input type="text" name="attr_weak_extra_name_3" />
+                        <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_extra_3" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
         </div>
 
         <div class="theme quarter_grid theme_4">
             <div class="clr">
                 <label class="label">Theme Name:</label>
-                <input type="text" name="attr_theme_name_4"/> 
+                <input type="text" name="attr_theme_name_4"/>
             </div>
             <div class="adv">
                 <div class="half_grid">
                     <label class="label label_small ">Attention</label>
                     <input type="checkbox" name="attr_att_10"/>
                     <input type="checkbox" name="attr_att_11"/>
-                    <input type="checkbox" name="attr_att_12"/> 
+                    <input type="checkbox" name="attr_att_12"/>
                 </div>
                 <div class="half_grid">
                     <label class="label label_small ">Fade / Crack</label>
                     <input type="checkbox" name="attr_fade_10"/>
                     <input type="checkbox" name="attr_fade_11"/>
-                    <input type="checkbox" name="attr_fade_12"/>    
+                    <input type="checkbox" name="attr_fade_12"/>
                 </div>
             </div>
             <div class="clr">
                 <label class="label">Mystery / Identity:</label>
-                <textarea name="attr_mystery_name_4"></textarea>  
+                <textarea name="attr_mystery_name_4"></textarea>
             </div>
             <div class="power_tag clr">
                 <label class="label">Power Tags:</label>
@@ -465,34 +546,61 @@
                     <input type="checkbox" class="quarter_grid burn_10" name="attr_tag_10_burn"/>
                     <div class="sheet-burned_10">
                         <label class="label label_small label_10 quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_10" name="attr_tag_10" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_10" name="attr_roll_tag_10" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_11"/>
                     <label class="label label_small quarter_grid">Burn</label>
                     <input type="checkbox" class="quarter_grid burn_11" name="attr_tag_11_burn"/>
-                    <div class="sheet-burned_11">   
+                    <div class="sheet-burned_11">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_11" name="attr_tag_11" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_11" name="attr_roll_tag_11" value="1" />
                     </div>
                 </div>
                 <div class="power-tag">
                     <input type="text" name="attr_tag_name_12"/>
                     <label class="label label_small quarter_grid">Burn</label>
-                    <input type="checkbox" class="quarter_grid burn_12" name="attr_tag_12_burn"/>   
+                    <input type="checkbox" class="quarter_grid burn_12" name="attr_tag_12_burn"/>
                     <div class="sheet-burned_12">
                         <label class="label label_small quarter_grid">Roll</label>
-                        <input type="checkbox" class="quarter_grid tag_12" name="attr_tag_12" value="1" />
+                        <input type="checkbox" class="quarter_grid tag_12" name="attr_roll_tag_12" value="1" />
                     </div>
                 </div>
+                <fieldset class="repeating_powertag-extra-4">
+                    <div class="power-tag">
+                        <input type="text" name="attr_tag_name_extra_4"/>
+                        <label class="label label_small quarter_grid">Burn</label>
+                        <input type="checkbox" class="quarter_grid burn_3" name="attr_tag_extra_burn_4"/>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_tag_extra_4" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
             <div class="clr weakness">
                 <label class="label">Weakness Tags:</label>
-                <input type="checkbox" class="" name="attr_weak_0" value="1" />
-                <textarea name="attr_weak_0_name"></textarea> 
+                <div class="weakness-tag">
+                    <input type="text" name="attr_weak_4_name" />
+                    <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                    <div class="sheet-burned_3">
+                        <label class="label label_small quarter_grid">Roll</label>
+                        <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_4" value="1" />
+                    </div>
+                </div>
+                <fieldset class="repeating_weaknesstag-extra-4">
+                    <div class="weakness-tag">
+                        <input type="text" name="attr_weak_extra_name_4" />
+                        <span class="sheet-quarter_grid burn_spacer">&nbsp;</span>
+                        <div class="sheet-burned_3">
+                            <label class="label label_small quarter_grid">Roll</label>
+                            <input type="checkbox" class="quarter_grid tag_3" name="attr_roll_weakness_tag_extra_4" value="1" />
+                        </div>
+                    </div>
+                </fieldset>
             </div>
-        </div>  
+        </div>
     </div>
     <div class="clr"></div>
 </div>
@@ -539,3 +647,147 @@
         {{/check}}
     </table>
 </rolltemplate>
+<script type="text/worker">
+
+    (function () {
+
+        var power_tag_names = [];
+        var weakness_tag_names = [];
+        var mod_names = [
+            "plusmod",
+            "minusmod"
+        ];
+
+        /** @var array list of events to trigger the power calculations. **/
+        var change_tag_events = mod_names.map(function(name) {
+            return "change:" + name;
+        });
+
+        /** Calculate the lists of roll checkbox power_tag_names, roll checkbox weakness_tag_names, and related change events. */
+        ['1', '2', '3', '4'].forEach(function(theme_id) {
+            // 3 power tags per theme
+            var theme_power_tag_names = [1,2,3].map(function(tag_number) {
+                return "roll_tag_" + ((theme_id-1)*3+tag_number);
+            });
+            power_tag_names = power_tag_names.concat(theme_power_tag_names);
+            change_tag_events = change_tag_events.concat(theme_power_tag_names.map(function(tag_name) {
+                return "change:" + tag_name;
+            }));
+            // 1 weakness tag per theme
+            var theme_weakness_tag_name = "roll_weakness_tag_" + theme_id;
+            change_tag_events.push("change:" + theme_weakness_tag_name);
+            weakness_tag_names.push(theme_weakness_tag_name);
+            // 1 each power and weakness tag extra repeating groups
+            change_tag_events.push("change:repeating_powertag-extra-" + theme_id);
+            change_tag_events.push("change:repeating_weaknesstag-extra-" + theme_id);
+        });
+        /** @var array list of all roll check tag attribute names, both power and weakness */
+        var all_attr_names = mod_names.concat(power_tag_names).concat(weakness_tag_names);
+
+        /** Points all of those events to the calculate_power function. */
+        on(change_tag_events.join(" "), calculate_power);
+
+        /** Calculate power when the sheet opens. */
+        on('sheet:opened', function (e) {
+            console.log('sheet:opened fired.');
+            calculate_power(e);
+        });
+
+        /**
+         * Calculates the power based on the checked roll checkboxes for tags on the sheet.
+         *
+         * @param e - the event for the change; ignored for this function as we calculate the power based on everything every time.
+         */
+        function calculate_power(e) {
+            console.log('Calculating power.');
+            /** @var array the list of dynamic (repeating section) checkboxes for power tags to be used in the calculation. */
+            var extra_powertag_names = [];
+
+            /** @var array the list of dynamic (repeating section) checkboxes for weakness tags to be used in the calculation. */
+            var extra_weaknesstag_names = [];
+
+            /**
+             * There are 4 themes, each with a power tag repeating section, and a weakness tag repeating section.
+             * Because the getSectionIDs() function doesn't take multiple section labels, I need to nest the callback
+             * functions.
+             *
+             * I tried using Promises, but apparently the getAttrs() function only works during the context of the callback
+             * function, and was throwing an error about the _activeCharacterId variable not being set.
+             *
+             * So, this is horrible, but, it works.  I expect major headaches in maintaining this.
+             */
+            getSectionIDs('powertag-extra-1', function(extra_powertag_rowids_theme) {
+                extra_powertag_names = extra_powertag_names.concat(extra_powertag_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_powertag-extra-1', 'roll_tag_extra_1')));
+                getSectionIDs('powertag-extra-2', function(extra_powertag_rowids_theme) {
+                    extra_powertag_names = extra_powertag_names.concat(extra_powertag_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_powertag-extra-2', 'roll_tag_extra_2')));
+                    getSectionIDs('powertag-extra-3', function(extra_powertag_rowids_theme) {
+                        extra_powertag_names = extra_powertag_names.concat(extra_powertag_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_powertag-extra-3', 'roll_tag_extra_3')));
+                        getSectionIDs('powertag-extra-4', function(extra_powertag_rowids_theme) {
+                            extra_powertag_names = extra_powertag_names.concat(extra_powertag_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_powertag-extra-4', 'roll_tag_extra_4')));
+                            getSectionIDs('weaknesstag-extra-1', function(extra_weaknesstags_rowids_theme) {
+                                extra_weaknesstag_names = extra_weaknesstag_names.concat(extra_weaknesstags_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_weaknesstag-extra-1', 'roll_weakness_tag_extra_1')));
+                                getSectionIDs('weaknesstag-extra-2', function(extra_weaknesstags_rowids_theme) {
+                                    extra_weaknesstag_names = extra_weaknesstag_names.concat(extra_weaknesstags_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_weaknesstag-extra-2', 'roll_weakness_tag_extra_2')));
+                                    getSectionIDs('weaknesstag-extra-3', function(extra_weaknesstags_rowids_theme) {
+                                        extra_weaknesstag_names = extra_weaknesstag_names.concat(extra_weaknesstags_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_weaknesstag-extra-3', 'roll_weakness_tag_extra_3')));
+                                        getSectionIDs('weaknesstag-extra-4', function(extra_weaknesstags_rowids_theme) {
+                                            extra_weaknesstag_names = extra_weaknesstag_names.concat(extra_weaknesstags_rowids_theme.map(repeating_attr_name.bind(null, 'repeating_weaknesstag-extra-4', 'roll_weakness_tag_extra_4')));
+                                            /** OK, all 8 dynamic sections have been queried for the attributes in them, now in extra_powertag_names and extra_weaknesstag_names.  Stick them all together for the call to getAttrs() */
+                                            var all_extra_attr_names = extra_powertag_names.concat(extra_weaknesstag_names);
+                                            var attr_names_to_get = all_attr_names.concat(all_extra_attr_names);
+                                            getAttrs(attr_names_to_get, function(values) {
+                                                /** values should have all the values of the attributes involved in the power calculation. */
+                                                var power = 0;
+                                                /** Count the checked static & dynamic power tags */
+                                                power_tag_names.forEach(function(powertag) {
+                                                    if (values[powertag] === "1") {
+                                                        power++;
+                                                    }
+                                                });
+                                                extra_powertag_names.forEach(function(powertag) {
+                                                    if (values[powertag] === "1") {
+                                                        power++;
+                                                    }
+                                                });
+                                                /** Count the checked static & dynamic weakness tags */
+                                                weakness_tag_names.forEach(function(weaknesstag) {
+                                                    if (values[weaknesstag] === "1") {
+                                                        power --;
+                                                    }
+                                                });
+                                                extra_weaknesstag_names.forEach(function(weaknesstag) {
+                                                    if (values[weaknesstag] === "1") {
+                                                        power--;
+                                                    }
+                                                });
+                                                /** Add / subtract the modifiers */
+                                                power += (values.plusmod - values.minusmod);
+                                                /** save power to the attribute */
+                                                setAttrs({ power: power });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        }
+
+        /**
+         * Gets the attribute name to be used in the call to getAttrs() for an attribute in a repeating section.
+         *
+         * @param repeating_section_name string
+         * @param attr_name string
+         * @param row_id string row_id is last because of the way I'm using this with the bind() function.
+         *
+         * @returns {string}
+         */
+        function repeating_attr_name(repeating_section_name, attr_name, row_id) {
+            return [repeating_section_name, row_id, attr_name].join('_');
+        }
+
+    })();
+
+</script>


### PR DESCRIPTION
Added repeating sections for each theme card to add power tags and weakness tags.

Added a sheet worker script to calculate the power of a roll based on the checked tags and the modifier fields, replacing the previous version's auto calculating value attribute.

Note: I originally wrote the calls to getSectionIDs() using Promises but that did not seem to work with the way the getAttrs() function works.  

If support for Promises was included with the API used by the sheet worker scripts, this type of thing would be much cleaner.