### PR TITLE
Ex3: Fix contention between 'Show MA Styles' and 'Craft: Geomancy'.

### DIFF
--- a/Exalted 3/Ex3-Sheet.css
+++ b/Exalted 3/Ex3-Sheet.css
@@ -357,6 +357,7 @@ input[type=checkbox].sheet-unnamed-toggle {
     width: 100%;
     height: 100%;
     margin: 0;
+    z-index: 5;
 }
 
 input[type=checkbox].sheet-unnamed-toggle + span::before {
@@ -367,6 +368,7 @@ input[type=checkbox].sheet-unnamed-toggle + span::before {
     line-height: 100%;
     font-size: 18px;
     overflow: hidden;
+    z-index: 4;
 }
 
 .sheet-layer7,
@@ -520,8 +522,8 @@ input[class^=sheet-dots] {
 }
 
 input.sheet-dots0 { z-index: 2; }
-.sheet-layer3 input.sheet-dots0 { z-index: 5; }
-.sheet-layer5 input.sheet-dots0 { z-index: 7; }
+.sheet-layer4 input.sheet-dots0 { z-index: 6; }
+.sheet-layer6 input.sheet-dots0 { z-index: 8; }
 
 input.sheet-dots0:checked ~ input.sheet-dots1,
 input.sheet-dots1:checked ~ input.sheet-dots2,


### PR DESCRIPTION
On the current sheet, it is impossible to click the radio buttons for Craft:Geomancy, since they are layered below the checkbox for Martial Arts "Show Styles", even though they appear visually to be layered in the opposite order.