### PR TITLE
[Star Wars 30th Anniversary Edition] Move to D6 system

### DIFF
--- a/Star Wars 30th Anniversary Edition/StarWars30thAnniversaryEdition.html
+++ b/Star Wars 30th Anniversary Edition/StarWars30thAnniversaryEdition.html
@@ -540,7 +540,7 @@
 
 <input type="hidden" name="attr_strengtharmor_dice_ref" value="0d6" />
 
-<script type="text/worker">
+<script type="text/worker"><!-- Sheet worker, and thus rolls from the sheet, doesn't work yet, will be updated by author soon -->
     var attrList = [
         "dexterity", "knowledge", "mechanical", "perception", "strength",
         "technical", "blaster", "brawling_parry", "dodge", "grenade",


### PR DESCRIPTION
Could this game be grouped under "D6", like Star Wars D6 is? This sheet is for essentially the same system.

https://en.wikipedia.org/wiki/Star_Wars:_The_Roleplaying_Game
https://en.wikipedia.org/wiki/Star_Wars:_The_Roleplaying_Game#Fantasy_Flight_Games_Reprint

The author will update the sheetworkers, so the sheet rolls will function, when he has time.