### PR TITLE
Update WOIN.HTML to fix two typos, add new fields

### DIFF
--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -84,7 +84,7 @@
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_wil" value="&{template:default} {{name= Willpower}} {{roll= [[@{willpower_1}d6]]}}">WIL</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_cha" value="&{template:default} {{name= Charisma}} {{roll= [[@{charisma_1}d6]]}}">CHA</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_luc" value="&{template:default} {{name= Luck}} {{roll= [[@{luck_1}d6]]}}">LUC</button></th>
-                <th><button type="roll" class="sheet-rollatrrib" name="roll_rep" value="&{template:default} {{name= Reputation}} {{roll= [[@{reputation_1}d6]]}}">REP</button></th>
+                <th><button type="roll" class="sheet-rollatrrib" name="roll_rep" value="&{template:default} {{name= Reputation}} {{roll= [[@{repuation_1}d6]]}}">REP</button></th>
                 <th>
                     <input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_switch7" value="0" checked/><span></span>
                     <input type="radio" class="sheet-block2 sheet-hidden" name="attr_sheet_switch7" value="1"/><span></span>
@@ -156,7 +156,7 @@
                 <th>
                     <div class="sheet-octo">
                         <div class="sheet-octo_inner">
-                            <input type="number" class="sheet-number1" name="attr_reputation_rank" value="0"/>
+                            <input type="number" class="sheet-number1" name="attr_repuation_rank" value="0"/>
                         </div>
                     </div>
                 </th>
@@ -213,8 +213,8 @@
                     <br><input type="number" class="sheet-hidden" name="attr_luck_1" value="0"/>
                 </th>
                 <th>
-                    <input type="number" class="sheet-number4" name="attr_reputation" value="0" readonly/>d6
-                    <br><input type="number" class="sheet-hidden" name="attr_reputation_1" value="0"/>
+                    <input type="number" class="sheet-number4" name="attr_repuation" value="0" readonly/>d6
+                    <br><input type="number" class="sheet-hidden" name="attr_repuation_1" value="0"/>
                 </th>
                 <th>
                     <input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_switch6" value="0" checked/><span></span>
@@ -589,7 +589,7 @@
                                     <option value="@{willpower}">Willpower</option>
                                     <option value="@{charisma}">Charisma</option>
                                     <option value="@{luck}">Luck</option>
-                                    <option value="@{reputation}">Reputation</option>
+                                    <option value="@{repuation}">Reputation</option>
                                     <option value="@{psionics}">Psionics</option>
                                 </select>
                             </td>
@@ -638,7 +638,7 @@
                                     <option value="@{willpower}">Willpower</option>
                                     <option value="@{charisma}">Charisma</option>
                                     <option value="@{luck}">Luck</option>
-                                    <option value="@{reputation}">Reputation</option>
+                                    <option value="@{repuation}">Reputation</option>
                                     <option value="@{psionics}">Psionics</option>
                                 </select>
                             </td>
@@ -1313,7 +1313,7 @@ on("change:repeating_skillsold:skill_rating sheet:opened", function() {
 });
     //Skill Dice Limit Dice, skillsnew
 on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rating change:repeating_skillsnew:skill_dice change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(["repeating_skillsnew_skill_select", "repeating_skillsnew_skill_rating", "repeating_skillsnew_skill_dice", "maximum_dice_pool", "magic", "psionics", "reputation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
+    getAttrs(["repeating_skillsnew_skill_select", "repeating_skillsnew_skill_rating", "repeating_skillsnew_skill_dice", "maximum_dice_pool", "magic", "psionics", "repuation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
 
         if (values.repeating_skillsnew_skill_select == 0) {
             setAttrs({ 
@@ -1389,10 +1389,10 @@ on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rat
         }
 		else if(values.repeating_skillsnew_skill_select == 9) {
             setAttrs({ 
-                repeating_skillsnew_skill_total: +values.repeating_skillsnew_skill_dice + +values.reputation,
+                repeating_skillsnew_skill_total: +values.repeating_skillsnew_skill_dice + +values.repuation,
                 repeating_skillsnew_skill_max_dice: +values.maximum_dice_pool,
                 repeating_skillsnew_skill_attrib: 'Reputation',
-                repeating_skillsnew_skill_attrib_score: +values.reputation
+                repeating_skillsnew_skill_attrib_score: +values.repuation
             })
         }
 		else if(values.repeating_skillsnew_skill_select == 10) {
@@ -1416,7 +1416,7 @@ on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rat
 
     //Skill Dice Limit Dice, skillsold
 on("change:repeating_skillsold:skill_select change:repeating_skillsold:skill_rating change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(["repeating_skillsold_skill_select", "repeating_skillsold_skill_rating", "maximum_dice_pool", "magic", "psionics", "reputation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
+    getAttrs(["repeating_skillsold_skill_select", "repeating_skillsold_skill_rating", "maximum_dice_pool", "magic", "psionics", "repuation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
 
         if (values.repeating_skillsold_skill_select == 0) {
             setAttrs({ 
@@ -1492,10 +1492,10 @@ on("change:repeating_skillsold:skill_select change:repeating_skillsold:skill_rat
         }
 		else if(values.repeating_skillsold_skill_select == 9) {
             setAttrs({ 
-                repeating_skillsold_skill_total: +values.repeating_skillsold_skill_rating + +values.reputation,
+                repeating_skillsold_skill_total: +values.repeating_skillsold_skill_rating + +values.repuation,
                 repeating_skillsold_skill_max_dice: +values.maximum_dice_pool,
                 repeating_skillsold_skill_attrib: 'Reputation',
-                repeating_skillsold_skill_attrib_score: +values.reputation
+                repeating_skillsold_skill_attrib_score: +values.repuation
             })
         }
 		else if(values.repeating_skillsold_skill_select == 10) {
@@ -1958,56 +1958,56 @@ on("change:luck change:luck_rank change:maximum_dice_pool sheet:opened", functio
     });
 });
 // Creating rep Dice Pool
-on("change:reputation_rank sheet:opened", function() {
-    getAttrs(["reputation_rank"], function(values) {
+on("change:repuation_rank sheet:opened", function() {
+    getAttrs(["repuation_rank"], function(values) {
 
-        if (values.reputation_rank == 0) {
+        if (values.repuation_rank == 0) {
             setAttrs({ 
-                reputation: 0
+                repuation: 0
             })
         }
-		else if(values.reputation_rank >= 1 && values.reputation_rank <= 2) {
+		else if(values.repuation_rank >= 1 && values.repuation_rank <= 2) {
             setAttrs({ 
-                reputation: 1
+                repuation: 1
             })
         }
-		else if(values.reputation_rank >= 3 && values.reputation_rank <= 5) {
+		else if(values.repuation_rank >= 3 && values.repuation_rank <= 5) {
             setAttrs({ 
-                reputation: 2
+                repuation: 2
             })
         }
-		else if(values.reputation_rank >= 6 && values.reputation_rank <= 9) {
+		else if(values.repuation_rank >= 6 && values.repuation_rank <= 9) {
             setAttrs({ 
-                reputation: 3
+                repuation: 3
             })
         }
-		else if(values.reputation_rank >= 10 && values.reputation_rank <= 14) {
+		else if(values.repuation_rank >= 10 && values.repuation_rank <= 14) {
             setAttrs({ 
-                reputation: 4
+                repuation: 4
             })
         }
-		else if(values.reputation_rank >= 15 && values.reputation_rank <= 20) {
+		else if(values.repuation_rank >= 15 && values.repuation_rank <= 20) {
             setAttrs({ 
-                reputation: 5
+                repuation: 5
             })
         }
-		else if(values.reputation_rank >= 21 && values.reputation_rank <= 27) {
+		else if(values.repuation_rank >= 21 && values.repuation_rank <= 27) {
             setAttrs({ 
-                reputation: 6
+                repuation: 6
             })
         }
-		else if(values.reputation_rank >= 28 && values.reputation_rank <= 35) {
+		else if(values.repuation_rank >= 28 && values.repuation_rank <= 35) {
             setAttrs({ 
-                reputation: 7
+                repuation: 7
             })
         }
     });
 });
-// Dice Pool Limit reputation
-on("change:reputation change:reputation_rank change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(['reputation', 'maximum_dice_pool'], function(values) {
+// Dice Pool Limit repuation
+on("change:repuation change:repuation_rank change:maximum_dice_pool sheet:opened", function() {
+    getAttrs(['repuation', 'maximum_dice_pool'], function(values) {
         setAttrs({ 
-            reputation_1: (Math.floor(Math.min.apply(null, Object.values(values)))) 
+            repuation_1: (Math.floor(Math.min.apply(null, Object.values(values)))) 
         });
     });
 });

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -80,11 +80,11 @@
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_agl" value="&{template:default} {{name= Agility}} {{roll= [[@{agility_1}d6]]}}">AGL</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_end" value="&{template:default} {{name= Endurance}} {{roll= [[@{endurance_1}d6]]}}">END</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_int" value="&{template:default} {{name= Intuition}} {{roll= [[@{intuition_1}d6]]}}">INT</button></th>
-                <th><button type="roll" class="sheet-rollatrrib" name="roll_log" value="&{template:default} {{name= Agility}} {{roll= [[@{logic_1}d6]]}}">LOG</button></th>
+                <th><button type="roll" class="sheet-rollatrrib" name="roll_log" value="&{template:default} {{name= Logic}} {{roll= [[@{logic_1}d6]]}}">LOG</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_wil" value="&{template:default} {{name= Willpower}} {{roll= [[@{willpower_1}d6]]}}">WIL</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_cha" value="&{template:default} {{name= Charisma}} {{roll= [[@{charisma_1}d6]]}}">CHA</button></th>
                 <th><button type="roll" class="sheet-rollatrrib" name="roll_luc" value="&{template:default} {{name= Luck}} {{roll= [[@{luck_1}d6]]}}">LUC</button></th>
-                <th><button type="roll" class="sheet-rollatrrib" name="roll_rep" value="&{template:default} {{name= Repuation}} {{roll= [[@{repuation_1}d6]]}}">REP</button></th>
+                <th><button type="roll" class="sheet-rollatrrib" name="roll_rep" value="&{template:default} {{name= Reputation}} {{roll= [[@{reputation_1}d6]]}}">REP</button></th>
                 <th>
                     <input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_switch7" value="0" checked/><span></span>
                     <input type="radio" class="sheet-block2 sheet-hidden" name="attr_sheet_switch7" value="1"/><span></span>
@@ -156,7 +156,7 @@
                 <th>
                     <div class="sheet-octo">
                         <div class="sheet-octo_inner">
-                            <input type="number" class="sheet-number1" name="attr_repuation_rank" value="0"/>
+                            <input type="number" class="sheet-number1" name="attr_reputation_rank" value="0"/>
                         </div>
                     </div>
                 </th>
@@ -213,8 +213,8 @@
                     <br><input type="number" class="sheet-hidden" name="attr_luck_1" value="0"/>
                 </th>
                 <th>
-                    <input type="number" class="sheet-number4" name="attr_repuation" value="0" readonly/>d6
-                    <br><input type="number" class="sheet-hidden" name="attr_repuation_1" value="0"/>
+                    <input type="number" class="sheet-number4" name="attr_reputation" value="0" readonly/>d6
+                    <br><input type="number" class="sheet-hidden" name="attr_reputation_1" value="0"/>
                 </th>
                 <th>
                     <input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_switch6" value="0" checked/><span></span>
@@ -252,7 +252,7 @@
                                     <option value="6">Willpower</option>
                                     <option value="7">Charisma</option>
                                     <option value="8">Luck</option>
-                                    <option value="9">Repuation</option>
+                                    <option value="9">Reputation</option>
                                     <option value="10">Psionics</option>
                                     <option value="11">Magic</option>
                                 </select>
@@ -295,7 +295,7 @@
                                     <option value="6">Willpower</option>
                                     <option value="7">Charisma</option>
                                     <option value="8">Luck</option>
-                                    <option value="9">Repuation</option>
+                                    <option value="9">Reputation</option>
                                     <option value="10">Psionics</option>
                                     <option value="11">Magic</option>
                                 </select>
@@ -455,11 +455,13 @@
                     </tr>
                     <tr>
                         <th>Soak</th>
-                        <th colspan="2">Health</th>
+                        <th>Health</th>
+	         <th>Max Health</th>
                     </tr>
                     <tr>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_soak" value="0" /></td>
-                        <td colspan="2"><input type="number" class="sheet-number2" style="width:80px;" name="attr_health" value="0" /></td>
+                        <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_health" value="0" /></td>
+	         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_maxhealth" value="0" /></td>
                     </tr>
                 </table>
             </div>
@@ -569,11 +571,12 @@
                             <th>Attack Mod.</th>
                             <th>Damage</th>
                             <th>Damage Mod.</th>
+<th>Damage Add.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd} ]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -586,13 +589,14 @@
                                     <option value="@{willpower}">Willpower</option>
                                     <option value="@{charisma}">Charisma</option>
                                     <option value="@{luck}">Luck</option>
-                                    <option value="@{repuation}">Repuation</option>
+                                    <option value="@{reputation}">Reputation</option>
                                     <option value="@{psionics}">Psionics</option>
                                 </select>
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
+<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>
@@ -616,11 +620,12 @@
                             <th>Attack Mod.</th>
                             <th>Damage</th>
                             <th>Damage Mod.</th>
+		<th>Damage Add.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd}]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -633,13 +638,14 @@
                                     <option value="@{willpower}">Willpower</option>
                                     <option value="@{charisma}">Charisma</option>
                                     <option value="@{luck}">Luck</option>
-                                    <option value="@{repuation}">Repuation</option>
+                                    <option value="@{reputation}">Reputation</option>
                                     <option value="@{psionics}">Psionics</option>
                                 </select>
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
+<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>
@@ -1307,7 +1313,7 @@ on("change:repeating_skillsold:skill_rating sheet:opened", function() {
 });
     //Skill Dice Limit Dice, skillsnew
 on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rating change:repeating_skillsnew:skill_dice change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(["repeating_skillsnew_skill_select", "repeating_skillsnew_skill_rating", "repeating_skillsnew_skill_dice", "maximum_dice_pool", "magic", "psionics", "repuation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
+    getAttrs(["repeating_skillsnew_skill_select", "repeating_skillsnew_skill_rating", "repeating_skillsnew_skill_dice", "maximum_dice_pool", "magic", "psionics", "reputation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
 
         if (values.repeating_skillsnew_skill_select == 0) {
             setAttrs({ 
@@ -1383,10 +1389,10 @@ on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rat
         }
 		else if(values.repeating_skillsnew_skill_select == 9) {
             setAttrs({ 
-                repeating_skillsnew_skill_total: +values.repeating_skillsnew_skill_dice + +values.repuation,
+                repeating_skillsnew_skill_total: +values.repeating_skillsnew_skill_dice + +values.reputation,
                 repeating_skillsnew_skill_max_dice: +values.maximum_dice_pool,
-                repeating_skillsnew_skill_attrib: 'Repuation',
-                repeating_skillsnew_skill_attrib_score: +values.repuation
+                repeating_skillsnew_skill_attrib: 'Reputation',
+                repeating_skillsnew_skill_attrib_score: +values.reputation
             })
         }
 		else if(values.repeating_skillsnew_skill_select == 10) {
@@ -1410,7 +1416,7 @@ on("change:repeating_skillsnew:skill_select change:repeating_skillsnew:skill_rat
 
     //Skill Dice Limit Dice, skillsold
 on("change:repeating_skillsold:skill_select change:repeating_skillsold:skill_rating change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(["repeating_skillsold_skill_select", "repeating_skillsold_skill_rating", "maximum_dice_pool", "magic", "psionics", "repuation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
+    getAttrs(["repeating_skillsold_skill_select", "repeating_skillsold_skill_rating", "maximum_dice_pool", "magic", "psionics", "reputation", "luck", "charisma", "willpower", "logic", "intuition", "endurance", "agility", "strength"], function(values) {
 
         if (values.repeating_skillsold_skill_select == 0) {
             setAttrs({ 
@@ -1486,10 +1492,10 @@ on("change:repeating_skillsold:skill_select change:repeating_skillsold:skill_rat
         }
 		else if(values.repeating_skillsold_skill_select == 9) {
             setAttrs({ 
-                repeating_skillsold_skill_total: +values.repeating_skillsold_skill_rating + +values.repuation,
+                repeating_skillsold_skill_total: +values.repeating_skillsold_skill_rating + +values.reputation,
                 repeating_skillsold_skill_max_dice: +values.maximum_dice_pool,
-                repeating_skillsold_skill_attrib: 'Repuation',
-                repeating_skillsold_skill_attrib_score: +values.repuation
+                repeating_skillsold_skill_attrib: 'Reputation',
+                repeating_skillsold_skill_attrib_score: +values.reputation
             })
         }
 		else if(values.repeating_skillsold_skill_select == 10) {
@@ -1952,56 +1958,56 @@ on("change:luck change:luck_rank change:maximum_dice_pool sheet:opened", functio
     });
 });
 // Creating rep Dice Pool
-on("change:repuation_rank sheet:opened", function() {
-    getAttrs(["repuation_rank"], function(values) {
+on("change:reputation_rank sheet:opened", function() {
+    getAttrs(["reputation_rank"], function(values) {
 
-        if (values.repuation_rank == 0) {
+        if (values.reputation_rank == 0) {
             setAttrs({ 
-                repuation: 0
+                reputation: 0
             })
         }
-		else if(values.repuation_rank >= 1 && values.repuation_rank <= 2) {
+		else if(values.reputation_rank >= 1 && values.reputation_rank <= 2) {
             setAttrs({ 
-                repuation: 1
+                reputation: 1
             })
         }
-		else if(values.repuation_rank >= 3 && values.repuation_rank <= 5) {
+		else if(values.reputation_rank >= 3 && values.reputation_rank <= 5) {
             setAttrs({ 
-                repuation: 2
+                reputation: 2
             })
         }
-		else if(values.repuation_rank >= 6 && values.repuation_rank <= 9) {
+		else if(values.reputation_rank >= 6 && values.reputation_rank <= 9) {
             setAttrs({ 
-                repuation: 3
+                reputation: 3
             })
         }
-		else if(values.repuation_rank >= 10 && values.repuation_rank <= 14) {
+		else if(values.reputation_rank >= 10 && values.reputation_rank <= 14) {
             setAttrs({ 
-                repuation: 4
+                reputation: 4
             })
         }
-		else if(values.repuation_rank >= 15 && values.repuation_rank <= 20) {
+		else if(values.reputation_rank >= 15 && values.reputation_rank <= 20) {
             setAttrs({ 
-                repuation: 5
+                reputation: 5
             })
         }
-		else if(values.repuation_rank >= 21 && values.repuation_rank <= 27) {
+		else if(values.reputation_rank >= 21 && values.reputation_rank <= 27) {
             setAttrs({ 
-                repuation: 6
+                reputation: 6
             })
         }
-		else if(values.repuation_rank >= 28 && values.repuation_rank <= 35) {
+		else if(values.reputation_rank >= 28 && values.reputation_rank <= 35) {
             setAttrs({ 
-                repuation: 7
+                reputation: 7
             })
         }
     });
 });
-// Dice Pool Limit repuation
-on("change:repuation change:repuation_rank change:maximum_dice_pool sheet:opened", function() {
-    getAttrs(['repuation', 'maximum_dice_pool'], function(values) {
+// Dice Pool Limit reputation
+on("change:reputation change:reputation_rank change:maximum_dice_pool sheet:opened", function() {
+    getAttrs(['reputation', 'maximum_dice_pool'], function(values) {
         setAttrs({ 
-            repuation_1: (Math.floor(Math.min.apply(null, Object.values(values)))) 
+            reputation_1: (Math.floor(Math.min.apply(null, Object.values(values)))) 
         });
     });
 });


### PR DESCRIPTION
This change would be to Fix the typo that when you roll Logic, it states you roll Agility. It will now say you roll Logic.
Reputation was written repuation everywhere. Made it Reputation again.
The sheet needed a field to add additional damage to a weapon roll, for example, when you want to roll 2d6+2. There was no way to add the +2. I added a field called Damage Add. for that.
The sheet needed a field to record current health and max health. Left the Health field as is and added a max Health field.