### PR TITLE
5e OGL fixed spellcasting lvls of non-full casters

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -8395,7 +8395,7 @@
                 return 0;
             }
             else {
-                return Math.ceil(parseInt(levels, 10) / 2);
+                return Math.floor(parseInt(levels, 10) / 2);
             }
         }
         else if(class_string === "third" || (class_string === "fighter" && arcane_fighter === "1") || (class_string === "rogue" && arcane_rogue === "1")) {
@@ -8403,7 +8403,7 @@
                 return 0;
             }
             else {
-                return Math.ceil(parseInt(levels, 10) / 3);
+                return Math.floor(parseInt(levels, 10) / 3);
             }
         }
         else {

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -8347,30 +8347,34 @@
             var callbacks = [];
             var multiclass = (v.multiclass1_flag && v.multiclass1_flag === "1") || (v.multiclass2_flag && v.multiclass2_flag === "1") || (v.multiclass3_flag && v.multiclass3_flag === "1") ? true : false;
             var finalclass = v["custom_class"] && v["custom_class"] != "0" ? v["cust_spellslots"] : v["class"];
-            var casterlevel = checkCasterLevel(finalclass.toLowerCase(), v["base_level"], v["arcane_fighter"], v["arcane_rogue"]);
             var finallevel = (v.base_level && v.base_level > 0) ? parseInt(v.base_level,10) : 1;
             var charclass = v.custom_class && v.custom_class != "0" ? v["cust_classname"] : v["class"];
             var hitdie_final = multiclass ? "?{Hit Die Class|" + charclass + ",@{hitdietype}" : "@{hitdietype}";
 
+            // This nested array is used to determine the overall spellcasting level for the character.
+            var classes = [ [finalclass.toLowerCase(), v["base_level"]] ];
+
             if(v.multiclass1_flag && v.multiclass1_flag === "1") {
                 var multiclasslevel = (v["multiclass1_lvl"] && v["multiclass1_lvl"] > 0) ? parseInt(v["multiclass1_lvl"], 10) : 1;
-                finallevel = finallevel + multiclasslevel; 
-                casterlevel = casterlevel + checkCasterLevel(v["multiclass1"], v["multiclass1_lvl"], v["arcane_fighter"], v["arcane_rogue"]);
+                finallevel = finallevel + multiclasslevel;
                 hitdie_final = hitdie_final + "|" + v["multiclass1"].charAt(0).toUpperCase() + v["multiclass1"].slice(1) + "," + checkHitDie(v["multiclass1"]);
+                classes.push([ v["multiclass1"], multiclasslevel ]);
             };
             if(v.multiclass2_flag && v.multiclass2_flag === "1") {
                 var multiclasslevel = (v["multiclass2_lvl"] && v["multiclass2_lvl"] > 0) ? parseInt(v["multiclass2_lvl"], 10) : 1;
-                finallevel = finallevel + multiclasslevel; 
-                casterlevel = casterlevel + checkCasterLevel(v["multiclass2"], v["multiclass2_lvl"], v["arcane_fighter"], v["arcane_rogue"]);
+                finallevel = finallevel + multiclasslevel;
                 hitdie_final = hitdie_final + "|" + v["multiclass2"].charAt(0).toUpperCase() + v["multiclass2"].slice(1) + "," + checkHitDie(v["multiclass2"]);
+                classes.push([ v["multiclass2"], multiclasslevel ]);
             };
             if(v.multiclass3_flag && v.multiclass3_flag === "1") {
                 var multiclasslevel = (v["multiclass3_lvl"] && v["multiclass3_lvl"] > 0) ? parseInt(v["multiclass3_lvl"], 10) : 1;
-                finallevel = finallevel + multiclasslevel; 
-                casterlevel = casterlevel + checkCasterLevel(v["multiclass3"], v["multiclass3_lvl"], v["arcane_fighter"], v["arcane_rogue"]);
+                finallevel = finallevel + multiclasslevel;
                 hitdie_final = hitdie_final + "|" + v["multiclass3"].charAt(0).toUpperCase() + v["multiclass3"].slice(1) + "," + checkHitDie(v["multiclass3"]);
+                classes.push([ v["multiclass3"], multiclasslevel ]);
             };
-            
+
+            var casterlevel = checkCasterLevel(classes, v["arcane_fighter"], v["arcane_rogue"]);
+
             update["hitdie_final"] = multiclass ? hitdie_final + "}" : hitdie_final;
             update["level"] = finallevel;
             update["caster_level"] = casterlevel;
@@ -8384,31 +8388,45 @@
         });
     };
 
-    var checkCasterLevel = function(class_string, levels, arcane_fighter, arcane_rogue) {
+    var isMultiCaster = function(classes, arcane_fighter, arcane_rogue) {
+        var singlecaster = false;
+        var multicaster = false;
+        _.each(classes, function(multiclass) {
+            var caster = getCasterType(multiclass[0], multiclass[1], arcane_fighter, arcane_rogue) > 0;
+            if(caster && singlecaster) {
+                multicaster = true;
+            } else if(caster) {
+                singlecaster = true;
+            }
+        });
+        return multicaster;
+    };
+
+    var getCasterType = function(class_string, levels, arcane_fighter, arcane_rogue) {
         var full = ["bard","cleric","druid","sorcerer","wizard","full"];
         var half = ["paladin","ranger","half"];
         if(full.indexOf(class_string) != -1) {
-            return parseInt(levels, 10);
-        }
-        else if(half.indexOf(class_string) != -1) {
-            if(levels == 1) {
-                return 0;
-            }
-            else {
-                return Math.floor(parseInt(levels, 10) / 2);
-            }
-        }
-        else if(class_string === "third" || (class_string === "fighter" && arcane_fighter === "1") || (class_string === "rogue" && arcane_rogue === "1")) {
-            if(levels == 1 || levels == 2) {
-                return 0;
-            }
-            else {
-                return Math.floor(parseInt(levels, 10) / 3);
-            }
-        }
-        else {
+            return 1;
+        } else if(half.indexOf(class_string) != -1) {
+            return (levels == 1) ? 0 : (1/2);
+        } else if(class_string === "third" || (class_string === "fighter" && arcane_fighter === "1") || (class_string === "rogue" && arcane_rogue === "1")) {
+            return (levels == 1 || levels == 2) ? 0 : (1/3);
+        } else {
             return 0;
         }
+    };
+
+    var checkCasterLevel = function(classes, arcane_fighter, arcane_rogue) {
+        console.log("CHECKING CASTER LEVEL");
+        var multicaster = isMultiCaster(classes, arcane_fighter, arcane_rogue);
+        var totalcasterlevel = 0;
+        _.each(classes, function(multiclass) {
+            var casterlevel = parseInt(multiclass[1], 10) * getCasterType(multiclass[0], multiclass[1], arcane_fighter, arcane_rogue);
+            // Characters with multiple spellcasting classes round down the casting level for that class
+            // Character with a single spellcasting class round up the casting level
+            totalcasterlevel = totalcasterlevel + (multicaster ? Math.floor(casterlevel) : Math.ceil(casterlevel));
+        });
+        return totalcasterlevel;
     };
 
     var checkHitDie = function(class_string) {


### PR DESCRIPTION
Half casters (Paladins and Rangers) and third casters (Arcane Tricksters and Eldritch Knights) will now calculate the correct number of spellslots. Previously the spell slots were rounding up to the next level of spellcasting when it should instead be rounded down.