### PR TITLE
Deadlands Classic: Fixes & Updates

### DIFF
--- a/Deadlands Classic/deadlandsclassic.css
+++ b/Deadlands Classic/deadlandsclassic.css
@@ -1,8 +1,12 @@
+.sheet-wrapper {
+  width: 850px;
+}
+
 /* ===== TABS ===== */
 
 /*this hides the contents of each tab by default*/
 .charsheet div[class^="sheet-section"] {
-	display: none;
+  display: none;
 }
 
 
@@ -12,20 +16,20 @@
 .charsheet input.sheet-tab4:checked ~ div.sheet-section-misc,
 .charsheet input.sheet-tab5:checked ~ div.sheet-section-core,
 .charsheet input.sheet-tab6:checked ~ div.sheet-section-obsolete {
-	display: block;
-	border: solid 1px black;
-	border-radius: 4px;
-	padding: 5px;
+  display: block;
+  border: solid 1px black;
+  border-radius: 4px;
+  padding: 5px;
 }
 
 /*this hides the radio button for each tab, makes it 130px wide and 40px tall and makes sure it's above everything else*/
 .charsheet input.sheet-tab {
-	width: 130px;
-	height: 40px;
-	cursor: pointer;
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
+  width: 130px;
+  height: 40px;
+  cursor: pointer;
+  position: relative;
+  opacity: 0;
+  z-index: 9999;
 }
 
 /*this styles the span with the tab information and slides to the left, so it appears underneath the radio button*/
@@ -62,7 +66,7 @@
 
 /* ===== Sheet Update Notice ===== */
 .charsheet input.sheet-notice:checked ~ span.sheet-notice {
-	display: none;
+  display: none;
 }
 
 .charsheet div.sheet-alert-close {
@@ -79,38 +83,38 @@
 }
 
 .charsheet input.sheet-notice {
-	height: 20px;
+  height: 20px;
      width: 20px;
-	cursor: pointer;
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
+  cursor: pointer;
+  position: relative;
+  opacity: 0;
+  z-index: 9999;
 }
 
 .charsheet span.sheet-alert-close {
-	height: 20px;
+  height: 20px;
      width: 20px;
-	cursor: pointer;
-	position: relative;
-	margin-left: -20px;
-	display: inline-block;
+  cursor: pointer;
+  position: relative;
+  margin-left: -20px;
+  display: inline-block;
 }
 
 .charsheet span.sheet-alert-content {
-	width: 750px;
-	display: inline-block;
+  width: 750px;
+  display: inline-block;
 }
 
 .charsheet span.sheet-notice {
-	width: 800px;
-	margin-left: auto;
-	margin-right: auto;
-	text-align: center;
+  width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
      display: inline-block;
      font-size: 13px;
      font-weight: bold;
      border-radius: 4px;
-	position: relative;
+  position: relative;
      vertical-align: middle;
 }
 
@@ -118,33 +122,29 @@
 
 /* ===== Layout Controls ===== */
 .ui-dialog .charsheet .sheet-4colrow {
-	display:block;
-	clear:both
+  display:block;
+  clear:both
 }
 
 .sheet-4colrow .sheet-col {
-	width:calc(25% - 21px);
-	margin-right:15px
+  width:calc(25% - 21px);
+  margin-right:15px
 }
 
-.sheet-h1, .sheet-h2, .sheet-h3{
+.sheet-h1, .sheet-h3{
     text-align: center;
     display: block;
 }
 
 .sheet-h1 {
-	font-size: 2em;
-	margin: .5em;
-	text-align: center;
+  font-size: 2em;
+  margin: .5em;
+  text-align: center;
 }
-.sheet-h2 {
-	font-size: 1.5em;
-	padding: 3px 0px;
-	margin: .2em;
-}
+
 .sheet-h3 {
-	font-size: 1.17em;
-	margin: .2em;
+  font-size: 1.17em;
+  margin: .2em;
 }
 
 .sheet-item {
@@ -153,8 +153,8 @@
 
 .sheet-itemright {
     margin: auto;
-	margin-right: 5px;
-	float: right;
+  margin-right: 5px;
+  float: right;
 }
 
 .sheet-big {
@@ -163,22 +163,22 @@
     text-align: center;
 }
 .sheet-xlarge {
-	width: 19%;
-	padding-right: 1%;
-	display: inline-block;
-	text-align: center;
+  width: 19%;
+  padding-right: 1%;
+  display: inline-block;
+  text-align: center;
 }
 .sheet-large {
-	width: 10%;
-	padding-right: 1%;
-	display: inline-block;
-	text-align: center;
+  width: 10%;
+  padding-right: 1%;
+  display: inline-block;
+  text-align: center;
 }
 .sheet-third {
-	width: 32%;
-	padding-right: 1%;
-	display: inline-block;
-	text-align: center;
+  width: 32%;
+  padding-right: 1%;
+  display: inline-block;
+  text-align: center;
 }
 .sheet-xxxlarge {
     width: 45%;
@@ -191,10 +191,10 @@
     text-align: center;
 }
 .sheet-xhuge {
-	width: 60%;
-	padding-right: 1%;
-	display: inline-block;
-	text-align: center;
+  width: 60%;
+  padding-right: 1%;
+  display: inline-block;
+  text-align: center;
 }
 .sheet-xxhuge {
     width: 75%;
@@ -203,13 +203,13 @@
 }
 .sheet-small {
     width: 5%;
-	padding-right: 1%;
+  padding-right: 1%;
     display: inline-block;
     text-align: center;
 }
 .sheet-small2 {
     width: 3%;
-	padding-right: 1%;
+  padding-right: 1%;
     display: inline-block;
     text-align: center;
 }
@@ -221,8 +221,8 @@
 }
 
 .sheet-center {
-    margin-left: auto;
-	margin-right: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 input[type=text], input[type=number], .sheet-textarea{
@@ -252,32 +252,8 @@ input[type=text], input[type=number], .sheet-textarea{
     text-align: center;
 }
 
-.sheet-chipswhite {
-    width: 8.5%;
-    display: inline-block;
-    text-align: center;
-}
-
-.sheet-chipsred {
-    width: 14.5%;
-    display: inline-block;
-    text-align: center;
-}
-
-.sheet-chipsblue {
-    width: 14.5%;
-    display: inline-block;
-    text-align: center;
-}
-
-.sheet-chipsleg {
-    width: 14.5%;
-    display: inline-block;
-    text-align: center;
-}
-
 .sheet-apthr {
-	margin-top: -1px;
+  margin-top: -1px;
 }
 
 .sheet-alert {
@@ -353,4 +329,156 @@ input[type=text], input[type=number], .sheet-textarea{
     width: 5.1%;
     display: inline-block;
     text-align: center;
+}
+
+/* Cassie's Cusotmizations */
+input[type=text],
+input[type=number] {
+  border: none;
+  border-bottom: 1px solid;
+  border-radius: 0px;
+}
+
+h2 {
+  color: #404040;
+  font-size: 1.5em;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: normal;
+  padding: 3px 0px;
+  margin: 0px;
+  text-align: center;
+  display: block;
+}
+
+button:hover {
+  color: #fff;
+  background-color: #2c424e;
+}
+
+textarea {
+  overflow: hidden;
+  overflow-wrap: break-word;
+  white-space: pre-line;
+}
+
+.sheet-buttons,
+.sheet-xxxlarge .repcontrol {
+  display: inline-block;
+}
+
+.sheet-chiprow,
+.sheet-windrow {
+  text-align: center;
+}
+
+.sheet-windrow {
+  margin-top: -20px;
+  margin-bottom: 5px;
+}
+
+.sheet-buttons input[type=radio],
+.sheet-windrow input[type=radio],
+.sheet-big input[type=radio],
+.sheet-location input[type=radio] {
+  display: inline-block;
+  text-align: center;
+  position: relative;
+  left: 20px;
+  width: 25px;
+  opacity: 0;
+  z-index: 2;
+}
+
+.sheet-big input[type=radio] + span {
+  position: relative;
+  left: -15px;
+}
+
+.sheet-big input[type=radio]  {
+  left: 10px;
+}
+
+.sheet-buttons input[type=radio]:hover + span,
+.sheet-buttons input[type=radio]:checked + span,
+.sheet-location input[type=radio]:hover + span,
+.sheet-location input[type=radio]:checked + span {
+  color: white;
+  font-size: 1rem;
+  text-shadow: 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000, -1px 0 0 #000;
+}
+
+.sheet-buttons input[type=radio] + span {
+  font-weight: bolder;
+  font-size: 1rem;
+}
+
+.sheet-buttonsred input[type=radio]:hover + span,
+.sheet-buttonsred input[type=radio]:checked + span {
+  color: #983842;
+}
+
+.sheet-buttonsblue input[type=radio]:hover + span,
+.sheet-buttonsblue input[type=radio]:checked + span {
+  color: #2095d0;
+}
+
+.sheet-buttonsleg input[type=radio]:hover + span,
+.sheet-buttonsleg input[type=radio]:checked + span {
+  color: #fadea2;
+}
+
+.sheet-windrow input[type=radio] {
+  left: -3px;
+  top: 18px;
+}
+
+.sheet-xxxlarge {
+  width: 40%;
+}
+
+.sheet-xxxlarge textarea {
+  width: 125%;
+}
+
+.sheet-xxxlarge .repcontainer {
+  display: inherit;
+  width: 88%;
+}
+
+.sheet-xxxlarge .repcontiner .repitem {
+  display: inline-flex;
+  width: 100%;
+}
+
+.sheet-xxxlarge .repcontrol {
+  width: 38px;
+  position: relative;
+  left: 5px;
+}
+
+.sheet-xxxlarge .sheet-xxhuge {
+  padding-bottom: 5px;
+}
+
+.sheet-location {
+  width: 27%;
+  float: right;
+}
+
+.sheet-location label {
+  display: inline;
+  margin-right: -10px;
+}
+
+.sheet-location span {
+  font-weight: bolder;
+}
+
+.sheet-rolltemplate-default caption {
+  background-color: #1d0d0c;
+  border-color: ;
+}
+
+.sheet-rolltemplate-default table {
+  border-color: #6d4b3e;
 }

--- a/Deadlands Classic/deadlandsclassic.html
+++ b/Deadlands Classic/deadlandsclassic.html
@@ -1,1906 +1,1888 @@
+<!-- Shooting & Perfomin-->
+
 <rolltemplate class="sheet-rolltemplate-simple">
 <div class="sheet-rolltemplate-default">
-	<table>
-		<caption>{{rollname}}</caption>
-		<tbody>
-		<tr>
-			<td>Result</td>
-			<td><span class="inlinerollresult showtip">{{dice}}</span></td>
-		</tr>
-		</tbody>
-	</table>
+  <table>
+    <caption>{{rollname}}</caption>
+    <tbody>
+    {{#dice}}
+    <tr>
+      <td>Result</td>
+      <td><span class="inlinerollresult showtip">{{dice}}</span></td>
+    </tr>
+    {{/dice}}
+    {{#strength}}
+    <tr>
+      <td>Strength</td>
+      <td><span class="inlinerollresult showtip">{{strength}}</span></td>
+    </tr>
+    {{/strength}}
+    {{#meleedamage}}
+    <tr>
+      <td>Weapon Damage</td>
+      <td>
+        <span class="inlinerollresult showtip">{{#rollTotal() meleedamage 0}}{{/rollTotal() meleedamage 0}}</span>
+        <span>{{#rollGreater() meleedamage 0}}{{meleedamage}}{{/rollGreater() meleedamage 0}}</span>
+      </td>
+    </tr>
+    {{/meleedamage}}
+    {{#damage}}
+    <tr>
+      <td>Damage</td>
+      <td><span class="inlinerollresult showtip">{{damage}}</span></td>
+    </tr>
+    {{/damage}}
+    {{#location}}
+    <tr>
+      <td>Location</td>
+      <td>
+        <span>{{#rollTotal() location 1}}Left Leg, {{location}}{{/rollTotal() location 1}}</span>
+        <span>{{#rollTotal() location 2}}Right Leg, {{location}}{{/rollTotal() location 2}}</span>
+        <span>{{#rollTotal() location 3}}Left Leg, {{location}}{{/rollTotal() location 3}}</span>
+        <span>{{#rollTotal() location 4}}Right Leg, {{location}}{{/rollTotal() location 4}}</span>
+        <span>{{#rollBetween() location 5 9}}Lower Guts, {{location}}{{/rollBetween() location 5 9}}</span>
+        <span>{{#rollTotal() location 10}}Gizzards, {{location}}{{/rollTotal() location 10}}</span>
+        <span>{{#rollTotal() location 11}}Left Arm, {{location}}{{/rollTotal() location 11}}</span>
+        <span>{{#rollTotal() location 12}}Right Arm, {{location}}{{/rollTotal() location 12}}</span>
+        <span>{{#rollTotal() location 13}}Left Arm, {{location}}{{/rollTotal() location 13}}</span>
+        <span>{{#rollTotal() location 14}}Right Arm, {{location}}{{/rollTotal() location 14}}</span>
+        <span>{{#rollBetween() location 15 19}}Upper Guts, {{location}}{{/rollBetween() location 15 19}}</span>
+        <span>{{#rollTotal() location 20}}Noggin, {{location}}{{/rollTotal() location 20}}</span>
+      </td>
+    </tr>
+    {{/location}}
+    </tbody>
+  </table>
 </div>
 </rolltemplate>
 
 <div class="sheet-wrapper">
-	<div class="sheet-row" style="margin-bottom: 15px;">
-		<span class="sheet-alert sheet-alert-warning sheet-notice">
-			<span class="sheet-alert-content">
-				This sheet has been recently updated. Some fields have been obsoleted. Please review and ensure your information is correct.
-			</span>
-		</span>
-	</div>
-	<!-- Sheet Header -->
-	<div class="sheet-3colrow">
-		<div class="sheet-col">
-			<div>
-				<div class="sheet-row sheet-h2">
-					Name:
-				</div>
-				<div class="sheet-row sheet-big">
-					<input type="text" name="attr_charname">
-				</div>
-			</div>
-		</div>
-		<div class="sheet-col">
-			<img src="http://i.imgur.com/IRCeOyE.png">
-		</div>
-		<div class="sheet-col">
-			<div>
-				<div class="sheet-row sheet-h2">
-					Occupation:
-				</div>
-				<div class="sheet-row sheet-big">
-					<input type="text" name="attr_charocc">
-				</div>
-			</div>
-		</div>
-	</div>
-	<br>
-	<!-- Navigation -->
-		<input type="radio" class="sheet-tab sheet-tab5" name="attr_core-tab" value="5" title="Core" checked="checked"/>
-		<span class="sheet-tab sheet-tab5" style='line-height: 40px;'>Core</span>
+  <!-- Sheet Header -->
+  <div class="sheet-3colrow">
+    <div class="sheet-col">
+      <div>
+        <div class="sheet-row">
+          <h2>Name:</h2>
+        </div>
+        <div class="sheet-row sheet-big buttons">
+          <input type="text" name="attr_charname" /> <br />
+          <h3>GM Roll Toggle</h3>
+          <input type="radio" name="attr_gmtoggle" value="/w gm " /><span>On</span>
+          <input type="radio" name="attr_gmtoggle" value="" checked="checked" /><span>Off</span>
+        </div>
+      </div>
+    </div>
+    <div class="sheet-col">
+      <img src="http://i.imgur.com/IRCeOyE.png">
+    </div>
+    <div class="sheet-col">
+      <div>
+        <div class="sheet-row">
+          <h2>Occupation:</h2>
+        </div>
+        <div class="sheet-row sheet-big">
+          <input type="text" name="attr_charocc">
+        </div>
+      </div>
+    </div>
+  </div>
+  <br>
+  <!-- Navigation -->
+    <input type="radio" class="sheet-tab sheet-tab5" name="attr_core-tab" value="5" title="Core" checked="checked"/>
+    <span class="sheet-tab sheet-tab5" style='line-height: 40px;'>Core</span>
 
-		<input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Traits &amp; Aptitudes" />
-		<span class="sheet-tab sheet-tab1" style='line-height: 40px;'>Traits &amp; Aptitudes</span>
+    <input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Traits &amp; Aptitudes" />
+    <span class="sheet-tab sheet-tab1" style='line-height: 40px;'>Traits &amp; Aptitudes</span>
 
-		<input type="radio" class="sheet-tab sheet-tab2" name="attr_core-tab" value="2" title="Combat Stuff"/>
-		<span class="sheet-tab sheet-tab2" style='line-height: 40px;'>Combat Stuff</span>
+    <input type="radio" class="sheet-tab sheet-tab2" name="attr_core-tab" value="2" title="Combat Stuff"/>
+    <span class="sheet-tab sheet-tab2" style='line-height: 40px;'>Combat Stuff</span>
 
-		<input type="radio" class="sheet-tab sheet-tab3" name="attr_core-tab" value="3" title="Arcane Ablities"/>
-		<span class="sheet-tab sheet-tab3" style='line-height: 40px;'>Arcane Ablities</span>
+    <input type="radio" class="sheet-tab sheet-tab3" name="attr_core-tab" value="3" title="Arcane Ablities"/>
+    <span class="sheet-tab sheet-tab3" style='line-height: 40px;'>Arcane Ablities</span>
 
-		<input type="radio" class="sheet-tab sheet-tab4" name="attr_core-tab" value="4" title="Misc"/>
-		<span class="sheet-tab sheet-tab4" style='line-height: 40px;'>Misc</span>
+    <input type="radio" class="sheet-tab sheet-tab4" name="attr_core-tab" value="4" title="Misc"/>
+    <span class="sheet-tab sheet-tab4" style='line-height: 40px;'>Misc</span>
 
-		<input type="radio" class="sheet-tab sheet-tab6" name="attr_core-tab" value="6" title="Obsolete Data"/>
-		<span class="sheet-tab sheet-tab6" style='line-height: 40px;'>Obsolete Data</span>
+    <input type="radio" class="sheet-tab sheet-tab6" name="attr_core-tab" value="6" title="Obsolete Data"/>
+    <span class="sheet-tab sheet-tab6" style='line-height: 40px;'>Obsolete Data</span>
 
-	<!-- Navigation -->
-	<br><br>
-	<div class="sheet-section-core">
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Core Attributes</div>
-			</div>
-			<div class="sheet-4colrow">
-				<div class="sheet-col">
-					<div class="sheet-item">
-						Pace:
-						<input type="number" name="attr_pace">
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-item">
-						Size:
-						<input type="number" name="attr_size">
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-item">
-						Max Wind:
-						<input type="number" name="attr_maxwind">
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-item">
-						Grit:
-						<input type="number" name="attr_grit">
-					</div>
-				</div>
-			</div>
-			<br>
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Fate Chips</div>
-			</div>
-			<div class="sheet-row">
-				<div class="sheet-row sheet-h3">
-					<div class="sheet-center">White Chips</div>
-				</div>
-				<div class="sheet-row">
-					<div class="sheet-item sheet-chipswhite"><b>0</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>1</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>2</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>3</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>4</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>5</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>6</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>7</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>8</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>9</b></div>
-					<div class="sheet-item sheet-chipswhite"><b>10</b></div>
-				</div>
-				<div class="sheet-row">
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="0">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="1">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="2">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="3">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="4">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="5">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="6">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="7">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="8">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="9">
-					</div>
-					<div class="sheet-item sheet-chipswhite">
-						<input type="radio" name="attr_fatew" value="10">
-					</div>
+  <!-- Navigation -->
+  <br><br>
+  <div class="sheet-section-core">
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Core Attributes</div>
+      </div>
+      <div class="sheet-4colrow">
+        <div class="sheet-col">
+          <div class="sheet-item">
+            Pace:
+            <input type="number" name="attr_pace">
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-item">
+            Size:
+            <input type="number" name="attr_size">
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-item">
+            Max Wind:
+            <input type="number" name="attr_maxwind">
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-item">
+            Grit:
+            <input type="number" name="attr_grit">
+          </div>
+        </div>
+      </div>
+      <br>
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Fate Chips</div>
+      </div>
+      <div class="sheet-row chiprow">
+        <div class="sheet-row sheet-h3">
+          <div class="sheet-center">White Chips</div>
+        </div>
+        <div class="sheet-row chiprow">
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="0" checked="checked"><span>0</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="1"><span>1</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="2"><span>2</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="3"><span>3</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="4"><span>4</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="5"><span>5</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="6"><span>6</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="7"><span>7</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="8"><span>8</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="9"><span>9</span>
+          </div>
+          <div class="sheet-item buttons">
+            <input type="radio" name="attr_fatew" value="10"><span>10</span>
+          </div>
+        </div>
+      </div>
+      <br>
+      <div class="sheet-3colrow">
+        <div class="sheet-col">
+          <div class="sheet-row sheet-h3">
+            <div class="sheet-center">Red Chips</div>
+          </div>
+          <div class="sheet-row chiprow">
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="0" checked="checked"><span>0</span>
+            </div>
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="1"><span>1</span>
+            </div>
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="2"><span>2</span>
+            </div>
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="3"><span>3</span>
+            </div>
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="4"><span>4</span>
+            </div>
+            <div class="sheet-item buttons buttonsred">
+              <input type="radio" name="attr_fater" value="5"><span>5</span>
+            </div>
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-row sheet-h3">
+            <div class="sheet-center">Blue Chips</div>
+          </div>
+          <div class="sheet-row chiprow">
+            <div class="sheet-item buttons buttonsblue">
+              <input type="radio" name="attr_fateb" value="0" checked="checked"><span>0</span>
+            </div>
+            <div class="sheet-item buttons buttonsblue">
+              <input type="radio" name="attr_fateb" value="1"><span>1</span>
+            </div>
+            <div class="sheet-item buttons buttonsblue">
+              <input type="radio" name="attr_fateb" value="2"><span>2</span>
+            </div>
+            <div class="sheet-item buttons buttonsblue">
+              <input type="radio" name="attr_fateb" value="3"><span>3</span>
+            </div>
+            <div class="sheet-item buttons buttonsblue">
+              <input type="radio" name="attr_fateb" value="4"><span>4</span>
+            </div>
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-row sheet-h3 chiprow">
+            <div class="sheet-center">Legend Chips</div>
+          </div>
+          <div class="sheet-row buttons chiprow">
+            <div class="sheet-item buttons buttonsleg">
+              <input type="radio" name="attr_fatel" value="0"><span>0</span>
+            </div>
+            <div class="sheet-item buttons buttonsleg">
+              <input type="radio" name="attr_fatel" value="1"><span>1</span>
+            </div>
+            <div class="sheet-item buttons buttonsleg">
+              <input type="radio" name="attr_fatel" value="2"><span>2</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br>
+    </div>
+    <br>
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Common Rolls</div>
+      </div>
+      <div class="sheet-4colrow">
+        <div class="sheet-col">
+          <div class="sheet-item sheet-xxxlarge"><label><b>Guts + Grit</b></label></div>
+          <div class="sheet-item sheet-small">
+            <button type="roll" name="roll_GutsGrit" value="@{gmtoggle}&{template:simple}  {{rollname=Guts+Grit}} {{dice=[[@{gutslvl}@{spidtype}!!k1+@{gutsmod}+@{grit}]]}}"></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Sheet Header -->
 
-				</div>
-			</div>
-			<br>
-			<div class="sheet-3colrow">
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h3">
-						<div class="sheet-center">Red Chips</div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsred"><b>0</b></div>
-						<div class="sheet-item sheet-chipsred"><b>1</b></div>
-						<div class="sheet-item sheet-chipsred"><b>2</b></div>
-						<div class="sheet-item sheet-chipsred"><b>3</b></div>
-						<div class="sheet-item sheet-chipsred"><b>4</b></div>
-						<div class="sheet-item sheet-chipsred"><b>5</b></div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="0">
-						</div>
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="1">
-						</div>
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="2">
-						</div>
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="3">
-						</div>
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="4">
-						</div>
-						<div class="sheet-item sheet-chipsred">
-							<input type="radio" name="attr_fater" value="5">
-						</div>
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h3">
-						<div class="sheet-center">Blue Chips</div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsblue"><b>0</b></div>
-						<div class="sheet-item sheet-chipsblue"><b>1</b></div>
-						<div class="sheet-item sheet-chipsblue"><b>2</b></div>
-						<div class="sheet-item sheet-chipsblue"><b>3</b></div>
-						<div class="sheet-item sheet-chipsblue"><b>4</b></div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsblue">
-							<input type="radio" name="attr_fateb" value="0">
-						</div>
-						<div class="sheet-item sheet-chipsblue">
-							<input type="radio" name="attr_fateb" value="1">
-						</div>
-						<div class="sheet-item sheet-chipsblue">
-							<input type="radio" name="attr_fateb" value="2">
-						</div>
-						<div class="sheet-item sheet-chipsblue">
-							<input type="radio" name="attr_fateb" value="3">
-						</div>
-						<div class="sheet-item sheet-chipsblue">
-							<input type="radio" name="attr_fateb" value="4">
-						</div>
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h3">
-						<div class="sheet-center">Legend Chips</div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsleg"><b>0</b></div>
-						<div class="sheet-item sheet-chipsleg"><b>1</b></div>
-						<div class="sheet-item sheet-chipsleg"><b>2</b></div>
-					</div>
-					<div class="sheet-row">
-						<div class="sheet-item sheet-chipsleg">
-							<input type="radio" name="attr_fatel" value="0">
-						</div>
-						<div class="sheet-item sheet-chipsleg">
-							<input type="radio" name="attr_fatel" value="1">
-						</div>
-						<div class="sheet-item sheet-chipsleg">
-							<input type="radio" name="attr_fatel" value="2">
-						</div>
-					</div>
-				</div>
-			</div>
-			<br>
-		</div>
-		<br>
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Common Rolls</div>
-			</div>
-			<div class="sheet-4colrow">
-				<div class="sheet-col">
-					<div class="sheet-item sheet-xxxlarge"><label><b>Guts + Grit</b></label></div>
-					<div class="sheet-item sheet-small">
-						<button type="roll" name="roll_GutsGrit" value="&{template:simple} {{rollname=Guts+Grit}} {{dice=[[@{gutslvl}@{spidtype}!!+@{gutsmod}+@{grit}]]}}"></button>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- Sheet Header -->
+  <!-- Traits & Aptitudes Tab -->
+  <div class="sheet-section-traits">
+    <div class="sheet-2colrow">
+      <div class="sheet-col">
+        <!-- Cognition -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Cognition</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_coglvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_cogdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Cognition}} {{dice=[[@{coglvl}@{cogdtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Artillery</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_artillerylvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_artillerymod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Artillery}} {{dice=[[@{artillerylvl}@{cogdtype}!!k1+@{artillerymod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Arts</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_artlvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_artconc">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_artconc" placeholder="Type Of Art"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_artconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Art - @{artconc}}} {{dice=[[@{artlvl}@{cogdtype}!!k1+@{artconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Scrutinize</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_scrutinizelvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_scrutinizemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Scrutinize}} {{dice=[[@{scrutinizelvl}@{cogdtype}!!k1+@{scrutinizemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Search(1)</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_searchlvl" value="1" placeholder="Always atleast 1"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_searchmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Search}} {{dice=[[@{searchlvl}@{cogdtype}!!k1+@{searchmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Trackin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_trackinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_trackinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Trackin'}} {{dice=[[@{trackinlvl}@{cogdtype}!!k1+@{trackinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extracogapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extracogapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extracogaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extracogaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extracogapt}}} {{dice=[[@{extracogaptlvl}@{cogdtype}!!k1+@{extracogaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Cognition -->
+        <!-- Deftness -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Deftness</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_deflvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_defdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Deftness" value="@{gmtoggle}&{template:simple}  {{rollname=Deftness}} {{dice=[[@{deflvl}@{defdtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Bow</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_bowlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_bowmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Bow" value="@{gmtoggle}&{template:simple}  {{rollname=Bow}} {{dice=[[@{bowlvl}@{defdtype}!!k1+@{bowmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Filchin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_filchinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_filchinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Filchin" value="@{gmtoggle}&{template:simple}  {{rollname=Filchin'}} {{dice=[[@{filchinlvl}@{defdtype}!!k1+@{filchinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Lockpickin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_lockpickinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_lockpickinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Lockpickin" value="@{gmtoggle}&{template:simple}  {{rollname=Lockpickin'}} {{dice=[[@{lockpickinlvl}@{defdtype}!!k1+@{lockpickinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Shootin'</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_shootinlvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_shootinconc">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_shootinconc" placeholder="Type of Gun"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_shootinconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_shootin" value="@{gmtoggle}&{template:simple}  {{rollname=Shootin' @{shootinconc}}} {{dice=[[@{shootinlvl}@{defdtype}!!k1+@{shootinconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Sleight o' Hand</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_sleightohandlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_sleightohandmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_sleightohand" value="@{gmtoggle}&{template:simple}  {{rollname=Sleight o' Hand}} {{dice=[[@{sleightohandlvl}@{defdtype}!!k1+@{sleightohandmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Speed Load</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_speedloadlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_speedloadmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_cognition" value="@{gmtoggle}&{template:simple}  {{rollname=Speed Load}} {{dice=[[@{speedloadlvl}@{defdtype}!!k1+@{speedloadmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Throwin'</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_throwinlvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_throwinconc">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_throwinconc" placeholder="Type of Weapon"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_throwincmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_Throwin" value="@{gmtoggle}&{template:simple}  {{rollname=Throwin' @{throwinconc}}} {{dice=[[@{throwinlvl}@{defdtype}!!k1+@{throwincmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extradefapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extradefapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extradefaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extradefaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extradefapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extradefapt}}} {{dice=[[@{extradefaptlvl}@{defdtype}!!k1+@{extradefaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Deftness -->
+      </div>
 
-	<!-- Traits & Aptitudes Tab -->
-	<div class="sheet-section-traits">
-		<div class="sheet-2colrow">
-			<div class="sheet-col">
-				<!-- Cognition -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Cognition</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_coglvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_cogdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Cognition}} {{dice=[[@{coglvl}@{cogdtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Artillery</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_artillerylvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_artillerymod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Artillery}} {{dice=[[@{artillerylvl}@{cogdtype}!!+@{artillerymod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Arts</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_artlvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_artconc">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_artconc" placeholder="Type Of Art"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_artconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Art - @{artconc}}} {{dice=[[@{artlvl}@{cogdtype}!!+@{artconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Scrutinize</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_scrutinizelvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_scrutinizemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Scrutinize}} {{dice=[[@{scrutinizelvl}@{cogdtype}!!+@{scrutinizemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Search(1)</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_searchlvl" value="1" placeholder="Always atleast 1"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_searchmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Search}} {{dice=[[@{searchlvl}@{cogdtype}!!+@{searchmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Trackin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_trackinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_trackinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Trackin'}} {{dice=[[@{trackinlvl}@{cogdtype}!!+@{trackinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extracogapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extracogapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extracogaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extracogaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=^@{extracogapt}}} {{dice=[[@{extracogaptlvl}@{cogdtype}!!+@{extracogaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Cognition -->
-				<!-- Deftness -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Deftness</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_deflvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_defdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Deftness" value="&{template:simple} {{rollname=Deftness}} {{dice=[[@{deflvl}@{defdtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Bow</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_bowlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_bowmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Bow" value="&{template:simple} {{rollname=Bow}} {{dice=[[@{bowlvl}@{defdtype}!!+@{bowmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Filchin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_filchinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_filchinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Filchin" value="&{template:simple} {{rollname=Filchin'}} {{dice=[[@{filchinlvl}@{defdtype}!!+@{filchinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Lockpickin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_lockpickinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_lockpickinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Lockpickin" value="&{template:simple} {{rollname=Lockpickin'}} {{dice=[[@{lockpickinlvl}@{defdtype}!!+@{lockpickinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Shootin'</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_shootinlvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_shootinconc">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_shootinconc" placeholder="Type of Gun"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_shootinconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_shootin" value="&{template:simple} {{rollname=Shootin' @{shootinconc}}} {{dice=[[@{shootinconc}@{defdtype}!!+@{shootinconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Sleight o' Hand</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_sleightohandlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_sleightohandmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_sleightohand" value="&{template:simple} {{rollname=Sleight o' Hand}} {{dice=[[@{sleightohandlvl}@{defdtype}!!+@{sleightohandmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Speed Load</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_speedloadlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_speedloadmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_cognition" value="&{template:simple} {{rollname=Speed Load}} {{dice=[[@{speedloadlvl}@{defdtype}!!+@{speedloadmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Throwin'</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_throwinlvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_throwinconc">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_throwinconc" placeholder="Type of Gun"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_throwincmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_Throwin" value="&{template:simple} {{rollname=Throwin' @{throwinconc}}} {{dice=[[@{throwinconc}@{defdtype}!!+@{throwincmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extradefapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extradefapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extradefaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extradefaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extradefapt" value="&{template:simple} {{rollname=^@{extradefapt}}} {{dice=[[@{extradefaptlvl}@{defdtype}!!+@{extradefaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Deftness -->
-			</div>
+      <div class="sheet-col">
+        <!-- Mien -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Mien</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_mienlvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_miendtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Mien" value="@{gmtoggle}&{template:simple}  {{rollname=Mien}} {{dice=[[@{mienlvl}@{miendtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Animal Wranglin'</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_aniwralvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_aniwraconc">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_aniwraconc" placeholder="Animal"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_aniwraconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_aniwra" value="@{gmtoggle}&{template:simple}  {{rollname=Animal Wranglin' @{aniwraconc}}} {{dice=[[@{aniwralvl}@{miendtype}!!k1+@{aniwraconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Leadership</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_leadershiplvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_leadershipmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Leadership" value="@{gmtoggle}&{template:simple}  {{rollname=Leadership}} {{dice=[[@{leadershiplvl}@{miendtype}!!k1+@{leadershipmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Overawe</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_overawelvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_overawemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Leadership" value="@{gmtoggle}&{template:simple}  {{rollname=Overawe}} {{dice=[[@{overawelvl}@{miendtype}!!k1+@{overawemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Performin'</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_performinlvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_performinconc">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_performinconc" placeholder="Singin"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_performinconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_Performin" value="@{gmtoggle}&{template:simple}  {{rollname=Performin' @{performinconc}}} {{dice=[[@{performinlvl}@{miendtype}!!k1+@{performinconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Persuasion</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_persuasionlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_persuasionmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Persuasion" value="@{gmtoggle}&{template:simple}  {{rollname=Persuasion}} {{dice=[[@{persuasionlvl}@{miendtype}!!k1+@{persuasionmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Tale Tellin</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_taletelllvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_taletellmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_TaleTellin" value="@{gmtoggle}&{template:simple}  {{rollname=Tale Tellin}} {{dice=[[@{taletelllvl}@{miendtype}!!k1+@{taletellmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extramienapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extramienapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extramienaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extramienaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extradefapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extramienapt}}} {{dice=[[@{extramienapt}@{miendtype}!!k1+@{extramienaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Mien -->
+        <!-- Spirit -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Spirit</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_spilvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_spidtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Mien" value="@{gmtoggle}&{template:simple}  {{rollname=Spirit}} {{dice=[[@{spilvl}@{spidtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Faith</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_faithlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_faithmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Faith" value="@{gmtoggle}&{template:simple}  {{rollname=Faith}} {{dice=[[@{faithlvl}@{spidtype}!!k1+@{faithmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Guts</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_gutslvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_gutsmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Guts" value="@{gmtoggle}&{template:simple}  {{rollname=Guts}} {{dice=[[@{gutslvl}@{spidtype}!!k1+@{gutsmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extraspiapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraspiapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extraspiaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extraspiaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extraspiapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extraspiapt}}} {{dice=[[@{extraspiaptlvl}@{spidtype}!!k1+@{extraspiaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Spirit -->
+        <!-- Strength -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Strength</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_strlvl" value=""></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_strdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Strength" value="@{gmtoggle}&{template:simple}  {{rollname=Strength}} {{dice=[[@{strlvl}@{strdtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extrastrapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extrastrapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extrastraptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extrastraptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extrastrapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extrastrapt}}} {{dice=[[@{extrastraptlvl}@{strdtype}!!k1+@{extrastraptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Strength -->
+        <!-- Vigor -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Vigor</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_viglvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_vigdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Vigor" value="@{gmtoggle}&{template:simple}  {{rollname=Vigor}} {{dice=[[@{viglvl}@{vigdtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extravigapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extravigapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extravigaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extravigaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extravigapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extravigapt}}} {{dice=[[@{extravigaptlvl}@{vigdtype}!!k1+@{extravigaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Vigor -->
+      </div>
+    </div>
+    <br>
+    <div class="sheet-2colrow">
+      <div class="sheet-col">
+        <!-- Knowledge -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Knowledge</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_knolvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_knodtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Knowledge" value="@{gmtoggle}&{template:simple}  {{rollname=Knowledge}} {{dice=[[@{knolvl}@{knodtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Academia</b></label></div>
+            </div>
+            <fieldset class="repeating_academiaconc">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_academianame" placeholder="Academia"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_academialvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_academiamod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_Academia" value="@{gmtoggle}&{template:simple}  {{rollname=Academia @{academianame}}} {{dice=[[@{academialvl}@{knodtype}!!k1+@{academiamod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Area Knowledge</b></label></div>
+            </div>
+            <div class="sheet-row">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third">Home County(2)</div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_akhomecountylvl" value="2"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_akhomecountymod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_akhomecounty" value="@{gmtoggle}&{template:simple}  {{rollname=Area Knowledge: Home County}} {{dice=[[@{akhomecountylvl}@{knodtype}!!k1+@{akhomecountymod}]]}}"></button>
+              </div>
+            </div>
+            <fieldset class="repeating_areakno">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_areaknoname" placeholder="Area"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_areaknolvl" value="2"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_areaknomod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_areakno" value="@{gmtoggle}&{template:simple}  {{rollname=Area Knowledge: @{areaknoname}}} {{dice=[[@{areaknolvl}@{knodtype}!!k1+@{areaknomod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Demolition</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_demolitionlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_demolitionmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Demolition" value="@{gmtoggle}&{template:simple}  {{rollname=Demolition}} {{dice=[[@{demolitionlvl}@{knodtype}!!k1+@{demolitionmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Disguise</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_disguiselvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_disguisemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Disguise" value="@{gmtoggle}&{template:simple}  {{rollname=Disguise}} {{dice=[[@{disguiselvl}@{knodtype}!!k1+@{disguisemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Language</b></label></div>
+            </div>
+            <fieldset class="repeating_language">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_languagename" placeholder="Language"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_languagelvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_languagemod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_Language" value="@{gmtoggle}&{template:simple}  {{rollname=Language: @{languagename}}} {{dice=[[@{languagelvl}@{knodtype}!!k1+@{languagemod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Mad Science</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_madscilvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_madscimod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_MadScience" value="@{gmtoggle}&{template:simple}  {{rollname=Mad Science}} {{dice=[[@{madscilvl}@{knodtype}!!k1+@{madscimod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Medicine</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_medicinelvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_medicine">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_medicineconc" placeholder="Medicine"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_medicineconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_Medicine" value="@{gmtoggle}&{template:simple}  {{rollname=Performin' @{medicineconc}}} {{dice=[[@{medicinelvl}@{knodtype}!!k1+@{medicineconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Professional</b></label></div>
+            </div>
+            <fieldset class="repeating_language">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_professionalname" placeholder="Professional"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_professionallvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_professionalmod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_Professional" value="@{gmtoggle}&{template:simple}  {{rollname=Professional @{professionalname}}} {{dice=[[@{professionallvl}@{knodtype}!!k1+@{professionalmod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Science</b></label></div>
+            </div>
+            <fieldset class="repeating_language">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_sciencename" placeholder="Chemistry"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_sciencelvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_sciencemod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_Science" value="@{gmtoggle}&{template:simple}  {{rollname=Science: @{sciencename}}} {{dice=[[@{sciencelvl}@{knodtype}!!k1+@{sciencemod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Trade</b></label></div>
+            </div>
+            <fieldset class="repeating_language">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_tradename" placeholder="Blacksmithing"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_tradelvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_trademod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_Trade" value="@{gmtoggle}&{template:simple}  {{rollname=Trade: @{sciencename}}} {{dice=[[@{tradelvl}@{knodtype}!!k1+@{trademod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extraknoapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraknoapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extraknoaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extraknoaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extraknoapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extraknoapt}}} {{dice=[[@{extraknoaptlvl}@{knodtype}!!k1+@{extraknoaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Knowledge -->
+      </div>
 
-			<div class="sheet-col">
-				<!-- Mien -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Mien</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_mienlvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_miendtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Mien" value="&{template:simple} {{rollname=Mien}} {{dice=[[@{mienlvl}@{miendtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Animal Wranglin'</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_aniwralvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_aniwraconc">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_aniwraconc" placeholder="Animal"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_aniwraconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_aniwra" value="&{template:simple} {{rollname=Animal Wranglin' @{aniwraconc}}} {{dice=[[@{aniwraconc}@{miendtype}!!+@{aniwraconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Leadership</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_leadershiplvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_leadershipmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Leadership" value="&{template:simple} {{rollname=Leadership}} {{dice=[[@{leadershiplvl}@{miendtype}!!+@{leadershipmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Overawe</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_overawelvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_overawemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Leadership" value="&{template:simple} {{rollname=Overawe}} {{dice=[[@{overawelvl}@{miendtype}!!+@{overawemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Performin'</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_performinlvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_performinconc">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_performinconc" placeholder="Animal"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_performinconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_Performin" value="&{template:simple} {{rollname=Performin' @{performinconc}}} {{dice=[[@{performinconc}@{miendtype}!!+@{performinconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Persuasion</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_persuasionlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_persuasionmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Persuasion" value="&{template:simple} {{rollname=Persuasion}} {{dice=[[@{persuasionlvl}@{miendtype}!!+@{persuasionmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Tale Tellin</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_taletelllvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_taletellmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_TaleTellin" value="&{template:simple} {{rollname=Tale Tellin}} {{dice=[[@{taletelllvl}@{miendtype}!!+@{taletellmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extramienapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extramienapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extramienaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extramienaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extradefapt" value="&{template:simple} {{rollname=^@{extramienapt}}} {{dice=[[@{extramienaptlvl}@{miendtype}!!+@{extramienaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Mien -->
-				<!-- Spirit -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Spirit</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_spilvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_spidtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Mien" value="&{template:simple} {{rollname=Spirit}} {{dice=[[@{spilvl}@{spidtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Faith</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_faithlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_faithmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Faith" value="&{template:simple} {{rollname=Faith}} {{dice=[[@{faithlvl}@{spidtype}!!+@{faithmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Guts</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_gutslvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_gutsmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Guts" value="&{template:simple} {{rollname=Guts}} {{dice=[[@{gutslvl}@{spidtype}!!+@{gutsmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extraspiapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraspiapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extraspiaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extraspiaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extraspiapt" value="&{template:simple} {{rollname=^@{extraspiapt}}} {{dice=[[@{extraspiaptlvl}@{spidtype}!!+@{extraspiaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Spirit -->
-				<!-- Strength -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Strength</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_strlvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_strdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Strength" value="&{template:simple} {{rollname=Strength}} {{dice=[[@{strlvl}@{strdtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extrastrapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extrastrapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extrastraptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extrastraptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extrastrapt" value="&{template:simple} {{rollname=^@{extrastrapt}}} {{dice=[[@{extrastraptlvl}@{strdtype}!!+@{extrastraptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Strength -->
-				<!-- Vigor -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Vigor</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_viglvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_vigdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Vigor" value="&{template:simple} {{rollname=Vigor}} {{dice=[[@{viglvl}@{vigdtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extravigapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extravigapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extravigaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extravigaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extravigapt" value="&{template:simple} {{rollname=^@{extravigapt}}} {{dice=[[@{extravigaptlvl}@{vigdtype}!!+@{extravigaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Vigor -->
-			</div>
-		</div>
-		<br>
-		<div class="sheet-2colrow">
-			<div class="sheet-col">
-				<!-- Knowledge -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Knowledge</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_knolvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_knodtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Knowledge" value="&{template:simple} {{rollname=Knowledge}} {{dice=[[@{knolvl}@{knodtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Academia</b></label></div>
-						</div>
-						<fieldset class="repeating_academiaconc">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_academianame" placeholder="Academia"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_academialvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_academiamod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_Academia" value="&{template:simple} {{rollname=Academia @{academianame}}} {{dice=[[@{academialvl}@{knodtype}!!+@{academiamod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Area Knowledge</b></label></div>
-						</div>
-						<div class="sheet-row">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third">Home County(2)</div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_akhomecountylvl" value="2"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_akhomecountymod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_akhomecounty" value="&{template:simple} {{rollname=Area Knowledge: Home County}} {{dice=[[@{akhomecountylvl}@{knodtype}!!+@{akhomecountymod}]]}}"></button>
-							</div>
-						</div>
-						<fieldset class="repeating_areakno">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_areaknoname" placeholder="Area"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_areaknolvl" value="2"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_areaknomod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_areakno" value="&{template:simple} {{rollname=Area Knowledge: @{areaknoname}}} {{dice=[[@{areaknolvl}@{knodtype}!!+@{areaknomod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Demolition</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_demolitionlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_demolitionmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Demolition" value="&{template:simple} {{rollname=Demolition}} {{dice=[[@{demolitionlvl}@{knodtype}!!+@{demolitionmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Disguise</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_disguiselvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_disguisemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Disguise" value="&{template:simple} {{rollname=Disguise}} {{dice=[[@{disguiselvl}@{knodtype}!!+@{disguisemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Language</b></label></div>
-						</div>
-						<fieldset class="repeating_language">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_languagename" placeholder="Language"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_languagelvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_languagemod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_Language" value="&{template:simple} {{rollname=Language: @{languagename}}} {{dice=[[@{languagelvl}@{knodtype}!!+@{languagemod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Mad Science</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_madscilvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_madscimod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_MadScience" value="&{template:simple} {{rollname=Mad Science}} {{dice=[[@{madscilvl}@{knodtype}!!+@{madscimod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Medicine</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_medicinelvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_medicine">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_medicineconc" placeholder="Medicine"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_medicineconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_Medicine" value="&{template:simple} {{rollname=Performin' @{medicineconc}}} {{dice=[[@{medicinelvl}@{knodtype}!!+@{medicineconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Professional</b></label></div>
-						</div>
-						<fieldset class="repeating_language">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_professionalname" placeholder="Professional"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_professionallvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_professionalmod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_Professional" value="&{template:simple} {{rollname=Professional @{professionalname}}} {{dice=[[@{professionallvl}@{knodtype}!!+@{professionalmod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Science</b></label></div>
-						</div>
-						<fieldset class="repeating_language">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_sciencename" placeholder="Professional"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_sciencelvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_sciencemod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_Science" value="&{template:simple} {{rollname=Science: @{sciencename}}} {{dice=[[@{sciencelvl}@{knodtype}!!+@{sciencemod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Trade</b></label></div>
-						</div>
-						<fieldset class="repeating_language">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_tradename" placeholder="Professional"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_tradelvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_trademod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_Trade" value="&{template:simple} {{rollname=Trade: @{sciencename}}} {{dice=[[@{tradelvl}@{knodtype}!!+@{trademod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extraknoapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraknoapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extraknoaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extraknoaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extraknoapt" value="&{template:simple} {{rollname=^@{extraknoapt}}} {{dice=[[@{extraknoaptlvl}@{knodtype}!!+@{extraknoaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Knowledge -->
-			</div>
+      <div class="sheet-col">
+        <!-- Smarts -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Smarts</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_smalvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_smadtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Smarts" value="@{gmtoggle}&{template:simple}  {{rollname=Smarts}} {{dice=[[@{smalvl}@{smadtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Bluff</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_blufflvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_bluffmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Bluff" value="@{gmtoggle}&{template:simple}  {{rollname=Bluff}} {{dice=[[@{blufflvl}@{smadtype}!!k1+@{bluffmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Gamblin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_gamblinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_gamblinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Gamblin" value="@{gmtoggle}&{template:simple}  {{rollname=Gamblin'}} {{dice=[[@{gamblinlvl}@{smadtype}!!k1+@{gamblinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Ridicule</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_ridiculelvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_ridiculemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Ridicule" value="@{gmtoggle}&{template:simple}  {{rollname=Ridicule}} {{dice=[[@{ridiculelvl}@{smadtype}!!k1+@{ridiculemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Scroungin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_scrounginlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_scrounginmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Scroungin" value="@{gmtoggle}&{template:simple}  {{rollname=Scroungin'}} {{dice=[[@{scrounginlvl}@{smadtype}!!k1+@{scrounginmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Streetwise</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_streetwiselvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_streetwisemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Streetwise" value="@{gmtoggle}&{template:simple}  {{rollname=Streetwise}} {{dice=[[@{streetwiselvl}@{smadtype}!!k1+@{streetwisemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Survival</b></label></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_survivallvl" placeholder="Level"></div>
+            </div>
+            <fieldset class="repeating_survivalcon">
+              <div class="sheet-item sheet-large">&nbsp;</div>
+              <div class="sheet-item sheet-third"><input type="text" name="attr_survivalconname" placeholder="Plains"></div>
+              <div class="sheet-item sheet-tiny">&nbsp;</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_survivalconcmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_Performin" value="@{gmtoggle}&{template:simple}  {{rollname=Survival @{survivalconname}}} {{dice=[[@{survivallvl}@{spidtype}!!k1+@{survivalconcmod}]]}}"></button>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Tinkerin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_tinkerinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_tinkerinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Tinkerin" value="@{gmtoggle}&{template:simple}  {{rollname=Tinkerin'}} {{dice=[[@{tinkerinlvl}@{smadtype}!!k1+@{tinkerinmod}]]}}"></button>
+            </div>
+          </div>
 
-			<div class="sheet-col">
-				<!-- Smarts -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Smarts</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_smalvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_smadtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Smarts" value="&{template:simple} {{rollname=Smarts}} {{dice=[[@{smalvl}@{smadtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Bluff</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_blufflvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_bluffmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Bluff" value="&{template:simple} {{rollname=Bluff}} {{dice=[[@{blufflvl}@{smadtype}!!+@{bluffmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Gamblin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_gamblinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_gamblinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Gamblin" value="&{template:simple} {{rollname=Gamblin'}} {{dice=[[@{gamblinlvl}@{smadtype}!!+@{gamblinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Ridicule</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_ridiculelvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_ridiculemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Ridicule" value="&{template:simple} {{rollname=Ridicule}} {{dice=[[@{ridiculelvl}@{smadtype}!!+@{ridiculemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Scroungin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_scrounginlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_scrounginmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Scroungin" value="&{template:simple} {{rollname=Scroungin'}} {{dice=[[@{scrounginlvl}@{smadtype}!!+@{scrounginmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Streetwise</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_streetwiselvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_streetwisemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Streetwise" value="&{template:simple} {{rollname=Streetwise}} {{dice=[[@{streetwiselvl}@{smadtype}!!+@{streetwisemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Survival</b></label></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_survivallvl" placeholder="Level"></div>
-						</div>
-						<fieldset class="repeating_survivalcon">
-							<div class="sheet-item sheet-large">&nbsp;</div>
-							<div class="sheet-item sheet-third"><input type="text" name="attr_survivalconname" placeholder="Animal"></div>
-							<div class="sheet-item sheet-tiny">&nbsp;</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_survivalconcmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_Performin" value="&{template:simple} {{rollname=Survival @{survivalconname}}} {{dice=[[@{survivallvl}@{spidtype}!!+@{survivalconcmod}]]}}"></button>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Tinkerin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_tinkerinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_tinkerinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Tinkerin" value="&{template:simple} {{rollname=Tinkerin'}} {{dice=[[@{tinkerinlvl}@{smadtype}!!+@{tinkerinmod}]]}}"></button>
-						</div>
-					</div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extrasmaapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extrasmaapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extrasmaaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extrasmaaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extrasmaapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extrasmaapt}}} {{dice=[[@{extrasmaaptlvl}@{smadtype}!!k1+@{extrasmaaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Smarts -->
+      </div>
+    </div>
+    <div class="sheet-2colrow">
+      <div class="sheet-col">
+        <!-- Nimbleness -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Nimbleness</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_nimlvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_nimdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Nimbleness" value="@{gmtoggle}&{template:simple}  {{rollname=Nimbleness}} {{dice=[[@{nimlvl}@{nimdtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Climbin'(1)</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_climbinlvl" value="1"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_climbinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Climbin" value="@{gmtoggle}&{template:simple}  {{rollname=Climbin'}} {{dice=[[@{climbinlvl}@{nimdtype}!!k1+@{climbinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Dodge</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_dodgelvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_dodgemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Dodge" value="@{gmtoggle}&{template:simple}  {{rollname=Dodge}} {{dice=[[@{dodgelvl}@{nimdtype}!!k1+@{dodgemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Drivin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_drivinlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_drivinmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Drivin" value="@{gmtoggle}&{template:simple}  {{rollname=Drivin'}} {{dice=[[@{drivinlvl}@{nimdtype}!!k1+@{drivinmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><label><b>Fightin'</b></label></div>
+            </div>
+            <fieldset class="repeating_fightin">
+              <div class="sheet-row">
+                <div class="sheet-item sheet-large">&nbsp;</div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_fightinname" placeholder="Brawlin’"></div>
+                <div class="sheet-item sheet-large"><input type="number" name="attr_fightinlvl" placeholder="Level"></div>
+                <div class="sheet-item sheet-tiny">+</div>
+                <div class="sheet-item sheet-large"><input type="text" name="attr_fightinmod" placeholder="Mod"></div>
+                <div class="sheet-itemright sheet-small">
+                  <button type="roll" name="roll_fightin" value="@{gmtoggle}&{template:simple}  {{rollname=Fightin' @{fightinname}}} {{dice=[[@{fightinlvl}@{nimdtype}!!k1+@{fightinmod}]]}}"></button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Horse Ridin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_horselvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_horsemod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_HorseRide" value="@{gmtoggle}&{template:simple}  {{rollname=Horse Ridin'}} {{dice=[[@{horselvl}@{nimdtype}!!k1+@{horsemod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Sneak(1)</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_sneaklvl" value="1"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_sneakmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Sneak" value="@{gmtoggle}&{template:simple}  {{rollname=Sneak}} {{dice=[[@{sneaklvl}@{nimdtype}!!k1+@{sneakmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Swimmin'</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_swimminlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_swimminmod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Swimmin" value="@{gmtoggle}&{template:simple}  {{rollname=Swimmin'}} {{dice=[[@{swimminlvl}@{nimdtype}!!k1+@{swimminmod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Teamster</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_teamsterlvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_teamstermod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_teamster" value="@{gmtoggle}&{template:simple}  {{rollname=Swimmin'}} {{dice=[[@{teamsterlvl}@{nimdtype}!!k1+@{teamstermod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extranimapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extranimapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extranimaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extranimaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extranimapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extranimapt}}} {{dice=[[@{extranimaptlvl}@{nimdtype}!!k1+@{extranimaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Nimbleness -->
+      </div>
+      <div class="sheet-col">
+        <!-- Quickness -->
+        <div class="sheet-borderdiv">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge sheet-h2"><label><b>Quickness</b></label></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_quilvl"></div>
+            <div class="sheet-item sheet-tiny">d</div>
+            <div class="sheet-item sheet-large">
+              <select name="attr_quidtype" class="dtype" style="margin-bottom: 0px; width: 60px">
+                <option select="selected" value="d4">4</option>
+                <option value="d6">6</option>
+                <option value="d8">8</option>
+                <option value="d10">10</option>
+                <option value="d12">12</option>
+              </select>
+            </div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_Quickness" value="@{gmtoggle}&{template:simple}  {{rollname=Quickness}} {{dice=[[@{quilvl}@{quidtype}!!k1]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-xhuge"><label><b>Quick Draw</b></label></div>
+            <div class="sheet-item sheet-large"><input type="number" name="attr_quidralvl" placeholder="Level"></div>
+            <div class="sheet-item sheet-tiny">+</div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_quidramod" placeholder="Mod"></div>
+            <div class="sheet-itemright sheet-small">
+              <button type="roll" name="roll_QuickDraw" value="@{gmtoggle}&{template:simple}  {{rollname=Quick Draw}} {{dice=[[@{quidralvl}@{quidtype}!!k1+@{quidramod}]]}}"></button>
+            </div>
+          </div>
+          <hr class="sheet-apthr">
+          <fieldset class="repeating_extraquidapt">
+            <div class="sheet-row">
+              <div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraquidapt" placeholder="Other Aptitude"></div>
+              <div class="sheet-item sheet-large"><input type="number" name="attr_extraquidaptlvl" placeholder="Level"></div>
+              <div class="sheet-item sheet-tiny">+</div>
+              <div class="sheet-item sheet-large"><input type="text" name="attr_extraquidaptmod" placeholder="Mod"></div>
+              <div class="sheet-itemright sheet-small">
+                <button type="roll" name="roll_extraquidapt" value="@{gmtoggle}&{template:simple}  {{rollname=^@{extraquidapt}}} {{dice=[[@{extraquidaptlvl}@{quidtype}!!k1+@{extraquidaptmod}]]}}"></button>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <!-- Quickness -->
+      </div>
+    </div>
+  </div>
+  <!-- Traits & Aptitudes Tab -->
 
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extrasmaapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extrasmaapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extrasmaaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extrasmaaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extrasmaapt" value="&{template:simple} {{rollname=^@{extrasmaapt}}} {{dice=[[@{extrasmaaptlvl}@{smadtype}!!+@{extrasmaaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Smarts -->
-			</div>
-		</div>
-		<div class="sheet-2colrow">
-			<div class="sheet-col">
-				<!-- Nimbleness -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Nimbleness</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_nimlvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_nimdtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Nimbleness" value="&{template:simple} {{rollname=Nimbleness}} {{dice=[[@{nimlvl}@{nimdtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Climbin'(1)</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_climbinlvl" value="1"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_climbinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Climbin" value="&{template:simple} {{rollname=Climbin'}} {{dice=[[@{climbinlvl}@{nimdtype}!!+@{climbinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Dodge</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_dodgelvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_dodgemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Dodge" value="&{template:simple} {{rollname=Dodge}} {{dice=[[@{dodgelvl}@{nimdtype}!!+@{dodgemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Drivin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_drivinlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_drivinmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Drivin" value="&{template:simple} {{rollname=Drivin'}} {{dice=[[@{drivinlvl}@{nimdtype}!!+@{drivinmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><label><b>Fightin'</b></label></div>
-						</div>
-						<fieldset class="repeating_fightin">
-							<div class="sheet-row">
-								<div class="sheet-item sheet-large">&nbsp;</div>
-								<div class="sheet-item sheet-third"><input type="text" name="attr_fightinname" placeholder="Academia"></div>
-								<div class="sheet-item sheet-large"><input type="number" name="attr_fightinlvl" placeholder="Level"></div>
-								<div class="sheet-item sheet-tiny">+</div>
-								<div class="sheet-item sheet-large"><input type="text" name="attr_fightinmod" placeholder="Mod"></div>
-								<div class="sheet-itemright sheet-small">
-									<button type="roll" name="roll_fightin" value="&{template:simple} {{rollname=Fightin' @{fightinname}}} {{dice=[[@{fightinlvl}@{nimdtype}!!+@{fightinmod}]]}}"></button>
-								</div>
-							</div>
-						</fieldset>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Horse Ridin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_horselvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_horsemod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_HorseRide" value="&{template:simple} {{rollname=Horse Ridin'}} {{dice=[[@{horselvl}@{nimdtype}!!+@{horsemod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Sneak(1)</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_sneaklvl" value="1"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_sneakmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Sneak" value="&{template:simple} {{rollname=Sneak}} {{dice=[[@{sneaklvl}@{nimdtype}!!+@{sneakmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Swimmin'</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_swimminlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_swimminmod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Swimmin" value="&{template:simple} {{rollname=Swimmin'}} {{dice=[[@{swimminlvl}@{nimdtype}!!+@{swimminmod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Teamster</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_teamsterlvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_teamstermod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_teamster" value="&{template:simple} {{rollname=Swimmin'}} {{dice=[[@{teamsterlvl}@{nimdtype}!!+@{teamstermod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extranimapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extranimapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extranimaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extranimaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extranimapt" value="&{template:simple} {{rollname=^@{extranimapt}}} {{dice=[[@{extranimaptlvl}@{nimdtype}!!+@{extranimaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Nimbleness -->
-			</div>
-			<div class="sheet-col">
-				<!-- Quickness -->
-				<div class="sheet-borderdiv">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge sheet-h2"><label><b>Quickness</b></label></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_quilvl"></div>
-						<div class="sheet-item sheet-tiny">d</div>
-						<div class="sheet-item sheet-large">
-							<select name="attr_quidtype" class="dtype" style="margin-bottom: 0px; width: 60px">
-								<option value="d4">4</option>
-								<option value="d6">6</option>
-								<option value="d8">8</option>
-								<option value="d10">10</option>
-								<option value="d12">12</option>
-							</select>
-						</div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_Quickness" value="&{template:simple} {{rollname=Quickness}} {{dice=[[@{quilvl}@{quidtype}!!]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-xhuge"><label><b>Quick Draw</b></label></div>
-						<div class="sheet-item sheet-large"><input type="number" name="attr_quidralvl" placeholder="Level"></div>
-						<div class="sheet-item sheet-tiny">+</div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_quidramod" placeholder="Mod"></div>
-						<div class="sheet-itemright sheet-small">
-							<button type="roll" name="roll_QuickDraw" value="&{template:simple} {{rollname=Quick Draw}} {{dice=[[@{quidralvl}@{quidtype}!!+@{quidramod}]]}}"></button>
-						</div>
-					</div>
-					<hr class="sheet-apthr">
-					<fieldset class="repeating_extraquidapt">
-						<div class="sheet-row">
-							<div class="sheet-item sheet-xhuge"><input type="text" name="attr_extraquidapt" placeholder="Other Aptitude"></div>
-							<div class="sheet-item sheet-large"><input type="number" name="attr_extraquidaptlvl" placeholder="Level"></div>
-							<div class="sheet-item sheet-tiny">+</div>
-							<div class="sheet-item sheet-large"><input type="text" name="attr_extraquidaptmod" placeholder="Mod"></div>
-							<div class="sheet-itemright sheet-small">
-								<button type="roll" name="roll_extraquidapt" value="&{template:simple} {{rollname=^@{extraquidapt}}} {{dice=[[@{extraquidaptlvl}@{quidtype}!!+@{extraquidaptmod}]]}}"></button>
-							</div>
-						</div>
-					</fieldset>
-				</div>
-				<!-- Quickness -->
-			</div>
-		</div>
-	</div>
-	<!-- Traits & Aptitudes Tab -->
+  <!-- Combat Stuff Tab -->
+  <div class="sheet-section-combat">
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Wounds</div>
+      </div>
+      <div class="sheet-row">
+        <div class="sheet-small2">
+          <b>L.Arm</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_larmwtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+        <div class="sheet-small2">
+          <b>L.Leg</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_llegwtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+        <div class="sheet-small2">
+          <b>Head</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_headwtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+        <div class="sheet-small2">
+          <b>Guts</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_gutswtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+        <div class="sheet-small2">
+          <b>R.Arm</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_rarmwtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+        <div class="sheet-small2">
+          <b>R.Leg</b>
+        </div>
+        <div class="sheet-large">
+          <select name="attr_rlegwtype" class="sheet-wounds">
+            <option value="0">None</option>
+            <option value="1">Light</option>
+            <option value="2">Heavy</option>
+            <option value="3">Serious</option>
+            <option value="4">Critical</option>
+            <option value="5">Maimed</option>
+          </select>
+        </div>
+      </div>
 
-	<!-- Combat Stuff Tab -->
-	<div class="sheet-section-combat">
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Wounds</div>
-			</div>
-			<div class="sheet-row">
-				<div class="sheet-small2">
-					<b>L.Arm</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_larmwtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-				<div class="sheet-small2">
-					<b>L.Leg</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_llegwtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-				<div class="sheet-small2">
-					<b>Head</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_headwtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-				<div class="sheet-small2">
-					<b>Guts</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_gutswtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-				<div class="sheet-small2">
-					<b>R.Arm</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_rarmwtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-				<div class="sheet-small2">
-					<b>R.Leg</b>
-				</div>
-				<div class="sheet-large">
-					<select name="attr_rlegwtype" class="sheet-wounds">
-						<option value="0">None</option>
-						<option value="1">Light</option>
-						<option value="2">Heavy</option>
-						<option value="3">Serious</option>
-						<option value="4">Critical</option>
-						<option value="5">Maimed</option>
-					</select>
-				</div>
-			</div>
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Wind</div>
+      </div>
+      <div class="sheet-row windrow">
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="0" checked="checked"><span>0</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="1"><span>1</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="2"><span>2</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="3"><span>3</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="4"><span>4</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="5"><span>5</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="6"><span>6</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="7"><span>7</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="8"><span>8</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="9"><span>9</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="10"><span>10</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="11"><span>11</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="12"><span>12</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="13"><span>13</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="14"><span>14</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="15"><span>15</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="16"><span>16</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="17"><span>17</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="18"><span>18</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="19"><span>19</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="20"><span>20</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="21"><span>21</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="22"><span>22</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="23"><span>23</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="24"><span>24</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="25"><span>25</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="26"><span>26</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="27"><span>27</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="28"><span>28</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="29"><span>29</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="30"><span>30</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="31"><span>31</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="32"><span>32</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="33"><span>33</span></div>
+          <div class="sheet-item sheet-wind buttons"><input type="radio" name="attr_wind" value="34"><span>34</span></div>
+      </div>
+    </div>
+    <br>
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Ammo</div>
+      </div>
+      <div class="sheet-row">
+        <div class="sheet-row">
+          <div class="sheet-item sheet-third"><label><b>Ammo Name</b></label></div>
+          <div class="sheet-item sheet-large"><label><b>QTY</b></label></div>
+          <div class="sheet-item sheet-xxxlarge"><label><b>Notes</b></label></div>
+        </div>
+        <fieldset class="repeating_ammo">
+          <div class="sheet-row">
+            <div class="sheet-item sheet-third"><input type="text" name="attr_ammoname" placeholder="Pistol (.40-.50)"></div>
+            <div class="sheet-item sheet-large"><input type="text" name="attr_ammoqty" placeholder="50"></div>
+            <div class="sheet-item sheet-xxxlarge"><textarea name="attr_ammonotes" class="sheet-shorttextarea" placeholder="Ammo notes"></textarea></div>
+          </div>
+        </fieldset>
+      </div>
 
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Wind</div>
-			</div>
-			<div class="sheet-row">
-				<div class="sheet-row">
-					<div class="sheet-item sheet-wind"><label><b>0</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>1</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>2</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>3</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>4</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>5</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>6</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>7</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>8</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>9</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>10</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>11</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>12</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>13</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>14</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>15</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>16</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>17</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>18</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>19</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>20</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>21</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>22</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>23</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>24</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>25</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>26</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>27</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>28</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>29</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>30</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>31</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>32</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>33</b></label></div>
-					<div class="sheet-item sheet-wind"><label><b>34</b></label></div>
-				</div>
-				<div class="sheet-row">
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="0"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="1"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="2"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="3"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="4"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="5"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="6"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="7"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="8"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="9"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="10"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="11"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="12"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="13"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="14"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="15"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="16"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="17"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="18"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="19"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="20"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="21"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="22"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="23"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" value="24" name="attr_wind"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="25"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="26"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="27"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="28"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="29"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="30"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="31"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="32"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="33"></div>
-					<div class="sheet-item sheet-wind"><input type="radio" name="attr_wind" value="34"></div>
-				</div>
-			</div>
-		</div>
-		<br>
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Ammo</div>
-			</div>
-			<div class="sheet-row">
-				<div class="sheet-row">
-					<div class="sheet-item sheet-third"><label><b>Ammo Name</b></label></div>
-					<div class="sheet-item sheet-large"><label><b>QTY</b></label></div>
-					<div class="sheet-item sheet-xxxlarge"><label><b>Notes</b></label></div>
-				</div>
-                <fieldset class="repeating_ammo">
-					<div class="sheet-row">
-						<div class="sheet-item sheet-third"><input type="text" name="attr_ammoname"></div>
-						<div class="sheet-item sheet-large"><input type="text" name="attr_ammoqty"></div>
-						<div class="sheet-item sheet-xxxlarge"><textarea name="attr_ammonotes" class="sheet-shorttextarea"></textarea></div>
-					</div>
-                </fieldset>
-			</div>
+    </div>
+    <br>
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Shootin Irons &amp; Such</div>
+      </div>
+      <div class="sheet-row">
+        <div class="sheet-item sheet-xlarge"><label><b>Weapon</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Shots</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>RoF</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Range</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Damage</b></label></div>
+        <div class="sheet-item sheet-xlarge location"><label><b>Location Toggle</b></label>
+          <input type="radio" name="attr_locationtoggle" value="{{location=[[1d20]]}}" /><span>On</span>
+          <input type="radio" name="attr_locationtoggle" value="" checked="checked" /><span>Off</span>
+        </div>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname1" placeholder="Colt Army"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots1" placeholder="6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof1" placeholder="1"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange1" placeholder="10"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg1">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage1" placeholder="3d6"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname1}}} {{damage=[[@{rngweapondamage1}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname2"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots2"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof2"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange2"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg2">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage2"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname2}}} {{damage=[[@{rngweaponrange2}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname3"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots3"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof3"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange3"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg3">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage3"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname3}}} {{damage=[[@{rngweaponrange3}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname4"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots4"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof4"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange4"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg4">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage4"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname4}}} {{damage=[[@{rngweaponrange4}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname5"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots5"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof5"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange5"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg5">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage5"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname5}}} {{damage=[[@{rngweaponrange5}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange6"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg6">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage6"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{rngweaponname6}}} {{damage=[[@{rngweapondamage6}!!]]}} @{locationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+    </div>
+    <br>
+    <div class="sheet-borderdiv">
+      <div class="sheet-row sheet-h1">
+        <div class="sheet-center">Hand-To-Hand Weapons</div>
+      </div>
+      <div class="sheet-row">
+        <div class="sheet-item sheet-xlarge"><label><b>Weapon</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Defense</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Speed</b></label></div>
+        <div class="sheet-item sheet-large"><label><b>Damage</b></label></div>
+        <div class="sheet-item sheet-xlarge location"><label><b>Location Toggle</b></label>
+          <input type="radio" name="attr_meleelocationtoggle" value="{{location=[[1d20]]}}" /><span>On</span>
+          <input type="radio" name="attr_meleelocationtoggle" value="" checked="checked" /><span>Off</span>
+        </div>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname1" value="" placeholder="Fist"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense1" value="" placeholder="-"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed1" value="" placeholder=""></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg1">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage1" value="" placeholder="(Add 0 to roll only STR)"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname1}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage1}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname2" placeholder="Knife"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense2" placeholder="+1"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed2"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg2">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage2" placeholder="1d4"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname2}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage2}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname3"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense3"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed3"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg3">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage3"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname3}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage3}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname4"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense4"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed4"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg4">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage4"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname4}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage4}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname5"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense5"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed5"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg5">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage5"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname5}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage5}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+      <div class="sheet-row" style="vertical-align: top;">
+        <div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense6"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed6"></div>
+        <div class="sheet-item sheet-xxxlarge">
+          <fieldset class="repeating_rngweapons_dmg6">
+            <div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage6"></div>
+            <div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="@{gmtoggle}&{template:simple} {{rollname=@{meleeweaponname6}}} {{strength=[[@{strlvl}@{strdtype}!!k1]]}} {{meleedamage=[[@{meleeweapondamage6}!!]]}} @{meleelocationtoggle}"></button></div>
+          </fieldset>
+        </div><br>
+        <hr>
+      </div>
+    </div>
+  </div>
+  <!-- Combat Stuff Tab -->
 
-		</div>
-		<br>
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Shootin Irons &amp; Such</div>
-			</div>
-			<div class="sheet-row">
-			<div class="sheet-row">
-				<div class="sheet-item sheet-xlarge"><label><b>Weapon</b></label></div>
-				<div class="sheet-item sheet-large"><label><b>Shots</b></label></div>
-				<div class="sheet-item sheet-large"><label><b>RoF</b></label></div>
-				<div class="sheet-item sheet-large"><label><b>Range</b></label></div>
-				<div class="sheet-item sheet-xxxlarge"><label><b>Damage</b></label></div>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname1"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots1"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof1"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange1"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg1">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage1"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage1}]] for dmg with a @{rngweaponname1}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname2"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots2"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof2"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange2"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg2">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage2"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage2}]] for dmg with a @{rngweaponname2}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname3"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots3"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof3"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange3"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg3">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage3"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage3}]] for dmg with a @{rngweaponname3}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname4"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots4"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof4"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange4"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg4">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage4"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage4}]] for dmg with a @{rngweaponname4}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname5"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots5"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof5"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange5"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg5">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage5"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage5}]] for dmg with a @{rngweaponname5}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_rngweaponname6"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponshots6"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrof6"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_rngweaponrange6"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg6">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_rngweapondamage6"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{rngweapondamage}]] for dmg with a @{rngweaponname6}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-		</div>
-		</div>
-		<br>
-		<div class="sheet-borderdiv">
-			<div class="sheet-row sheet-h1">
-				<div class="sheet-center">Hand-To-Hand Weapons</div>
-			</div>
-			<div class="sheet-row">
-			<div class="sheet-row">
-				<div class="sheet-item sheet-xlarge"><label><b>Weapon</b></label></div>
-				<div class="sheet-item sheet-large"><label><b>Defense</b></label></div>
-				<div class="sheet-item sheet-large"><label><b>Speed</b></label></div>
-				<div class="sheet-item sheet-xxxlarge"><label><b>Damage</b></label></div>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname1"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense1"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed1"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg1">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage1"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage1}]] for dmg with a @{meleeweapondamage1}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname2"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense2"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed2"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg2">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage2"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage2}]] for dmg with a @{meleeweaponname2}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname3"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense3"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed3"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg3">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage3"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage3}]] for dmg with a @{meleeweaponname3}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname4"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense4"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed4"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg4">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage4"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage4}]] for dmg with a @{meleeweaponname4}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname5"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense5"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed5"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg5">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage5"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage5}]] for dmg with a @{meleeweaponname5}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-			<div class="sheet-row" style="vertical-align: top;">
-				<div class="sheet-item sheet-xlarge"><input type="text" name="attr_meleeweaponname6"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweapondefense6"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_meleeweaponspeed6"></div>
-				<div class="sheet-item sheet-xxxlarge">
-					<fieldset class="repeating_rngweapons_dmg6">
-						<div class="sheet-item sheet-xxhuge"><input type="text" name="attr_meleeweapondamage6"></div>
-						<div class="sheet-item sheet-xlarge"><button type="roll" name="roll_mien" value="/em rolls [[@{meleeweapondamage}]] for dmg with a @{meleeweaponname6}."></button></div>
-					</fieldset>
-				</div><br>
-				<hr>
-			</div>
-		</div>
-		</div>
-	</div>
-	<!-- Combat Stuff Tab -->
+  <!-- Arcane Ablities Tab -->
+  <div class="sheet-section-arcane">
+    <div class="sheet-row sheet-h1">
+      <div class="sheet-center">Arcane Abilities</div>
+    </div>
+    <div class="sheet-row">
+      <div class="sheet-item sheet-large"><label><b>Hexslingin'</b></label></div>
+      <div class="sheet-item sheet-small"><input type="number" name="attr_hexslinginlvl"></div>
+      <div class="sheet-item sheet-large"><b>Ritual</b></div>
+      <div class="sheet-item sheet-small">
+        <input type="number" name="attr_rituallvl">
+      </div>
+      <div class="sheet-item sheet-large"><b>Rituals</b></div>
+      <div class="sheet-item sheet-huge">
+        <input type="text" name="attr_rituals">
+      </div>
+    </div>
+    <br>
+    <div class="sheet-row">
+      <div class="sheet-item sheet-large"><label><b>Power</b></label></div>
+      <div class="sheet-item sheet-small"><label><b>Speed</b></label></div>
+      <div class="sheet-item sheet-large"><label><b>Duration</b></label></div>
+      <div class="sheet-item sheet-small"><label><b>Range</b></label></div>
+      <div class="sheet-item sheet-small"><label><b>Trait</b></label></div>
+      <div class="sheet-item sheet-small"><label><b>TN</b></label></div>
+      <div class="sheet-item sheet-large"><label><b>Notes</b></label></div>
+      <fieldset class="repeating_spells" style="display: none;">
+        <div class="sheet-item sheet-large"><input type="text" name="attr_spellname" placeholder="Shadow Man"></div>
+        <div class="sheet-item sheet-small"><input type="number" name="attr_spellspeed" placeholder="2"></div>
+        <div class="sheet-item sheet-large"><input type="text" name="attr_spelldur" placeholder="Concentration"></div>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spellran" placeholder="Self"></div>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltrait" placeholder="Smarts"></div>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltn" placeholder="Target Number"></div>
+        <div class="sheet-item sheet-huge"><textarea name="attr_spellnotes" class="sheet-shorttextarea" placeholder="Notes"></textarea></div>
+      </fieldset>
+      <div class="repcontainer" data-groupname="repeating_spells"></div>
+    </div>
+  </div>
+  <!-- Arcane Ablities Tab -->
 
-	<!-- Arcane Ablities Tab -->
-	<div class="sheet-section-arcane">
-		<div class="sheet-row sheet-h1">
-			<div class="sheet-center">Arcane Abilities</div>
-		</div>
-		<div class="sheet-row">
-			<div class="sheet-item sheet-large"><label><b>Hexslingin'</b></label></div>
-			<div class="sheet-item sheet-small"><input type="number" name="attr_hexslinginlvl"></div>
-			<div class="sheet-item sheet-large"><b>Ritual</b></div>
-			<div class="sheet-item sheet-small">
-				<input type="number" name="attr_rituallvl">
-			</div>
-			<div class="sheet-item sheet-large"><b>Rituals</b></div>
-			<div class="sheet-item sheet-huge">
-				<input type="text" name="attr_rituals">
-			</div>
-		</div>
-		<br>
-		<div class="sheet-row">
-			<div class="sheet-item sheet-large"><label><b>Power</b></label></div>
-			<div class="sheet-item sheet-small"><label><b>Speed</b></label></div>
-			<div class="sheet-item sheet-large"><label><b>Duration</b></label></div>
-			<div class="sheet-item sheet-small"><label><b>Range</b></label></div>
-			<div class="sheet-item sheet-small"><label><b>Trait</b></label></div>
-			<div class="sheet-item sheet-small"><label><b>TN</b></label></div>
-			<div class="sheet-item sheet-large"><label><b>Notes</b></label></div>
-			<fieldset class="repeating_spells" style="display: none;">
-				<div class="sheet-item sheet-large"><input type="text" name="attr_spellname"></div>
-				<div class="sheet-item sheet-small"><input type="number" name="attr_spellspeed"></div>
-				<div class="sheet-item sheet-large"><input type="text" name="attr_spelldur"></div>
-				<div class="sheet-item sheet-small"><input type="text" name="attr_spellran"></div>
-				<div class="sheet-item sheet-small"><input type="text" name="attr_spelltrait"></div>
-				<div class="sheet-item sheet-small"><input type="text" name="attr_spelltn"></div>
-				<div class="sheet-item sheet-huge"><textarea name="attr_spellnotes" class="sheet-shorttextarea"></textarea></div>
-			</fieldset>
-			<div class="repcontainer" data-groupname="repeating_spells"></div>
-		</div>
-	</div>
-	<!-- Arcane Ablities Tab -->
+  <!-- Misc Tab -->
+  <div class="sheet-section-misc">
+    <div class="sheet-row">
+      <div class="sheet-2colrow">
+        <div class="sheet-col">
+          <div class="sheet-row">
+            <h2>Edges</h2>
+          </div>
+          <fieldset class="repeating_edges">
+            <div class="sheet-row sheet-textarea">
+              <input type="text" name="attr_edgename" placeholder="Edge name"><br>
+              <textarea name="attr_edgesdesc" class="sheet-shorttextarea"></textarea>
+            </div>
+          </fieldset>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-row">
+            <h2>Hindrances</h2>
+          </div>
+          <fieldset class="repeating_hinds">
+            <div class="sheet-row sheet-textarea">
+              <input type="text" name="attr_hindname" placeholder="Hindrance name"><br>
+              <textarea name="attr_hinddesc" class="sheet-shorttextarea"></textarea>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+      <div class="sheet-2colrow">
+        <div class="sheet-col">
+          <div class="sheet-row">
+            <h2>Equipment</h2>
+          </div>
+          <div class="sheet-row sheet-textarea">
+            <textarea name="attr_equipment" class="sheet-textarea" placeholder="Equipment"></textarea>
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-row">
+          <h2>Money</h2>
+          </div>
+          <div class="sheet-row sheet-textarea">
+            <textarea name="attr_money" class="sheet-textarea" placeholder="Money"></textarea>
+          </div>
+        </div>
+      </div>
+      <div class="sheet-2colrow">
+        <div class="sheet-col">
+          <div class="sheet-row">
+            <h2>Your Worst Nightmare</h2>
+          </div>
+          <div class="sheet-row sheet-textarea">
+            <textarea name="attr_nightmare" class="sheet-textarea" placeholder="Elm Street"></textarea>
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-row">
+            <h2>Character Notes</h2>
+          </div>
+          <div class="sheet-row sheet-textarea">
+            <textarea name="attr_notes" class="sheet-textarea" placeholder="Notes"></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Misc Tab -->
 
-	<!-- Misc Tab -->
-	<div class="sheet-section-misc">
-		<div class="sheet-row">
-			<div class="sheet-2colrow">
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h2">
-						Edges
-					</div>
-					<fieldset class="repeating_edges">
-						<div class="sheet-row sheet-textarea">
-							<input type="text" name="attr_edgename"><br>
-							<textarea name="attr_edgesdesc" class="sheet-shorttextarea"></textarea>
-						</div>
-					</fieldset>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h2">
-						Hindrances
-					</div>
-					<fieldset class="repeating_hinds">
-						<div class="sheet-row sheet-textarea">
-							<input type="text" name="attr_hindname"><br>
-							<textarea name="attr_hinddesc" class="sheet-shorttextarea"></textarea>
-						</div>
-					</fieldset>
-				</div>
-			</div>
-			<div class="sheet-2colrow">
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h2">
-						Equipment
-					</div>
-					<div class="sheet-row sheet-textarea">
-						<textarea name="attr_equipment" class="sheet-textarea"></textarea>
-					</div>
-				</div>
-			</div>
-			<div class="sheet-2colrow">
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h2">
-						Your Worst Nightmare
-					</div>
-					<div class="sheet-row sheet-textarea">
-						<textarea name="attr_nightmare" class="sheet-textarea"></textarea>
-					</div>
-				</div>
-				<div class="sheet-col">
-					<div class="sheet-row sheet-h2">
-						Character Notes
-					</div>
-					<div class="sheet-row sheet-textarea">
-						<textarea name="attr_notes" class="sheet-textarea" rows=""></textarea>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- Misc Tab -->
-
-	<!-- Obsolete Data Tab -->
-	<div class="sheet-section-obsolete">
-		<div class="sheet-row">
-			<div class="sheet-alert sheet-alert-warning">
-				Data on this tab will be removed over time. It is obsolete fields from the orginal Kevin Justus sheet design.
-			</div>
-		</div>
-		<div class="sheet-2colrow">
-		  <div class="sheet-col">
-		    <div class="sheet-h2">Shootin Irons &amp; Such</div>
-		<div>
-		<table>
-		  <tbody>
-		    <tr>
-		  <th><p><b>Weapon</b></p></th>
-		  <th><p><b>Shots</b></p></th>
-		  <th><p><b>RoF</b></p></th>
-		  <th><p><b>Range</b></p></th>
-		  <th><p><b>Damage</b></p></th>
-		    </tr>
-		  <tr>
-		    <td><input type="text" name="attr_weapon1name" style="width: 100px"></td>
-		<td><input type="number" name="attr_weapon1shots" style="width: 50px"></td>
-		<td><input type="number" name="attr_weapon1rof" style="width: 40px"></td>
-		<td><input type="number" name="attr_weapon1range" style="width: 50px"></td>
-		<td><input type="text" name="attr_weapon1damage" style="width: 80px"></td>
-		  </tr><tr>
-		    <td><input type="text" name="attr_weapon2name" style="width: 100px"></td>
-		<td><input type="number" name="attr_weapon2shots" style="width: 50px"></td>
-		<td><input type="number" name="attr_weapon2rof" style="width: 40px"></td>
-		<td><input type="number" name="attr_weapon2range" style="width: 50px"></td>
-		<td><input type="text" name="attr_weapon2damage" style="width: 80px"></td>
-		  </tr>
-		<tr>
-		    <td><input type="text" name="attr_weapon3name" style="width: 100px"></td>
-		<td><input type="number" name="attr_weapon3shots" style="width: 50px"></td>
-		<td><input type="number" name="attr_weapon3rof" style="width: 40px"></td>
-		<td><input type="number" name="attr_weapon3range" style="width: 50px"></td>
-		<td><input type="text" name="attr_weapon3damage" style="width: 80px"></td>
-		  </tr>
-		</tbody>
-		</table>
-		</div>
-		<div class="sheet-h2">Hand-To-Hand Weapons</div>
-		<div>
-		<table>
-		  <tbody>
-		    <tr>
-		      <th><p><b>Weapon</b></p></th>
-		      <th><p><b>Defense</b></p></th>
-		      <th><p><b>Speed</b></p></th>
-		      <th><p><b>Damage</b></p></th>
-		</tr>
-		<tr>
-		  <td>
-		  <input type="text" name="attr_weapon4name" value="Fist" style="width: 100px" disabled="" data-formula="Fist">
-		  </td>
-		  <td>
-		  <input type="number" name="attr_weapon4def" value="0" style="width: 50px" disabled="" data-formula="0">
-		  </td>
-		  <td>
-		    <input type="number" name="attr_weapon4speed" value="1" style="width: 40px" disabled="" data-formula="1">
-		  </td>
-		  <td>
-		    <input type="text" name="attr_weapon4damage" style="width: 100px">
-		  </td>
-		</tr>
-		<tr>
-		  <td>
-		  <input type="text" name="attr_weapon5name" style="width: 100px">
-		  </td>
-		  <td>
-		  <input type="number" name="attr_weapon5def" style="width: 50px">
-		  </td>
-		  <td>
-		    <input type="number" name="attr_weapon5speed" style="width: 40px">
-		  </td>
-		  <td>
-		    <input type="text" name="attr_weapon5damage" style="width: 100px">
-		  </td>
-		</tr>
-		<tr>
-		  <td>
-		  <input type="text" name="attr_weapon6name" style="width: 100px">
-		  </td>
-		  <td>
-		  <input type="number" name="attr_weapon6def" style="width: 50px">
-		  </td>
-		  <td>
-		    <input type="number" name="attr_weapon6speed" style="width: 40px">
-		  </td>
-		  <td>
-		    <input type="text" name="attr_weapon6damage" style="width: 100px">
-		  </td>
-		</tr>
-		  </tbody>
-		</table>
-		</div>
-		</div>
-		<div class="sheet-col">
-		  <div class="sheet-2colrow">
-		  <div class="sheet-col">
-		    <div class="sheet-row sheet-h3">Ammo One</div>
-		        <div class="sheet-row"><div class="sheet-row">
-		<div class="sheet-item sheet-ammo1"><b>0</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>1</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>2</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>3</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>4</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>5</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>6</b></div>
-		</div>
-		<div class="sheet-row">
-		    <div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="0">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="1">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="2">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="3">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="4">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="5">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo1" value="6"></div></div>
-		  </div></div>
-		  <div class="sheet-col">
-		  <div class="sheet-row sheet-h3">Ammo Two</div>
-		        <div class="sheet-row">
-		<div class="sheet-row">
-		<div class="sheet-item sheet-ammo1"><b>0</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>1</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>2</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>3</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>4</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>5</b></div>
-		  <div class="sheet-item sheet-ammo1"><b>6</b></div>
-		</div>
-		<div class="sheet-row">
-		    <div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="0">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="1">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="2">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="3">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="4">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="5">
-		</div>
-		<div class="sheet-item sheet-ammo1">
-		  <input type="radio" name="attr_ammo2" value="6"></div></div>
+  <!-- Obsolete Data Tab -->
+  <div class="sheet-section-obsolete">
+    <div class="sheet-row">
+      <div class="sheet-alert sheet-alert-warning">
+          <div class="sheet-row" style="margin-bottom: 15px;">
+          This sheet has been recently updated. Some fields have been obsoleted. Please review and ensure your information is correct.<br />
+          Data on this tab will be removed over time. It is obsolete fields from the orginal Kevin Justus sheet design.
+          </div>
+      </div>
+    </div>
+    <div class="sheet-2colrow">
+      <div class="sheet-col">
+        <div class="sheet-h2">Shootin Irons &amp; Such</div>
+    <div>
+    <table>
+      <tbody>
+        <tr>
+      <th><p><b>Weapon</b></p></th>
+      <th><p><b>Shots</b></p></th>
+      <th><p><b>RoF</b></p></th>
+      <th><p><b>Range</b></p></th>
+      <th><p><b>Damage</b></p></th>
+        </tr>
+      <tr>
+        <td><input type="text" name="attr_weapon1name" style="width: 100px"></td>
+    <td><input type="number" name="attr_weapon1shots" style="width: 50px"></td>
+    <td><input type="number" name="attr_weapon1rof" style="width: 40px"></td>
+    <td><input type="number" name="attr_weapon1range" style="width: 50px"></td>
+    <td><input type="text" name="attr_weapon1damage" style="width: 80px"></td>
+      </tr><tr>
+        <td><input type="text" name="attr_weapon2name" style="width: 100px"></td>
+    <td><input type="number" name="attr_weapon2shots" style="width: 50px"></td>
+    <td><input type="number" name="attr_weapon2rof" style="width: 40px"></td>
+    <td><input type="number" name="attr_weapon2range" style="width: 50px"></td>
+    <td><input type="text" name="attr_weapon2damage" style="width: 80px"></td>
+      </tr>
+    <tr>
+        <td><input type="text" name="attr_weapon3name" style="width: 100px"></td>
+    <td><input type="number" name="attr_weapon3shots" style="width: 50px"></td>
+    <td><input type="number" name="attr_weapon3rof" style="width: 40px"></td>
+    <td><input type="number" name="attr_weapon3range" style="width: 50px"></td>
+    <td><input type="text" name="attr_weapon3damage" style="width: 80px"></td>
+      </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="sheet-h2">Hand-To-Hand Weapons</div>
+    <div>
+    <table>
+      <tbody>
+        <tr>
+          <th><p><b>Weapon</b></p></th>
+          <th><p><b>Defense</b></p></th>
+          <th><p><b>Speed</b></p></th>
+          <th><p><b>Damage</b></p></th>
+    </tr>
+    <tr>
+      <td>
+      <input type="text" name="attr_weapon4name" value="Fist" style="width: 100px" disabled="" data-formula="Fist">
+      </td>
+      <td>
+      <input type="number" name="attr_weapon4def" value="0" style="width: 50px" disabled="" data-formula="0">
+      </td>
+      <td>
+        <input type="number" name="attr_weapon4speed" value="1" style="width: 40px" disabled="" data-formula="1">
+      </td>
+      <td>
+        <input type="text" name="attr_weapon4damage" style="width: 100px">
+      </td>
+    </tr>
+    <tr>
+      <td>
+      <input type="text" name="attr_weapon5name" style="width: 100px">
+      </td>
+      <td>
+      <input type="number" name="attr_weapon5def" style="width: 50px">
+      </td>
+      <td>
+        <input type="number" name="attr_weapon5speed" style="width: 40px">
+      </td>
+      <td>
+        <input type="text" name="attr_weapon5damage" style="width: 100px">
+      </td>
+    </tr>
+    <tr>
+      <td>
+      <input type="text" name="attr_weapon6name" style="width: 100px">
+      </td>
+      <td>
+      <input type="number" name="attr_weapon6def" style="width: 50px">
+      </td>
+      <td>
+        <input type="number" name="attr_weapon6speed" style="width: 40px">
+      </td>
+      <td>
+        <input type="text" name="attr_weapon6damage" style="width: 100px">
+      </td>
+    </tr>
+      </tbody>
+    </table>
+    </div>
+    </div>
+    <div class="sheet-col">
+      <div class="sheet-2colrow">
+      <div class="sheet-col">
+        <div class="sheet-row sheet-h3">Ammo One</div>
+            <div class="sheet-row"><div class="sheet-row">
+    <div class="sheet-item sheet-ammo1"><b>0</b></div>
+      <div class="sheet-item sheet-ammo1"><b>1</b></div>
+      <div class="sheet-item sheet-ammo1"><b>2</b></div>
+      <div class="sheet-item sheet-ammo1"><b>3</b></div>
+      <div class="sheet-item sheet-ammo1"><b>4</b></div>
+      <div class="sheet-item sheet-ammo1"><b>5</b></div>
+      <div class="sheet-item sheet-ammo1"><b>6</b></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="0">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="1">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="2">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="3">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="4">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="5">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo1" value="6"></div></div>
+      </div></div>
+      <div class="sheet-col">
+      <div class="sheet-row sheet-h3">Ammo Two</div>
+            <div class="sheet-row">
+    <div class="sheet-row">
+    <div class="sheet-item sheet-ammo1"><b>0</b></div>
+      <div class="sheet-item sheet-ammo1"><b>1</b></div>
+      <div class="sheet-item sheet-ammo1"><b>2</b></div>
+      <div class="sheet-item sheet-ammo1"><b>3</b></div>
+      <div class="sheet-item sheet-ammo1"><b>4</b></div>
+      <div class="sheet-item sheet-ammo1"><b>5</b></div>
+      <div class="sheet-item sheet-ammo1"><b>6</b></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="0">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="1">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="2">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="3">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="4">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="5">
+    </div>
+    <div class="sheet-item sheet-ammo1">
+      <input type="radio" name="attr_ammo2" value="6"></div></div>
 
 
 
-		</div></div></div>
-		<div class="sheet-row"><div class="sheet-row"><div class="sheet-h3">Ammo Three</div>
-		</div>
-		<div class="sheet-row"><div class="sheet-row"><div class="sheet-row">
-		    <div class="sheet-item sheet-ammo3"><b>0</b></div>
-		<div class="sheet-item sheet-ammo3"><b>1</b></div>
-		<div class="sheet-item sheet-ammo3"><b>2</b></div>
-		<div class="sheet-item sheet-ammo3"><b>3</b></div>
-		<div class="sheet-item sheet-ammo3"><b>4</b></div>
-		<div class="sheet-item sheet-ammo3"><b>5</b></div>
-		<div class="sheet-item sheet-ammo3"><b>6</b></div>
-		<div class="sheet-item sheet-ammo3"><b>7</b></div>
-		<div class="sheet-item sheet-ammo3"><b>8</b></div>
-		<div class="sheet-item sheet-ammo3"><b>9</b></div>
-		<div class="sheet-item sheet-ammo3"><b>10</b></div>
-		<div class="sheet-item sheet-ammo3"><b>11</b></div>
-		<div class="sheet-item sheet-ammo3"><b>12</b></div>
-		<div class="sheet-item sheet-ammo3"><b>13</b></div>
-		<div class="sheet-item sheet-ammo3"><b>14</b></div>
-		<div class="sheet-item sheet-ammo3"><b>15</b></div>
-		  </div>
+    </div></div></div>
+    <div class="sheet-row"><div class="sheet-row"><div class="sheet-h3">Ammo Three</div>
+    </div>
+    <div class="sheet-row"><div class="sheet-row"><div class="sheet-row">
+        <div class="sheet-item sheet-ammo3"><b>0</b></div>
+    <div class="sheet-item sheet-ammo3"><b>1</b></div>
+    <div class="sheet-item sheet-ammo3"><b>2</b></div>
+    <div class="sheet-item sheet-ammo3"><b>3</b></div>
+    <div class="sheet-item sheet-ammo3"><b>4</b></div>
+    <div class="sheet-item sheet-ammo3"><b>5</b></div>
+    <div class="sheet-item sheet-ammo3"><b>6</b></div>
+    <div class="sheet-item sheet-ammo3"><b>7</b></div>
+    <div class="sheet-item sheet-ammo3"><b>8</b></div>
+    <div class="sheet-item sheet-ammo3"><b>9</b></div>
+    <div class="sheet-item sheet-ammo3"><b>10</b></div>
+    <div class="sheet-item sheet-ammo3"><b>11</b></div>
+    <div class="sheet-item sheet-ammo3"><b>12</b></div>
+    <div class="sheet-item sheet-ammo3"><b>13</b></div>
+    <div class="sheet-item sheet-ammo3"><b>14</b></div>
+    <div class="sheet-item sheet-ammo3"><b>15</b></div>
+      </div>
 
-		  <div class="sheet-row">
-		    <div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="0">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="1">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="2">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="3">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="4">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="5">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="6">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="7">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="8">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="9">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="10">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="11">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="12">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="13">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="14">
-		</div>
-		<div class="sheet-item sheet-ammo3">
-		  <input type="radio" name="attr_ammo3" value="15">
-		</div>
-		  </div>
-		  </div></div>
-		  </div>
-		  </div></div>
-	</div>
-	<!-- Obsolete Data Tab -->
+      <div class="sheet-row">
+        <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="0">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="1">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="2">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="3">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="4">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="5">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="6">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="7">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="8">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="9">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="10">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="11">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="12">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="13">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="14">
+    </div>
+    <div class="sheet-item sheet-ammo3">
+      <input type="radio" name="attr_ammo3" value="15">
+    </div>
+      </div>
+      </div></div>
+      </div>
+      </div></div>
+  </div>
+  <!-- Obsolete Data Tab -->
 </div>


### PR DESCRIPTION
Fixed the broken repeating field buttons. 
Improved the Roll Macros to include "k" to keep the highest for skills.
Updated the weapon roll buttons to include the GM & Location toggles mentioned below
Updated Hand to Hand weapons to now also roll Str & damage in the roll template
Added placeholders & update incorrect ones
Added a whisper to GM roll toggle
Added a Location Weapon shot toggle
Changed all the inputs to opacity 0 and put numbers on top of them with hover & checked feedback
Gave the page a width to fix minimization/maximization issues
Added to the roll template & changed the colors
Fixed the CSS for weapons damage repeating fields section
Added "Selected" to Options so they have a default value now
Added a Money text field in Misc
General CSS improvements
**No attributes were harmed in the making of this update**