### PR TITLE
[Pokemon Tabletop Adventure - Sun & Moon] Corrections

### DIFF
--- a/PokemonTabletopAdventures - Sun & Moon/PTA.html
+++ b/PokemonTabletopAdventures - Sun & Moon/PTA.html
@@ -147,102 +147,102 @@
                 <tr>
                     <td>Browbeat</td>
                     <td><input type="number" name="attr_browbeat" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Browbeat Check}} {{skill=[[1d20+@{atkmod}+@{browbeat}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a browbeat Check}}' name='roll_BrowbeatCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Browbeat Check}} {{skill=[[1d20+[[@{atkmod}+@{browbeat}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a browbeat Check}}' name='roll_BrowbeatCheck' /></td>
                 </tr>
                 <tr>
                     <td>Jump</td>
                     <td><input type="number" name="attr_jump" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Jump Check}} {{skill=[[1d20+@{atkmod}+@{jump}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a jump Check}}' name='roll_JumpCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Jump Check}} {{skill=[[1d20+[[@{atkmod}+@{jump}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a jump Check}}' name='roll_JumpCheck' /></td>
                 </tr>
                 <tr>
                     <td>Sprint</td>
                     <td><input type="number" name="attr_sprint" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Sprint Check}} {{skill=[[1d20+@{atkmod}+@{sprint}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a sprint Check}}' name='roll_SprintCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Sprint Check}} {{skill=[[1d20+[[@{atkmod}+@{sprint}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a sprint Check}}' name='roll_SprintCheck' /></td>
                 </tr>
                 <tr>
                     <td>Strength</td>
                     <td><input type="number" name="attr_strength" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Strength Check}} {{skill=[[1d20+@{atkmod}+@{strength}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a strength Check}}' name='roll_StrengthCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Strength Check}} {{skill=[[1d20+[[@{atkmod}+@{strength}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a strength Check}}' name='roll_StrengthCheck' /></td>
                 </tr>
                 <tr>
                     <td>Concentration</td>
                     <td><input type="number" name="attr_concentration" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Concentration Check}} {{skill=[[1d20+@{defmod}+@{concentration}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a concentration Check}}' name='roll_ConcentrationCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Concentration Check}} {{skill=[[1d20+[[@{defmod}+@{concentration}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a concentration Check}}' name='roll_ConcentrationCheck' /></td>
                 </tr>
                 <tr>
                     <td>Deflection</td>
                     <td><input type="number" name="attr_deflection" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Deflection Check}} {{skill=[[1d20+@{defmod}+@{deflection}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a deflection Check}}' name='roll_DeflectionCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Deflection Check}} {{skill=[[1d20+[[@{defmod}+@{deflection}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a deflection Check}}' name='roll_DeflectionCheck' /></td>
                 </tr>
                 <tr>
                     <td>Healing</td>
                     <td><input type="number" name="attr_healing" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Healing Check}} {{skill=[[1d20+@{defmod}+@{healing}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a healing Check}}' name='roll_HealingCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Healing Check}} {{skill=[[1d20+[[@{defmod}+@{healing}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a healing Check}}' name='roll_HealingCheck' /></td>
                 </tr>
                 <tr>
                     <td>Tireless</td>
                     <td><input type="number" name="attr_tireless" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Tireless Check}} {{skill=[[1d20+@{defmod}+@{tireless}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a tireless Check}}' name='roll_TirelessCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Tireless Check}} {{skill=[[1d20+[[@{defmod}+@{tireless}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a tireless Check}}' name='roll_TirelessCheck' /></td>
                 </tr>
                 <tr>
                     <td>Engineering</td>
                     <td><input type="number" name="attr_engineering" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Engineering Check}} {{skill=[[1d20+@{satkmod}+@{engineering}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs an engineering Check}}' name='roll_EngineeringCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Engineering Check}} {{skill=[[1d20+[[@{satkmod}+@{engineering}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an engineering Check}}' name='roll_EngineeringCheck' /></td>
                 </tr>
                 <tr>
                     <td>History</td>
                     <td><input type="number" name="attr_history" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=History Check}} {{skill=[[1d20+@{satkmod}+@{history}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs an history Check}}' name='roll_HistoryCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=History Check}} {{skill=[[1d20+[[@{satkmod}+@{history}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an history Check}}' name='roll_HistoryCheck' /></td>
                 </tr>
                 <tr>
                     <td>Investigate</td>
                     <td><input type="number" name="attr_investigate" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Investigate Check}} {{skill=[[1d20+@{satkmod}+@{investigate}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs an investigate Check}}' name='roll_InvestigateCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Investigate Check}} {{skill=[[1d20+[[@{satkmod}+@{investigate}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an investigate Check}}' name='roll_InvestigateCheck' /></td>
                 </tr>
                 <tr>
                     <td>Programming</td>
                     <td><input type="number" name="attr_programming" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Programming Check}} {{skill=[[1d20+@{satkmod}+@{programming}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a programming Check}}' name='roll_ProgrammingCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Programming Check}} {{skill=[[1d20+[[@{satkmod}+@{programming}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a programming Check}}' name='roll_ProgrammingCheck' /></td>
                 </tr>
                 <tr>
                     <td>Bluff/Diplomacy</td>
                     <td><input type="number" name="attr_bluff_diplomacy" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Bluff/Diplomacy Check}} {{skill=[[1d20+@{sdefmod}+@{bluff_diplomacy}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a bluff/diplomacy Check}}' name='roll_Bluff_DiplomacyCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Bluff/Diplomacy Check}} {{skill=[[1d20+[[@{sdefmod}+@{bluff_diplomacy}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a bluff/diplomacy Check}}' name='roll_Bluff_DiplomacyCheck' /></td>
                 </tr>
                 <tr>
                     <td>Perception</td>
                     <td><input type="number" name="attr_perception" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Perception Check}} {{skill=[[1d20+@{sdefmod}+@{perception}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a perception Check}}' name='roll_PerceptionCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Perception Check}} {{skill=[[1d20+[[@{sdefmod}+@{perception}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a perception Check}}' name='roll_PerceptionCheck' /></td>
                 </tr>
                 <tr>
                     <td>Sooth</td>
                     <td><input type="number" name="attr_sooth" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Sooth Check}} {{skill=[[1d20+@{sdefmod}+@{sooth}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a sooth Check}}' name='roll_SoothCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Sooth Check}} {{skill=[[1d20+[[@{sdefmod}+@{sooth}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a sooth Check}}' name='roll_SoothCheck' /></td>
                 </tr>
                 <tr>
                     <td>Streetwise</td>
                     <td><input type="number" name="attr_streetwise" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Streetwise Check}} {{skill=[[1d20+@{sdefmod}+@{streetwise}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a streetwise Check}}' name='roll_StreetwiseCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Streetwise Check}} {{skill=[[1d20+[[@{sdefmod}+@{streetwise}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a streetwise Check}}' name='roll_StreetwiseCheck' /></td>
                 </tr>
                 <tr>
                     <td>Acrobatics</td>
                     <td><input type="number" name="attr_acrobatics" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Acrobatics Check}} {{skill=[[1d20+@{sdefmod}+@{acrobatics}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs an acrobatics Check}}' name='roll_AcrobaticsCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Acrobatics Check}} {{skill=[[1d20+[[@{sdefmod}+@{acrobatics}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an acrobatics Check}}' name='roll_AcrobaticsCheck' /></td>
                 </tr>
                 <tr>
                     <td>Perform</td>
                     <td><input type="number" name="attr_perform" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Perform Check}} {{skill=[[1d20+@{sdefmod}+@{perform}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a perform Check}}' name='roll_PerformCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Perform Check}} {{skill=[[1d20+[[@{sdefmod}+@{perform}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a perform Check}}' name='roll_PerformCheck' /></td>
                 </tr>
                 <tr>
                     <td>Sleight of Hand</td>
                     <td><input type="number" name="attr_sleight" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Sleight of Hand Check}} {{skill=[[1d20+@{sdefmod}+@{sleight}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a Sleight of Hand Check}}' name='roll_SleightCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Sleight of Hand Check}} {{skill=[[1d20+[[@{sdefmod}+@{sleight}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a Sleight of Hand Check}}' name='roll_SleightCheck' /></td>
                 </tr>
                 <tr>
                     <td>Stealth</td>
                     <td><input type="number" name="attr_stealth" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Stealth Check}} {{skill=[[1d20+@{sdefmod}+@{stealth}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a stealth Check}}' name='roll_StealthCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Stealth Check}} {{skill=[[1d20+[[@{sdefmod}+@{stealth}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a stealth Check}}' name='roll_StealthCheck' /></td>
                 </tr>
             </tbody>
         </table>

--- a/PokemonTabletopAdventures - Sun & Moon/PTA.html
+++ b/PokemonTabletopAdventures - Sun & Moon/PTA.html
@@ -215,6 +215,11 @@
                     <button type='roll' value= '&{template:skill} {{name=Perception Check}} {{skill=[[1d20+@{sdefmod}+@{perception}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a perception Check}}' name='roll_PerceptionCheck' /></td>
                 </tr>
                 <tr>
+                    <td>Sooth</td>
+                    <td><input type="number" name="attr_sooth" class="sheet-short" min="0">
+                    <button type='roll' value= '&{template:skill} {{name=Sooth Check}} {{skill=[[1d20+@{sdefmod}+@{sooth}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a sooth Check}}' name='roll_SoothCheck' /></td>
+                </tr>
+                <tr>
                     <td>Streetwise</td>
                     <td><input type="number" name="attr_streetwise" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Streetwise Check}} {{skill=[[1d20+@{sdefmod}+@{streetwise}*2+?{Misc. Skill Bonus}]]}} {{effect= @{character_name} performs a streetwise Check}}' name='roll_StreetwiseCheck' /></td>

--- a/PokemonTabletopAdventures - Sun & Moon/PTA.html
+++ b/PokemonTabletopAdventures - Sun & Moon/PTA.html
@@ -130,19 +130,19 @@
             <tbody>
                 <tr>
                     <td>Breathless</td>
-                    <td><input type="radio" name="attr_breathless" class="sheet-short"></td>
+                    <td><input type="checkbox" name="attr_breathless" class="sheet-short"></td>
                 </tr>
                 <tr>
                     <td>Fasting</td>
-                    <td><input type="radio" name="attr_fasting" class="sheet-short"></td>
+                    <td><input type="checkbox" name="attr_fasting" class="sheet-short"></td>
                 </tr>
                 <tr>
                     <td>Resistant</td>
-                    <td><input type="radio" name="attr_resistant" class="sheet-short"></td>
+                    <td><input type="checkbox" name="attr_resistant" class="sheet-short"></td>
                 </tr>
                 <tr>
                     <td>Endurance</td>
-                    <td><input type="radio" name="attr_endurance" class="sheet-short"></td>
+                    <td><input type="checkbox" name="attr_endurance" class="sheet-short"></td>
                 </tr>
                 <tr>
                     <td>Browbeat</td>

--- a/PokemonTabletopAdventures - Sun & Moon/PTA.html
+++ b/PokemonTabletopAdventures - Sun & Moon/PTA.html
@@ -145,104 +145,104 @@
                     <td><input type="checkbox" name="attr_endurance" class="sheet-short"></td>
                 </tr>
                 <tr>
-                    <td>Browbeat</td>
+                    <td>Browbeat (ATK)</td>
                     <td><input type="number" name="attr_browbeat" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Browbeat Check}} {{skill=[[1d20+[[@{atkmod}+@{browbeat}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a browbeat Check}}' name='roll_BrowbeatCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Jump</td>
+                    <td>Jump (ATK)</td>
                     <td><input type="number" name="attr_jump" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Jump Check}} {{skill=[[1d20+[[@{atkmod}+@{jump}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a jump Check}}' name='roll_JumpCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Sprint</td>
+                    <td>Sprint (ATK)</td>
                     <td><input type="number" name="attr_sprint" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Sprint Check}} {{skill=[[1d20+[[@{atkmod}+@{sprint}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a sprint Check}}' name='roll_SprintCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Strength</td>
+                    <td>Strength (ATK)</td>
                     <td><input type="number" name="attr_strength" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Strength Check}} {{skill=[[1d20+[[@{atkmod}+@{strength}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a strength Check}}' name='roll_StrengthCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Concentration</td>
+                    <td>Concentration (DEF)</td>
                     <td><input type="number" name="attr_concentration" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Concentration Check}} {{skill=[[1d20+[[@{defmod}+@{concentration}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a concentration Check}}' name='roll_ConcentrationCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Deflection</td>
+                    <td>Deflection (DEF)</td>
                     <td><input type="number" name="attr_deflection" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Deflection Check}} {{skill=[[1d20+[[@{defmod}+@{deflection}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a deflection Check}}' name='roll_DeflectionCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Healing</td>
+                    <td>Healing (DEF)</td>
                     <td><input type="number" name="attr_healing" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Healing Check}} {{skill=[[1d20+[[@{defmod}+@{healing}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a healing Check}}' name='roll_HealingCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Tireless</td>
+                    <td>Tireless (DEF)</td>
                     <td><input type="number" name="attr_tireless" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Tireless Check}} {{skill=[[1d20+[[@{defmod}+@{tireless}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a tireless Check}}' name='roll_TirelessCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Engineering</td>
+                    <td>Engineering (SATK)</td>
                     <td><input type="number" name="attr_engineering" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Engineering Check}} {{skill=[[1d20+[[@{satkmod}+@{engineering}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an engineering Check}}' name='roll_EngineeringCheck' /></td>
                 </tr>
                 <tr>
-                    <td>History</td>
+                    <td>History (SATK)</td>
                     <td><input type="number" name="attr_history" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=History Check}} {{skill=[[1d20+[[@{satkmod}+@{history}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an history Check}}' name='roll_HistoryCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Investigate</td>
+                    <td>Investigate (SATK)</td>
                     <td><input type="number" name="attr_investigate" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Investigate Check}} {{skill=[[1d20+[[@{satkmod}+@{investigate}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an investigate Check}}' name='roll_InvestigateCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Programming</td>
+                    <td>Programming (SATK)</td>
                     <td><input type="number" name="attr_programming" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Programming Check}} {{skill=[[1d20+[[@{satkmod}+@{programming}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a programming Check}}' name='roll_ProgrammingCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Bluff/Diplomacy</td>
+                    <td>Bluff/Diplomacy (SDEF)</td>
                     <td><input type="number" name="attr_bluff_diplomacy" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Bluff/Diplomacy Check}} {{skill=[[1d20+[[@{sdefmod}+@{bluff_diplomacy}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a bluff/diplomacy Check}}' name='roll_Bluff_DiplomacyCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Perception</td>
+                    <td>Perception (SDEF)</td>
                     <td><input type="number" name="attr_perception" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Perception Check}} {{skill=[[1d20+[[@{sdefmod}+@{perception}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a perception Check}}' name='roll_PerceptionCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Sooth</td>
+                    <td>Sooth (SDEF)</td>
                     <td><input type="number" name="attr_sooth" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Sooth Check}} {{skill=[[1d20+[[@{sdefmod}+@{sooth}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a sooth Check}}' name='roll_SoothCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Streetwise</td>
+                    <td>Streetwise (SDEF)</td>
                     <td><input type="number" name="attr_streetwise" class="sheet-short" min="0">
                     <button type='roll' value= '&{template:skill} {{name=Streetwise Check}} {{skill=[[1d20+[[@{sdefmod}+@{streetwise}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a streetwise Check}}' name='roll_StreetwiseCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Acrobatics</td>
+                    <td>Acrobatics (SPD)</td>
                     <td><input type="number" name="attr_acrobatics" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Acrobatics Check}} {{skill=[[1d20+[[@{sdefmod}+@{acrobatics}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an acrobatics Check}}' name='roll_AcrobaticsCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Acrobatics Check}} {{skill=[[1d20+[[@{spdmod}+@{acrobatics}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs an acrobatics Check}}' name='roll_AcrobaticsCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Perform</td>
+                    <td>Perform (SPD)</td>
                     <td><input type="number" name="attr_perform" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Perform Check}} {{skill=[[1d20+[[@{sdefmod}+@{perform}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a perform Check}}' name='roll_PerformCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Perform Check}} {{skill=[[1d20+[[@{spdmod}+@{perform}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a perform Check}}' name='roll_PerformCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Sleight of Hand</td>
+                    <td>Sleight of Hand (SPD)</td>
                     <td><input type="number" name="attr_sleight" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Sleight of Hand Check}} {{skill=[[1d20+[[@{sdefmod}+@{sleight}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a Sleight of Hand Check}}' name='roll_SleightCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Sleight of Hand Check}} {{skill=[[1d20+[[@{spdmod}+@{sleight}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a Sleight of Hand Check}}' name='roll_SleightCheck' /></td>
                 </tr>
                 <tr>
-                    <td>Stealth</td>
+                    <td>Stealth (SPD)</td>
                     <td><input type="number" name="attr_stealth" class="sheet-short" min="0">
-                    <button type='roll' value= '&{template:skill} {{name=Stealth Check}} {{skill=[[1d20+[[@{sdefmod}+@{stealth}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a stealth Check}}' name='roll_StealthCheck' /></td>
+                    <button type='roll' value= '&{template:skill} {{name=Stealth Check}} {{skill=[[1d20+[[@{spdmod}+@{stealth}*2+?{Misc. Skill Bonus}]]]]}} {{effect= @{character_name} performs a stealth Check}}' name='roll_StealthCheck' /></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
The update to the Sun & Moon version contained a few mistakes I corrected:
 - Added "Sooth", a forgotten trainer skill
 - Added the stat in the skill name so player can quickly see what stat is linked to what skill
 - Changed the "radio" input to "checkbox", so it can be un-checked
 - Changer the formula for the trainer skill roll to correct a bug occuring when leaving the "Misc. Skill Modifier" blank
 - Corrected the roll formula for 4 skills, as the wrong stat was used