### PR TITLE
Ex3: Add support for battle groups.

### DIFF
--- a/Exalted 3/Ex3-Sheet.css
+++ b/Exalted 3/Ex3-Sheet.css
@@ -235,19 +235,25 @@ input, select, option, optgroup, textarea, .sheet-normal-caps, .btn:not([type=ro
     height: calc(6em + 30px);
 }
 
-.sheet-motes {
+.sheet-motes,
+.sheet-battle-group-row {
     margin-top: 10px;
     clear: right;
     position: relative;
     padding-left: 30px;
 }
 
-.sheet-motes input[type=number] {
+.sheet-motes input[type=number],
+.sheet-battle-group-row input[type=number] {
     width: 1.75em;
     font-size: 16px;
 }
 
-.sheet-motes:last-child input[type=number] { width: 71px; }
+.sheet-motes:last-child input[type=number],
+.sheet-battle-group-row:last-child input[type=number],
+.sheet-battle-group-row select {
+    width: 71px;
+}
 
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
@@ -259,12 +265,21 @@ input[type=number] {
     -moz-appearance: textfield;
 }
 
-.sheet-motes span { display: inline-block; }
+.sheet-motes span,
+.sheet-battle-group-row span {
+    display: inline-block;
+}
 
-.sheet-motes span:last-child {
+.sheet-motes span:last-child,
+.sheet-battle-group-row span:last-child {
     position: absolute;
     right: 40px;
     font-size: 20px;
+}
+
+.sheet-battle-group-row select:last-child {
+    position: absolute;
+    right: 40px;
 }
 
 textarea {
@@ -641,6 +656,17 @@ input.sheet-tab-settings-sheet:checked ~ div.sheet-tab-settings-sheet,
 {                                 
    display: block;
 }
+
+.sheet-battle-group[value="0"] ~ div.sheet-tab-character-sheet .sheet-battle-group-header,
+.sheet-battle-group[value="0"] ~ div.sheet-tab-character-sheet .sheet-battle-group-body {
+    display: none;
+}
+
+.sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet > .sheet-health-track,
+.sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet > .sheet-health-header {
+    display: none;
+}
+
 
 input.sheet-tab {
    width: 140px;

--- a/Exalted 3/Ex3-Sheet.html
+++ b/Exalted 3/Ex3-Sheet.html
@@ -49,6 +49,12 @@
         })).execute();
     }));
 
+    on('sheet:opened change:battlegroup change:battlegroup-size change:battlegroup-health-levels', TAS._fn(function updateBattleGroupMagnitude(e) {
+        getAttrs(["battlegroup-size", "battlegroup-health-levels"], TAS._fn(function determineBattleGroupMagnitude(values) {
+            setAttrs({"battlegroup-magnitude_max": parseInt(values["battlegroup-size"]) + parseInt(values["battlegroup-health-levels"])});
+        }));
+    }));
+
     on('change:caste', TAS._fn(function updateMotePool(eventInfo){
         getAttrs(["caste"], TAS._fn(function determineMotePool(values){
             var periEquation = "0";
@@ -544,6 +550,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
             <input class="sheet-tab sheet-tab-spells sheet-tab-spell-sheet" name="attr_sheet" title="Sorceries" type="radio" value="3">
             <input class="sheet-tab sheet-tab-settings sheet-tab-settings-sheet" name="attr_sheet" title="y" type="radio" value="4">
         </form>
+        <input class="sheet-battle-group" name="attr_battlegroup" type="hidden" value="0">
         <div class="sheet-body sheet-tab-content sheet-tab-character-sheet">
             <div class="sheet-3colrow">
                 <div class="sheet-col">
@@ -1771,6 +1778,57 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                     </fieldset>
                 </div><!-- /sheet-col abilities -->
                 <div class="sheet-2col">
+                    <h1 class="sheet-battle-group-header"><span data-i18n="battle-group">Battle Group</span></h1>
+                    <div class="sheet-battle-group-body sheet-2colrow">
+                        <div class="sheet-col">
+                            <div class="sheet-battle-group-row">
+                                <span data-i18n="drill">Drill</span>:
+                                <select name="attr_battlegroup-drill">
+                                    <option data-i18n="poor" value="Poor">Poor</option>
+                                    <option data-i18n="average" value="Average" selected="selected">Average</option>
+                                    <option data-i18n="elite" value="Elite">Elite</option>
+                                </select>
+                            </div>
+                            <div class="sheet-battle-group-row">
+                                <span data-i18n="might">Might</span>:
+                                <select name="attr_battlegroup-might">
+                                    <option value="0" selected="selected">0</option>
+                                    <option value="1">1</option>
+                                    <option value="2">2</option>
+                                    <option value="3">3</option>
+                                </select>
+                            </div>
+                            <div class="sheet-battle-group-row">
+                                <label>
+                                    <input type="checkbox" name="attr_battlegroup-perfect-morale" value="1"><span></span>
+                                    <span data-i18n="perfect-morale">Perfect Morale</span>
+                                    <span></span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="sheet-col">
+                            <div class="sheet-battle-group-row">
+                                <span data-i18n="magnitude">Magnitude</span>:
+                                <span>
+                                    <input type="number" name="attr_battlegroup-magnitude" value="8"> |
+                                    <input type="number" name="attr_battlegroup-magnitude_max" readonly="readonly">
+                                </span>
+                            </div>
+                            <div class="sheet-battle-group-row">
+                                <span data-i18n="size">Size</span>:
+                                <span>
+                                    <input type="number" name="attr_battlegroup-size" value="1"> |
+                                    <input type="number" name="attr_battlegroup-size_max" value="1">
+                                </span>
+                            </div>
+                            <div class="sheet-battle-group-row">
+                                <span data-i18n="health-levels">Health Levels</span>:
+                                <span>
+                                    <input type="number" name="attr_battlegroup-health-levels" value="7">
+                                </span>
+                            </div>
+                        </div>
+                    </div><!-- /sheet-battle-group-body-->
                     <h1><span data-i18n="merits">Merits</span></h1>
                     <fieldset class="repeating_merits">
                         <input type="text" name="attr_repmerits-name" data-i18n-placeholder="merits-place" placeholder="Artifact">
@@ -2043,7 +2101,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                     </div>
                 </div>
             </div><!-- /sheet-table defenses -->
-            <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="health-levels">Health Levels</strong></div>
+            <div class="sheet-health-header sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="health-levels">Health Levels</strong></div>
             <div class="sheet-health-track">
                 <input type="hidden" name="attr_wound-penalty" value="0">
                 <div class="sheet-health-level">
@@ -2592,7 +2650,6 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                 </div>
             </div><!-- /sheet-health-track -->
 
-
             <h1><span data-i18n="intimacies">Intimacies</span></h1>
             <input type="hidden" value="0" name="attr_init-intimacies">
             <div class="sheet-table">
@@ -2702,6 +2759,11 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
             </fieldset><!-- /sheet-table sorceries -->
         </div><!-- /sheet-body -->
         <div class="sheet-body sheet-tab-content sheet-tab-settings-sheet">
+            <h1><span data-i18n="character-type">Character Type</span></h1>
+            <label>
+                <input type="checkbox" name="attr_battlegroup" value="1"><span></span>
+                <span data-i18n="battle-group">battle group</span>
+            </label>
             <h1><span data-i18n="mote-pool-equations">Mote Pool Equations</span></h1>
             <label data-i18n="max-personal-motes">Max Personal Motes</label>
             <input type="text" name="attr_personal-equation" value="@{essence} * 3 + 10"><span> </span>

--- a/Exalted 3/sheet.json
+++ b/Exalted 3/sheet.json
@@ -1,8 +1,8 @@
 {
     "html": "Ex3-Sheet.html",
     "css": "Ex3-Sheet.css",
-    "authors": "Brian Shields, Kevin Justus, Paul Deschenes, Ludvig Lindblad",
+    "authors": "Brian Shields, Kevin Justus, Paul Deschenes, Ludvig Lindblad, Theodore Alteneder",
     "preview": "Ex3-Sheet.png",
-    "roll20userid": "235259, 129882, 2709",
+    "roll20userid": "235259, 129882, 2709, 1381761",
     "instructions": "A character sheet for use with Exalted 3rd Edition. Designed to be universal, hence the favored checkboxes and supernal field under Attributes as well as Abilities."
 }

--- a/Exalted 3/translation.json
+++ b/Exalted 3/translation.json
@@ -227,5 +227,15 @@
     "keywords": "Keywords",
     "control": "Control",
     "spell-desc-place": "",
-    "charm-desc-place": ""
+    "charm-desc-place": "",
+    "size": "Size",
+    "drill": "Drill",
+    "magnitude": "Magnitude",
+    "perfect-morale": "Perfect Morale",
+    "poor": "Poor",
+    "average": "Average",
+    "elite": "Elite",
+    "might": "Might",
+    "character-type": "Character Type",
+    "battle-group": "Battle Group"
 }


### PR DESCRIPTION
Updates Exalted 3 character sheet to add support for battle groups.

Adds a toggle to the settings page to flag a character as a "battle group". This toggle hides the health track on the main page and adds a section for battle-group-specific traits (as described on page 206-210 of the core rulebook).