### PR TITLE
[Open Legend] NPC Section & More

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.css
+++ b/Open Legend Basic by Great Moustache/Open Legend.css
@@ -493,6 +493,9 @@
     font-size: 2.0em;
     font-family: Georgia, Verdana, sans-serif;
 }
+.sheet-smallCaps {
+    font-variant: small-caps;
+}
 /* START alignment */
 .sheet-textLeft,
 .sheet-rolltemplate-openLegend .sheet-textLeft,
@@ -692,7 +695,52 @@ input[type=number] {
     color: black;
     font-size: 40px;
 }
-.sheet-inputNumberLargeSkinny input[type=number] {
+.sheet-inputNumberLargeNarrow input[type=number] {
+    border-bottom: 0px;
+    border-top: 0px;
+    border-left: 0px;
+    border-right: 0px;
+    background: #cccccc;
+    box-shadow: none;
+    -webkit-appearance: none;
+	-moz-appearance: textfield;
+    height: 70px;
+    width: 60px;
+    text-align: center;
+    color: black;
+    font-size: 40px;
+}
+.sheet-inputNumberLargeShort input[type=number] {
+    border-bottom: 0px;
+    border-top: 0px;
+    border-left: 0px;
+    border-right: 0px;
+    background: #cccccc;
+    box-shadow: none;
+    -webkit-appearance: none;
+	-moz-appearance: textfield;
+    height: 50px;
+    width: 80px;
+    text-align: center;
+    color: black;
+    font-size: 40px;
+}
+.sheet-inputNumberLargeNarrowShort input[type=number] {
+    border-bottom: 0px;
+    border-top: 0px;
+    border-left: 0px;
+    border-right: 0px;
+    background: #cccccc;
+    box-shadow: none;
+    -webkit-appearance: none;
+	-moz-appearance: textfield;
+    height: 50px;
+    width: 60px;
+    text-align: center;
+    color: black;
+    font-size: 40px;
+}
+.sheet-inputNumberLargeLethal input[type=number] {
     border-bottom: 0px;
     border-top: 0px;
     border-left: 0px;
@@ -707,6 +755,50 @@ input[type=number] {
     color: #cccccc;
     font-size: 40px;
 }
+.sheet-inputNumberLargeLethalShort input[type=number] {
+    border-bottom: 0px;
+    border-top: 0px;
+    border-left: 0px;
+    border-right: 0px;
+    background: #111111;
+    box-shadow: none;
+    -webkit-appearance: none;
+	-moz-appearance: textfield;
+    height: 50px;
+    width: 60px;
+    text-align: center;
+    color: #cccccc;
+    font-size: 40px;
+}
+
+    /*** FOR CHECKBOX SELECTION ***/
+        /*** FOR SHOW/HIDE ***/
+input[type=checkbox].sheet-tab-hide {
+    display: inline-block;
+    width: 24px;
+    opacity: 0;
+    z-index: 2;
+}
+input[type=checkbox].sheet-tab-hide + div {
+    display: inline-block;
+    margin-left: -27px;
+    width: 25px;
+    font-family: pictos;
+    font-size: 2.0em;
+    color: #A0A0A0;
+    cursor: pointer;
+}
+input[type=checkbox].sheet-tab-hide:checked + div {
+    display: inline-block;
+    color: black;
+}
+input[type=checkbox].sheet-tab-hide:hover + div,
+input[type=checkbox].sheet-tab-hide:hover * {
+    display: inline-block;
+    color: blue;
+}
+        /*** END FOR SHOW/HIDE ***/
+    /*** END FOR CHECKBOX SELECTION ***/
 
     /*** FOR RADIO SELECTION ***/
         /*** FOR MAIN SHEET ***/
@@ -836,6 +928,48 @@ input[type=radio].sheet-tab-action.sheet-effect:checked + span {
     color: black;
     height: 18px;
     line-height: 18px;
+}
+	/*** Input as text for dice size (usually d4/d6/d8/d10 etc) ***/
+.sheet-inputDiceNum input[type=text] {
+    box-shadow: none;
+    padding: 0px;
+    margin: 0px;
+    width: 15px;
+    background: none;
+    border: none;
+/***    border-top: solid 1px #111111;
+    border-bottom: solid 1px #111111;
+    border-left: solid 1px #111111;
+    border-right: 0px; ***/
+    text-align: right;
+}
+	/*** Input as text for dice size (usually d4/d6/d8/d10 etc) ***/
+.sheet-inputDiceType select {
+    border: 0px;
+    background: none;
+    box-shadow: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+	appearance: none;
+    -webkit-border-radius: 0px;
+    border-radius: 0px;
+    color: black;
+    text-align: left;
+    display: inline-block;
+    padding: 0px;
+    margin: 0px;
+    line-height: 18px;
+    height: 18px;
+    width: 35px;
+}
+.sheet-inputDiceType input[type=text] {
+    box-shadow: none;
+    padding: 0px;
+    margin: 0px;
+    width: 35px;
+    background: none;
+    border: none;
+    text-align: left;
 }
 	/*** Input as text for dice size (usually d4/d6/d8/d10 etc) ***/
 .sheet-inputDice input[type=text] {
@@ -1142,6 +1276,31 @@ input[type=radio].sheet-tab-sheet.sheet-options:checked ~ .sheet-option-main.she
     display: block;
 }
 
+.sheet-displaySheetCharacter,
+.sheet-displaySheetAltForm1,
+.sheet-displaySheetAltForm2,
+.sheet-displaySheetCompanion1,
+.sheet-displaySheetCompanion2,
+.sheet-displaySheetCompanion3,
+.sheet-displaySheetNPC {
+    display: none;
+}
+
+.sheet-display_sheet_type[value="character"] ~ .sheet-displaySheetCharacter,
+.sheet-display_sheet_type[value="alt form 1"] ~ .sheet-displaySheetCharacter.sheet-main,
+.sheet-display_sheet_type[value="alt form 2"] ~ .sheet-displaySheetCharacter.sheet-main,
+.sheet-display_sheet_type[value="companion 1"] ~ .sheet-displaySheetCharacter.sheet-main,
+.sheet-display_sheet_type[value="companion 2"] ~ .sheet-displaySheetCharacter.sheet-main,
+.sheet-display_sheet_type[value="companion 3"] ~ .sheet-displaySheetCharacter.sheet-main,
+.sheet-display_sheet_type[value="alt form 1"] ~ .sheet-displaySheetAltForm1,
+.sheet-display_sheet_type[value="alt form 2"] ~ .sheet-displaySheetAltForm2,
+.sheet-display_sheet_type[value="companion 1"] ~ .sheet-displaySheetCompanion1,
+.sheet-display_sheet_type[value="companion 2"] ~ .sheet-displaySheetCompanion2,
+.sheet-display_sheet_type[value="companion 3"] ~ .sheet-displaySheetCompanion3,
+.sheet-display_sheet_type[value="npc"] ~ .sheet-displaySheetNPC {
+    display: inline-block;
+}
+
 .sheet-option-action {
     display: none;
 }
@@ -1172,6 +1331,14 @@ input[type=checkbox].sheet-display-boon.sheet-pl6:checked ~ .sheet-option-boon.s
 input[type=checkbox].sheet-display-boon.sheet-pl7:checked ~ .sheet-option-boon.sheet-pl7,
 input[type=checkbox].sheet-display-boon.sheet-pl8:checked ~ .sheet-option-boon.sheet-pl8,
 input[type=checkbox].sheet-display-boon.sheet-pl9:checked ~ .sheet-option-boon.sheet-pl9 {
+    display: inline-block;
+}
+
+.sheet-show-hide {
+    display: none;
+}
+
+input[type=checkbox].sheet-tab-hide:checked ~ .sheet-show-hide {
     display: inline-block;
 }
 

--- a/Open Legend Basic by Great Moustache/Open Legend.css
+++ b/Open Legend Basic by Great Moustache/Open Legend.css
@@ -735,7 +735,7 @@ input[type=number] {
     -webkit-appearance: none;
 	-moz-appearance: textfield;
     height: 50px;
-    width: 60px;
+    width: 55px;
     text-align: center;
     color: black;
     font-size: 40px;

--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -33,6 +33,1561 @@
 		otherInventoryFixColumns2();
 	});
 	
+// NPC section workerscripts
+// *******************************************************
+// *******************************************************
+    // Function called for determining the size of the dice based on the score given
+    function calcAttributeDiceValue (value) {
+            if(value*1 === 0 || value*1 <= 0) { return 0;
+            } else if (value*1 === 1) {  return 4;
+            } else if (value*1 === 2 || value*1 === 5) {  return 6;
+            } else if (value*1 === 3 || value*1 === 6 || value*1 === 8 || value*1 >= 10) {  return 8;
+            } else if (value*1 === 4 || value*1 === 7 || value*1 === 9) {  return 10;
+            }
+    };
+	// On Change for the score for NPC#1-5 Attribute1 to auto-calc the attribute dice
+	on("change:npc1_prime_attribute1_score", function() {
+	    getAttrs(["npc1_prime_attribute1_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc1_prime_attribute1_score*1);
+	        var type = calcAttributeDiceValue(values.npc1_prime_attribute1_score*1);
+            setAttrs({
+                "npc1_prime_attribute1_dice_number": number,
+                "npc1_prime_attribute1_dice_type": type
+            });
+        });
+    });
+	on("change:npc2_prime_attribute1_score", function() {
+	    getAttrs(["npc2_prime_attribute1_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc2_prime_attribute1_score*1);
+	        var type = calcAttributeDiceValue(values.npc2_prime_attribute1_score*1);
+            setAttrs({
+                "npc2_prime_attribute1_dice_number": number,
+                "npc2_prime_attribute1_dice_type": type
+            });
+        });
+    });
+	on("change:npc3_prime_attribute1_score", function() {
+	    getAttrs(["npc3_prime_attribute1_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc3_prime_attribute1_score*1);
+	        var type = calcAttributeDiceValue(values.npc3_prime_attribute1_score*1);
+            setAttrs({
+                "npc3_prime_attribute1_dice_number": number,
+                "npc3_prime_attribute1_dice_type": type
+            });
+        });
+    });
+	on("change:npc4_prime_attribute1_score", function() {
+	    getAttrs(["npc4_prime_attribute1_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc4_prime_attribute1_score*1);
+	        var type = calcAttributeDiceValue(values.npc4_prime_attribute1_score*1);
+            setAttrs({
+                "npc4_prime_attribute1_dice_number": number,
+                "npc4_prime_attribute1_dice_type": type
+            });
+        });
+    });
+	on("change:npc5_prime_attribute1_score", function() {
+	    getAttrs(["npc5_prime_attribute1_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc5_prime_attribute1_score*1);
+	        var type = calcAttributeDiceValue(values.npc5_prime_attribute1_score*1);
+            setAttrs({
+                "npc5_prime_attribute1_dice_number": number,
+                "npc5_prime_attribute1_dice_type": type
+            });
+        });
+    });
+	// On Change for the score for NPC#1-5 Attribute2 to auto-calc the attribute dice
+	on("change:npc1_prime_attribute2_score", function() {
+	    getAttrs(["npc1_prime_attribute2_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc1_prime_attribute2_score*1);
+	        var type = calcAttributeDiceValue(values.npc1_prime_attribute2_score*1);
+            setAttrs({
+                "npc1_prime_attribute2_dice_number": number,
+                "npc1_prime_attribute2_dice_type": type
+            });
+        });
+    });
+	on("change:npc2_prime_attribute2_score", function() {
+	    getAttrs(["npc2_prime_attribute2_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc2_prime_attribute2_score*1);
+	        var type = calcAttributeDiceValue(values.npc2_prime_attribute2_score*1);
+            setAttrs({
+                "npc2_prime_attribute2_dice_number": number,
+                "npc2_prime_attribute2_dice_type": type
+            });
+        });
+    });
+	on("change:npc3_prime_attribute2_score", function() {
+	    getAttrs(["npc3_prime_attribute2_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc3_prime_attribute2_score*1);
+	        var type = calcAttributeDiceValue(values.npc3_prime_attribute2_score*1);
+            setAttrs({
+                "npc3_prime_attribute2_dice_number": number,
+                "npc3_prime_attribute2_dice_type": type
+            });
+        });
+    });
+	on("change:npc4_prime_attribute2_score", function() {
+	    getAttrs(["npc4_prime_attribute2_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc4_prime_attribute2_score*1);
+	        var type = calcAttributeDiceValue(values.npc4_prime_attribute2_score*1);
+            setAttrs({
+                "npc4_prime_attribute2_dice_number": number,
+                "npc4_prime_attribute2_dice_type": type
+            });
+        });
+    });
+	on("change:npc5_prime_attribute2_score", function() {
+	    getAttrs(["npc5_prime_attribute2_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc5_prime_attribute2_score*1);
+	        var type = calcAttributeDiceValue(values.npc5_prime_attribute2_score*1);
+            setAttrs({
+                "npc5_prime_attribute2_dice_number": number,
+                "npc5_prime_attribute2_dice_type": type
+            });
+        });
+    });
+	// On Change for the score for NPC#1-5 Attribute3 to auto-calc the attribute dice
+	on("change:npc1_prime_attribute3_score", function() {
+	    getAttrs(["npc1_prime_attribute3_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc1_prime_attribute3_score*1);
+	        var type = calcAttributeDiceValue(values.npc1_prime_attribute3_score*1);
+            setAttrs({
+                "npc1_prime_attribute3_dice_number": number,
+                "npc1_prime_attribute3_dice_type": type
+            });
+        });
+    });
+	on("change:npc2_prime_attribute3_score", function() {
+	    getAttrs(["npc2_prime_attribute3_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc2_prime_attribute3_score*1);
+	        var type = calcAttributeDiceValue(values.npc2_prime_attribute3_score*1);
+            setAttrs({
+                "npc2_prime_attribute3_dice_number": number,
+                "npc2_prime_attribute3_dice_type": type
+            });
+        });
+    });
+	on("change:npc3_prime_attribute3_score", function() {
+	    getAttrs(["npc3_prime_attribute3_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc3_prime_attribute3_score*1);
+	        var type = calcAttributeDiceValue(values.npc3_prime_attribute3_score*1);
+            setAttrs({
+                "npc3_prime_attribute3_dice_number": number,
+                "npc3_prime_attribute3_dice_type": type
+            });
+        });
+    });
+	on("change:npc4_prime_attribute3_score", function() {
+	    getAttrs(["npc4_prime_attribute3_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc4_prime_attribute3_score*1);
+	        var type = calcAttributeDiceValue(values.npc4_prime_attribute3_score*1);
+            setAttrs({
+                "npc4_prime_attribute3_dice_number": number,
+                "npc4_prime_attribute3_dice_type": type
+            });
+        });
+    });
+	on("change:npc5_prime_attribute3_score", function() {
+	    getAttrs(["npc5_prime_attribute3_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc5_prime_attribute3_score*1);
+	        var type = calcAttributeDiceValue(values.npc5_prime_attribute3_score*1);
+            setAttrs({
+                "npc5_prime_attribute3_dice_number": number,
+                "npc5_prime_attribute3_dice_type": type
+            });
+        });
+    });
+	// On Change for the score for NPC#1-5 Initiative to auto-calc the attribute dice
+	on("change:npc1_initiative_score", function() {
+	    getAttrs(["npc1_initiative_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc1_initiative_score*1);
+	        var type = calcAttributeDiceValue(values.npc1_initiative_score*1);
+            setAttrs({
+                "npc1_initiative_dice_number": number,
+                "npc1_initiative_dice_type": type
+            });
+        });
+    });
+	on("change:npc2_initiative_score", function() {
+	    getAttrs(["npc2_initiative_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc2_initiative_score*1);
+	        var type = calcAttributeDiceValue(values.npc2_initiative_score*1);
+            setAttrs({
+                "npc2_initiative_dice_number": number,
+                "npc2_initiative_dice_type": type
+            });
+        });
+    });
+	on("change:npc3_initiative_score", function() {
+	    getAttrs(["npc3_initiative_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc3_initiative_score*1);
+	        var type = calcAttributeDiceValue(values.npc3_initiative_score*1);
+            setAttrs({
+                "npc3_initiative_dice_number": number,
+                "npc3_initiative_dice_type": type
+            });
+        });
+    });
+	on("change:npc4_initiative_score", function() {
+	    getAttrs(["npc4_initiative_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc4_initiative_score*1);
+	        var type = calcAttributeDiceValue(values.npc4_initiative_score*1);
+            setAttrs({
+                "npc4_initiative_dice_number": number,
+                "npc4_initiative_dice_type": type
+            });
+        });
+    });
+	on("change:npc5_initiative_score", function() {
+	    getAttrs(["npc5_initiative_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.npc5_initiative_score*1);
+	        var type = calcAttributeDiceValue(values.npc5_initiative_score*1);
+            setAttrs({
+                "npc5_initiative_dice_number": number,
+                "npc5_initiative_dice_type": type
+            });
+        });
+    });
+	// On Change for the score for NPC#1-5 Secondary Attributes to auto-calc the attribute dice
+	on("change:repeating_npc1secondary:score", function() {
+	    getAttrs(["repeating_npc1secondary_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc1secondary_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc1secondary_score*1);
+            setAttrs({
+                "repeating_npc1secondary_dice_number": number,
+                "repeating_npc1secondary_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc2secondary:score", function() {
+	    getAttrs(["repeating_npc2secondary_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc2secondary_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc2secondary_score*1);
+            setAttrs({
+                "repeating_npc2secondary_dice_number": number,
+                "repeating_npc2secondary_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc3secondary:score", function() {
+	    getAttrs(["repeating_npc3secondary_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc3secondary_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc3secondary_score*1);
+            setAttrs({
+                "repeating_npc3secondary_dice_number": number,
+                "repeating_npc3secondary_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc4secondary:score", function() {
+	    getAttrs(["repeating_npc4secondary_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc4secondary_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc4secondary_score*1);
+            setAttrs({
+                "repeating_npc4secondary_dice_number": number,
+                "repeating_npc4secondary_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc5secondary:score", function() {
+	    getAttrs(["repeating_npc5secondary_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc5secondary_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc5secondary_score*1);
+            setAttrs({
+                "repeating_npc5secondary_dice_number": number,
+                "repeating_npc5secondary_dice_type": type
+            });
+        });
+    });
+	// On Change for the score for NPC#1-5 Favored Actions to auto-calc the attribute dice
+	on("change:repeating_npc1actions:score", function() {
+	    getAttrs(["repeating_npc1actions_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc1actions_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc1actions_score*1);
+            setAttrs({
+                "repeating_npc1actions_dice_number": number,
+                "repeating_npc1actions_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc2actions:score", function() {
+	    getAttrs(["repeating_npc2actions_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc2actions_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc2actions_score*1);
+            setAttrs({
+                "repeating_npc2actions_dice_number": number,
+                "repeating_npc2actions_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc3actions:score", function() {
+	    getAttrs(["repeating_npc3actions_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc3actions_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc3actions_score*1);
+            setAttrs({
+                "repeating_npc3actions_dice_number": number,
+                "repeating_npc3actions_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc4actions:score", function() {
+	    getAttrs(["repeating_npc4actions_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc4actions_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc4actions_score*1);
+            setAttrs({
+                "repeating_npc4actions_dice_number": number,
+                "repeating_npc4actions_dice_type": type
+            });
+        });
+    });
+	on("change:repeating_npc5actions:score", function() {
+	    getAttrs(["repeating_npc5actions_score"], function(values) {
+	        var number = calcAttributeDiceNumber(values.repeating_npc5actions_score*1);
+	        var type = calcAttributeDiceValue(values.repeating_npc5actions_score*1);
+            setAttrs({
+                "repeating_npc5actions_dice_number": number,
+                "repeating_npc5actions_dice_type": type
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1-5 Primary Attribute 1 if any variables are updated
+    on("change:npc1_prime_attribute1_dice_number change:npc1_prime_attribute1_dice_type change:npc1_prime_attribute1_default_advantage", function() {
+        getAttrs(["npc1_prime_attribute1_score", "npc1_prime_attribute1_dice_number", "npc1_prime_attribute1_dice_type", "npc1_prime_attribute1_default_advantage"], function(values) {
+            var number = values.npc1_prime_attribute1_dice_number*1;
+            var type = "d" + values.npc1_prime_attribute1_dice_type + "!!";
+			var roll = "";
+			if(values.npc1_prime_attribute1_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc1_prime_attribute1_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc1_prime_attribute1_roll": roll
+            });
+        });
+    });
+    on("change:npc2_prime_attribute1_dice_number change:npc2_prime_attribute1_dice_type change:npc2_prime_attribute1_default_advantage", function() {
+        getAttrs(["npc2_prime_attribute1_score", "npc2_prime_attribute1_dice_number", "npc2_prime_attribute1_dice_type", "npc2_prime_attribute1_default_advantage"], function(values) {
+            var number = values.npc2_prime_attribute1_dice_number*1;
+            var type = "d" + values.npc2_prime_attribute1_dice_type + "!!";
+			var roll = "";
+			if(values.npc2_prime_attribute1_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc2_prime_attribute1_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc2_prime_attribute1_roll": roll
+            });
+        });
+    });
+    on("change:npc3_prime_attribute1_dice_number change:npc3_prime_attribute1_dice_type change:npc3_prime_attribute1_default_advantage", function() {
+        getAttrs(["npc3_prime_attribute1_score", "npc3_prime_attribute1_dice_number", "npc3_prime_attribute1_dice_type", "npc3_prime_attribute1_default_advantage"], function(values) {
+            var number = values.npc3_prime_attribute1_dice_number*1;
+            var type = "d" + values.npc3_prime_attribute1_dice_type + "!!";
+			var roll = "";
+			if(values.npc3_prime_attribute1_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc3_prime_attribute1_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc3_prime_attribute1_roll": roll
+            });
+        });
+    });
+    on("change:npc4_prime_attribute1_dice_number change:npc4_prime_attribute1_dice_type change:npc4_prime_attribute1_default_advantage", function() {
+        getAttrs(["npc4_prime_attribute1_score", "npc4_prime_attribute1_dice_number", "npc4_prime_attribute1_dice_type", "npc4_prime_attribute1_default_advantage"], function(values) {
+            var number = values.npc4_prime_attribute1_dice_number*1;
+            var type = "d" + values.npc4_prime_attribute1_dice_type + "!!";
+			var roll = "";
+			if(values.npc4_prime_attribute1_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc4_prime_attribute1_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc4_prime_attribute1_roll": roll
+            });
+        });
+    });
+    on("change:npc5_prime_attribute1_dice_number change:npc5_prime_attribute1_dice_type change:npc5_prime_attribute1_default_advantage", function() {
+        getAttrs(["npc5_prime_attribute1_score", "npc5_prime_attribute1_dice_number", "npc5_prime_attribute1_dice_type", "npc5_prime_attribute1_default_advantage"], function(values) {
+            var number = values.npc5_prime_attribute1_dice_number*1;
+            var type = "d" + values.npc5_prime_attribute1_dice_type + "!!";
+			var roll = "";
+			if(values.npc5_prime_attribute1_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc5_prime_attribute1_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc5_prime_attribute1_roll": roll
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1-5 Primary Attribute 2 if any variables are updated
+    on("change:npc1_prime_attribute2_dice_number change:npc1_prime_attribute2_dice_type change:npc1_prime_attribute2_default_advantage", function() {
+        getAttrs(["npc1_prime_attribute2_score", "npc1_prime_attribute2_dice_number", "npc1_prime_attribute2_dice_type", "npc1_prime_attribute2_default_advantage"], function(values) {
+            var number = values.npc1_prime_attribute2_dice_number*1;
+            var type = "d" + values.npc1_prime_attribute2_dice_type + "!!";
+			var roll = "";
+			if(values.npc1_prime_attribute2_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc1_prime_attribute2_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc1_prime_attribute2_roll": roll
+            });
+        });
+    });
+    on("change:npc2_prime_attribute2_dice_number change:npc2_prime_attribute2_dice_type change:npc2_prime_attribute2_default_advantage", function() {
+        getAttrs(["npc2_prime_attribute2_score", "npc2_prime_attribute2_dice_number", "npc2_prime_attribute2_dice_type", "npc2_prime_attribute2_default_advantage"], function(values) {
+            var number = values.npc2_prime_attribute2_dice_number*1;
+            var type = "d" + values.npc2_prime_attribute2_dice_type + "!!";
+			var roll = "";
+			if(values.npc2_prime_attribute2_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc2_prime_attribute2_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc2_prime_attribute2_roll": roll
+            });
+        });
+    });
+    on("change:npc3_prime_attribute2_dice_number change:npc3_prime_attribute2_dice_type change:npc3_prime_attribute2_default_advantage", function() {
+        getAttrs(["npc3_prime_attribute2_score", "npc3_prime_attribute2_dice_number", "npc3_prime_attribute2_dice_type", "npc3_prime_attribute2_default_advantage"], function(values) {
+            var number = values.npc3_prime_attribute2_dice_number*1;
+            var type = "d" + values.npc3_prime_attribute2_dice_type + "!!";
+			var roll = "";
+			if(values.npc3_prime_attribute2_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc3_prime_attribute2_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc3_prime_attribute2_roll": roll
+            });
+        });
+    });
+    on("change:npc4_prime_attribute2_dice_number change:npc4_prime_attribute2_dice_type change:npc4_prime_attribute2_default_advantage", function() {
+        getAttrs(["npc4_prime_attribute2_score", "npc4_prime_attribute2_dice_number", "npc4_prime_attribute2_dice_type", "npc4_prime_attribute2_default_advantage"], function(values) {
+            var number = values.npc4_prime_attribute2_dice_number*1;
+            var type = "d" + values.npc4_prime_attribute2_dice_type + "!!";
+			var roll = "";
+			if(values.npc4_prime_attribute2_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc4_prime_attribute2_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc4_prime_attribute2_roll": roll
+            });
+        });
+    });
+    on("change:npc5_prime_attribute2_dice_number change:npc5_prime_attribute2_dice_type change:npc5_prime_attribute2_default_advantage", function() {
+        getAttrs(["npc5_prime_attribute2_score", "npc5_prime_attribute2_dice_number", "npc5_prime_attribute2_dice_type", "npc5_prime_attribute2_default_advantage"], function(values) {
+            var number = values.npc5_prime_attribute2_dice_number*1;
+            var type = "d" + values.npc5_prime_attribute2_dice_type + "!!";
+			var roll = "";
+			if(values.npc5_prime_attribute2_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc5_prime_attribute2_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc5_prime_attribute2_roll": roll
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1-5 Primary Attribute 3 if any variables are updated
+    on("change:npc1_prime_attribute3_dice_number change:npc1_prime_attribute3_dice_type change:npc1_prime_attribute3_default_advantage", function() {
+        getAttrs(["npc1_prime_attribute3_score", "npc1_prime_attribute3_dice_number", "npc1_prime_attribute3_dice_type", "npc1_prime_attribute3_default_advantage"], function(values) {
+            var number = values.npc1_prime_attribute3_dice_number*1;
+            var type = "d" + values.npc1_prime_attribute3_dice_type + "!!";
+			var roll = "";
+			if(values.npc1_prime_attribute3_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc1_prime_attribute3_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc1_prime_attribute3_roll": roll
+            });
+        });
+    });
+    on("change:npc2_prime_attribute3_dice_number change:npc2_prime_attribute3_dice_type change:npc2_prime_attribute3_default_advantage", function() {
+        getAttrs(["npc2_prime_attribute3_score", "npc2_prime_attribute3_dice_number", "npc2_prime_attribute3_dice_type", "npc2_prime_attribute3_default_advantage"], function(values) {
+            var number = values.npc2_prime_attribute3_dice_number*1;
+            var type = "d" + values.npc2_prime_attribute3_dice_type + "!!";
+			var roll = "";
+			if(values.npc2_prime_attribute3_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc2_prime_attribute3_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc2_prime_attribute3_roll": roll
+            });
+        });
+    });
+    on("change:npc3_prime_attribute3_dice_number change:npc3_prime_attribute3_dice_type change:npc3_prime_attribute3_default_advantage", function() {
+        getAttrs(["npc3_prime_attribute3_score", "npc3_prime_attribute3_dice_number", "npc3_prime_attribute3_dice_type", "npc3_prime_attribute3_default_advantage"], function(values) {
+            var number = values.npc3_prime_attribute3_dice_number*1;
+            var type = "d" + values.npc3_prime_attribute3_dice_type + "!!";
+			var roll = "";
+			if(values.npc3_prime_attribute3_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc3_prime_attribute3_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc3_prime_attribute3_roll": roll
+            });
+        });
+    });
+    on("change:npc4_prime_attribute3_dice_number change:npc4_prime_attribute3_dice_type change:npc4_prime_attribute3_default_advantage", function() {
+        getAttrs(["npc4_prime_attribute3_score", "npc4_prime_attribute3_dice_number", "npc4_prime_attribute3_dice_type", "npc4_prime_attribute3_default_advantage"], function(values) {
+            var number = values.npc4_prime_attribute3_dice_number*1;
+            var type = "d" + values.npc4_prime_attribute3_dice_type + "!!";
+			var roll = "";
+			if(values.npc4_prime_attribute3_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc4_prime_attribute3_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc4_prime_attribute3_roll": roll
+            });
+        });
+    });
+    on("change:npc5_prime_attribute3_dice_number change:npc5_prime_attribute3_dice_type change:npc5_prime_attribute3_default_advantage", function() {
+        getAttrs(["npc5_prime_attribute3_score", "npc5_prime_attribute3_dice_number", "npc5_prime_attribute3_dice_type", "npc5_prime_attribute3_default_advantage"], function(values) {
+            var number = values.npc5_prime_attribute3_dice_number*1;
+            var type = "d" + values.npc5_prime_attribute3_dice_type + "!!";
+			var roll = "";
+			if(values.npc5_prime_attribute3_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc5_prime_attribute3_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc5_prime_attribute3_roll": roll
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1-5 Initiative if any variables are updated
+    on("change:npc1_initiative_dice_number change:npc1_initiative_dice_type change:npc1_initiative_default_advantage", function() {
+        getAttrs(["npc1_initiative_score", "npc1_initiative_dice_number", "npc1_initiative_dice_type", "npc1_initiative_default_advantage"], function(values) {
+            var number = values.npc1_initiative_dice_number*1;
+            var type = "d" + values.npc1_initiative_dice_type + "!!";
+			var roll = "";
+			if(values.npc1_initiative_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc1_initiative_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc1_initiative_roll": roll
+            });
+        });
+    });
+    on("change:npc2_initiative_dice_number change:npc2_initiative_dice_type change:npc2_initiative_default_advantage", function() {
+        getAttrs(["npc2_initiative_score", "npc2_initiative_dice_number", "npc2_initiative_dice_type", "npc2_initiative_default_advantage"], function(values) {
+            var number = values.npc2_initiative_dice_number*1;
+            var type = "d" + values.npc2_initiative_dice_type + "!!";
+			var roll = "";
+			if(values.npc2_initiative_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc2_initiative_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc2_initiative_roll": roll
+            });
+        });
+    });
+    on("change:npc3_initiative_dice_number change:npc3_initiative_dice_type change:npc3_initiative_default_advantage", function() {
+        getAttrs(["npc3_initiative_score", "npc3_initiative_dice_number", "npc3_initiative_dice_type", "npc3_initiative_default_advantage"], function(values) {
+            var number = values.npc3_initiative_dice_number*1;
+            var type = "d" + values.npc3_initiative_dice_type + "!!";
+			var roll = "";
+			if(values.npc3_initiative_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc3_initiative_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc3_initiative_roll": roll
+            });
+        });
+    });
+    on("change:npc4_initiative_dice_number change:npc4_initiative_dice_type change:npc4_initiative_default_advantage", function() {
+        getAttrs(["npc4_initiative_score", "npc4_initiative_dice_number", "npc4_initiative_dice_type", "npc4_initiative_default_advantage"], function(values) {
+            var number = values.npc4_initiative_dice_number*1;
+            var type = "d" + values.npc4_initiative_dice_type + "!!";
+			var roll = "";
+			if(values.npc4_initiative_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc4_initiative_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc4_initiative_roll": roll
+            });
+        });
+    });
+    on("change:npc5_initiative_dice_number change:npc5_initiative_dice_type change:npc5_initiative_default_advantage", function() {
+        getAttrs(["npc5_initiative_score", "npc5_initiative_dice_number", "npc5_initiative_dice_type", "npc5_initiative_default_advantage"], function(values) {
+            var number = values.npc5_initiative_dice_number*1;
+            var type = "d" + values.npc5_initiative_dice_type + "!!";
+			var roll = "";
+			if(values.npc5_initiative_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.npc5_initiative_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "npc5_initiative_roll": roll
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1-5 Secondary Attributes if any variables are updated
+    on("change:repeating_npc1secondary:dice_number change:repeating_npc1secondary:dice_type change:repeating_npc1secondary:default_advantage", function() {
+        getAttrs(["repeating_npc1secondary_score", "repeating_npc1secondary_dice_number", "repeating_npc1secondary_dice_type", "repeating_npc1secondary_default_advantage"], function(values) {
+            var number = values.repeating_npc1secondary_dice_number*1;
+            var type = "d" + values.repeating_npc1secondary_dice_type + "!!";
+			var roll = "";
+			if(values.repeating_npc1secondary_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc1secondary_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "repeating_npc1secondary_roll": roll
+            });
+        });
+    });
+    on("change:repeating_npc2secondary:dice_number change:repeating_npc2secondary:dice_type change:repeating_npc2secondary:default_advantage", function() {
+        getAttrs(["repeating_npc2secondary_score", "repeating_npc2secondary_dice_number", "repeating_npc2secondary_dice_type", "repeating_npc2secondary_default_advantage"], function(values) {
+            var number = values.repeating_npc2secondary_dice_number*1;
+            var type = "d" + values.repeating_npc2secondary_dice_type + "!!";
+			var roll = "";
+			if(values.repeating_npc2secondary_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc2secondary_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "repeating_npc2secondary_roll": roll
+            });
+        });
+    });
+    on("change:repeating_npc3secondary:dice_number change:repeating_npc3secondary:dice_type change:repeating_npc3secondary:default_advantage", function() {
+        getAttrs(["repeating_npc3secondary_score", "repeating_npc3secondary_dice_number", "repeating_npc3secondary_dice_type", "repeating_npc3secondary_default_advantage"], function(values) {
+            var number = values.repeating_npc3secondary_dice_number*1;
+            var type = "d" + values.repeating_npc3secondary_dice_type + "!!";
+			var roll = "";
+			if(values.repeating_npc3secondary_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc3secondary_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "repeating_npc3secondary_roll": roll
+            });
+        });
+    });
+    on("change:repeating_npc4secondary:dice_number change:repeating_npc4secondary:dice_type change:repeating_npc4secondary:default_advantage", function() {
+        getAttrs(["repeating_npc4secondary_score", "repeating_npc4secondary_dice_number", "repeating_npc4secondary_dice_type", "repeating_npc4secondary_default_advantage"], function(values) {
+            var number = values.repeating_npc4secondary_dice_number*1;
+            var type = "d" + values.repeating_npc4secondary_dice_type + "!!";
+			var roll = "";
+			if(values.repeating_npc4secondary_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc4secondary_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "repeating_npc4secondary_roll": roll
+            });
+        });
+    });
+    on("change:repeating_npc5secondary:dice_number change:repeating_npc5secondary:dice_type change:repeating_npc5secondary:default_advantage", function() {
+        getAttrs(["repeating_npc5secondary_score", "repeating_npc5secondary_dice_number", "repeating_npc5secondary_dice_type", "repeating_npc5secondary_default_advantage"], function(values) {
+            var number = values.repeating_npc5secondary_dice_number*1;
+            var type = "d" + values.repeating_npc5secondary_dice_type + "!!";
+			var roll = "";
+			if(values.repeating_npc5secondary_score*1 === 0) {
+				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]}}";
+			} else {
+				roll = "{{roll=[[1d20!! + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc5secondary_default_advantage*1 + "}]]" + type + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+			}
+            setAttrs({
+                "repeating_npc5secondary_roll": roll
+            });
+        });
+    });
+
+	// On Change for calculating rolls for NPC#1 Favored Actions if any variables are updated
+    on("change:repeating_npc1actions:use_d20_advantage change:repeating_npc1actions:use_destructive_trance change:repeating_npc1actions:default_advantage change:repeating_npc1actions:tab_action change:repeating_npc1actions:dice_number change:repeating_npc1actions:dice_type change:repeating_npc1actions:effect_dice_number change:repeating_npc1actions:effect_dice_type change:repeating_npc1actions:use_power_level_1 change:repeating_npc1actions:action_pl1 change:repeating_npc1actions:use_power_level_2 change:repeating_npc1actions:action_pl2 change:repeating_npc1actions:use_power_level_3 change:repeating_npc1actions:action_pl3 change:repeating_npc1actions:use_power_level_4 change:repeating_npc1actions:action_pl4 change:repeating_npc1actions:use_power_level_5 change:repeating_npc1actions:action_pl5 change:repeating_npc1actions:use_power_level_6 change:repeating_npc1actions:action_pl6 change:repeating_npc1actions:use_power_level_7 change:repeating_npc1actions:action_pl7 change:repeating_npc1actions:use_power_level_8 change:repeating_npc1actions:action_pl8 change:repeating_npc1actions:use_power_level_9 change:repeating_npc1actions:action_pl9", function() {
+        getAttrs(["repeating_npc1actions_score", "repeating_npc1actions_use_d20_advantage", "repeating_npc1actions_use_destructive_trance", "repeating_npc1actions_default_advantage", "repeating_npc1actions_tab_action", "repeating_npc1actions_dice_number", "repeating_npc1actions_dice_type", "repeating_npc1actions_effect_dice_number", "repeating_npc1actions_effect_dice_type", "repeating_npc1actions_use_power_level_1", "repeating_npc1actions_action_pl1", "repeating_npc1actions_use_power_level_2", "repeating_npc1actions_action_pl2", "repeating_npc1actions_use_power_level_3", "repeating_npc1actions_action_pl3", "repeating_npc1actions_use_power_level_4", "repeating_npc1actions_action_pl4", "repeating_npc1actions_use_power_level_5", "repeating_npc1actions_action_pl5", "repeating_npc1actions_use_power_level_6", "repeating_npc1actions_action_pl6", "repeating_npc1actions_use_power_level_7", "repeating_npc1actions_action_pl7", "repeating_npc1actions_use_power_level_8", "repeating_npc1actions_action_pl8", "repeating_npc1actions_use_power_level_9", "repeating_npc1actions_action_pl9"], function(values) {
+            var number = values.repeating_npc1actions_dice_number*1;
+            var type = "d" + values.repeating_npc1actions_dice_type + "!!";
+			var destructive = "";
+			var destructive20 = "";
+			var blank = "";
+            var powerLevelLow = 0;
+            var powerLevelHigh = 0;
+    // Start high and end low to determine the lowest Power Level to use for the given Boon
+            if(values.repeating_npc1actions_use_power_level_9 === "1") {    powerLevelLow = 9; }
+            if(values.repeating_npc1actions_use_power_level_8 === "1") {    powerLevelLow = 8; }
+            if(values.repeating_npc1actions_use_power_level_7 === "1") {    powerLevelLow = 7; }
+            if(values.repeating_npc1actions_use_power_level_6 === "1") {    powerLevelLow = 6; }
+            if(values.repeating_npc1actions_use_power_level_5 === "1") {    powerLevelLow = 5; }
+            if(values.repeating_npc1actions_use_power_level_4 === "1") {    powerLevelLow = 4; }
+            if(values.repeating_npc1actions_use_power_level_3 === "1") {    powerLevelLow = 3; }
+            if(values.repeating_npc1actions_use_power_level_2 === "1") {    powerLevelLow = 2; }
+            if(values.repeating_npc1actions_use_power_level_1 === "1") {    powerLevelLow = 1; }
+    // Start low and end high to determine the highest Power Level to use for the given Boon
+            if(values.repeating_npc1actions_use_power_level_1 === "1") {    powerLevelHigh = 1; }
+            if(values.repeating_npc1actions_use_power_level_2 === "1") {    powerLevelHigh = 2; }
+            if(values.repeating_npc1actions_use_power_level_3 === "1") {    powerLevelHigh = 3; }
+            if(values.repeating_npc1actions_use_power_level_4 === "1") {    powerLevelHigh = 4; }
+            if(values.repeating_npc1actions_use_power_level_5 === "1") {    powerLevelHigh = 5; }
+            if(values.repeating_npc1actions_use_power_level_6 === "1") {    powerLevelHigh = 6; }
+            if(values.repeating_npc1actions_use_power_level_7 === "1") {    powerLevelHigh = 7; }
+            if(values.repeating_npc1actions_use_power_level_8 === "1") {    powerLevelHigh = 8; }
+            if(values.repeating_npc1actions_use_power_level_9 === "1") {    powerLevelHigh = 9; }
+    // Assign only the Power Levels that exists across ones that don't exist for display vs roll in roll template
+            var usePL1 = "";
+            var titlePL1 = "";
+            var usePL2 = "";
+            var titlePL2 = "";
+            var usePL3 = "";
+            var titlePL3 = "";
+            var usePL4 = "";
+            var titlePL4 = "";
+            var usePL5 = "";
+            var titlePL5 = "";
+            var usePL6 = "";
+            var titlePL6 = "";
+            var usePL7 = "";
+            var titlePL7 = "";
+            var usePL8 = "";
+            var titlePL8 = "";
+            var usePL9 = "";
+            var titlePL9 = "";
+            if(values.repeating_npc1actions_use_power_level_1 === "1" && values.repeating_npc1actions_score*1 > 0) {
+                usePL1 = values.repeating_npc1actions_action_pl1;
+                titlePL1 = "Power Level 1 Info";
+            } else {
+                usePL1 = "";
+                titlePL1 = "";
+            }
+            if(values.repeating_npc1actions_use_power_level_2 === "1" && values.repeating_npc1actions_score*1 > 1) {
+                usePL2 = values.repeating_npc1actions_action_pl2;
+                titlePL2 = "Power Level 2 Info";
+            } else {
+                usePL2 = usePL1;
+                titlePL2 = titlePL1;
+            }
+            if(values.repeating_npc1actions_use_power_level_3 === "1" && values.repeating_npc1actions_score*1 > 2) {
+                usePL3 = values.repeating_npc1actions_action_pl3;
+                titlePL3 = "Power Level 3 Info";
+            } else {
+                usePL3 = usePL2;
+                titlePL3 = titlePL2;
+            }
+            if(values.repeating_npc1actions_use_power_level_4 === "1" && values.repeating_npc1actions_score*1 > 3) {
+                usePL4 = values.repeating_npc1actions_action_pl4;
+                titlePL4 = "Power Level 4 Info";
+            } else {
+                usePL4 = usePL3;
+                titlePL4 = titlePL3;
+            }
+            if(values.repeating_npc1actions_use_power_level_5 === "1" && values.repeating_npc1actions_score*1 > 4) {
+                usePL5 = values.repeating_npc1actions_action_pl5;
+                titlePL5 = "Power Level 5 Info";
+            } else {
+                usePL5 = usePL4;
+                titlePL5 = titlePL4;
+            }
+            if(values.repeating_npc1actions_use_power_level_6 === "1" && values.repeating_npc1actions_score*1 > 5) {
+                usePL6 = values.repeating_npc1actions_action_pl6;
+                titlePL6 = "Power Level 6 Info";
+            } else {
+                usePL6 = usePL5;
+                titlePL6 = titlePL5;
+            }
+            if(values.repeating_npc1actions_use_power_level_7 === "1" && values.repeating_npc1actions_score*1 > 6) {
+                usePL7 = values.repeating_npc1actions_action_pl7;
+                titlePL7 = "Power Level 7 Info";
+            } else {
+                usePL7 = usePL6;
+                titlePL7 = titlePL6;
+            }
+            if(values.repeating_npc1actions_use_power_level_8 === "1" && values.repeating_npc1actions_score*1 > 7) {
+                usePL8 = values.repeating_npc1actions_action_pl8;
+                titlePL8 = "Power Level 8 Info";
+            } else {
+                usePL8 = usePL7;
+                titlePL8 = titlePL7;
+            }
+            if(values.repeating_npc1actions_use_power_level_9 === "1" && values.repeating_npc1actions_score*1 > 8) {
+                usePL9 = values.repeating_npc1actions_action_pl9;
+                titlePL9 = "Power Level 9 Info";
+            } else {
+                usePL9 = usePL8;
+                titlePL9 = titlePL8;
+            }
+            
+
+			if(values.repeating_npc1actions_use_destructive_trance === "Yes") {
+				destructive = ">" + (values.repeating_npc1actions_dice_type*1 - 1);
+				destructive20 = ">19";
+			}
+			var roll = "";
+			if(values.repeating_npc1actions_tab_action === "effect") {
+			    roll = "{{roll=[[" + values.repeating_npc1actions_effect_dice_number + values.repeating_npc1actions_effect_dice_type + "]]}}";
+			} else {
+    			if(values.repeating_npc1actions_score*1 === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    			    if(values.repeating_npc1actions_use_d20_advantage === "Yes") {
+        				roll = "{{roll=[[2d20!!" + destructive20 + "k1 + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc1actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    } else {
+        				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc1actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    }
+    			}
+			}
+            setAttrs({
+                "repeating_npc1actions_dice_roll": roll,
+                "repeating_npc1actions_power_level_low": powerLevelLow,
+                "repeating_npc1actions_power_level_high": powerLevelHigh,
+                "repeating_npc1actions_pl1": usePL1,
+                "repeating_npc1actions_pl1_title": titlePL1,
+                "repeating_npc1actions_pl2": usePL2,
+                "repeating_npc1actions_pl2_title": titlePL2,
+                "repeating_npc1actions_pl3": usePL3,
+                "repeating_npc1actions_pl3_title": titlePL3,
+                "repeating_npc1actions_pl4": usePL4,
+                "repeating_npc1actions_pl4_title": titlePL4,
+                "repeating_npc1actions_pl5": usePL5,
+                "repeating_npc1actions_pl5_title": titlePL5,
+                "repeating_npc1actions_pl6": usePL6,
+                "repeating_npc1actions_pl6_title": titlePL6,
+                "repeating_npc1actions_pl7": usePL7,
+                "repeating_npc1actions_pl7_title": titlePL7,
+                "repeating_npc1actions_pl8": usePL8,
+                "repeating_npc1actions_pl8_title": titlePL8,
+                "repeating_npc1actions_pl9": usePL9,
+                "repeating_npc1actions_pl9_title": titlePL9
+            });
+        });
+    });
+	// On Change for calculating rolls for NPC#2 Favored Actions if any variables are updated
+    on("change:repeating_npc2actions:use_d20_advantage change:repeating_npc2actions:use_destructive_trance change:repeating_npc2actions:default_advantage change:repeating_npc2actions:tab_action change:repeating_npc2actions:dice_number change:repeating_npc2actions:dice_type change:repeating_npc2actions:effect_dice_number change:repeating_npc2actions:effect_dice_type change:repeating_npc2actions:use_power_level_1 change:repeating_npc2actions:action_pl1 change:repeating_npc2actions:use_power_level_2 change:repeating_npc2actions:action_pl2 change:repeating_npc2actions:use_power_level_3 change:repeating_npc2actions:action_pl3 change:repeating_npc2actions:use_power_level_4 change:repeating_npc2actions:action_pl4 change:repeating_npc2actions:use_power_level_5 change:repeating_npc2actions:action_pl5 change:repeating_npc2actions:use_power_level_6 change:repeating_npc2actions:action_pl6 change:repeating_npc2actions:use_power_level_7 change:repeating_npc2actions:action_pl7 change:repeating_npc2actions:use_power_level_8 change:repeating_npc2actions:action_pl8 change:repeating_npc2actions:use_power_level_9 change:repeating_npc2actions:action_pl9", function() {
+        getAttrs(["repeating_npc2actions_score", "repeating_npc2actions_use_d20_advantage", "repeating_npc2actions_use_destructive_trance", "repeating_npc2actions_default_advantage", "repeating_npc2actions_tab_action", "repeating_npc2actions_dice_number", "repeating_npc2actions_dice_type", "repeating_npc2actions_effect_dice_number", "repeating_npc2actions_effect_dice_type", "repeating_npc2actions_use_power_level_1", "repeating_npc2actions_action_pl1", "repeating_npc2actions_use_power_level_2", "repeating_npc2actions_action_pl2", "repeating_npc2actions_use_power_level_3", "repeating_npc2actions_action_pl3", "repeating_npc2actions_use_power_level_4", "repeating_npc2actions_action_pl4", "repeating_npc2actions_use_power_level_5", "repeating_npc2actions_action_pl5", "repeating_npc2actions_use_power_level_6", "repeating_npc2actions_action_pl6", "repeating_npc2actions_use_power_level_7", "repeating_npc2actions_action_pl7", "repeating_npc2actions_use_power_level_8", "repeating_npc2actions_action_pl8", "repeating_npc2actions_use_power_level_9", "repeating_npc2actions_action_pl9"], function(values) {
+            var number = values.repeating_npc2actions_dice_number*1;
+            var type = "d" + values.repeating_npc2actions_dice_type + "!!";
+			var destructive = "";
+			var destructive20 = "";
+			var blank = "";
+            var powerLevelLow = 0;
+            var powerLevelHigh = 0;
+    // Start high and end low to determine the lowest Power Level to use for the given Boon
+            if(values.repeating_npc2actions_use_power_level_9 === "1") {    powerLevelLow = 9; }
+            if(values.repeating_npc2actions_use_power_level_8 === "1") {    powerLevelLow = 8; }
+            if(values.repeating_npc2actions_use_power_level_7 === "1") {    powerLevelLow = 7; }
+            if(values.repeating_npc2actions_use_power_level_6 === "1") {    powerLevelLow = 6; }
+            if(values.repeating_npc2actions_use_power_level_5 === "1") {    powerLevelLow = 5; }
+            if(values.repeating_npc2actions_use_power_level_4 === "1") {    powerLevelLow = 4; }
+            if(values.repeating_npc2actions_use_power_level_3 === "1") {    powerLevelLow = 3; }
+            if(values.repeating_npc2actions_use_power_level_2 === "1") {    powerLevelLow = 2; }
+            if(values.repeating_npc2actions_use_power_level_1 === "1") {    powerLevelLow = 1; }
+    // Start low and end high to determine the highest Power Level to use for the given Boon
+            if(values.repeating_npc2actions_use_power_level_1 === "1") {    powerLevelHigh = 1; }
+            if(values.repeating_npc2actions_use_power_level_2 === "1") {    powerLevelHigh = 2; }
+            if(values.repeating_npc2actions_use_power_level_3 === "1") {    powerLevelHigh = 3; }
+            if(values.repeating_npc2actions_use_power_level_4 === "1") {    powerLevelHigh = 4; }
+            if(values.repeating_npc2actions_use_power_level_5 === "1") {    powerLevelHigh = 5; }
+            if(values.repeating_npc2actions_use_power_level_6 === "1") {    powerLevelHigh = 6; }
+            if(values.repeating_npc2actions_use_power_level_7 === "1") {    powerLevelHigh = 7; }
+            if(values.repeating_npc2actions_use_power_level_8 === "1") {    powerLevelHigh = 8; }
+            if(values.repeating_npc2actions_use_power_level_9 === "1") {    powerLevelHigh = 9; }
+    // Assign only the Power Levels that exists across ones that don't exist for display vs roll in roll template
+            var usePL1 = "";
+            var titlePL1 = "";
+            var usePL2 = "";
+            var titlePL2 = "";
+            var usePL3 = "";
+            var titlePL3 = "";
+            var usePL4 = "";
+            var titlePL4 = "";
+            var usePL5 = "";
+            var titlePL5 = "";
+            var usePL6 = "";
+            var titlePL6 = "";
+            var usePL7 = "";
+            var titlePL7 = "";
+            var usePL8 = "";
+            var titlePL8 = "";
+            var usePL9 = "";
+            var titlePL9 = "";
+            if(values.repeating_npc2actions_use_power_level_1 === "1" && values.repeating_npc2actions_score*1 > 0) {
+                usePL1 = values.repeating_npc2actions_action_pl1;
+                titlePL1 = "Power Level 1 Info";
+            } else {
+                usePL1 = "";
+                titlePL1 = "";
+            }
+            if(values.repeating_npc2actions_use_power_level_2 === "1" && values.repeating_npc2actions_score*1 > 1) {
+                usePL2 = values.repeating_npc2actions_action_pl2;
+                titlePL2 = "Power Level 2 Info";
+            } else {
+                usePL2 = usePL1;
+                titlePL2 = titlePL1;
+            }
+            if(values.repeating_npc2actions_use_power_level_3 === "1" && values.repeating_npc2actions_score*1 > 2) {
+                usePL3 = values.repeating_npc2actions_action_pl3;
+                titlePL3 = "Power Level 3 Info";
+            } else {
+                usePL3 = usePL2;
+                titlePL3 = titlePL2;
+            }
+            if(values.repeating_npc2actions_use_power_level_4 === "1" && values.repeating_npc2actions_score*1 > 3) {
+                usePL4 = values.repeating_npc2actions_action_pl4;
+                titlePL4 = "Power Level 4 Info";
+            } else {
+                usePL4 = usePL3;
+                titlePL4 = titlePL3;
+            }
+            if(values.repeating_npc2actions_use_power_level_5 === "1" && values.repeating_npc2actions_score*1 > 4) {
+                usePL5 = values.repeating_npc2actions_action_pl5;
+                titlePL5 = "Power Level 5 Info";
+            } else {
+                usePL5 = usePL4;
+                titlePL5 = titlePL4;
+            }
+            if(values.repeating_npc2actions_use_power_level_6 === "1" && values.repeating_npc2actions_score*1 > 5) {
+                usePL6 = values.repeating_npc2actions_action_pl6;
+                titlePL6 = "Power Level 6 Info";
+            } else {
+                usePL6 = usePL5;
+                titlePL6 = titlePL5;
+            }
+            if(values.repeating_npc2actions_use_power_level_7 === "1" && values.repeating_npc2actions_score*1 > 6) {
+                usePL7 = values.repeating_npc2actions_action_pl7;
+                titlePL7 = "Power Level 7 Info";
+            } else {
+                usePL7 = usePL6;
+                titlePL7 = titlePL6;
+            }
+            if(values.repeating_npc2actions_use_power_level_8 === "1" && values.repeating_npc2actions_score*1 > 7) {
+                usePL8 = values.repeating_npc2actions_action_pl8;
+                titlePL8 = "Power Level 8 Info";
+            } else {
+                usePL8 = usePL7;
+                titlePL8 = titlePL7;
+            }
+            if(values.repeating_npc2actions_use_power_level_9 === "1" && values.repeating_npc2actions_score*1 > 8) {
+                usePL9 = values.repeating_npc2actions_action_pl9;
+                titlePL9 = "Power Level 9 Info";
+            } else {
+                usePL9 = usePL8;
+                titlePL9 = titlePL8;
+            }
+            
+
+			if(values.repeating_npc2actions_use_destructive_trance === "Yes") {
+				destructive = ">" + (values.repeating_npc2actions_dice_type*1 - 1);
+				destructive20 = ">19";
+			}
+			var roll = "";
+			if(values.repeating_npc2actions_tab_action === "effect") {
+			    roll = "{{roll=[[" + values.repeating_npc2actions_effect_dice_number + values.repeating_npc2actions_effect_dice_type + "]]}}";
+			} else {
+    			if(values.repeating_npc2actions_score*1 === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    			    if(values.repeating_npc2actions_use_d20_advantage === "Yes") {
+        				roll = "{{roll=[[2d20!!" + destructive20 + "k1 + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc2actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    } else {
+        				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc2actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    }
+    			}
+			}
+            setAttrs({
+                "repeating_npc2actions_dice_roll": roll,
+                "repeating_npc2actions_power_level_low": powerLevelLow,
+                "repeating_npc2actions_power_level_high": powerLevelHigh,
+                "repeating_npc2actions_pl1": usePL1,
+                "repeating_npc2actions_pl1_title": titlePL1,
+                "repeating_npc2actions_pl2": usePL2,
+                "repeating_npc2actions_pl2_title": titlePL2,
+                "repeating_npc2actions_pl3": usePL3,
+                "repeating_npc2actions_pl3_title": titlePL3,
+                "repeating_npc2actions_pl4": usePL4,
+                "repeating_npc2actions_pl4_title": titlePL4,
+                "repeating_npc2actions_pl5": usePL5,
+                "repeating_npc2actions_pl5_title": titlePL5,
+                "repeating_npc2actions_pl6": usePL6,
+                "repeating_npc2actions_pl6_title": titlePL6,
+                "repeating_npc2actions_pl7": usePL7,
+                "repeating_npc2actions_pl7_title": titlePL7,
+                "repeating_npc2actions_pl8": usePL8,
+                "repeating_npc2actions_pl8_title": titlePL8,
+                "repeating_npc2actions_pl9": usePL9,
+                "repeating_npc2actions_pl9_title": titlePL9
+            });
+        });
+    });
+	// On Change for calculating rolls for NPC#3 Favored Actions if any variables are updated
+    on("change:repeating_npc3actions:use_d20_advantage change:repeating_npc3actions:use_destructive_trance change:repeating_npc3actions:default_advantage change:repeating_npc3actions:tab_action change:repeating_npc3actions:dice_number change:repeating_npc3actions:dice_type change:repeating_npc3actions:effect_dice_number change:repeating_npc3actions:effect_dice_type change:repeating_npc3actions:use_power_level_1 change:repeating_npc3actions:action_pl1 change:repeating_npc3actions:use_power_level_2 change:repeating_npc3actions:action_pl2 change:repeating_npc3actions:use_power_level_3 change:repeating_npc3actions:action_pl3 change:repeating_npc3actions:use_power_level_4 change:repeating_npc3actions:action_pl4 change:repeating_npc3actions:use_power_level_5 change:repeating_npc3actions:action_pl5 change:repeating_npc3actions:use_power_level_6 change:repeating_npc3actions:action_pl6 change:repeating_npc3actions:use_power_level_7 change:repeating_npc3actions:action_pl7 change:repeating_npc3actions:use_power_level_8 change:repeating_npc3actions:action_pl8 change:repeating_npc3actions:use_power_level_9 change:repeating_npc3actions:action_pl9", function() {
+        getAttrs(["repeating_npc3actions_score", "repeating_npc3actions_use_d20_advantage", "repeating_npc3actions_use_destructive_trance", "repeating_npc3actions_default_advantage", "repeating_npc3actions_tab_action", "repeating_npc3actions_dice_number", "repeating_npc3actions_dice_type", "repeating_npc3actions_effect_dice_number", "repeating_npc3actions_effect_dice_type", "repeating_npc3actions_use_power_level_1", "repeating_npc3actions_action_pl1", "repeating_npc3actions_use_power_level_2", "repeating_npc3actions_action_pl2", "repeating_npc3actions_use_power_level_3", "repeating_npc3actions_action_pl3", "repeating_npc3actions_use_power_level_4", "repeating_npc3actions_action_pl4", "repeating_npc3actions_use_power_level_5", "repeating_npc3actions_action_pl5", "repeating_npc3actions_use_power_level_6", "repeating_npc3actions_action_pl6", "repeating_npc3actions_use_power_level_7", "repeating_npc3actions_action_pl7", "repeating_npc3actions_use_power_level_8", "repeating_npc3actions_action_pl8", "repeating_npc3actions_use_power_level_9", "repeating_npc3actions_action_pl9"], function(values) {
+            var number = values.repeating_npc3actions_dice_number*1;
+            var type = "d" + values.repeating_npc3actions_dice_type + "!!";
+			var destructive = "";
+			var destructive20 = "";
+			var blank = "";
+            var powerLevelLow = 0;
+            var powerLevelHigh = 0;
+    // Start high and end low to determine the lowest Power Level to use for the given Boon
+            if(values.repeating_npc3actions_use_power_level_9 === "1") {    powerLevelLow = 9; }
+            if(values.repeating_npc3actions_use_power_level_8 === "1") {    powerLevelLow = 8; }
+            if(values.repeating_npc3actions_use_power_level_7 === "1") {    powerLevelLow = 7; }
+            if(values.repeating_npc3actions_use_power_level_6 === "1") {    powerLevelLow = 6; }
+            if(values.repeating_npc3actions_use_power_level_5 === "1") {    powerLevelLow = 5; }
+            if(values.repeating_npc3actions_use_power_level_4 === "1") {    powerLevelLow = 4; }
+            if(values.repeating_npc3actions_use_power_level_3 === "1") {    powerLevelLow = 3; }
+            if(values.repeating_npc3actions_use_power_level_2 === "1") {    powerLevelLow = 2; }
+            if(values.repeating_npc3actions_use_power_level_1 === "1") {    powerLevelLow = 1; }
+    // Start low and end high to determine the highest Power Level to use for the given Boon
+            if(values.repeating_npc3actions_use_power_level_1 === "1") {    powerLevelHigh = 1; }
+            if(values.repeating_npc3actions_use_power_level_2 === "1") {    powerLevelHigh = 2; }
+            if(values.repeating_npc3actions_use_power_level_3 === "1") {    powerLevelHigh = 3; }
+            if(values.repeating_npc3actions_use_power_level_4 === "1") {    powerLevelHigh = 4; }
+            if(values.repeating_npc3actions_use_power_level_5 === "1") {    powerLevelHigh = 5; }
+            if(values.repeating_npc3actions_use_power_level_6 === "1") {    powerLevelHigh = 6; }
+            if(values.repeating_npc3actions_use_power_level_7 === "1") {    powerLevelHigh = 7; }
+            if(values.repeating_npc3actions_use_power_level_8 === "1") {    powerLevelHigh = 8; }
+            if(values.repeating_npc3actions_use_power_level_9 === "1") {    powerLevelHigh = 9; }
+    // Assign only the Power Levels that exists across ones that don't exist for display vs roll in roll template
+            var usePL1 = "";
+            var titlePL1 = "";
+            var usePL2 = "";
+            var titlePL2 = "";
+            var usePL3 = "";
+            var titlePL3 = "";
+            var usePL4 = "";
+            var titlePL4 = "";
+            var usePL5 = "";
+            var titlePL5 = "";
+            var usePL6 = "";
+            var titlePL6 = "";
+            var usePL7 = "";
+            var titlePL7 = "";
+            var usePL8 = "";
+            var titlePL8 = "";
+            var usePL9 = "";
+            var titlePL9 = "";
+            if(values.repeating_npc3actions_use_power_level_1 === "1" && values.repeating_npc3actions_score*1 > 0) {
+                usePL1 = values.repeating_npc3actions_action_pl1;
+                titlePL1 = "Power Level 1 Info";
+            } else {
+                usePL1 = "";
+                titlePL1 = "";
+            }
+            if(values.repeating_npc3actions_use_power_level_2 === "1" && values.repeating_npc3actions_score*1 > 1) {
+                usePL2 = values.repeating_npc3actions_action_pl2;
+                titlePL2 = "Power Level 2 Info";
+            } else {
+                usePL2 = usePL1;
+                titlePL2 = titlePL1;
+            }
+            if(values.repeating_npc3actions_use_power_level_3 === "1" && values.repeating_npc3actions_score*1 > 2) {
+                usePL3 = values.repeating_npc3actions_action_pl3;
+                titlePL3 = "Power Level 3 Info";
+            } else {
+                usePL3 = usePL2;
+                titlePL3 = titlePL2;
+            }
+            if(values.repeating_npc3actions_use_power_level_4 === "1" && values.repeating_npc3actions_score*1 > 3) {
+                usePL4 = values.repeating_npc3actions_action_pl4;
+                titlePL4 = "Power Level 4 Info";
+            } else {
+                usePL4 = usePL3;
+                titlePL4 = titlePL3;
+            }
+            if(values.repeating_npc3actions_use_power_level_5 === "1" && values.repeating_npc3actions_score*1 > 4) {
+                usePL5 = values.repeating_npc3actions_action_pl5;
+                titlePL5 = "Power Level 5 Info";
+            } else {
+                usePL5 = usePL4;
+                titlePL5 = titlePL4;
+            }
+            if(values.repeating_npc3actions_use_power_level_6 === "1" && values.repeating_npc3actions_score*1 > 5) {
+                usePL6 = values.repeating_npc3actions_action_pl6;
+                titlePL6 = "Power Level 6 Info";
+            } else {
+                usePL6 = usePL5;
+                titlePL6 = titlePL5;
+            }
+            if(values.repeating_npc3actions_use_power_level_7 === "1" && values.repeating_npc3actions_score*1 > 6) {
+                usePL7 = values.repeating_npc3actions_action_pl7;
+                titlePL7 = "Power Level 7 Info";
+            } else {
+                usePL7 = usePL6;
+                titlePL7 = titlePL6;
+            }
+            if(values.repeating_npc3actions_use_power_level_8 === "1" && values.repeating_npc3actions_score*1 > 7) {
+                usePL8 = values.repeating_npc3actions_action_pl8;
+                titlePL8 = "Power Level 8 Info";
+            } else {
+                usePL8 = usePL7;
+                titlePL8 = titlePL7;
+            }
+            if(values.repeating_npc3actions_use_power_level_9 === "1" && values.repeating_npc3actions_score*1 > 8) {
+                usePL9 = values.repeating_npc3actions_action_pl9;
+                titlePL9 = "Power Level 9 Info";
+            } else {
+                usePL9 = usePL8;
+                titlePL9 = titlePL8;
+            }
+            
+
+			if(values.repeating_npc3actions_use_destructive_trance === "Yes") {
+				destructive = ">" + (values.repeating_npc3actions_dice_type*1 - 1);
+				destructive20 = ">19";
+			}
+			var roll = "";
+			if(values.repeating_npc3actions_tab_action === "effect") {
+			    roll = "{{roll=[[" + values.repeating_npc3actions_effect_dice_number + values.repeating_npc3actions_effect_dice_type + "]]}}";
+			} else {
+    			if(values.repeating_npc3actions_score*1 === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    			    if(values.repeating_npc3actions_use_d20_advantage === "Yes") {
+        				roll = "{{roll=[[2d20!!" + destructive20 + "k1 + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc3actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    } else {
+        				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc3actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    }
+    			}
+			}
+            setAttrs({
+                "repeating_npc3actions_dice_roll": roll,
+                "repeating_npc3actions_power_level_low": powerLevelLow,
+                "repeating_npc3actions_power_level_high": powerLevelHigh,
+                "repeating_npc3actions_pl1": usePL1,
+                "repeating_npc3actions_pl1_title": titlePL1,
+                "repeating_npc3actions_pl2": usePL2,
+                "repeating_npc3actions_pl2_title": titlePL2,
+                "repeating_npc3actions_pl3": usePL3,
+                "repeating_npc3actions_pl3_title": titlePL3,
+                "repeating_npc3actions_pl4": usePL4,
+                "repeating_npc3actions_pl4_title": titlePL4,
+                "repeating_npc3actions_pl5": usePL5,
+                "repeating_npc3actions_pl5_title": titlePL5,
+                "repeating_npc3actions_pl6": usePL6,
+                "repeating_npc3actions_pl6_title": titlePL6,
+                "repeating_npc3actions_pl7": usePL7,
+                "repeating_npc3actions_pl7_title": titlePL7,
+                "repeating_npc3actions_pl8": usePL8,
+                "repeating_npc3actions_pl8_title": titlePL8,
+                "repeating_npc3actions_pl9": usePL9,
+                "repeating_npc3actions_pl9_title": titlePL9
+            });
+        });
+    });
+	// On Change for calculating rolls for NPC#4 Favored Actions if any variables are updated
+    on("change:repeating_npc4actions:use_d20_advantage change:repeating_npc4actions:use_destructive_trance change:repeating_npc4actions:default_advantage change:repeating_npc4actions:tab_action change:repeating_npc4actions:dice_number change:repeating_npc4actions:dice_type change:repeating_npc4actions:effect_dice_number change:repeating_npc4actions:effect_dice_type change:repeating_npc4actions:use_power_level_1 change:repeating_npc4actions:action_pl1 change:repeating_npc4actions:use_power_level_2 change:repeating_npc4actions:action_pl2 change:repeating_npc4actions:use_power_level_3 change:repeating_npc4actions:action_pl3 change:repeating_npc4actions:use_power_level_4 change:repeating_npc4actions:action_pl4 change:repeating_npc4actions:use_power_level_5 change:repeating_npc4actions:action_pl5 change:repeating_npc4actions:use_power_level_6 change:repeating_npc4actions:action_pl6 change:repeating_npc4actions:use_power_level_7 change:repeating_npc4actions:action_pl7 change:repeating_npc4actions:use_power_level_8 change:repeating_npc4actions:action_pl8 change:repeating_npc4actions:use_power_level_9 change:repeating_npc4actions:action_pl9", function() {
+        getAttrs(["repeating_npc4actions_score", "repeating_npc4actions_use_d20_advantage", "repeating_npc4actions_use_destructive_trance", "repeating_npc4actions_default_advantage", "repeating_npc4actions_tab_action", "repeating_npc4actions_dice_number", "repeating_npc4actions_dice_type", "repeating_npc4actions_effect_dice_number", "repeating_npc4actions_effect_dice_type", "repeating_npc4actions_use_power_level_1", "repeating_npc4actions_action_pl1", "repeating_npc4actions_use_power_level_2", "repeating_npc4actions_action_pl2", "repeating_npc4actions_use_power_level_3", "repeating_npc4actions_action_pl3", "repeating_npc4actions_use_power_level_4", "repeating_npc4actions_action_pl4", "repeating_npc4actions_use_power_level_5", "repeating_npc4actions_action_pl5", "repeating_npc4actions_use_power_level_6", "repeating_npc4actions_action_pl6", "repeating_npc4actions_use_power_level_7", "repeating_npc4actions_action_pl7", "repeating_npc4actions_use_power_level_8", "repeating_npc4actions_action_pl8", "repeating_npc4actions_use_power_level_9", "repeating_npc4actions_action_pl9"], function(values) {
+            var number = values.repeating_npc4actions_dice_number*1;
+            var type = "d" + values.repeating_npc4actions_dice_type + "!!";
+			var destructive = "";
+			var destructive20 = "";
+			var blank = "";
+            var powerLevelLow = 0;
+            var powerLevelHigh = 0;
+    // Start high and end low to determine the lowest Power Level to use for the given Boon
+            if(values.repeating_npc4actions_use_power_level_9 === "1") {    powerLevelLow = 9; }
+            if(values.repeating_npc4actions_use_power_level_8 === "1") {    powerLevelLow = 8; }
+            if(values.repeating_npc4actions_use_power_level_7 === "1") {    powerLevelLow = 7; }
+            if(values.repeating_npc4actions_use_power_level_6 === "1") {    powerLevelLow = 6; }
+            if(values.repeating_npc4actions_use_power_level_5 === "1") {    powerLevelLow = 5; }
+            if(values.repeating_npc4actions_use_power_level_4 === "1") {    powerLevelLow = 4; }
+            if(values.repeating_npc4actions_use_power_level_3 === "1") {    powerLevelLow = 3; }
+            if(values.repeating_npc4actions_use_power_level_2 === "1") {    powerLevelLow = 2; }
+            if(values.repeating_npc4actions_use_power_level_1 === "1") {    powerLevelLow = 1; }
+    // Start low and end high to determine the highest Power Level to use for the given Boon
+            if(values.repeating_npc4actions_use_power_level_1 === "1") {    powerLevelHigh = 1; }
+            if(values.repeating_npc4actions_use_power_level_2 === "1") {    powerLevelHigh = 2; }
+            if(values.repeating_npc4actions_use_power_level_3 === "1") {    powerLevelHigh = 3; }
+            if(values.repeating_npc4actions_use_power_level_4 === "1") {    powerLevelHigh = 4; }
+            if(values.repeating_npc4actions_use_power_level_5 === "1") {    powerLevelHigh = 5; }
+            if(values.repeating_npc4actions_use_power_level_6 === "1") {    powerLevelHigh = 6; }
+            if(values.repeating_npc4actions_use_power_level_7 === "1") {    powerLevelHigh = 7; }
+            if(values.repeating_npc4actions_use_power_level_8 === "1") {    powerLevelHigh = 8; }
+            if(values.repeating_npc4actions_use_power_level_9 === "1") {    powerLevelHigh = 9; }
+    // Assign only the Power Levels that exists across ones that don't exist for display vs roll in roll template
+            var usePL1 = "";
+            var titlePL1 = "";
+            var usePL2 = "";
+            var titlePL2 = "";
+            var usePL3 = "";
+            var titlePL3 = "";
+            var usePL4 = "";
+            var titlePL4 = "";
+            var usePL5 = "";
+            var titlePL5 = "";
+            var usePL6 = "";
+            var titlePL6 = "";
+            var usePL7 = "";
+            var titlePL7 = "";
+            var usePL8 = "";
+            var titlePL8 = "";
+            var usePL9 = "";
+            var titlePL9 = "";
+            if(values.repeating_npc4actions_use_power_level_1 === "1" && values.repeating_npc4actions_score*1 > 0) {
+                usePL1 = values.repeating_npc4actions_action_pl1;
+                titlePL1 = "Power Level 1 Info";
+            } else {
+                usePL1 = "";
+                titlePL1 = "";
+            }
+            if(values.repeating_npc4actions_use_power_level_2 === "1" && values.repeating_npc4actions_score*1 > 1) {
+                usePL2 = values.repeating_npc4actions_action_pl2;
+                titlePL2 = "Power Level 2 Info";
+            } else {
+                usePL2 = usePL1;
+                titlePL2 = titlePL1;
+            }
+            if(values.repeating_npc4actions_use_power_level_3 === "1" && values.repeating_npc4actions_score*1 > 2) {
+                usePL3 = values.repeating_npc4actions_action_pl3;
+                titlePL3 = "Power Level 3 Info";
+            } else {
+                usePL3 = usePL2;
+                titlePL3 = titlePL2;
+            }
+            if(values.repeating_npc4actions_use_power_level_4 === "1" && values.repeating_npc4actions_score*1 > 3) {
+                usePL4 = values.repeating_npc4actions_action_pl4;
+                titlePL4 = "Power Level 4 Info";
+            } else {
+                usePL4 = usePL3;
+                titlePL4 = titlePL3;
+            }
+            if(values.repeating_npc4actions_use_power_level_5 === "1" && values.repeating_npc4actions_score*1 > 4) {
+                usePL5 = values.repeating_npc4actions_action_pl5;
+                titlePL5 = "Power Level 5 Info";
+            } else {
+                usePL5 = usePL4;
+                titlePL5 = titlePL4;
+            }
+            if(values.repeating_npc4actions_use_power_level_6 === "1" && values.repeating_npc4actions_score*1 > 5) {
+                usePL6 = values.repeating_npc4actions_action_pl6;
+                titlePL6 = "Power Level 6 Info";
+            } else {
+                usePL6 = usePL5;
+                titlePL6 = titlePL5;
+            }
+            if(values.repeating_npc4actions_use_power_level_7 === "1" && values.repeating_npc4actions_score*1 > 6) {
+                usePL7 = values.repeating_npc4actions_action_pl7;
+                titlePL7 = "Power Level 7 Info";
+            } else {
+                usePL7 = usePL6;
+                titlePL7 = titlePL6;
+            }
+            if(values.repeating_npc4actions_use_power_level_8 === "1" && values.repeating_npc4actions_score*1 > 7) {
+                usePL8 = values.repeating_npc4actions_action_pl8;
+                titlePL8 = "Power Level 8 Info";
+            } else {
+                usePL8 = usePL7;
+                titlePL8 = titlePL7;
+            }
+            if(values.repeating_npc4actions_use_power_level_9 === "1" && values.repeating_npc4actions_score*1 > 8) {
+                usePL9 = values.repeating_npc4actions_action_pl9;
+                titlePL9 = "Power Level 9 Info";
+            } else {
+                usePL9 = usePL8;
+                titlePL9 = titlePL8;
+            }
+            
+
+			if(values.repeating_npc4actions_use_destructive_trance === "Yes") {
+				destructive = ">" + (values.repeating_npc4actions_dice_type*1 - 1);
+				destructive20 = ">19";
+			}
+			var roll = "";
+			if(values.repeating_npc4actions_tab_action === "effect") {
+			    roll = "{{roll=[[" + values.repeating_npc4actions_effect_dice_number + values.repeating_npc4actions_effect_dice_type + "]]}}";
+			} else {
+    			if(values.repeating_npc4actions_score*1 === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    			    if(values.repeating_npc4actions_use_d20_advantage === "Yes") {
+        				roll = "{{roll=[[2d20!!" + destructive20 + "k1 + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc4actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    } else {
+        				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc4actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    }
+    			}
+			}
+            setAttrs({
+                "repeating_npc4actions_dice_roll": roll,
+                "repeating_npc4actions_power_level_low": powerLevelLow,
+                "repeating_npc4actions_power_level_high": powerLevelHigh,
+                "repeating_npc4actions_pl1": usePL1,
+                "repeating_npc4actions_pl1_title": titlePL1,
+                "repeating_npc4actions_pl2": usePL2,
+                "repeating_npc4actions_pl2_title": titlePL2,
+                "repeating_npc4actions_pl3": usePL3,
+                "repeating_npc4actions_pl3_title": titlePL3,
+                "repeating_npc4actions_pl4": usePL4,
+                "repeating_npc4actions_pl4_title": titlePL4,
+                "repeating_npc4actions_pl5": usePL5,
+                "repeating_npc4actions_pl5_title": titlePL5,
+                "repeating_npc4actions_pl6": usePL6,
+                "repeating_npc4actions_pl6_title": titlePL6,
+                "repeating_npc4actions_pl7": usePL7,
+                "repeating_npc4actions_pl7_title": titlePL7,
+                "repeating_npc4actions_pl8": usePL8,
+                "repeating_npc4actions_pl8_title": titlePL8,
+                "repeating_npc4actions_pl9": usePL9,
+                "repeating_npc4actions_pl9_title": titlePL9
+            });
+        });
+    });
+	// On Change for calculating rolls for NPC#5 Favored Actions if any variables are updated
+    on("change:repeating_npc5actions:use_d20_advantage change:repeating_npc5actions:use_destructive_trance change:repeating_npc5actions:default_advantage change:repeating_npc5actions:tab_action change:repeating_npc5actions:dice_number change:repeating_npc5actions:dice_type change:repeating_npc5actions:effect_dice_number change:repeating_npc5actions:effect_dice_type change:repeating_npc5actions:use_power_level_1 change:repeating_npc5actions:action_pl1 change:repeating_npc5actions:use_power_level_2 change:repeating_npc5actions:action_pl2 change:repeating_npc5actions:use_power_level_3 change:repeating_npc5actions:action_pl3 change:repeating_npc5actions:use_power_level_4 change:repeating_npc5actions:action_pl4 change:repeating_npc5actions:use_power_level_5 change:repeating_npc5actions:action_pl5 change:repeating_npc5actions:use_power_level_6 change:repeating_npc5actions:action_pl6 change:repeating_npc5actions:use_power_level_7 change:repeating_npc5actions:action_pl7 change:repeating_npc5actions:use_power_level_8 change:repeating_npc5actions:action_pl8 change:repeating_npc5actions:use_power_level_9 change:repeating_npc5actions:action_pl9", function() {
+        getAttrs(["repeating_npc5actions_score", "repeating_npc5actions_use_d20_advantage", "repeating_npc5actions_use_destructive_trance", "repeating_npc5actions_default_advantage", "repeating_npc5actions_tab_action", "repeating_npc5actions_dice_number", "repeating_npc5actions_dice_type", "repeating_npc5actions_effect_dice_number", "repeating_npc5actions_effect_dice_type", "repeating_npc5actions_use_power_level_1", "repeating_npc5actions_action_pl1", "repeating_npc5actions_use_power_level_2", "repeating_npc5actions_action_pl2", "repeating_npc5actions_use_power_level_3", "repeating_npc5actions_action_pl3", "repeating_npc5actions_use_power_level_4", "repeating_npc5actions_action_pl4", "repeating_npc5actions_use_power_level_5", "repeating_npc5actions_action_pl5", "repeating_npc5actions_use_power_level_6", "repeating_npc5actions_action_pl6", "repeating_npc5actions_use_power_level_7", "repeating_npc5actions_action_pl7", "repeating_npc5actions_use_power_level_8", "repeating_npc5actions_action_pl8", "repeating_npc5actions_use_power_level_9", "repeating_npc5actions_action_pl9"], function(values) {
+            var number = values.repeating_npc5actions_dice_number*1;
+            var type = "d" + values.repeating_npc5actions_dice_type + "!!";
+			var destructive = "";
+			var destructive20 = "";
+			var blank = "";
+            var powerLevelLow = 0;
+            var powerLevelHigh = 0;
+    // Start high and end low to determine the lowest Power Level to use for the given Boon
+            if(values.repeating_npc5actions_use_power_level_9 === "1") {    powerLevelLow = 9; }
+            if(values.repeating_npc5actions_use_power_level_8 === "1") {    powerLevelLow = 8; }
+            if(values.repeating_npc5actions_use_power_level_7 === "1") {    powerLevelLow = 7; }
+            if(values.repeating_npc5actions_use_power_level_6 === "1") {    powerLevelLow = 6; }
+            if(values.repeating_npc5actions_use_power_level_5 === "1") {    powerLevelLow = 5; }
+            if(values.repeating_npc5actions_use_power_level_4 === "1") {    powerLevelLow = 4; }
+            if(values.repeating_npc5actions_use_power_level_3 === "1") {    powerLevelLow = 3; }
+            if(values.repeating_npc5actions_use_power_level_2 === "1") {    powerLevelLow = 2; }
+            if(values.repeating_npc5actions_use_power_level_1 === "1") {    powerLevelLow = 1; }
+    // Start low and end high to determine the highest Power Level to use for the given Boon
+            if(values.repeating_npc5actions_use_power_level_1 === "1") {    powerLevelHigh = 1; }
+            if(values.repeating_npc5actions_use_power_level_2 === "1") {    powerLevelHigh = 2; }
+            if(values.repeating_npc5actions_use_power_level_3 === "1") {    powerLevelHigh = 3; }
+            if(values.repeating_npc5actions_use_power_level_4 === "1") {    powerLevelHigh = 4; }
+            if(values.repeating_npc5actions_use_power_level_5 === "1") {    powerLevelHigh = 5; }
+            if(values.repeating_npc5actions_use_power_level_6 === "1") {    powerLevelHigh = 6; }
+            if(values.repeating_npc5actions_use_power_level_7 === "1") {    powerLevelHigh = 7; }
+            if(values.repeating_npc5actions_use_power_level_8 === "1") {    powerLevelHigh = 8; }
+            if(values.repeating_npc5actions_use_power_level_9 === "1") {    powerLevelHigh = 9; }
+    // Assign only the Power Levels that exists across ones that don't exist for display vs roll in roll template
+            var usePL1 = "";
+            var titlePL1 = "";
+            var usePL2 = "";
+            var titlePL2 = "";
+            var usePL3 = "";
+            var titlePL3 = "";
+            var usePL4 = "";
+            var titlePL4 = "";
+            var usePL5 = "";
+            var titlePL5 = "";
+            var usePL6 = "";
+            var titlePL6 = "";
+            var usePL7 = "";
+            var titlePL7 = "";
+            var usePL8 = "";
+            var titlePL8 = "";
+            var usePL9 = "";
+            var titlePL9 = "";
+            if(values.repeating_npc5actions_use_power_level_1 === "1" && values.repeating_npc5actions_score*1 > 0) {
+                usePL1 = values.repeating_npc5actions_action_pl1;
+                titlePL1 = "Power Level 1 Info";
+            } else {
+                usePL1 = "";
+                titlePL1 = "";
+            }
+            if(values.repeating_npc5actions_use_power_level_2 === "1" && values.repeating_npc5actions_score*1 > 1) {
+                usePL2 = values.repeating_npc5actions_action_pl2;
+                titlePL2 = "Power Level 2 Info";
+            } else {
+                usePL2 = usePL1;
+                titlePL2 = titlePL1;
+            }
+            if(values.repeating_npc5actions_use_power_level_3 === "1" && values.repeating_npc5actions_score*1 > 2) {
+                usePL3 = values.repeating_npc5actions_action_pl3;
+                titlePL3 = "Power Level 3 Info";
+            } else {
+                usePL3 = usePL2;
+                titlePL3 = titlePL2;
+            }
+            if(values.repeating_npc5actions_use_power_level_4 === "1" && values.repeating_npc5actions_score*1 > 3) {
+                usePL4 = values.repeating_npc5actions_action_pl4;
+                titlePL4 = "Power Level 4 Info";
+            } else {
+                usePL4 = usePL3;
+                titlePL4 = titlePL3;
+            }
+            if(values.repeating_npc5actions_use_power_level_5 === "1" && values.repeating_npc5actions_score*1 > 4) {
+                usePL5 = values.repeating_npc5actions_action_pl5;
+                titlePL5 = "Power Level 5 Info";
+            } else {
+                usePL5 = usePL4;
+                titlePL5 = titlePL4;
+            }
+            if(values.repeating_npc5actions_use_power_level_6 === "1" && values.repeating_npc5actions_score*1 > 5) {
+                usePL6 = values.repeating_npc5actions_action_pl6;
+                titlePL6 = "Power Level 6 Info";
+            } else {
+                usePL6 = usePL5;
+                titlePL6 = titlePL5;
+            }
+            if(values.repeating_npc5actions_use_power_level_7 === "1" && values.repeating_npc5actions_score*1 > 6) {
+                usePL7 = values.repeating_npc5actions_action_pl7;
+                titlePL7 = "Power Level 7 Info";
+            } else {
+                usePL7 = usePL6;
+                titlePL7 = titlePL6;
+            }
+            if(values.repeating_npc5actions_use_power_level_8 === "1" && values.repeating_npc5actions_score*1 > 7) {
+                usePL8 = values.repeating_npc5actions_action_pl8;
+                titlePL8 = "Power Level 8 Info";
+            } else {
+                usePL8 = usePL7;
+                titlePL8 = titlePL7;
+            }
+            if(values.repeating_npc5actions_use_power_level_9 === "1" && values.repeating_npc5actions_score*1 > 8) {
+                usePL9 = values.repeating_npc5actions_action_pl9;
+                titlePL9 = "Power Level 9 Info";
+            } else {
+                usePL9 = usePL8;
+                titlePL9 = titlePL8;
+            }
+            
+
+			if(values.repeating_npc5actions_use_destructive_trance === "Yes") {
+				destructive = ">" + (values.repeating_npc5actions_dice_type*1 - 1);
+				destructive20 = ">19";
+			}
+			var roll = "";
+			if(values.repeating_npc5actions_tab_action === "effect") {
+			    roll = "{{roll=[[" + values.repeating_npc5actions_effect_dice_number + values.repeating_npc5actions_effect_dice_type + "]]}}";
+			} else {
+    			if(values.repeating_npc5actions_score*1 === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    			    if(values.repeating_npc5actions_use_d20_advantage === "Yes") {
+        				roll = "{{roll=[[2d20!!" + destructive20 + "k1 + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc5actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    } else {
+        				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_npc5actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			    }
+    			}
+			}
+            setAttrs({
+                "repeating_npc5actions_dice_roll": roll,
+                "repeating_npc5actions_power_level_low": powerLevelLow,
+                "repeating_npc5actions_power_level_high": powerLevelHigh,
+                "repeating_npc5actions_pl1": usePL1,
+                "repeating_npc5actions_pl1_title": titlePL1,
+                "repeating_npc5actions_pl2": usePL2,
+                "repeating_npc5actions_pl2_title": titlePL2,
+                "repeating_npc5actions_pl3": usePL3,
+                "repeating_npc5actions_pl3_title": titlePL3,
+                "repeating_npc5actions_pl4": usePL4,
+                "repeating_npc5actions_pl4_title": titlePL4,
+                "repeating_npc5actions_pl5": usePL5,
+                "repeating_npc5actions_pl5_title": titlePL5,
+                "repeating_npc5actions_pl6": usePL6,
+                "repeating_npc5actions_pl6_title": titlePL6,
+                "repeating_npc5actions_pl7": usePL7,
+                "repeating_npc5actions_pl7_title": titlePL7,
+                "repeating_npc5actions_pl8": usePL8,
+                "repeating_npc5actions_pl8_title": titlePL8,
+                "repeating_npc5actions_pl9": usePL9,
+                "repeating_npc5actions_pl9_title": titlePL9
+            });
+        });
+    });
+    
+	// On Change for NPC#1-5 Lethal Damage change hp max
+	on("change:npc1_current_lethal", function() {
+	    getAttrs(["npc1_current_lethal", "npc1_previous_lethal", "Npc1_hp_max"], function(values) {
+	        var currentLethal = values.npc1_current_lethal*1;
+	        var previousLethal = values.npc1_previous_lethal*1;
+	        var currentHPmax = values.Npc1_hp_max*1;
+	        var tempMax = currentHPmax*1 + (previousLethal*1 - currentLethal*1);
+            setAttrs({
+                "npc1_previous_lethal": currentLethal*1,
+                "Npc1_hp_max": tempMax*1
+            });
+        });
+    });
+	on("change:npc2_current_lethal", function() {
+	    getAttrs(["npc2_current_lethal", "npc2_previous_lethal", "Npc2_hp_max"], function(values) {
+	        var currentLethal = values.npc2_current_lethal*1;
+	        var previousLethal = values.npc2_previous_lethal*1;
+	        var currentHPmax = values.Npc2_hp_max*1;
+	        var tempMax = currentHPmax*1 + (previousLethal*1 - currentLethal*1);
+            setAttrs({
+                "npc2_previous_lethal": currentLethal*1,
+                "Npc2_hp_max": tempMax*1
+            });
+        });
+    });
+	on("change:npc3_current_lethal", function() {
+	    getAttrs(["npc3_current_lethal", "npc3_previous_lethal", "Npc3_hp_max"], function(values) {
+	        var currentLethal = values.npc3_current_lethal*1;
+	        var previousLethal = values.npc3_previous_lethal*1;
+	        var currentHPmax = values.Npc3_hp_max*1;
+	        var tempMax = currentHPmax*1 + (previousLethal*1 - currentLethal*1);
+            setAttrs({
+                "npc3_previous_lethal": currentLethal*1,
+                "Npc3_hp_max": tempMax*1
+            });
+        });
+    });
+	on("change:npc4_current_lethal", function() {
+	    getAttrs(["npc4_current_lethal", "npc4_previous_lethal", "Npc4_hp_max"], function(values) {
+	        var currentLethal = values.npc4_current_lethal*1;
+	        var previousLethal = values.npc4_previous_lethal*1;
+	        var currentHPmax = values.Npc4_hp_max*1;
+	        var tempMax = currentHPmax*1 + (previousLethal*1 - currentLethal*1);
+            setAttrs({
+                "npc4_previous_lethal": currentLethal*1,
+                "Npc4_hp_max": tempMax*1
+            });
+        });
+    });
+	on("change:npc5_current_lethal", function() {
+	    getAttrs(["npc5_current_lethal", "npc5_previous_lethal", "Npc5_hp_max"], function(values) {
+	        var currentLethal = values.npc5_current_lethal*1;
+	        var previousLethal = values.npc5_previous_lethal*1;
+	        var currentHPmax = values.Npc5_hp_max*1;
+	        var tempMax = currentHPmax*1 + (previousLethal*1 - currentLethal*1);
+            setAttrs({
+                "npc5_previous_lethal": currentLethal*1,
+                "Npc5_hp_max": tempMax*1
+            });
+        });
+    });
+// *******************************************************
+// *******************************************************
+// END NPC section workerscripts
+	
 	// Function to combine the Non-Essential Inventory & Notes sections (3 into 1)
 	// **** To be removed after a few months, only needed for pre-existing characters
 	// **** Put in January 2018
@@ -913,13 +2468,54 @@
         });
     });
 
+    on("change:display_sheet_type change:companion_feat_given", function() {
+        getAttrs(["xp"], function(values) {
+    		calcXPpoints(values.xp);
+        });
+    })
+
 	// Function to run when XP is changed
 	function calcXPpoints(value) {
-        setAttrs({
-            "attribute_points": value*3 + 40,
-            "feat_total_points": value*1 + 6,
-            "xp": value*1
-        });
+	    getAttrs(["display_sheet_type", "companion_feat_given"], function(values) {
+	        var attributePoints = 0;
+	        var featPoints = 0;
+	        var exp = 0;
+	        if(values.display_sheet_type === "character") {
+	            attributePoints = value*3 + 40;
+	            featPoints = value*1 + 6;
+	            exp = value*1;
+	        }
+	        if(values.display_sheet_type === "alt form 1") {
+	            attributePoints = (value*3 + 40)/2;
+	            featPoints = 3;
+	            exp = value*1;
+	        }
+	        if(values.display_sheet_type === "alt form 2") {
+	            attributePoints = value*3 + 40;
+	            featPoints = value*1 + 3;
+	            exp = value*1;
+	        }
+	        if(values.display_sheet_type === "companion 1") {
+	            attributePoints = (Math.floor(value/3)+1)*4 + 20;
+	            featPoints = 0;
+	            exp = value*1;
+	        }
+	        if(values.display_sheet_type === "companion 2") {
+	            attributePoints = (Math.floor(value/3)+1)*4 + 20;
+	            featPoints = 3;
+	            exp = value*1;
+	        }
+	        if(values.display_sheet_type === "companion 3") {
+	            attributePoints = (Math.floor(value/3)+1)*6 + 30;
+	            featPoints = 3 + values.companion_feat_given*1;
+	            exp = value*1;
+	        }
+            setAttrs({
+                "attribute_points": attributePoints,
+                "feat_total_points": featPoints,
+                "xp": exp
+            });
+	    });
 	};
 
     // Anytime Agility score is changed, update cost and dice
@@ -2159,7 +3755,7 @@
         getSectionIDs("repeating_actions", function(actionsArray) {
          if(actionsArray.length > 0) {
             _.each(actionsArray, function(currentID, i) {
-                getAttrs(["repeating_actions_" + currentID + "_action_attribute", "repeating_actions_" + currentID + "_dice_modifier", "repeating_actions_" + currentID + "_use_power_level_1", "repeating_actions_" + currentID + "_action_pl1", "repeating_actions_" + currentID + "_use_power_level_2", "repeating_actions_" + currentID + "_action_pl2", "repeating_actions_" + currentID + "_use_power_level_3", "repeating_actions_" + currentID + "_action_pl3", "repeating_actions_" + currentID + "_use_power_level_4", "repeating_actions_" + currentID + "_action_pl4", "repeating_actions_" + currentID + "_use_power_level_5", "repeating_actions_" + currentID + "_action_pl5", "repeating_actions_" + currentID + "_use_power_level_6", "repeating_actions_" + currentID + "_action_pl6", "repeating_actions_" + currentID + "_use_power_level_7", "repeating_actions_" + currentID + "_action_pl7", "repeating_actions_" + currentID + "_use_power_level_8", "repeating_actions_" + currentID + "_action_pl8", "repeating_actions_" + currentID + "_use_power_level_9", "repeating_actions_" + currentID + "_action_pl9", "repeating_actions_" + currentID + "_use_destructive_trance", "repeating_actions_" + currentID + "_default_advantage", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
+                getAttrs(["repeating_actions_" + currentID + "_effect_dice_number", "repeating_actions_" + currentID + "_effect_dice_type", "repeating_actions_" + currentID + "_tab_action", "repeating_actions_" + currentID + "_action_attribute", "repeating_actions_" + currentID + "_dice_modifier", "repeating_actions_" + currentID + "_use_power_level_1", "repeating_actions_" + currentID + "_action_pl1", "repeating_actions_" + currentID + "_use_power_level_2", "repeating_actions_" + currentID + "_action_pl2", "repeating_actions_" + currentID + "_use_power_level_3", "repeating_actions_" + currentID + "_action_pl3", "repeating_actions_" + currentID + "_use_power_level_4", "repeating_actions_" + currentID + "_action_pl4", "repeating_actions_" + currentID + "_use_power_level_5", "repeating_actions_" + currentID + "_action_pl5", "repeating_actions_" + currentID + "_use_power_level_6", "repeating_actions_" + currentID + "_action_pl6", "repeating_actions_" + currentID + "_use_power_level_7", "repeating_actions_" + currentID + "_action_pl7", "repeating_actions_" + currentID + "_use_power_level_8", "repeating_actions_" + currentID + "_action_pl8", "repeating_actions_" + currentID + "_use_power_level_9", "repeating_actions_" + currentID + "_action_pl9", "repeating_actions_" + currentID + "_use_destructive_trance", "repeating_actions_" + currentID + "_default_advantage", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
                     var update = {};
                     var score = 0;
 					var displayScore = 0;
@@ -2336,12 +3932,16 @@
                         usePL9 = usePL8;
                         titlePL9 = titlePL8;
                     }
-            
-        			if(score === 0) {
-        				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
-        			} else {
-        				roll = "[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_actions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]";
-        			}
+
+                    if(v["repeating_actions_" + currentID + "_tab_action"] === "effect") {
+                        roll = "{{roll=[[" + v["repeating_actions_" + currentID + "_effect_dice_number"] + v["repeating_actions_" + currentID + "_effect_dice_type"] + "]]}}";
+                    } else {
+            			if(score === 0) {
+            				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+            			} else {
+            				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_actions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+            			}
+                    }
                     update["repeating_actions_" + currentID + "_power_level_low"] = powerLevelLow;
                     update["repeating_actions_" + currentID + "_power_level_high"] = powerLevelHigh;
         			update["repeating_actions_" + currentID + "_dice_roll"] = roll;
@@ -2376,7 +3976,7 @@
         getSectionIDs("repeating_otheractions", function(actionsArray) {
          if(actionsArray.length > 0) {
             _.each(actionsArray, function(currentID, i) {
-                getAttrs(["repeating_otheractions_" + currentID + "_action_attribute", "repeating_otheractions_" + currentID + "_dice_modifier", "repeating_otheractions_" + currentID + "_use_destructive_trance", "repeating_otheractions_" + currentID + "_default_advantage", "repeating_otheractions_" + currentID + "_use_power_level_1", "repeating_otheractions_" + currentID + "_action_pl1", "repeating_otheractions_" + currentID + "_use_power_level_2", "repeating_otheractions_" + currentID + "_action_pl2", "repeating_otheractions_" + currentID + "_use_power_level_3", "repeating_otheractions_" + currentID + "_action_pl3", "repeating_otheractions_" + currentID + "_use_power_level_4", "repeating_otheractions_" + currentID + "_action_pl4", "repeating_otheractions_" + currentID + "_use_power_level_5", "repeating_otheractions_" + currentID + "_action_pl5", "repeating_otheractions_" + currentID + "_use_power_level_6", "repeating_otheractions_" + currentID + "_action_pl6", "repeating_otheractions_" + currentID + "_use_power_level_7", "repeating_otheractions_" + currentID + "_action_pl7", "repeating_otheractions_" + currentID + "_use_power_level_8", "repeating_otheractions_" + currentID + "_action_pl8", "repeating_otheractions_" + currentID + "_use_power_level_9", "repeating_otheractions_" + currentID + "_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
+                getAttrs(["repeating_otheractions_" + currentID + "_effect_dice_number", "repeating_otheractions_" + currentID + "_effect_dice_type", "repeating_otheractions_" + currentID + "_tab_action", "repeating_otheractions_" + currentID + "_action_attribute", "repeating_otheractions_" + currentID + "_dice_modifier", "repeating_otheractions_" + currentID + "_use_destructive_trance", "repeating_otheractions_" + currentID + "_default_advantage", "repeating_otheractions_" + currentID + "_use_power_level_1", "repeating_otheractions_" + currentID + "_action_pl1", "repeating_otheractions_" + currentID + "_use_power_level_2", "repeating_otheractions_" + currentID + "_action_pl2", "repeating_otheractions_" + currentID + "_use_power_level_3", "repeating_otheractions_" + currentID + "_action_pl3", "repeating_otheractions_" + currentID + "_use_power_level_4", "repeating_otheractions_" + currentID + "_action_pl4", "repeating_otheractions_" + currentID + "_use_power_level_5", "repeating_otheractions_" + currentID + "_action_pl5", "repeating_otheractions_" + currentID + "_use_power_level_6", "repeating_otheractions_" + currentID + "_action_pl6", "repeating_otheractions_" + currentID + "_use_power_level_7", "repeating_otheractions_" + currentID + "_action_pl7", "repeating_otheractions_" + currentID + "_use_power_level_8", "repeating_otheractions_" + currentID + "_action_pl8", "repeating_otheractions_" + currentID + "_use_power_level_9", "repeating_otheractions_" + currentID + "_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
                     var updateother = {};
                     var score = 0;
 					var displayScore = 0;
@@ -2485,63 +4085,63 @@
                     var titlePL8 = "";
                     var usePL9 = "";
                     var titlePL9 = "";
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_1"] === "1" && displayScore > 0) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_1"] === "1" && displayScore > 0) {
                         usePL1 = v["repeating_otheractions_" + currentID + "_action_pl1"];
                         titlePL1 = "Power Level 1 Info";
                     } else {
                         usePL1 = "";
                         titlePL1 = "";
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_2"] === "1" && displayScore > 1) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_2"] === "1" && displayScore > 1) {
                         usePL2 = v["repeating_otheractions_" + currentID + "_action_pl2"];
                         titlePL2 = "Power Level 2 Info";
                     } else {
                         usePL2 = usePL1;
                         titlePL2 = titlePL1;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_3"] === "1" && displayScore > 2) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_3"] === "1" && displayScore > 2) {
                         usePL3 = v["repeating_otheractions_" + currentID + "_action_pl3"];
                         titlePL3 = "Power Level 3 Info";
                     } else {
                         usePL3 = usePL2;
                         titlePL3 = titlePL2;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_4"] === "1" && displayScore > 3) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_4"] === "1" && displayScore > 3) {
                         usePL4 = v["repeating_otheractions_" + currentID + "_action_pl4"];
                         titlePL4 = "Power Level 4 Info";
                     } else {
                         usePL4 = usePL3;
                         titlePL4 = titlePL3;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_5"] === "1" && displayScore > 4) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_5"] === "1" && displayScore > 4) {
                         usePL5 = v["repeating_otheractions_" + currentID + "_action_pl5"];
                         titlePL5 = "Power Level 5 Info";
                     } else {
                         usePL5 = usePL4;
                         titlePL5 = titlePL4;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_6"] === "1" && displayScore > 5) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_6"] === "1" && displayScore > 5) {
                         usePL6 = v["repeating_otheractions_" + currentID + "_action_pl6"];
                         titlePL6 = "Power Level 6 Info";
                     } else {
                         usePL6 = usePL5;
                         titlePL6 = titlePL5;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_7"] === "1" && displayScore > 6) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_7"] === "1" && displayScore > 6) {
                         usePL7 = v["repeating_otheractions_" + currentID + "_action_pl7"];
                         titlePL7 = "Power Level 7 Info";
                     } else {
                         usePL7 = usePL6;
                         titlePL7 = titlePL6;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_8"] === "1" && displayScore > 7) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_8"] === "1" && displayScore > 7) {
                         usePL8 = v["repeating_otheractions_" + currentID + "_action_pl8"];
                         titlePL8 = "Power Level 8 Info";
                     } else {
                         usePL8 = usePL7;
                         titlePL8 = titlePL7;
                     }
-                    if(v["repeating_otheractions_" + currentID + "use_power_level_9"] === "1" && displayScore > 8) {
+                    if(v["repeating_otheractions_" + currentID + "_use_power_level_9"] === "1" && displayScore > 8) {
                         usePL9 = v["repeating_otheractions_" + currentID + "_action_pl9"];
                         titlePL9 = "Power Level 9 Info";
                     } else {
@@ -2554,11 +4154,15 @@
 						destructive20 = ">19";
 					}
                     var roll = "";
-        			if(score === 0) {
-        				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
-        			} else {
-        				roll = "[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_otheractions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]";
-        			}
+                    if(v["repeating_otheractions_" + currentID + "_tab_action"] === "effect") {
+                        roll = "{{roll=[[" + v["repeating_otheractions_" + currentID + "_effect_dice_number"] + v["repeating_otheractions_" + currentID + "_effect_dice_type"] + "]]}}";
+                    } else {
+            			if(score === 0) {
+            				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+            			} else {
+            				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + v["repeating_otheractions_" + currentID + "_default_advantage"]*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+            			}
+                    }
                     updateother["repeating_otheractions_" + currentID + "_power_level_low"] = powerLevelLow;
                     updateother["repeating_otheractions_" + currentID + "_power_level_high"] = powerLevelHigh;
         			updateother["repeating_otheractions_" + currentID + "_dice_roll"] = roll;
@@ -2709,8 +4313,8 @@
     });
 
 	// On Change for calculating rolls for Actions
-    on("change:repeating_actions:action_attribute change:repeating_actions:dice_modifier change:repeating_actions:use_destructive_trance change:repeating_actions:default_advantage change:repeating_actions:use_power_level_1 change:repeating_actions:action_pl1 change:repeating_actions:use_power_level_2 change:repeating_actions:action_pl2 change:repeating_actions:use_power_level_3 change:repeating_actions:action_pl3 change:repeating_actions:use_power_level_4 change:repeating_actions:action_pl4 change:repeating_actions:use_power_level_5 change:repeating_actions:action_pl5 change:repeating_actions:use_power_level_6 change:repeating_actions:action_pl6 change:repeating_actions:use_power_level_7 change:repeating_actions:action_pl7 change:repeating_actions:use_power_level_8 change:repeating_actions:action_pl8 change:repeating_actions:use_power_level_9 change:repeating_actions:action_pl9", function() {
-        getAttrs(["repeating_actions_action_attribute", "repeating_actions_dice_modifier", "repeating_actions_use_destructive_trance", "repeating_actions_default_advantage", "repeating_actions_use_power_level_1", "repeating_actions_action_pl1", "repeating_actions_use_power_level_2", "repeating_actions_action_pl2", "repeating_actions_use_power_level_3", "repeating_actions_action_pl3", "repeating_actions_use_power_level_4", "repeating_actions_action_pl4", "repeating_actions_use_power_level_5", "repeating_actions_action_pl5", "repeating_actions_use_power_level_6", "repeating_actions_action_pl6", "repeating_actions_use_power_level_7", "repeating_actions_action_pl7", "repeating_actions_use_power_level_8", "repeating_actions_action_pl8", "repeating_actions_use_power_level_9", "repeating_actions_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
+    on("change:repeating_actions:tab_action change:repeating_actions:effect_dice_number change:repeating_actions:effect_dice_type change:repeating_actions:action_attribute change:repeating_actions:dice_modifier change:repeating_actions:use_destructive_trance change:repeating_actions:default_advantage change:repeating_actions:use_power_level_1 change:repeating_actions:action_pl1 change:repeating_actions:use_power_level_2 change:repeating_actions:action_pl2 change:repeating_actions:use_power_level_3 change:repeating_actions:action_pl3 change:repeating_actions:use_power_level_4 change:repeating_actions:action_pl4 change:repeating_actions:use_power_level_5 change:repeating_actions:action_pl5 change:repeating_actions:use_power_level_6 change:repeating_actions:action_pl6 change:repeating_actions:use_power_level_7 change:repeating_actions:action_pl7 change:repeating_actions:use_power_level_8 change:repeating_actions:action_pl8 change:repeating_actions:use_power_level_9 change:repeating_actions:action_pl9", function() {
+        getAttrs(["repeating_actions_effect_dice_number", "repeating_actions_effect_dice_type", "repeating_actions_tab_action", "repeating_actions_action_attribute", "repeating_actions_dice_modifier", "repeating_actions_use_destructive_trance", "repeating_actions_default_advantage", "repeating_actions_use_power_level_1", "repeating_actions_action_pl1", "repeating_actions_use_power_level_2", "repeating_actions_action_pl2", "repeating_actions_use_power_level_3", "repeating_actions_action_pl3", "repeating_actions_use_power_level_4", "repeating_actions_action_pl4", "repeating_actions_use_power_level_5", "repeating_actions_action_pl5", "repeating_actions_use_power_level_6", "repeating_actions_action_pl6", "repeating_actions_use_power_level_7", "repeating_actions_action_pl7", "repeating_actions_use_power_level_8", "repeating_actions_action_pl8", "repeating_actions_use_power_level_9", "repeating_actions_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
             var score = 0;
 			var displayScore = 0;
             if(values.repeating_actions_action_attribute === "Agility") {
@@ -2889,11 +4493,16 @@
 				destructive20 = ">19";
 			}
 			var roll = "";
-			if(score === 0) {
-				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
-			} else {
-				roll = "[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]";
-			}
+            if(values.repeating_actions_tab_action === "effect") {
+                roll = "{{roll=[[" + values.repeating_actions_effect_dice_number + values.repeating_actions_effect_dice_type + "]]}}";
+            } else {
+    			if(score === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_actions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			}
+            }
+
             setAttrs({
 				"repeating_actions_attribute_score": displayScore,
                 "repeating_actions_dice_roll": roll,
@@ -2922,8 +4531,8 @@
     });
 
 		// On Change for calculating rolls for Other Actions
-    on("change:repeating_otheractions:action_attribute change:repeating_otheractions:dice_modifier change:repeating_otheractions:use_destructive_trance change:repeating_otheractions:default_advantage change:repeating_otheractions:use_power_level_1 change:repeating_otheractions:action_pl1 change:repeating_otheractions:use_power_level_2 change:repeating_otheractions:action_pl2 change:repeating_otheractions:use_power_level_3 change:repeating_otheractions:action_pl3 change:repeating_otheractions:use_power_level_4 change:repeating_otheractions:action_pl4 change:repeating_otheractions:use_power_level_5 change:repeating_otheractions:action_pl5 change:repeating_otheractions:use_power_level_6 change:repeating_otheractions:action_pl6 change:repeating_otheractions:use_power_level_7 change:repeating_otheractions:action_pl7 change:repeating_otheractions:use_power_level_8 change:repeating_otheractions:action_pl8 change:repeating_otheractions:use_power_level_9 change:repeating_otheractions:action_pl9", function() {
-        getAttrs(["repeating_otheractions_action_attribute", "repeating_otheractions_dice_modifier", "repeating_otheractions_use_destructive_trance", "repeating_otheractions_default_advantage", "repeating_otheractions_use_power_level_1", "repeating_otheractions_action_pl1", "repeating_otheractions_use_power_level_2", "repeating_otheractions_action_pl2", "repeating_otheractions_use_power_level_3", "repeating_otheractions_action_pl3", "repeating_otheractions_use_power_level_4", "repeating_otheractions_action_pl4", "repeating_otheractions_use_power_level_5", "repeating_otheractions_action_pl5", "repeating_otheractions_use_power_level_6", "repeating_otheractions_action_pl6", "repeating_otheractions_use_power_level_7", "repeating_otheractions_action_pl7", "repeating_otheractions_use_power_level_8", "repeating_otheractions_action_pl8", "repeating_otheractions_use_power_level_9", "repeating_otheractions_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
+    on("change:repeating_otheractions:tab_action change:repeating_otheractions:effect_dice_number change:repeating_otheractions:effect_dice_type change:repeating_otheractions:action_attribute change:repeating_otheractions:dice_modifier change:repeating_otheractions:use_destructive_trance change:repeating_otheractions:default_advantage change:repeating_otheractions:use_power_level_1 change:repeating_otheractions:action_pl1 change:repeating_otheractions:use_power_level_2 change:repeating_otheractions:action_pl2 change:repeating_otheractions:use_power_level_3 change:repeating_otheractions:action_pl3 change:repeating_otheractions:use_power_level_4 change:repeating_otheractions:action_pl4 change:repeating_otheractions:use_power_level_5 change:repeating_otheractions:action_pl5 change:repeating_otheractions:use_power_level_6 change:repeating_otheractions:action_pl6 change:repeating_otheractions:use_power_level_7 change:repeating_otheractions:action_pl7 change:repeating_otheractions:use_power_level_8 change:repeating_otheractions:action_pl8 change:repeating_otheractions:use_power_level_9 change:repeating_otheractions:action_pl9", function() {
+        getAttrs(["repeating_otheractions_tab_action", "repeating_otheractions_effect_dice_number", "repeating_otheractions_effect_dice_type", "repeating_otheractions_action_attribute", "repeating_otheractions_dice_modifier", "repeating_otheractions_use_destructive_trance", "repeating_otheractions_default_advantage", "repeating_otheractions_use_power_level_1", "repeating_otheractions_action_pl1", "repeating_otheractions_use_power_level_2", "repeating_otheractions_action_pl2", "repeating_otheractions_use_power_level_3", "repeating_otheractions_action_pl3", "repeating_otheractions_use_power_level_4", "repeating_otheractions_action_pl4", "repeating_otheractions_use_power_level_5", "repeating_otheractions_action_pl5", "repeating_otheractions_use_power_level_6", "repeating_otheractions_action_pl6", "repeating_otheractions_use_power_level_7", "repeating_otheractions_action_pl7", "repeating_otheractions_use_power_level_8", "repeating_otheractions_action_pl8", "repeating_otheractions_use_power_level_9", "repeating_otheractions_action_pl9", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
             var score = 0;
 			var displayScore = 0;
             if(values.repeating_otheractions_action_attribute === "Agility") {
@@ -3100,11 +4709,15 @@
 				destructive20 = ">19";
 			}
 			var roll = "";
-			if(score === 0) {
-				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]";
-			} else {
-				roll = "[[1d20!!" + destructive20 + " + [[" +number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_otheractions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]";
-			}
+            if(values.repeating_otheractions_tab_action === "effect") {
+                roll = "{{roll=[[" + values.repeating_otheractions_effect_dice_number + values.repeating_otheractions_effect_dice_type + "]]}}";
+            } else {
+    			if(score === 0) {
+    				roll = "{{roll=[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!" + destructive20 + "|Advantage,2d20!!" + destructive20 + "kh1|Disadvantage,2d20!!" + destructive20 + "kl1}]]}}";
+    			} else {
+    				roll = "{{roll=[[1d20!!" + destructive20 + " + [[" + number + "+?{# of Advantage/Disadvantage Dice|" + values.repeating_otheractions_default_advantage*1 + "}]]" + type + destructive + "k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[" + number + "]]|Disadvantage,l[[" + number + "]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}";
+    			}
+            }
             setAttrs({
                 "repeating_otheractions_attribute_score": displayScore,
                 "repeating_otheractions_dice_roll": roll,
@@ -3156,29 +4769,56 @@ on("change:repeating_featsLeft", function() {
 <!-- Main body of Character Sheet -->
 <div class="container">     <!-- defines the width/height & behavior of the page -->
     <input type="hidden" name="attr_template_border" value="Normal" />
+    <input type="hidden" class="display_sheet_type" name="attr_display_sheet_type" value="character" />
     <input type="hidden" name="attr_h" value="Advantage" />
     <input type="hidden" name="attr_l" value="Disadvantage" />
     <input class="tab-chat public" type="radio" name="attr_tab_chat" checked="checked" value=""><div>Public</div>
     <input class="tab-chat gm" type="radio" name="attr_tab_chat" value="/w GM"><div>To GM</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Primary Character</div>
-<!--
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Alternate Form Tier 1</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Alternate Form Tier 2</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Companion Tier 1</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Companion Tier 2</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">Companion Tier 3</div>
-    <div class="column inlineBlock padAll vertMiddle bold textLarge borderBottom">NPC</div>
--->
+    <div class="displaySheetCharacter column padAll vertMiddle bold textLarge borderBottom">Primary Character</div>
+    <div class="displaySheetAltForm1 column padAll vertMiddle bold textLarge borderBottom">Alternate Form Tier 1</div>
+    <div class="displaySheetAltForm2 column padAll vertMiddle bold textLarge borderBottom">Alternate Form Tier 2</div>
+    <div class="displaySheetCompanion1 column padAll vertMiddle bold textLarge borderBottom">Companion Tier 1</div>
+    <div class="displaySheetCompanion2 column padAll vertMiddle bold textLarge borderBottom">Companion Tier 2</div>
+    <div class="displaySheetCompanion3 column padAll vertMiddle bold textLarge borderBottom">Companion Tier 3</div>
+    <div class="displaySheetNPC column padAll vertMiddle bold textLarge borderBottom">NPC/Summon</div>
     <input class="tab-sheet main" type="radio" name="attr_tab_sheet" checked="checked" value="main"><div>Main</div>
     <input class="tab-sheet background" type="radio" name="attr_tab_sheet" value="background"><div>Background</div>
     <input class="tab-sheet options" type="radio" name="attr_tab_sheet" value="options"><div>Options</div>
     <div class="inlineBlock vertBottom" style="width: 110px;">      <!-- Right Third of 2/3 rows for info (Open Legend Logo) -->
         <div class="column width100 textCenter vertBottom"><img src="http://www.openlegendrpg.com/assets/img/open_legend_lg_logo.png" alt="Open Legend Open source roleplaying game" /></div>
     </div>
-    <div class="column textSmall inlineBlock padLeft vertMiddle bold">Version 1.9.2</div>
+    <div class="column textSmall inlineBlock padLeft vertMiddle bold">Version 1.9.5</div>
     <div class="row width100 padBottom"></div>
 <!-- Sheet Options, Change Logs, and Links -->
-    <div class="option-main options width100">
+    <div class="option-main options width100 padTop marginTop">
+        <div class="row">
+            <div class="column width20 inlineBlock bold vertBottom">Type of Character Sheet: </div>
+            <div class="column width20 inlineBlock inputSelect">
+                <select name="attr_display_sheet_type">
+                    <optgroup label=""></optgroup>
+                        <option value="character" selected="selected">Primary Character</option>
+                        <option value="npc">NPC or Summon</option>
+                    <optgroup label=""></optgroup>
+                        <option value="alt form 1">Alternate Form Tier 1</option>
+                        <option value="alt form 2">Alternate Form Tier 2</option>
+                    <optgroup label=""></optgroup>
+                        <option value="companion 1">Companion Tier 1</option>
+                        <option value="companion 2">Companion Tier 2</option>
+                        <option value="companion 3">Companion Tier 3</option>
+                </select>
+            </div>
+            <div class="column width30 inlineBlock bold vertBottom">Theme of Game (Border choices): </div>
+            <div class="column width20 inlineBlock inputSelect">
+                <select name="attr_display_alternate_border">
+                        <option value="fantasy" selected="selected">Fantasy: Scrolls</option>
+                        <option value="on">Modern: Industrial</option>
+                </select>
+            </div>
+        </div>
+        <div class="borderAllDotted borderRound marginTop marginBottom marginRight marginLeft red">
+        <div class="row">
+            <div class="column width90 inlineBlock textSmall bold">This section to be removed soon when other sections updated.</div>
+        </div>
         <div class="row width100">
             <div class="column sliders inlineBlock textSmall bold">Character Info</div>
             <div class="column sliders inlineBlock textSmall bold">Goals & Beliefs</div>
@@ -3239,6 +4879,7 @@ on("change:repeating_featsLeft", function() {
                 <div class="checkboxSlider"><input type="checkbox" class="checkboxSliderInvis" name="attr_display_alternate_border" value="on" /><label></label></div>   
             </div>
         </div>
+        </div>
         <div class="row">
             <div class="column textLargest bolder textshadow boxshadow">More Coming Soon</div>
             <div class="column">This is just the groundwork, stuff going on behind the scenes. Options like borders, Treat the sheet as: Alt Form/Companion/NPC, etc. If you would like to provide feedback or see more indepth updates, visit: https://community.openlegendrpg.com/t/roll20-character-sheet/162</div>
@@ -3246,36 +4887,51 @@ on("change:repeating_featsLeft", function() {
         <div class="row">
             <div class="column textLargest bolder textshadow">Changelog</div>
             <div class="column">Below is the changelog of what has been going on with the Sheet so you can see exactly what has happened in latest updates.</div>
-
-            <div class="width90 inlineBlock boxShadow marginBottom marginTop">
-                <div class="column width100 textLarge bold borderBottom textLeft">1.9.2 on 2018 May 8th</div>
-                <div class="column width100 textLeft">Added Whisper to GM option</div>
-                <div class="column width100 textLeft padLeft">- global button to make any roll you click on the sheet go to the GM</div>
-            </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
-                <div class="column width100 textLarge bold borderBottom textLeft">1.9.1 on 2018 May 8th</div>
-                <div class="column width100 textLeft">Made Background Tab for the sheet</div>
-                <div class="column width100 textLeft padLeft">- Moved Character Info & Beliefs, Goals, Instincts Sections</div>
-                <div class="column width100 textLeft padLeft">- Added more data fields for the Character Info section</div>
-                <div class="column width100 textLeft">GUI Display at Top</div>
-                <div class="column width100 textLeft padLeft">- Added what type of sheet it is for future updates</div>
-                <div class="column width100 textLeft padLeft">- Moved OL logo up and smaller along with version</div>
-                <div class="column width100 textLeft padLeft">- Hidden groundwork for a tab button for whispering rolls to the GM</div>
-            </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
-                <div class="column width100 textLarge bold borderBottom textLeft">1.9.0 on 2018 May 7th</div>
-                <div class="column width100 textLeft">Massive update to Favored & Other Actions sections</div>
-                <div class="column width100 textLeft padLeft">- Select if action is an Attack (Damaging or Bane), Boon, or Effect</div>
-                <div class="column width100 textLeft padLeft">- Effect isn’t quite fully functional yet in that there is a pop-up that doesn’t do anything, but will still roll the dice you choose</div>
-                <div class="column width100 textLeft">Backgrounds for the borders updated</div>
-                <div class="column width100 textLeft padLeft">- Also white background for things sent to chat</div>
-                <div class="column width100 textLeft">Prep work for NPC/Alt Form/Companion tabs</div>
-                <div class="column width100 textLeft padLeft">- Nothing functioning on the user side yet</div>
-                <div class="column width100 textLeft">Options Tab added</div>
-                <div class="column width100 textLeft padLeft">- Just information for now, functionality added in next update</div>
+<!-- Make the Change Log scrollable so takes up less space
+    Might end up just removing the changelog, not sure it is really needed here -->
+            <div class="width100 height150 scroll">
+                <div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.5 on 2018 May 11th</div>
+                    <div class="column width100 textLeft">Sheet Type Selection added</div>
+                    <div class="column width100 textLeft padLeft">- Pick between: Primary Character, NPC/Summons, Alt form Tier 1 or 2, Companion Tier 1, 2, or 3</div>
+                    <div class="column width100 textLeft padLeft">- Changes the calculations for Attribute Points & Feat points based on what is selected</div>
+                    <div class="column width100 textLeft padLeft">- Adds some entry fields were applicable</div>
+                    <div class="column width100 textLeft padLeft">- For NPC, shows a completely different sheet for "Quick" build</div>
+                </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.3 on 2018 May 10th</div>
+                    <div class="column width100 textLeft">Fix for "Other Actions" section & Effects</div>
+                    <div class="column width100 textLeft padLeft">- On Load function for Other Actions wasn't doign the Power Levels correctly</div>
+                    <div class="column width100 textLeft padLeft">- Forgot to make Effects dice explode (all dice in OL explode!!)</div>
+                </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.2 on 2018 May 8th</div>
+                    <div class="column width100 textLeft">Added Whisper to GM option</div>
+                    <div class="column width100 textLeft padLeft">- global button to make any roll you click on the sheet go to the GM</div>
+                </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.1 on 2018 May 8th</div>
+                    <div class="column width100 textLeft">Made Background Tab for the sheet</div>
+                    <div class="column width100 textLeft padLeft">- Moved Character Info & Beliefs, Goals, Instincts Sections</div>
+                    <div class="column width100 textLeft padLeft">- Added more data fields for the Character Info section</div>
+                    <div class="column width100 textLeft">GUI Display at Top</div>
+                    <div class="column width100 textLeft padLeft">- Added what type of sheet it is for future updates</div>
+                    <div class="column width100 textLeft padLeft">- Moved OL logo up and smaller along with version</div>
+                    <div class="column width100 textLeft padLeft">- Hidden groundwork for a tab button for whispering rolls to the GM</div>
+                </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.0 on 2018 May 7th</div>
+                    <div class="column width100 textLeft">Massive update to Favored & Other Actions sections</div>
+                    <div class="column width100 textLeft padLeft">- Select if action is an Attack (Damaging or Bane), Boon, or Effect</div>
+                    <div class="column width100 textLeft padLeft">- Effect isn’t quite fully functional yet in that there is a pop-up that doesn’t do anything, but will still roll the dice you choose</div>
+                    <div class="column width100 textLeft">Backgrounds for the borders updated</div>
+                    <div class="column width100 textLeft padLeft">- Also white background for things sent to chat</div>
+                    <div class="column width100 textLeft">Prep work for NPC/Alt Form/Companion tabs</div>
+                    <div class="column width100 textLeft padLeft">- Nothing functioning on the user side yet</div>
+                    <div class="column width100 textLeft">Options Tab added</div>
+                    <div class="column width100 textLeft padLeft">- Just information for now, functionality added in next update</div>
+                </div>
             </div>
         </div>
     </div>
-<!-- Character Sheet version for Background Info -->
-    <div class="option-main background width100">
+<!-- START Background Tab -->
+    <div class="option-main background width100 padTop marginTop">
         <div class="row">
      <!-- section for basic Character information -->
             <input type="hidden" class="display_character_flag" name="attr_display_character_flag" value="show" />
@@ -3303,18 +4959,14 @@ on("change:repeating_featsLeft", function() {
                     <div class="column width1of3 inlineBlock textCenter inputName"><input type="text" name="attr_weight" /></div>
                 </div>
                 <div class="inlineBlock width1of3 padTop">      <!-- Middle Third of 2/3 rows for info (Archetype, Level, XP) -->
-                    <div class="column width1of3 inlineBlock textCenter bold vertBottom">Size</div>
-                    <div class="column width1of3 inlineBlock textCenter bold vertBottom">Eyes</div>
-                    <div class="column width1of3 inlineBlock textCenter bold vertBottom">Hair</div>
-                    <div class="column width1of3 inlineBlock textCenter inputName"><input type="text" name="attr_size" /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputName"><input type="text" name="attr_eyes" /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputName"><input type="text" name="attr_hair" /></div>
+                    <div class="column width45 inlineBlock textCenter bold vertBottom">Gender</div>
+                    <div class="column width45 inlineBlock textCenter bold vertBottom">Size</div>
+                    <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_gender" /></div>
+                    <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_size" /></div>
                 </div>
                 <div class="inlineBlock width1of3 padTop">      <!-- Middle Third of 2/3 rows for info (Archetype, Level, XP) -->
-                    <div class="column width1of3 inlineBlock textCenter bold vertBottom">Skin</div>
-                    <div class="column width2of3 inlineBlock textCenter bold vertBottom">Ancestory</div>
-                    <div class="column width1of3 inlineBlock textCenter inputName"><input type="text" name="attr_skin" /></div>
-                    <div class="column width2of3 inlineBlock textCenter inputName"><input type="text" name="attr_ancestory" /></div>
+                    <div class="column width90 inlineBlock textCenter bold vertBottom">Heritage</div>
+                    <div class="column width90 inlineBlock textCenter inputName"><input type="text" name="attr_ancestory" /></div>
                 </div>
                 <div class="width100">                   <!-- Bottom 1/3 of rows for Description of Character -->
                     <div class="column width100 textLeft bold vertBottom">Description</div>
@@ -3384,1594 +5036,4373 @@ on("change:repeating_featsLeft", function() {
          <!-- end section for Goals and Beliefs information -->
         </div>
     </div>
+<!-- END Background Tab -->
 <!-- Character Sheet version for Main -->
-    <div class="option-main main width100">
-        <div class="row">
-     <!-- Left Column for Attributes -->
-       <!-- Attributes are setup so that clicking the name of the attribute will roll it -->
-        <input type="hidden" class="display_attributes_flag" name="attr_display_attributes_flag" value="show" />
-        <div class="third inlineBlock vertTop displayAttributes">
-            <div class="attributes padTop">
-                <div class="width100 height5"></div>
-                <div class="column width100 textLargest bold">Attributes</div>
+    <div class="option-main main width100 padTop marginTop">
+        <input type="hidden" class="display_sheet_type" name="attr_display_sheet_type" value="character" />
+<!-- START NPC Tab -->
+        <div class="displaySheetNPC width100">
+            <div class="row">
+                <div class="column width90 inlineBlock vertTop marginBottom boxShadow textLeft">
+                    <span class="bold">Designed for NPC Quick Builds and Player Summons.</span> For a complex NPC build, use the regular (Primary) Character sheet.<br />
+                    Dice will only update when you change the "Score" value. You can manual change the dice to another value b/c of items or other effects the NPC might have on them.<br />
+                    Stats entered into the NPCs can be used on tokens, look for "npc1........" "npc2........." from the drop down.
+                </div>
+<!-- NPC #1 -->
+    <!-- LEFT third of NPC 1 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginBottom smallCaps">NPC #1 Information</div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Name</div>
+                    <div class="column width85 inlineBlock textCenter inputName"><input type="text" name="attr_npc1_name" value="Name" /></div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Level</div>
+                    <div class="column width15 inlineBlock textCenter inputName"><input type="text" name="attr_npc1_level" value="1" /></div>
+                    <div class="column width25 inlineBlock textCenter bold vertBottom">Archetype</div>
+                    <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_npc1_archetype" /></div>
+                    <div class="column width100 textLeft bold vertBottom">Description</div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc1_description"></textarea></div>
+                    </div>
+                    <div class="column width100 textLeft bold vertBottom inventoryButton"><button type="roll" name="roll_npc1_inventory" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc1_name}}} {{subTitle=Inventory}} {{description=@{npc1_inventory}}}">Treasure/Inventory</button></div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc1_inventory"></textarea></div>
+                    </div>
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop marginBottom">Speed</div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc1_speed1_name" value="Ground" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_Npc1_speed1" value=30 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc1_speed2_name" value="Swim" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc1_speed2" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc1_speed3_name" value="Climb" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc1_speed3" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc1_speed4_name" value="Fly" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc1_speed4" value=0 /></div>
+                </div>
+    <!-- MIDDLE third of NPC 1 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Primary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- 1st Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc1_attribute1" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc1_prime_attribute1_name} Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Score of @{npc1_prime_attribute1_score}}} @{npc1_prime_attribute1_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc1_prime_attribute1_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc1_prime_attribute1_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute1_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc1_prime_attribute1_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc1_prime_attribute1_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 1st Attribute -->
+        <!-- 2nd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc1_attribute2" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc1_prime_attribute2_name} Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Score of @{npc1_prime_attribute2_score}}} @{npc1_prime_attribute2_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc1_prime_attribute2_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc1_prime_attribute2_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute2_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc1_prime_attribute2_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc1_prime_attribute2_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute2_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 2nd Attribute -->
+        <!-- 3rd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc1_attribute3" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc1_prime_attribute3_name} Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Score of @{npc1_prime_attribute3_score}}} @{npc1_prime_attribute3_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc1_prime_attribute3_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc1_prime_attribute3_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute3_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc1_prime_attribute3_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc1_prime_attribute3_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 3rd Attribute -->
+        <!-- Initiative -->
+                    <div class="row">
+                        <div class="column width55 inlineBlock textLarge speedButton"><button type="roll" name="roll_npc1_initiative" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Initiative Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Score of @{npc1_initiative_score}}} @{npc1_initiative_roll} {{description=Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                        <input type="hidden" name="attr_npc1_initiative_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_initiative_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc1_initiative_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc1_initiative_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc1_initiative_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END Initiative -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Secondary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- Repeating Secondary Attributes -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc1secondary">
+                            <div class="row">
+                                <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc1_secondary_attribute" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{name} Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Score of @{score}}} @{roll}">Roll</button></div>
+                                <div class="column width45 inlineBlock inputSelect">
+                                    <select name="attr_name">
+            							<optgroup label="Select Attribute">
+            								<option value="None" selected="selected">Select Attribute</option>
+            							</optgroup>
+            							<optgroup label="Physical">
+            								<option value="Agility">Agility</option>
+            								<option value="Fortitude">Fortitude</option>
+            								<option value="Might">Might</option>
+            							</optgroup>
+            							<optgroup label="Mental">
+            								<option value="Learning">Learning</option>
+            								<option value="Logic">Logic</option>
+            								<option value="Perception">Perception</option>
+            								<option value="Will">Will</option>
+            							</optgroup>
+            							<optgroup label="Social">
+            								<option value="Deception">Deception</option>
+            								<option value="Persuasion">Persuasion</option>
+            								<option value="Presence">Presence</option>
+            							</optgroup>
+            							<optgroup label="Extraordinary">
+            								<option value="Alteration">Alteration</option>
+            								<option value="Creation">Creation</option>
+            								<option value="Energy">Energy</option>
+            								<option value="Entropy">Entropy</option>
+            								<option value="Influence">Influence</option>
+            								<option value="Movement">Movement</option>
+            								<option value="Prescience">Prescience</option>
+            								<option value="Protection">Protection</option>
+            							</optgroup>
+                                    </select>
+                                </div>
+                                <input type="hidden" name="attr_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d8!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_score" value=3 /></div>
+                                <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                <div class="column inlineBlock inputDiceType">
+                                    <select name="attr_dice_type">
+                                        <option value=0>d0</option>
+                                        <option value=4>d4!!</option>
+                                        <option value=6>d6!!</option>
+                                        <option value=8 selected="selected">d8!!</option>
+                                        <option value=10>d10!!</option>
+                                        <option value=12>d12!!</option>
+                                        <option value=20>d20!!</option>
+                                    </select>
+                                </div>
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_default_advantage" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Secondary Attributes -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Feats</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width70">Feat Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width20">Cost</div>
+        <!-- END TITLES -->
+        <!-- Repeating Feats -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc1feats">
+                            <div class="row">
+                                <div class="column inlineBlock textCenter inputName width70"><input type="text" name="attr_name" /></div>
+                                <div class="column inlineBlock textCenter inputNumber30 width20"><input type="number" name="attr_cost" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Feats -->
+                </div>
+    <!-- RIGHT third of NPC 1 -->
+                <div class="third inlineBlock vertTop">
+        <!-- Defenses (yep, HP is a defense) -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
+                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width25">Toughness</div>
+                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width25">Resist</div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_guard" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_toughness" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_resolve" value=10 /></div>
+                    <div class="column width25 inlineBlock speedButton vertBottom">
+                        <button type="roll" name="roll_npc1_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                        <button type="roll" name="roll_npc1_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
+                        <button type="roll" name="roll_npc1_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                    </div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
+                    <div class="column inlineBlock textCenter bold width1of3">Lethal</div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc1_hp" value=10 /></div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc1_hp_max" value=10 /></div>
+                    <input type="hidden" name="attr_npc1_previous_lethal" value=0 />
+                    <div class="column width1of3 inlineBlock inputNumberLargeLethalShort"><input type="number" name="attr_npc1_current_lethal" value=0 /></div>
+        <!-- END Defenses (yep, HP is a defense) -->
+        <!-- Favored Actions -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop">Favored Actions</div>
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_npc1actions">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <input class="tab-hide" type="checkbox" name="attr_npc1_action_hide" value="on" checked="checked" /><div>y</div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_npc1action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{npc1_name}}} {{subTitleAdd=@{name} @{score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <div class="width100 show-hide">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                <!-- What kind of Action selection -->
+                                    <div class="column padTop">
+                                    <div class="column inlineBlock">This Action is:</div>
+                                    <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                    <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                    <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+        
+                                    <input type="hidden" name="attr_dice_roll" value=0 />
+                                    
+                                    <div class="option-action attack inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Attack Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action boon inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Invoking Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action both width60 inlineBlock"><div class="row">
+                                        <div class="column width50 inlineBlock">&nbsp;</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Score</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Dice</div>
+                                        <div class="column inlineBlock inputSelect" style="width: 54%;">
+                                            <select name="attr_name">
+                    							<optgroup label="Select Attribute">
+                    								<option value="None" selected="selected">Select Attribute</option>
+                    							</optgroup>
+                    							<optgroup label="Physical">
+                    								<option value="Agility">Agility</option>
+                    								<option value="Fortitude">Fortitude</option>
+                    								<option value="Might">Might</option>
+                    							</optgroup>
+                    							<optgroup label="Mental">
+                    								<option value="Learning">Learning</option>
+                    								<option value="Logic">Logic</option>
+                    								<option value="Perception">Perception</option>
+                    								<option value="Will">Will</option>
+                    							</optgroup>
+                    							<optgroup label="Social">
+                    								<option value="Deception">Deception</option>
+                    								<option value="Persuasion">Persuasion</option>
+                    								<option value="Presence">Presence</option>
+                    							</optgroup>
+                    							<optgroup label="Extraordinary">
+                    								<option value="Alteration">Alteration</option>
+                    								<option value="Creation">Creation</option>
+                    								<option value="Energy">Energy</option>
+                    								<option value="Entropy">Entropy</option>
+                    								<option value="Influence">Influence</option>
+                    								<option value="Movement">Movement</option>
+                    								<option value="Prescience">Prescience</option>
+                    								<option value="Protection">Protection</option>
+                    							</optgroup>
+                                            </select>
+                                        </div>
+                                        <div class="column inlineBlock textCenter inputNumber30 width15"><input type="number" name="attr_score" value=3 /></div>
+                                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                        <div class="column inlineBlock inputDiceType">
+                                            <select name="attr_dice_type">
+                                                <option value=0>d0</option>
+                                                <option value=4>d4!!</option>
+                                                <option value=6>d6!!</option>
+                                                <option value=8 selected="selected">d8!!</option>
+                                                <option value=10>d10!!</option>
+                                                <option value=12>d12!!</option>
+                                                <option value=20>d20!!</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action attack width100"><div class="row">
+                                        <div class="column width100 bold italic textCenter">vs</div>
+                                        <div class="column inlineBlock bold textSmall textRight" style="width: 37%;">Target Defense:</div>
+                                        <div class="column width60 inlineBlock inputSelect">
+                                            <select name="attr_action_target">
+                                                <option value="None" selected="selected">None</option>
+                                                <option value="Guard">Guard</option>
+                                                <option value="Toughness">Toughness</option>
+                                                <option value="Resolve">Resolve</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action both"><div class="row">
+            							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+            							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_d20_advantage" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Advantage on d20 (very Cruel)</div>
+                                    </div></div>
+        
+                                    <div class="option-action effect width100"><div class="row padTop">
+                                        <div class="column width90 inlineBlock borderAllDotted borderRound gray bold textSmall">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputSelect">
+                                            <select name="attr_effect_dice_type">
+                                                <option value="None" selected="selected">Dice Size</option>
+                                                <option value="d4!!">d4</option>
+                                                <option value="d6!!">d6</option>
+                                                <option value="d8!!">d8</option>
+                                                <option value="d10!!">d10</option>
+                                                <option value="d12!!">d12</option>
+                                                <option value="d20!!">d20</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action all width100"><div class="row padTop">
+                                        <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                        <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                    </div></div>
+        
+                                    <div class="option-action boon"><div class="row">
+                                        <input type="hidden" name="attr_power_level_low" value="0" />
+                                        <input type="hidden" name="attr_power_level_high" value="0" />
+                                        <div class="column width100 bold">Power Levels Available to Boon</div>
+                                        <div class="column width100 bold textLarge">
+                                            <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                            <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                            <div class="width100"></div>
+                                            <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                            <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                            <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                            <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                            <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                            <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                            <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                            <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                            <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                        </div>
+                                    </div></div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Favored Actions -->
+                </div>
+<!-- END NPC #1 -->
+        <!-- Blank Space between NPCs -->
+                <div class="height5 black width100 marginTop marginBottom"></div>
+        <!-- END Blank Space between NPCs -->
+<!-- NPC #2 -->
+                <div class="row" style="background-color: rgba(1,1,1,0.1);">
+        <!-- LEFT third of NPC 2 -->
+                    <div class="third inlineBlock vertTop">
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginBottom smallCaps">NPC #2 Information</div>
+                        <div class="column width15 inlineBlock textCenter bold vertBottom">Name</div>
+                        <div class="column width85 inlineBlock textCenter inputName"><input type="text" name="attr_npc2_name" value="Name" /></div>
+                        <div class="column width15 inlineBlock textCenter bold vertBottom">Level</div>
+                        <div class="column width15 inlineBlock textCenter inputName"><input type="text" name="attr_npc2_level" value="1" /></div>
+                        <div class="column width25 inlineBlock textCenter bold vertBottom">Archetype</div>
+                        <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_npc2_archetype" /></div>
+                        <div class="column width100 textLeft bold vertBottom">Description</div>
+                        <div class="row padBottom">
+                            <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc2_description"></textarea></div>
+                        </div>
+                        <div class="column width100 textLeft bold vertBottom inventoryButton"><button type="roll" name="roll_npc2_inventory" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc2_name}}} {{subTitle=Inventory}} {{description=@{npc2_inventory}}}">Treasure/Inventory</button></div>
+                        <div class="row padBottom">
+                            <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc2_inventory"></textarea></div>
+                        </div>
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop marginBottom">Speed</div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc2_speed1_name" value="Ground" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_Npc2_speed1" value=30 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc2_speed2_name" value="Swim" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc2_speed2" value=15 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc2_speed3_name" value="Climb" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc2_speed3" value=15 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc2_speed4_name" value="Fly" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc2_speed4" value=0 /></div>
+                    </div>
+        <!-- MIDDLE third of NPC 2 -->
+                    <div class="third inlineBlock vertTop">
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Primary Attributes</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+            <!-- END TITLES -->
+            <!-- 1st Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc2_attribute1" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc2_prime_attribute1_name} Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Score of @{npc2_prime_attribute1_score}}} @{npc2_prime_attribute1_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc2_prime_attribute1_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc2_prime_attribute1_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute1_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc2_prime_attribute1_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc2_prime_attribute1_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute1_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 1st Attribute -->
+            <!-- 2nd Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc2_attribute2" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc2_prime_attribute2_name} Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Score of @{npc2_prime_attribute2_score}}} @{npc2_prime_attribute2_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc2_prime_attribute2_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc2_prime_attribute2_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute2_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc2_prime_attribute2_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc2_prime_attribute2_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute2_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 2nd Attribute -->
+            <!-- 3rd Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc2_attribute3" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc2_prime_attribute3_name} Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Score of @{npc2_prime_attribute3_score}}} @{npc2_prime_attribute3_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc2_prime_attribute3_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc2_prime_attribute3_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute3_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc2_prime_attribute3_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc2_prime_attribute3_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_prime_attribute1_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 3rd Attribute -->
+            <!-- Initiative -->
+                        <div class="row">
+                            <div class="column width55 inlineBlock textLarge speedButton"><button type="roll" name="roll_npc2_initiative" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Initiative Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Score of @{npc2_initiative_score}}} @{npc2_initiative_roll} {{description=Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                            <input type="hidden" name="attr_npc2_initiative_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_initiative_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc2_initiative_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc2_initiative_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc2_initiative_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END Initiative -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Secondary Attributes</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+            <!-- END TITLES -->
+            <!-- Repeating Secondary Attributes -->
+                        <div class="column width100 vertTop">
+                            <fieldset class="repeating_npc2secondary">
+                                <div class="row">
+                                    <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc2_secondary_attribute" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{name} Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Score of @{score}}} @{roll}">Roll</button></div>
+                                    <div class="column width45 inlineBlock inputSelect">
+                                        <select name="attr_name">
+                							<optgroup label="Select Attribute">
+                								<option value="None" selected="selected">Select Attribute</option>
+                							</optgroup>
+                							<optgroup label="Physical">
+                								<option value="Agility">Agility</option>
+                								<option value="Fortitude">Fortitude</option>
+                								<option value="Might">Might</option>
+                							</optgroup>
+                							<optgroup label="Mental">
+                								<option value="Learning">Learning</option>
+                								<option value="Logic">Logic</option>
+                								<option value="Perception">Perception</option>
+                								<option value="Will">Will</option>
+                							</optgroup>
+                							<optgroup label="Social">
+                								<option value="Deception">Deception</option>
+                								<option value="Persuasion">Persuasion</option>
+                								<option value="Presence">Presence</option>
+                							</optgroup>
+                							<optgroup label="Extraordinary">
+                								<option value="Alteration">Alteration</option>
+                								<option value="Creation">Creation</option>
+                								<option value="Energy">Energy</option>
+                								<option value="Entropy">Entropy</option>
+                								<option value="Influence">Influence</option>
+                								<option value="Movement">Movement</option>
+                								<option value="Prescience">Prescience</option>
+                								<option value="Protection">Protection</option>
+                							</optgroup>
+                                        </select>
+                                    </div>
+                                    <input type="hidden" name="attr_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d8!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                                    <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_score" value=3 /></div>
+                                    <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                    <div class="column inlineBlock inputDiceType">
+                                        <select name="attr_dice_type">
+                                            <option value=0>d0</option>
+                                            <option value=4>d4!!</option>
+                                            <option value=6>d6!!</option>
+                                            <option value=8 selected="selected">d8!!</option>
+                                            <option value=10>d10!!</option>
+                                            <option value=12>d12!!</option>
+                                            <option value=20>d20!!</option>
+                                        </select>
+                                    </div>
+                                    <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_default_advantage" value=0 /></div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Repeating Secondary Attributes -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Feats</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width70">Feat Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width20">Cost</div>
+            <!-- END TITLES -->
+            <!-- Repeating Feats -->
+                        <div class="column width100 vertTop">
+                            <fieldset class="repeating_npc2feats">
+                                <div class="row">
+                                    <div class="column inlineBlock textCenter inputName width70"><input type="text" name="attr_name" /></div>
+                                    <div class="column inlineBlock textCenter inputNumber30 width20"><input type="number" name="attr_cost" value=0 /></div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Repeating Feats -->
+                    </div>
+        <!-- RIGHT third of NPC 2 -->
+                    <div class="third inlineBlock vertTop">
+            <!-- Defenses (yep, HP is a defense) -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
+                        <div class="column inlineBlock textCenter bold width25">Guard</div>
+                        <div class="column inlineBlock textCenter bold width25">Toughness</div>
+                        <div class="column inlineBlock textCenter bold width25">Resolve</div>
+                        <div class="column inlineBlock textCenter bold width25">Resist</div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_guard" value=10 /></div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_toughness" value=10 /></div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_resolve" value=10 /></div>
+                        <div class="column width25 inlineBlock speedButton vertBottom">
+                            <button type="roll" name="roll_npc2_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                            <button type="roll" name="roll_npc2_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
+                            <button type="roll" name="roll_npc2_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                        </div>
+                        <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
+                        <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
+                        <div class="column inlineBlock textCenter bold width1of3">Lethal</div>
+                        <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc2_hp" value=10 /></div>
+                        <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc2_hp_max" value=10 /></div>
+                        <input type="hidden" name="attr_npc2_previous_lethal" value=0 />
+                        <div class="column width1of3 inlineBlock inputNumberLargeLethalShort"><input type="number" name="attr_npc2_current_lethal" value=0 /></div>
+            <!-- END Defenses (yep, HP is a defense) -->
+            <!-- Favored Actions -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop">Favored Actions</div>
+                    <!-- Headings for the actions -->
+                        <div class="column width25 bold italic inlineBlock textCenter">Settings</div>
+                        <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                    <!-- Add actions as needed Section (repeating fields) -->
+                        <div class="column width100 vertTop padRight">
+                            <fieldset class="repeating_npc2actions">
+                                <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                    <input class="tab-hide" type="checkbox" name="attr_npc2_action_hide" value="on" checked="checked" /><div>y</div>
+                                    <div class="width90 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_npc2action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{npc2_name}}} {{subTitleAdd=@{name} @{score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                    <div class="width100 show-hide">
+                                        <div class="column width25 inlineBlock bold">Name: </div>
+                                        <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                    <!-- What kind of Action selection -->
+                                        <div class="column padTop">
+                                        <div class="column inlineBlock">This Action is:</div>
+                                        <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                        <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                        <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+            
+                                        <input type="hidden" name="attr_dice_roll" value=0 />
+                                        
+                                        <div class="option-action attack inlineBlock" style="width: 38%;"><div class="row padTop">
+                                            <div class="column width100 inlineBlock bold textSmall textRight">Attack Attribute:</div>
+                                        </div></div>
+                                        <div class="option-action boon inlineBlock" style="width: 38%;"><div class="row padTop">
+                                            <div class="column width100 inlineBlock bold textSmall textRight">Invoking Attribute:</div>
+                                        </div></div>
+                                        <div class="option-action both width60 inlineBlock"><div class="row">
+                                            <div class="column width50 inlineBlock">&nbsp;</div>
+                                            <div class="column width25 inlineBlock bold textSmall">Score</div>
+                                            <div class="column width25 inlineBlock bold textSmall">Dice</div>
+                                            <div class="column inlineBlock inputSelect" style="width: 54%;">
+                                                <select name="attr_name">
+                        							<optgroup label="Select Attribute">
+                        								<option value="None" selected="selected">Select Attribute</option>
+                        							</optgroup>
+                        							<optgroup label="Physical">
+                        								<option value="Agility">Agility</option>
+                        								<option value="Fortitude">Fortitude</option>
+                        								<option value="Might">Might</option>
+                        							</optgroup>
+                        							<optgroup label="Mental">
+                        								<option value="Learning">Learning</option>
+                        								<option value="Logic">Logic</option>
+                        								<option value="Perception">Perception</option>
+                        								<option value="Will">Will</option>
+                        							</optgroup>
+                        							<optgroup label="Social">
+                        								<option value="Deception">Deception</option>
+                        								<option value="Persuasion">Persuasion</option>
+                        								<option value="Presence">Presence</option>
+                        							</optgroup>
+                        							<optgroup label="Extraordinary">
+                        								<option value="Alteration">Alteration</option>
+                        								<option value="Creation">Creation</option>
+                        								<option value="Energy">Energy</option>
+                        								<option value="Entropy">Entropy</option>
+                        								<option value="Influence">Influence</option>
+                        								<option value="Movement">Movement</option>
+                        								<option value="Prescience">Prescience</option>
+                        								<option value="Protection">Protection</option>
+                        							</optgroup>
+                                                </select>
+                                            </div>
+                                            <div class="column inlineBlock textCenter inputNumber30 width15"><input type="number" name="attr_score" value=3 /></div>
+                                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                            <div class="column inlineBlock inputDiceType">
+                                                <select name="attr_dice_type">
+                                                    <option value=0>d0</option>
+                                                    <option value=4>d4!!</option>
+                                                    <option value=6>d6!!</option>
+                                                    <option value=8 selected="selected">d8!!</option>
+                                                    <option value=10>d10!!</option>
+                                                    <option value=12>d12!!</option>
+                                                    <option value=20>d20!!</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action attack width100"><div class="row">
+                                            <div class="column width100 bold italic textCenter">vs</div>
+                                            <div class="column inlineBlock bold textSmall textRight" style="width: 37%;">Target Defense:</div>
+                                            <div class="column width60 inlineBlock inputSelect">
+                                                <select name="attr_action_target">
+                                                    <option value="None" selected="selected">None</option>
+                                                    <option value="Guard">Guard</option>
+                                                    <option value="Toughness">Toughness</option>
+                                                    <option value="Resolve">Resolve</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action both"><div class="row">
+                							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+                							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                            <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                            <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                            <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_d20_advantage" value="Yes" /></div>
+                                            <div class="column width75 textSmall bold textLeft inlineBlock"> Advantage on d20 (very Cruel)</div>
+                                        </div></div>
+            
+                                        <div class="option-action effect width100"><div class="row padTop">
+                                            <div class="column width90 inlineBlock borderAllDotted borderRound gray bold textSmall">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                            <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                            <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                            <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                            <div class="column width30 inlineBlock inputSelect">
+                                                <select name="attr_effect_dice_type">
+                                                    <option value="None" selected="selected">Dice Size</option>
+                                                    <option value="d4!!">d4</option>
+                                                    <option value="d6!!">d6</option>
+                                                    <option value="d8!!">d8</option>
+                                                    <option value="d10!!">d10</option>
+                                                    <option value="d12!!">d12</option>
+                                                    <option value="d20!!">d20</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action all width100"><div class="row padTop">
+                                            <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                            <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                        </div></div>
+            
+                                        <div class="option-action boon"><div class="row">
+                                            <input type="hidden" name="attr_power_level_low" value="0" />
+                                            <input type="hidden" name="attr_power_level_high" value="0" />
+                                            <div class="column width100 bold">Power Levels Available to Boon</div>
+                                            <div class="column width100 bold textLarge">
+                                                <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                                <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                                <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                                <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                                <div class="width100"></div>
+                                                <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                                <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                                <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                                <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                                <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                                <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                                <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                                <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                                <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                            </div>
+                                        </div></div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Favored Actions -->
+                    </div>
+                </div>
+<!-- END NPC #2 -->
+        <!-- Blank Space between NPCs -->
+                <div class="height5 black width100 marginTop marginBottom"></div>
+        <!-- END Blank Space between NPCs -->
+<!-- NPC #3 -->
+    <!-- LEFT third of NPC 3 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginBottom smallCaps">NPC #3 Information</div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Name</div>
+                    <div class="column width85 inlineBlock textCenter inputName"><input type="text" name="attr_npc3_name" value="Name" /></div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Level</div>
+                    <div class="column width15 inlineBlock textCenter inputName"><input type="text" name="attr_npc3_level" value="1" /></div>
+                    <div class="column width25 inlineBlock textCenter bold vertBottom">Archetype</div>
+                    <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_npc3_archetype" /></div>
+                    <div class="column width100 textLeft bold vertBottom">Description</div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc3_description"></textarea></div>
+                    </div>
+                    <div class="column width100 textLeft bold vertBottom inventoryButton"><button type="roll" name="roll_npc3_inventory" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc3_name}}} {{subTitle=Inventory}} {{description=@{npc3_inventory}}}">Treasure/Inventory</button></div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc3_inventory"></textarea></div>
+                    </div>
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop marginBottom">Speed</div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc3_speed1_name" value="Ground" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_Npc3_speed1" value=30 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc3_speed2_name" value="Swim" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc3_speed2" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc3_speed3_name" value="Climb" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc3_speed3" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc3_speed4_name" value="Fly" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc3_speed4" value=0 /></div>
+                </div>
+    <!-- MIDDLE third of NPC 3 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Primary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- 1st Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc3_attribute1" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc3_prime_attribute1_name} Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Score of @{npc3_prime_attribute1_score}}} @{npc3_prime_attribute1_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc3_prime_attribute1_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc3_prime_attribute1_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute1_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc3_prime_attribute1_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc3_prime_attribute1_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 1st Attribute -->
+        <!-- 2nd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc3_attribute2" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc3_prime_attribute2_name} Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Score of @{npc3_prime_attribute2_score}}} @{npc3_prime_attribute2_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc3_prime_attribute2_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc3_prime_attribute2_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute2_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc3_prime_attribute2_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc3_prime_attribute2_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute2_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 2nd Attribute -->
+        <!-- 3rd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc3_attribute3" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc3_prime_attribute3_name} Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Score of @{npc3_prime_attribute3_score}}} @{npc3_prime_attribute3_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc3_prime_attribute3_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc3_prime_attribute3_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute3_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc3_prime_attribute3_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc3_prime_attribute3_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 3rd Attribute -->
+        <!-- Initiative -->
+                    <div class="row">
+                        <div class="column width55 inlineBlock textLarge speedButton"><button type="roll" name="roll_npc3_initiative" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Initiative Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Score of @{npc3_initiative_score}}} @{npc3_initiative_roll} {{description=Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                        <input type="hidden" name="attr_npc3_initiative_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_initiative_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc3_initiative_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc3_initiative_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc3_initiative_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END Initiative -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Secondary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- Repeating Secondary Attributes -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc3secondary">
+                            <div class="row">
+                                <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc3_secondary_attribute" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{name} Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Score of @{score}}} @{roll}">Roll</button></div>
+                                <div class="column width45 inlineBlock inputSelect">
+                                    <select name="attr_name">
+            							<optgroup label="Select Attribute">
+            								<option value="None" selected="selected">Select Attribute</option>
+            							</optgroup>
+            							<optgroup label="Physical">
+            								<option value="Agility">Agility</option>
+            								<option value="Fortitude">Fortitude</option>
+            								<option value="Might">Might</option>
+            							</optgroup>
+            							<optgroup label="Mental">
+            								<option value="Learning">Learning</option>
+            								<option value="Logic">Logic</option>
+            								<option value="Perception">Perception</option>
+            								<option value="Will">Will</option>
+            							</optgroup>
+            							<optgroup label="Social">
+            								<option value="Deception">Deception</option>
+            								<option value="Persuasion">Persuasion</option>
+            								<option value="Presence">Presence</option>
+            							</optgroup>
+            							<optgroup label="Extraordinary">
+            								<option value="Alteration">Alteration</option>
+            								<option value="Creation">Creation</option>
+            								<option value="Energy">Energy</option>
+            								<option value="Entropy">Entropy</option>
+            								<option value="Influence">Influence</option>
+            								<option value="Movement">Movement</option>
+            								<option value="Prescience">Prescience</option>
+            								<option value="Protection">Protection</option>
+            							</optgroup>
+                                    </select>
+                                </div>
+                                <input type="hidden" name="attr_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d8!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_score" value=3 /></div>
+                                <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                <div class="column inlineBlock inputDiceType">
+                                    <select name="attr_dice_type">
+                                        <option value=0>d0</option>
+                                        <option value=4>d4!!</option>
+                                        <option value=6>d6!!</option>
+                                        <option value=8 selected="selected">d8!!</option>
+                                        <option value=10>d10!!</option>
+                                        <option value=12>d12!!</option>
+                                        <option value=20>d20!!</option>
+                                    </select>
+                                </div>
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_default_advantage" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Secondary Attributes -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Feats</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width70">Feat Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width20">Cost</div>
+        <!-- END TITLES -->
+        <!-- Repeating Feats -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc3feats">
+                            <div class="row">
+                                <div class="column inlineBlock textCenter inputName width70"><input type="text" name="attr_name" /></div>
+                                <div class="column inlineBlock textCenter inputNumber30 width20"><input type="number" name="attr_cost" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Feats -->
+                </div>
+    <!-- RIGHT third of NPC 3 -->
+                <div class="third inlineBlock vertTop">
+        <!-- Defenses (yep, HP is a defense) -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
+                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width25">Toughness</div>
+                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width25">Resist</div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_guard" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_toughness" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_resolve" value=10 /></div>
+                    <div class="column width25 inlineBlock speedButton vertBottom">
+                        <button type="roll" name="roll_npc3_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                        <button type="roll" name="roll_npc3_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
+                        <button type="roll" name="roll_npc3_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                    </div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
+                    <div class="column inlineBlock textCenter bold width1of3">Lethal</div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc3_hp" value=10 /></div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc3_hp_max" value=10 /></div>
+                    <input type="hidden" name="attr_npc3_previous_lethal" value=0 />
+                    <div class="column width1of3 inlineBlock inputNumberLargeLethalShort"><input type="number" name="attr_npc3_current_lethal" value=0 /></div>
+        <!-- END Defenses (yep, HP is a defense) -->
+        <!-- Favored Actions -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop">Favored Actions</div>
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_npc3actions">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <input class="tab-hide" type="checkbox" name="attr_npc3_action_hide" value="on" checked="checked" /><div>y</div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_npc3action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{npc3_name}}} {{subTitleAdd=@{name} @{score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <div class="width100 show-hide">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                <!-- What kind of Action selection -->
+                                    <div class="column padTop">
+                                    <div class="column inlineBlock">This Action is:</div>
+                                    <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                    <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                    <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+        
+                                    <input type="hidden" name="attr_dice_roll" value=0 />
+                                    
+                                    <div class="option-action attack inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Attack Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action boon inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Invoking Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action both width60 inlineBlock"><div class="row">
+                                        <div class="column width50 inlineBlock">&nbsp;</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Score</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Dice</div>
+                                        <div class="column inlineBlock inputSelect" style="width: 54%;">
+                                            <select name="attr_name">
+                    							<optgroup label="Select Attribute">
+                    								<option value="None" selected="selected">Select Attribute</option>
+                    							</optgroup>
+                    							<optgroup label="Physical">
+                    								<option value="Agility">Agility</option>
+                    								<option value="Fortitude">Fortitude</option>
+                    								<option value="Might">Might</option>
+                    							</optgroup>
+                    							<optgroup label="Mental">
+                    								<option value="Learning">Learning</option>
+                    								<option value="Logic">Logic</option>
+                    								<option value="Perception">Perception</option>
+                    								<option value="Will">Will</option>
+                    							</optgroup>
+                    							<optgroup label="Social">
+                    								<option value="Deception">Deception</option>
+                    								<option value="Persuasion">Persuasion</option>
+                    								<option value="Presence">Presence</option>
+                    							</optgroup>
+                    							<optgroup label="Extraordinary">
+                    								<option value="Alteration">Alteration</option>
+                    								<option value="Creation">Creation</option>
+                    								<option value="Energy">Energy</option>
+                    								<option value="Entropy">Entropy</option>
+                    								<option value="Influence">Influence</option>
+                    								<option value="Movement">Movement</option>
+                    								<option value="Prescience">Prescience</option>
+                    								<option value="Protection">Protection</option>
+                    							</optgroup>
+                                            </select>
+                                        </div>
+                                        <div class="column inlineBlock textCenter inputNumber30 width15"><input type="number" name="attr_score" value=3 /></div>
+                                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                        <div class="column inlineBlock inputDiceType">
+                                            <select name="attr_dice_type">
+                                                <option value=0>d0</option>
+                                                <option value=4>d4!!</option>
+                                                <option value=6>d6!!</option>
+                                                <option value=8 selected="selected">d8!!</option>
+                                                <option value=10>d10!!</option>
+                                                <option value=12>d12!!</option>
+                                                <option value=20>d20!!</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action attack width100"><div class="row">
+                                        <div class="column width100 bold italic textCenter">vs</div>
+                                        <div class="column inlineBlock bold textSmall textRight" style="width: 37%;">Target Defense:</div>
+                                        <div class="column width60 inlineBlock inputSelect">
+                                            <select name="attr_action_target">
+                                                <option value="None" selected="selected">None</option>
+                                                <option value="Guard">Guard</option>
+                                                <option value="Toughness">Toughness</option>
+                                                <option value="Resolve">Resolve</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action both"><div class="row">
+            							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+            							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_d20_advantage" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Advantage on d20 (very Cruel)</div>
+                                    </div></div>
+        
+                                    <div class="option-action effect width100"><div class="row padTop">
+                                        <div class="column width90 inlineBlock borderAllDotted borderRound gray bold textSmall">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputSelect">
+                                            <select name="attr_effect_dice_type">
+                                                <option value="None" selected="selected">Dice Size</option>
+                                                <option value="d4!!">d4</option>
+                                                <option value="d6!!">d6</option>
+                                                <option value="d8!!">d8</option>
+                                                <option value="d10!!">d10</option>
+                                                <option value="d12!!">d12</option>
+                                                <option value="d20!!">d20</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action all width100"><div class="row padTop">
+                                        <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                        <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                    </div></div>
+        
+                                    <div class="option-action boon"><div class="row">
+                                        <input type="hidden" name="attr_power_level_low" value="0" />
+                                        <input type="hidden" name="attr_power_level_high" value="0" />
+                                        <div class="column width100 bold">Power Levels Available to Boon</div>
+                                        <div class="column width100 bold textLarge">
+                                            <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                            <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                            <div class="width100"></div>
+                                            <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                            <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                            <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                            <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                            <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                            <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                            <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                            <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                            <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                        </div>
+                                    </div></div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Favored Actions -->
+                </div>
+<!-- END NPC #3 -->
+        <!-- Blank Space between NPCs -->
+                <div class="height5 black width100 marginTop marginBottom"></div>
+        <!-- END Blank Space between NPCs -->
+<!-- NPC #4 -->
+                <div class="row" style="background-color: rgba(1,1,1,0.1);">
+    <!-- LEFT third of NPC 4 -->
+                    <div class="third inlineBlock vertTop">
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginBottom smallCaps">NPC #4 Information</div>
+                        <div class="column width15 inlineBlock textCenter bold vertBottom">Name</div>
+                        <div class="column width85 inlineBlock textCenter inputName"><input type="text" name="attr_npc4_name" value="Name" /></div>
+                        <div class="column width15 inlineBlock textCenter bold vertBottom">Level</div>
+                        <div class="column width15 inlineBlock textCenter inputName"><input type="text" name="attr_npc4_level" value="1" /></div>
+                        <div class="column width25 inlineBlock textCenter bold vertBottom">Archetype</div>
+                        <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_npc4_archetype" /></div>
+                        <div class="column width100 textLeft bold vertBottom">Description</div>
+                        <div class="row padBottom">
+                            <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc4_description"></textarea></div>
+                        </div>
+                        <div class="column width100 textLeft bold vertBottom inventoryButton"><button type="roll" name="roll_npc4_inventory" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc4_name}}} {{subTitle=Inventory}} {{description=@{npc4_inventory}}}">Treasure/Inventory</button></div>
+                        <div class="row padBottom">
+                            <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc4_inventory"></textarea></div>
+                        </div>
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop marginBottom">Speed</div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc4_speed1_name" value="Ground" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_Npc4_speed1" value=30 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc4_speed2_name" value="Swim" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc4_speed2" value=15 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc4_speed3_name" value="Climb" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc4_speed3" value=15 /></div>
+                        <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc4_speed4_name" value="Fly" /></div>
+                        <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc4_speed4" value=0 /></div>
+                    </div>
+        <!-- MIDDLE third of NPC 4 -->
+                    <div class="third inlineBlock vertTop">
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Primary Attributes</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+            <!-- END TITLES -->
+            <!-- 1st Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc4_attribute1" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc4_prime_attribute1_name} Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Score of @{npc4_prime_attribute1_score}}} @{npc4_prime_attribute1_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc4_prime_attribute1_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc4_prime_attribute1_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute1_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc4_prime_attribute1_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc4_prime_attribute1_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute1_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 1st Attribute -->
+            <!-- 2nd Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc4_attribute2" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc4_prime_attribute2_name} Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Score of @{npc4_prime_attribute2_score}}} @{npc4_prime_attribute2_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc4_prime_attribute2_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc4_prime_attribute2_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute2_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc4_prime_attribute2_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc4_prime_attribute2_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute2_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 2nd Attribute -->
+            <!-- 3rd Attribute -->
+                        <div class="row">
+                            <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc4_attribute3" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc4_prime_attribute3_name} Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Score of @{npc4_prime_attribute3_score}}} @{npc4_prime_attribute3_roll}">Roll</button></div>
+                            <div class="column width45 inlineBlock inputSelect">
+                                <select name="attr_npc4_prime_attribute3_name">
+        							<optgroup label="Select Attribute">
+        								<option value="None" selected="selected">Select Attribute</option>
+        							</optgroup>
+        							<optgroup label="Physical">
+        								<option value="Agility">Agility</option>
+        								<option value="Fortitude">Fortitude</option>
+        								<option value="Might">Might</option>
+        							</optgroup>
+        							<optgroup label="Mental">
+        								<option value="Learning">Learning</option>
+        								<option value="Logic">Logic</option>
+        								<option value="Perception">Perception</option>
+        								<option value="Will">Will</option>
+        							</optgroup>
+        							<optgroup label="Social">
+        								<option value="Deception">Deception</option>
+        								<option value="Persuasion">Persuasion</option>
+        								<option value="Presence">Presence</option>
+        							</optgroup>
+        							<optgroup label="Extraordinary">
+        								<option value="Alteration">Alteration</option>
+        								<option value="Creation">Creation</option>
+        								<option value="Energy">Energy</option>
+        								<option value="Entropy">Entropy</option>
+        								<option value="Influence">Influence</option>
+        								<option value="Movement">Movement</option>
+        								<option value="Prescience">Prescience</option>
+        								<option value="Protection">Protection</option>
+        							</optgroup>
+                                </select>
+                            </div>
+                            <input type="hidden" name="attr_npc4_prime_attribute3_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute3_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc4_prime_attribute3_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc4_prime_attribute3_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_prime_attribute1_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END 3rd Attribute -->
+            <!-- Initiative -->
+                        <div class="row">
+                            <div class="column width55 inlineBlock textLarge speedButton"><button type="roll" name="roll_npc4_initiative" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Initiative Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Score of @{npc4_initiative_score}}} @{npc4_initiative_roll} {{description=Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                            <input type="hidden" name="attr_npc4_initiative_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_initiative_score" value=4 /></div>
+                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc4_initiative_dice_number" value="1" /></div>
+                            <div class="column inlineBlock inputDiceType">
+                                <select name="attr_npc4_initiative_dice_type">
+                                    <option value=0>d0</option>
+                                    <option value=4>d4!!</option>
+                                    <option value=6>d6!!</option>
+                                    <option value=8>d8!!</option>
+                                    <option value=10 selected="selected">d10!!</option>
+                                    <option value=12>d12!!</option>
+                                    <option value=20>d20!!</option>
+                                </select>
+                            </div>
+                            <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc4_initiative_default_advantage" value=0 /></div>
+                        </div>
+            <!-- END Initiative -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Secondary Attributes</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                        <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+            <!-- END TITLES -->
+            <!-- Repeating Secondary Attributes -->
+                        <div class="column width100 vertTop">
+                            <fieldset class="repeating_npc4secondary">
+                                <div class="row">
+                                    <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc4_secondary_attribute" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{name} Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Score of @{score}}} @{roll}">Roll</button></div>
+                                    <div class="column width45 inlineBlock inputSelect">
+                                        <select name="attr_name">
+                							<optgroup label="Select Attribute">
+                								<option value="None" selected="selected">Select Attribute</option>
+                							</optgroup>
+                							<optgroup label="Physical">
+                								<option value="Agility">Agility</option>
+                								<option value="Fortitude">Fortitude</option>
+                								<option value="Might">Might</option>
+                							</optgroup>
+                							<optgroup label="Mental">
+                								<option value="Learning">Learning</option>
+                								<option value="Logic">Logic</option>
+                								<option value="Perception">Perception</option>
+                								<option value="Will">Will</option>
+                							</optgroup>
+                							<optgroup label="Social">
+                								<option value="Deception">Deception</option>
+                								<option value="Persuasion">Persuasion</option>
+                								<option value="Presence">Presence</option>
+                							</optgroup>
+                							<optgroup label="Extraordinary">
+                								<option value="Alteration">Alteration</option>
+                								<option value="Creation">Creation</option>
+                								<option value="Energy">Energy</option>
+                								<option value="Entropy">Entropy</option>
+                								<option value="Influence">Influence</option>
+                								<option value="Movement">Movement</option>
+                								<option value="Prescience">Prescience</option>
+                								<option value="Protection">Protection</option>
+                							</optgroup>
+                                        </select>
+                                    </div>
+                                    <input type="hidden" name="attr_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d8!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                                    <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_score" value=3 /></div>
+                                    <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                    <div class="column inlineBlock inputDiceType">
+                                        <select name="attr_dice_type">
+                                            <option value=0>d0</option>
+                                            <option value=4>d4!!</option>
+                                            <option value=6>d6!!</option>
+                                            <option value=8 selected="selected">d8!!</option>
+                                            <option value=10>d10!!</option>
+                                            <option value=12>d12!!</option>
+                                            <option value=20>d20!!</option>
+                                        </select>
+                                    </div>
+                                    <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_default_advantage" value=0 /></div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Repeating Secondary Attributes -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Feats</div>
+            <!-- TITLES -->
+                        <div class="column inlineBlock textCenter textSmall bold width70">Feat Name</div>
+                        <div class="column inlineBlock textCenter textSmall bold width20">Cost</div>
+            <!-- END TITLES -->
+            <!-- Repeating Feats -->
+                        <div class="column width100 vertTop">
+                            <fieldset class="repeating_npc4feats">
+                                <div class="row">
+                                    <div class="column inlineBlock textCenter inputName width70"><input type="text" name="attr_name" /></div>
+                                    <div class="column inlineBlock textCenter inputNumber30 width20"><input type="number" name="attr_cost" value=0 /></div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Repeating Feats -->
+                    </div>
+        <!-- RIGHT third of NPC 4 -->
+                    <div class="third inlineBlock vertTop">
+            <!-- Defenses (yep, HP is a defense) -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
+                        <div class="column inlineBlock textCenter bold width25">Guard</div>
+                        <div class="column inlineBlock textCenter bold width25">Toughness</div>
+                        <div class="column inlineBlock textCenter bold width25">Resolve</div>
+                        <div class="column inlineBlock textCenter bold width25">Resist</div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_guard" value=10 /></div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_toughness" value=10 /></div>
+                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_resolve" value=10 /></div>
+                        <div class="column width25 inlineBlock speedButton vertBottom">
+                            <button type="roll" name="roll_npc4_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                            <button type="roll" name="roll_npc4_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
+                            <button type="roll" name="roll_npc4_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                        </div>
+                        <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
+                        <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
+                        <div class="column inlineBlock textCenter bold width1of3">Lethal</div>
+                        <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc4_hp" value=10 /></div>
+                        <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc4_hp_max" value=10 /></div>
+                        <input type="hidden" name="attr_npc4_previous_lethal" value=0 />
+                        <div class="column width1of3 inlineBlock inputNumberLargeLethalShort"><input type="number" name="attr_npc4_current_lethal" value=0 /></div>
+            <!-- END Defenses (yep, HP is a defense) -->
+            <!-- Favored Actions -->
+                        <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop">Favored Actions</div>
+                    <!-- Headings for the actions -->
+                        <div class="column width25 bold italic inlineBlock textCenter">Settings</div>
+                        <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                    <!-- Add actions as needed Section (repeating fields) -->
+                        <div class="column width100 vertTop padRight">
+                            <fieldset class="repeating_npc4actions">
+                                <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                    <input class="tab-hide" type="checkbox" name="attr_npc4_action_hide" value="on" checked="checked" /><div>y</div>
+                                    <div class="width90 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_npc4action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{npc4_name}}} {{subTitleAdd=@{name} @{score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                    <div class="width100 show-hide">
+                                        <div class="column width25 inlineBlock bold">Name: </div>
+                                        <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                    <!-- What kind of Action selection -->
+                                        <div class="column padTop">
+                                        <div class="column inlineBlock">This Action is:</div>
+                                        <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                        <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                        <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+            
+                                        <input type="hidden" name="attr_dice_roll" value=0 />
+                                        
+                                        <div class="option-action attack inlineBlock" style="width: 38%;"><div class="row padTop">
+                                            <div class="column width100 inlineBlock bold textSmall textRight">Attack Attribute:</div>
+                                        </div></div>
+                                        <div class="option-action boon inlineBlock" style="width: 38%;"><div class="row padTop">
+                                            <div class="column width100 inlineBlock bold textSmall textRight">Invoking Attribute:</div>
+                                        </div></div>
+                                        <div class="option-action both width60 inlineBlock"><div class="row">
+                                            <div class="column width50 inlineBlock">&nbsp;</div>
+                                            <div class="column width25 inlineBlock bold textSmall">Score</div>
+                                            <div class="column width25 inlineBlock bold textSmall">Dice</div>
+                                            <div class="column inlineBlock inputSelect" style="width: 54%;">
+                                                <select name="attr_name">
+                        							<optgroup label="Select Attribute">
+                        								<option value="None" selected="selected">Select Attribute</option>
+                        							</optgroup>
+                        							<optgroup label="Physical">
+                        								<option value="Agility">Agility</option>
+                        								<option value="Fortitude">Fortitude</option>
+                        								<option value="Might">Might</option>
+                        							</optgroup>
+                        							<optgroup label="Mental">
+                        								<option value="Learning">Learning</option>
+                        								<option value="Logic">Logic</option>
+                        								<option value="Perception">Perception</option>
+                        								<option value="Will">Will</option>
+                        							</optgroup>
+                        							<optgroup label="Social">
+                        								<option value="Deception">Deception</option>
+                        								<option value="Persuasion">Persuasion</option>
+                        								<option value="Presence">Presence</option>
+                        							</optgroup>
+                        							<optgroup label="Extraordinary">
+                        								<option value="Alteration">Alteration</option>
+                        								<option value="Creation">Creation</option>
+                        								<option value="Energy">Energy</option>
+                        								<option value="Entropy">Entropy</option>
+                        								<option value="Influence">Influence</option>
+                        								<option value="Movement">Movement</option>
+                        								<option value="Prescience">Prescience</option>
+                        								<option value="Protection">Protection</option>
+                        							</optgroup>
+                                                </select>
+                                            </div>
+                                            <div class="column inlineBlock textCenter inputNumber30 width15"><input type="number" name="attr_score" value=3 /></div>
+                                            <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                            <div class="column inlineBlock inputDiceType">
+                                                <select name="attr_dice_type">
+                                                    <option value=0>d0</option>
+                                                    <option value=4>d4!!</option>
+                                                    <option value=6>d6!!</option>
+                                                    <option value=8 selected="selected">d8!!</option>
+                                                    <option value=10>d10!!</option>
+                                                    <option value=12>d12!!</option>
+                                                    <option value=20>d20!!</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action attack width100"><div class="row">
+                                            <div class="column width100 bold italic textCenter">vs</div>
+                                            <div class="column inlineBlock bold textSmall textRight" style="width: 37%;">Target Defense:</div>
+                                            <div class="column width60 inlineBlock inputSelect">
+                                                <select name="attr_action_target">
+                                                    <option value="None" selected="selected">None</option>
+                                                    <option value="Guard">Guard</option>
+                                                    <option value="Toughness">Toughness</option>
+                                                    <option value="Resolve">Resolve</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action both"><div class="row">
+                							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+                							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                            <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                            <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                            <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_d20_advantage" value="Yes" /></div>
+                                            <div class="column width75 textSmall bold textLeft inlineBlock"> Advantage on d20 (very Cruel)</div>
+                                        </div></div>
+            
+                                        <div class="option-action effect width100"><div class="row padTop">
+                                            <div class="column width90 inlineBlock borderAllDotted borderRound gray bold textSmall">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                            <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                            <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                            <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                            <div class="column width30 inlineBlock inputSelect">
+                                                <select name="attr_effect_dice_type">
+                                                    <option value="None" selected="selected">Dice Size</option>
+                                                    <option value="d4!!">d4</option>
+                                                    <option value="d6!!">d6</option>
+                                                    <option value="d8!!">d8</option>
+                                                    <option value="d10!!">d10</option>
+                                                    <option value="d12!!">d12</option>
+                                                    <option value="d20!!">d20</option>
+                                                </select>
+                                            </div>
+                                        </div></div>
+            
+                                        <div class="option-action all width100"><div class="row padTop">
+                                            <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                            <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                        </div></div>
+            
+                                        <div class="option-action boon"><div class="row">
+                                            <input type="hidden" name="attr_power_level_low" value="0" />
+                                            <input type="hidden" name="attr_power_level_high" value="0" />
+                                            <div class="column width100 bold">Power Levels Available to Boon</div>
+                                            <div class="column width100 bold textLarge">
+                                                <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                                <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                                <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                                <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                                <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                                <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                                <div class="width100"></div>
+                                                <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                                <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                                <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                                <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                                <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                                <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                                <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                                <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                                <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                            </div>
+                                        </div></div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+            <!-- END Favored Actions -->
+                    </div>
+                </div>
+<!-- END NPC #4 -->
+        <!-- Blank Space between NPCs -->
+                <div class="height5 black width100 marginTop marginBottom"></div>
+        <!-- END Blank Space between NPCs -->
+<!-- NPC #5 -->
+    <!-- LEFT third of NPC 5 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginBottom smallCaps">NPC #5 Information</div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Name</div>
+                    <div class="column width85 inlineBlock textCenter inputName"><input type="text" name="attr_npc5_name" value="Name" /></div>
+                    <div class="column width15 inlineBlock textCenter bold vertBottom">Level</div>
+                    <div class="column width15 inlineBlock textCenter inputName"><input type="text" name="attr_npc5_level" value="1" /></div>
+                    <div class="column width25 inlineBlock textCenter bold vertBottom">Archetype</div>
+                    <div class="column width45 inlineBlock textCenter inputName"><input type="text" name="attr_npc5_archetype" /></div>
+                    <div class="column width100 textLeft bold vertBottom">Description</div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc5_description"></textarea></div>
+                    </div>
+                    <div class="column width100 textLeft bold vertBottom inventoryButton"><button type="roll" name="roll_npc5_inventory" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc5_name}}} {{subTitle=Inventory}} {{description=@{npc5_inventory}}}">Treasure/Inventory</button></div>
+                    <div class="row padBottom">
+                        <div class="column width100 textCenter vertTop resizeVert"><textarea class="width100 height50" name="attr_npc5_inventory"></textarea></div>
+                    </div>
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop marginBottom">Speed</div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc5_speed1_name" value="Ground" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_Npc5_speed1" value=30 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc5_speed2_name" value="Swim" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc5_speed2" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc5_speed3_name" value="Climb" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc5_speed3" value=15 /></div>
+                    <div class="column inlineBlock textCenter inputName width25"><input type="text" name="attr_npc5_speed4_name" value="Fly" /></div>
+                    <div class="column width25 inlineBlock inputNumber60"><input type="number" name="attr_npc5_speed4" value=0 /></div>
+                </div>
+    <!-- MIDDLE third of NPC 5 -->
+                <div class="third inlineBlock vertTop">
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Primary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- 1st Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc5_attribute1" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc5_prime_attribute1_name} Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Score of @{npc5_prime_attribute1_score}}} @{npc5_prime_attribute1_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc5_prime_attribute1_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc5_prime_attribute1_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute1_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc5_prime_attribute1_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc5_prime_attribute1_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 1st Attribute -->
+        <!-- 2nd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc5_attribute2" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc5_prime_attribute2_name} Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Score of @{npc5_prime_attribute2_score}}} @{npc5_prime_attribute2_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc5_prime_attribute2_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc5_prime_attribute2_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute2_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc5_prime_attribute2_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc5_prime_attribute2_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute2_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 2nd Attribute -->
+        <!-- 3rd Attribute -->
+                    <div class="row">
+                        <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc5_attribute3" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{npc5_prime_attribute3_name} Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Score of @{npc5_prime_attribute3_score}}} @{npc5_prime_attribute3_roll}">Roll</button></div>
+                        <div class="column width45 inlineBlock inputSelect">
+                            <select name="attr_npc5_prime_attribute3_name">
+    							<optgroup label="Select Attribute">
+    								<option value="None" selected="selected">Select Attribute</option>
+    							</optgroup>
+    							<optgroup label="Physical">
+    								<option value="Agility">Agility</option>
+    								<option value="Fortitude">Fortitude</option>
+    								<option value="Might">Might</option>
+    							</optgroup>
+    							<optgroup label="Mental">
+    								<option value="Learning">Learning</option>
+    								<option value="Logic">Logic</option>
+    								<option value="Perception">Perception</option>
+    								<option value="Will">Will</option>
+    							</optgroup>
+    							<optgroup label="Social">
+    								<option value="Deception">Deception</option>
+    								<option value="Persuasion">Persuasion</option>
+    								<option value="Presence">Presence</option>
+    							</optgroup>
+    							<optgroup label="Extraordinary">
+    								<option value="Alteration">Alteration</option>
+    								<option value="Creation">Creation</option>
+    								<option value="Energy">Energy</option>
+    								<option value="Entropy">Entropy</option>
+    								<option value="Influence">Influence</option>
+    								<option value="Movement">Movement</option>
+    								<option value="Prescience">Prescience</option>
+    								<option value="Protection">Protection</option>
+    							</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_npc5_prime_attribute3_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute3_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc5_prime_attribute3_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc5_prime_attribute3_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_prime_attribute1_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END 3rd Attribute -->
+        <!-- Initiative -->
+                    <div class="row">
+                        <div class="column width55 inlineBlock textLarge speedButton"><button type="roll" name="roll_npc5_initiative" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Initiative Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Score of @{npc5_initiative_score}}} @{npc5_initiative_roll} {{description=Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                        <input type="hidden" name="attr_npc5_initiative_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d10!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_initiative_score" value=4 /></div>
+                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_npc5_initiative_dice_number" value="1" /></div>
+                        <div class="column inlineBlock inputDiceType">
+                            <select name="attr_npc5_initiative_dice_type">
+                                <option value=0>d0</option>
+                                <option value=4>d4!!</option>
+                                <option value=6>d6!!</option>
+                                <option value=8>d8!!</option>
+                                <option value=10 selected="selected">d10!!</option>
+                                <option value=12>d12!!</option>
+                                <option value=20>d20!!</option>
+                            </select>
+                        </div>
+                        <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_npc5_initiative_default_advantage" value=0 /></div>
+                    </div>
+        <!-- END Initiative -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Secondary Attributes</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width60">Attribute Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width10">Score</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Dice</div>
+                    <div class="column inlineBlock textCenter textSmall bold width15">Adv/Dis</div>
+        <!-- END TITLES -->
+        <!-- Repeating Secondary Attributes -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc5secondary">
+                            <div class="row">
+                                <div class="column width10 inlineBlock vertMiddle textSmall attributeButton silver borderAll"><button type="roll" name="roll_npc5_secondary_attribute" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=@{name} Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Score of @{score}}} @{roll}">Roll</button></div>
+                                <div class="column width45 inlineBlock inputSelect">
+                                    <select name="attr_name">
+            							<optgroup label="Select Attribute">
+            								<option value="None" selected="selected">Select Attribute</option>
+            							</optgroup>
+            							<optgroup label="Physical">
+            								<option value="Agility">Agility</option>
+            								<option value="Fortitude">Fortitude</option>
+            								<option value="Might">Might</option>
+            							</optgroup>
+            							<optgroup label="Mental">
+            								<option value="Learning">Learning</option>
+            								<option value="Logic">Logic</option>
+            								<option value="Perception">Perception</option>
+            								<option value="Will">Will</option>
+            							</optgroup>
+            							<optgroup label="Social">
+            								<option value="Deception">Deception</option>
+            								<option value="Persuasion">Persuasion</option>
+            								<option value="Presence">Presence</option>
+            							</optgroup>
+            							<optgroup label="Extraordinary">
+            								<option value="Alteration">Alteration</option>
+            								<option value="Creation">Creation</option>
+            								<option value="Energy">Energy</option>
+            								<option value="Entropy">Entropy</option>
+            								<option value="Influence">Influence</option>
+            								<option value="Movement">Movement</option>
+            								<option value="Prescience">Prescience</option>
+            								<option value="Protection">Protection</option>
+            							</optgroup>
+                                    </select>
+                                </div>
+                                <input type="hidden" name="attr_roll" value="{{roll=[[1d20!! + [[1+?{# of Advantage/Disadvantage Dice|0}]]d8!!k?{Do you have Advantage or Disadvantage?|Neither/Advantage,[[1]]|Disadvantage,l[[1]]}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}}" />     <!-- hidden value of the roll button string -->
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_score" value=3 /></div>
+                                <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                <div class="column inlineBlock inputDiceType">
+                                    <select name="attr_dice_type">
+                                        <option value=0>d0</option>
+                                        <option value=4>d4!!</option>
+                                        <option value=6>d6!!</option>
+                                        <option value=8 selected="selected">d8!!</option>
+                                        <option value=10>d10!!</option>
+                                        <option value=12>d12!!</option>
+                                        <option value=20>d20!!</option>
+                                    </select>
+                                </div>
+                                <div class="column inlineBlock textCenter inputNumber30 width10"><input type="number" name="attr_default_advantage" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Secondary Attributes -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter marginTop smallCaps">Feats</div>
+        <!-- TITLES -->
+                    <div class="column inlineBlock textCenter textSmall bold width70">Feat Name</div>
+                    <div class="column inlineBlock textCenter textSmall bold width20">Cost</div>
+        <!-- END TITLES -->
+        <!-- Repeating Feats -->
+                    <div class="column width100 vertTop">
+                        <fieldset class="repeating_npc5feats">
+                            <div class="row">
+                                <div class="column inlineBlock textCenter inputName width70"><input type="text" name="attr_name" /></div>
+                                <div class="column inlineBlock textCenter inputNumber30 width20"><input type="number" name="attr_cost" value=0 /></div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Repeating Feats -->
+                </div>
+    <!-- RIGHT third of NPC 5 -->
+                <div class="third inlineBlock vertTop">
+        <!-- Defenses (yep, HP is a defense) -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
+                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width25">Toughness</div>
+                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width25">Resist</div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_guard" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_toughness" value=10 /></div>
+                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_resolve" value=10 /></div>
+                    <div class="column width25 inlineBlock speedButton vertBottom">
+                        <button type="roll" name="roll_npc5_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                        <button type="roll" name="roll_npc5_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
+                        <button type="roll" name="roll_npc5_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                    </div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
+                    <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
+                    <div class="column inlineBlock textCenter bold width1of3">Lethal</div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc5_hp" value=10 /></div>
+                    <div class="column width1of3 inlineBlock inputNumberLargeShort"><input type="number" name="attr_Npc5_hp_max" value=10 /></div>
+                    <input type="hidden" name="attr_npc5_previous_lethal" value=0 />
+                    <div class="column width1of3 inlineBlock inputNumberLargeLethalShort"><input type="number" name="attr_npc5_current_lethal" value=0 /></div>
+        <!-- END Defenses (yep, HP is a defense) -->
+        <!-- Favored Actions -->
+                    <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps marginTop">Favored Actions</div>
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_npc5actions">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <input class="tab-hide" type="checkbox" name="attr_npc5_action_hide" value="on" checked="checked" /><div>y</div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_npc5action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{npc5_name}}} {{subTitleAdd=@{name} @{score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <div class="width100 show-hide">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                <!-- What kind of Action selection -->
+                                    <div class="column padTop">
+                                    <div class="column inlineBlock">This Action is:</div>
+                                    <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                    <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                    <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+        
+                                    <input type="hidden" name="attr_dice_roll" value=0 />
+                                    
+                                    <div class="option-action attack inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Attack Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action boon inlineBlock" style="width: 38%;"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall textRight">Invoking Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action both width60 inlineBlock"><div class="row">
+                                        <div class="column width50 inlineBlock">&nbsp;</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Score</div>
+                                        <div class="column width25 inlineBlock bold textSmall">Dice</div>
+                                        <div class="column inlineBlock inputSelect" style="width: 54%;">
+                                            <select name="attr_name">
+                    							<optgroup label="Select Attribute">
+                    								<option value="None" selected="selected">Select Attribute</option>
+                    							</optgroup>
+                    							<optgroup label="Physical">
+                    								<option value="Agility">Agility</option>
+                    								<option value="Fortitude">Fortitude</option>
+                    								<option value="Might">Might</option>
+                    							</optgroup>
+                    							<optgroup label="Mental">
+                    								<option value="Learning">Learning</option>
+                    								<option value="Logic">Logic</option>
+                    								<option value="Perception">Perception</option>
+                    								<option value="Will">Will</option>
+                    							</optgroup>
+                    							<optgroup label="Social">
+                    								<option value="Deception">Deception</option>
+                    								<option value="Persuasion">Persuasion</option>
+                    								<option value="Presence">Presence</option>
+                    							</optgroup>
+                    							<optgroup label="Extraordinary">
+                    								<option value="Alteration">Alteration</option>
+                    								<option value="Creation">Creation</option>
+                    								<option value="Energy">Energy</option>
+                    								<option value="Entropy">Entropy</option>
+                    								<option value="Influence">Influence</option>
+                    								<option value="Movement">Movement</option>
+                    								<option value="Prescience">Prescience</option>
+                    								<option value="Protection">Protection</option>
+                    							</optgroup>
+                                            </select>
+                                        </div>
+                                        <div class="column inlineBlock textCenter inputNumber30 width15"><input type="number" name="attr_score" value=3 /></div>
+                                        <div class="column inlineBlock inputDiceNum"><input type="text" name="attr_dice_number" value="1" /></div>
+                                        <div class="column inlineBlock inputDiceType">
+                                            <select name="attr_dice_type">
+                                                <option value=0>d0</option>
+                                                <option value=4>d4!!</option>
+                                                <option value=6>d6!!</option>
+                                                <option value=8 selected="selected">d8!!</option>
+                                                <option value=10>d10!!</option>
+                                                <option value=12>d12!!</option>
+                                                <option value=20>d20!!</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action attack width100"><div class="row">
+                                        <div class="column width100 bold italic textCenter">vs</div>
+                                        <div class="column inlineBlock bold textSmall textRight" style="width: 37%;">Target Defense:</div>
+                                        <div class="column width60 inlineBlock inputSelect">
+                                            <select name="attr_action_target">
+                                                <option value="None" selected="selected">None</option>
+                                                <option value="Guard">Guard</option>
+                                                <option value="Toughness">Toughness</option>
+                                                <option value="Resolve">Resolve</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action both"><div class="row">
+            							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+            							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_d20_advantage" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Advantage on d20 (very Cruel)</div>
+                                    </div></div>
+        
+                                    <div class="option-action effect width100"><div class="row padTop">
+                                        <div class="column width90 inlineBlock borderAllDotted borderRound gray bold textSmall">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputSelect">
+                                            <select name="attr_effect_dice_type">
+                                                <option value="None" selected="selected">Dice Size</option>
+                                                <option value="d4!!">d4</option>
+                                                <option value="d6!!">d6</option>
+                                                <option value="d8!!">d8</option>
+                                                <option value="d10!!">d10</option>
+                                                <option value="d12!!">d12</option>
+                                                <option value="d20!!">d20</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action all width100"><div class="row padTop">
+                                        <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                        <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                    </div></div>
+        
+                                    <div class="option-action boon"><div class="row">
+                                        <input type="hidden" name="attr_power_level_low" value="0" />
+                                        <input type="hidden" name="attr_power_level_high" value="0" />
+                                        <div class="column width100 bold">Power Levels Available to Boon</div>
+                                        <div class="column width100 bold textLarge">
+                                            <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                            <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                            <div class="width100"></div>
+                                            <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                            <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                            <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                            <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                            <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                            <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                            <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                            <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                            <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                        </div>
+                                    </div></div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+        <!-- END Favored Actions -->
+                </div>
+<!-- END NPC #5 -->
             </div>
-            <div class="row padBottom">
-                <div class="column width30 inlineBlock textCenter vertBottom bold">Total Points</div>   <!-- Track how many points you have TO spend -->
-                <div class="column width20 inlineBlock textCenter vertBottom inputNumber60"><input type="number" name="attr_attribute_points" value=40 /></div>
-                <div class="column width30 inlineBlock textCenter vertBottom bold">Points Spent</div>   <!-- Track how many points you HAVE spent -->
-                <div class="column width20 inlineBlock textCenter vertBottom inputNumber60"><input type="number" name="attr_attribute_points_spent" value=0 /></div>
-            </div>
-        <!-- Physical Attributes -->
-            <div class="column width100 textLeft bold textLarger gray">PHYSICAL</div>
-          <!-- Header Area -->
-            <div class="row width100">
-                <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
-                </div>
-            </div>
-          <!-- Agility -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_agility_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="agility_display_sub_flag" name="attr_agility_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Agility Roll}} {{subTitle= @{character_name}}} {{roll= @{agility_dice_roll}}}">Agility</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_agility_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_agility_cost" value="@{agility_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_agility_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_agility_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="agility_display_settings_flag" name="attr_agility_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Dodge attacks, move with stealth, perform acrobatics, shoot a bow, pick a pocket</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_agility_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_agility_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_agility_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Agility.</div>
-                </div>
-            </div>
-          <!-- Fortitude -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_fortitude_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="agility_display_sub_flag" name="attr_fortitude_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Fortitude Roll}} {{subTitle= @{character_name}}} {{roll= @{fortitude_dice_roll}}}">Fortitude</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_fortitude_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_fortitude_cost" value="@{fortitude_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_fortitude_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_fortitude_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="fortitude_display_settings_flag" name="attr_fortitude_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, survive in a desert, wear heavy armor</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_fortitude_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_fortitude_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_fortitude_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
-                </div>
-            </div>
-          <!-- Might -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_might_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="agility_display_sub_flag" name="attr_might_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Might Roll}} {{subTitle= @{character_name}}} {{roll= @{might_dice_roll}}}">Might</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_might_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_might_cost" value="@{might_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_might_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_might_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="might_display_settings_flag" name="attr_might_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_might_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_might_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_might_substitution" value=0 />
-                    <div class="column width90 inlineBlock">Substitution affects Max Heavy Carry</div>
-                    <div class="column width10 inlineBlock"><input type="checkbox" class="checks25" name="attr_might_substitution_heavy" /></div>
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Might.</div>
-                </div>
-            </div>
-        <!-- end of physical attributes -->
-        <!-- Mental Attributes -->
-            <div class="column width100 textLeft bold textLarger gray">MENTAL</div>
-          <!-- Header Area -->
-            <div class="row width100">
-                <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
-                </div>
-            </div>
-          <!-- Learning -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_learning_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="learning_display_sub_flag" name="attr_learning_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Learning Roll}} {{subTitle= @{character_name}}} {{roll= @{learning_dice_roll}}}">Learning</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_learning_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_learning_cost" value="@{learning_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_learning_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_learning_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="learning_display_settings_flag" name="attr_learning_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Recall facts about history, arcane magic, the natural world, or any information you picked up from an external source</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_learning_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_learning_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_learning_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Learning.</div>
-                </div>
-            </div>
-          <!-- Logic -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_logic_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="logic_display_sub_flag" name="attr_logic_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Logic Roll}} {{subTitle= @{character_name}}} {{roll= @{logic_dice_roll}}}">Logic</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_logic_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_logic_cost" value="@{logic_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_logic_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_logic_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="logic_display_settings_flag" name="attr_logic_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Innovate a new crafting method, decipher a code, jury-rig a device, get the gist of a language you don’t speak</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_logic_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_logic_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_logic_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Logic.</div>
-                </div>
-            </div>
-          <!-- Perception -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_perception_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="perception_display_sub_flag" name="attr_perception_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Perception Roll}} {{subTitle= @{character_name}}} {{roll= @{perception_dice_roll}}}">Perception</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_perception_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_perception_cost" value="@{perception_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_perception_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_perception_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="perception_display_settings_flag" name="attr_perception_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_perception_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_perception_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_perception_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Perception.</div>
-                </div>
-            </div>
-          <!-- Will -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_will_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="will_display_sub_flag" name="attr_will_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Will Roll}} {{subTitle= @{character_name}}} {{roll= @{will_dice_roll}}}">Will</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_will_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_will_cost" value="@{will_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_will_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_will_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="will_display_settings_flag" name="attr_will_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Maintain your resolve, resist torture, study long hours, stay awake on watch, stave off insanity</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_will_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_will_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_will_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Will.</div>
-                </div>
-            </div>
-        <!-- end mental attributes -->
-        <!-- Social Attributes -->
-            <div class="column width100 textLeft bold textLarger gray">SOCIAL</div>
-          <!-- Header Area -->
-            <div class="row width100">
-                <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
-                </div>
-            </div>
-          <!-- Deception -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_deception_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="deception_display_sub_flag" name="attr_deception_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Deception Roll}} {{subTitle= @{character_name}}} {{roll= @{deception_dice_roll}}}">Deception</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_deception_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_deception_cost" value="@{deception_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_deception_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_deception_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="deception_display_settings_flag" name="attr_deception_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Tell a lie, bluff at cards, disguise yourself, spread rumors, swindle a sucker</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_deception_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_deception_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_deception_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Deception.</div>
-                </div>
-            </div>
-          <!-- Persuasion -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_persuasion_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="persuasion_display_sub_flag" name="attr_persuasion_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Persuasion Roll}} {{subTitle= @{character_name}}} {{roll= @{persuasion_dice_roll}}}">Persuasion</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_persuasion_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_persuasion_cost" value="@{persuasion_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_persuasion_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_persuasion_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="persuasion_display_settings_flag" name="attr_persuasion_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Negotiate a deal, convince someone, haggle a good price, pry information</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_persuasion_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_persuasion_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_persuasion_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Persuasion.</div>
-                </div>
-            </div>
-          <!-- Presence -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_presence_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="presence_display_sub_flag" name="attr_presence_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Presence Roll}} {{subTitle= @{character_name}}} {{roll= @{presence_dice_roll}}}">Presence</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_presence_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_presence_cost" value="@{presence_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_presence_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_presence_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="presence_display_settings_flag" name="attr_presence_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Give a speech, sing a song, inspire an army, exert your force of personality, have luck smile upon you</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_presence_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_presence_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_presence_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Presence.</div>
-                </div>
-            </div>
-        <!-- end of Social attributes -->
-        <!-- Extraordinary Attributes -->
-            <div class="column width100 textLeft bold textLarger gray">EXTRAORDINARY</div>
-          <!-- Header Area -->
-            <div class="row width100">
-                <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
-                    <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
-                </div>
-            </div>
-          <!-- Alteration -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_alteration_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="alteration_display_sub_flag" name="attr_alteration_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Alteration Roll}} {{subTitle= @{character_name}}} {{roll= @{alteration_dice_roll}}}">Alteration</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_alteration_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_alteration_cost" value="@{alteration_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_alteration_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_alteration_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="alteration_display_settings_flag" name="attr_alteration_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Change shape, alter molecular structures, transmute one material into another</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_alteration_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_alteration_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_alteration_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Alteration.</div>
-                </div>
-            </div>
-          <!-- Creation -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_creation_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="creation_display_sub_flag" name="attr_creation_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Creation Roll}} {{subTitle= @{character_name}}} {{roll= @{creation_dice_roll}}}">Creation</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_creation_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_creation_cost" value="@{creation_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_creation_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_creation_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="creation_display_settings_flag" name="attr_creation_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Channel higher powers, manifest something from nothing, regenerate, divinely bolster</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_creation_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_creation_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_creation_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Creation.</div>
-                </div>
-            </div>
-          <!-- Energy -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_energy_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="energy_display_sub_flag" name="attr_energy_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Energy Roll}} {{subTitle= @{character_name}}} {{roll= @{energy_dice_roll}}}">Energy</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_energy_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_energy_cost" value="@{energy_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_energy_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_energy_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="energy_display_settings_flag" name="attr_energy_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Create and control the elements—fire, cold, electricity</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_energy_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_energy_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_energy_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Energy.</div>
-                </div>
-            </div>
-          <!-- Entropy -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_entropy_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="entropy_display_sub_flag" name="attr_entropy_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Entropy Roll}} {{subTitle= @{character_name}}} {{roll= @{entropy_dice_roll}}}">Entropy</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_entropy_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_entropy_cost" value="@{entropy_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_entropy_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_entropy_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="entropy_display_settings_flag" name="attr_entropy_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Disintegrate matter, kill with a word, create undead, sicken others</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_entropy_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_entropy_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_entropy_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Entropy.</div>
-                </div>
-            </div>
-          <!-- Influence -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_influence_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="influence_display_sub_flag" name="attr_influence_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Influence Roll}} {{subTitle= @{character_name}}} {{roll= @{influence_dice_roll}}}">Influence</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_influence_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_influence_cost" value="@{influence_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_influence_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_influence_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="influence_display_settings_flag" name="attr_influence_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Control the minds of others, speak telepathically, instill fear, create illusory figments, cloak with invisibility</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_influence_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_influence_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_influence_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Influence.</div>
-                </div>
-            </div>
-          <!-- Movement -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_movement_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="movement_display_sub_flag" name="attr_movement_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Movement Roll}} {{subTitle= @{character_name}}} {{roll= @{movement_dice_roll}}}">Movement</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_movement_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_movement_cost" value="@{movement_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_movement_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_movement_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="movement_display_settings_flag" name="attr_movement_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Teleport, fly, hasten, telekinetically push</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_movement_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_movement_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_movement_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Movement.</div>
-                </div>
-            </div>
-          <!-- Prescience -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_prescience_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="prescience_display_sub_flag" name="attr_prescience_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Prescience Roll}} {{subTitle= @{character_name}}} {{roll= @{prescience_dice_roll}}}">Prescience</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_prescience_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_prescience_cost" value="@{prescience_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_prescience_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_prescience_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="prescience_display_settings_flag" name="attr_prescience_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">See the future, read minds or auras, view from afar, detect magic or evil, communicate with extraplanar entities</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_prescience_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_prescience_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_prescience_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Prescience.</div>
-                </div>
-            </div>
-          <!-- Protection -->
-            <div class="row width100">
-                <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_protection_settings_flag" value="on" /><span>y</span></div>
-                <input type="hidden" class="protection_display_sub_flag" name="attr_protection_display_sub_flag" value="hide" />
-                <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
-                    <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Protection Roll}} {{subTitle= @{character_name}}} {{roll= @{protection_dice_roll}}}">Protection</button>
-                </div>
-                <div class="width55 inlineBlock">
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_protection_score" value=0 /></div>
-                    <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_protection_cost" value="@{protection_cost}" disabled="disabled" /></div>
-                    <input type="hidden" name="attr_protection_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
-                    <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_protection_dice" value=0 /></div>
-                </div>
-                <input type="hidden" class="protection_display_settings_flag" name="attr_protection_display_settings_flag" value="hide" />
-                <div class="width100 displaySettings padBottom">
-                    <div class="column width95 inlineBlock boxShadow textSmall">Protect from damage, break supernatural influence, dispel magic, exile extradimensional beings</div>
-                    <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_dice_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_cost_modifier" value=0 /></div>
-                    <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
-                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_default_advantage" value=0 /></div>
-                    <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_protection_dice_d20">
-                            <option value="1d20!!" selected="selected">Normal</option>
-                            <option value="2d20!!kh1">Advantage</option>
-                            <option value="2d20!!kl1">Disadvantage</option>
-                        </select>
-                    </div>
-                    <div class="column width60 inlineBlock">Attribute Substitution:</div>
-                    <div class="column width40 inlineBlock inputSelect">
-                        <select name="attr_protection_substitution_select">
-    						<optgroup label="Select Attribute">
-    							<option value="None" selected="selected">No Substitution</option>
-    						</optgroup>
-    						<optgroup label="Physical">
-    							<option value="Agility">Agility</option>
-    							<option value="Fortitude">Fortitude</option>
-    							<option value="Might">Might</option>
-    						</optgroup>
-    						<optgroup label="Mental">
-    							<option value="Learning">Learning</option>
-    							<option value="Logic">Logic</option>
-    							<option value="Perception">Perception</option>
-    							<option value="Will">Will</option>
-    						</optgroup>
-    						<optgroup label="Social">
-    							<option value="Deception">Deception</option>
-    							<option value="Persuasion">Persuasion</option>
-    							<option value="Presence">Presence</option>
-    						</optgroup>
-    						<optgroup label="Extraordinary">
-    							<option value="Alteration">Alteration</option>
-    							<option value="Creation">Creation</option>
-    							<option value="Energy">Energy</option>
-    							<option value="Entropy">Entropy</option>
-    							<option value="Influence">Influence</option>
-    							<option value="Movement">Movement</option>
-    							<option value="Prescience">Prescience</option>
-    							<option value="Protection">Protection</option>
-    						</optgroup>
-                        </select>
-                    </div>
-                    <input type="hidden" name="attr_protection_substitution" value=0 />
-                    <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
-    				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Protection.</div>
-                </div>
-            </div>
-        <!-- end of EXTRAORDINARY attributes -->
         </div>
-     <!-- end of left column for Attributes -->
-    <div class="twoThird inlineBlock">
-     <!-- Middle column for defenses & actions -->
-        <input type="hidden" class="display_defenses_flag" name="attr_display_defenses_flag" value="show" />
-        <div class="third inlineBlock vertTop displayDefenses">
-       <!-- Guard information -->
-            <div class="width100 padAll">
-                <div class="evasion vertTop padTop">
-                    <div class="inlineBlock vertTop" style="width: 155px;">
-                        <div class="column width100 textCenter resistButton">
-                            <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Guard</button>
-                        </div>
-                        <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
-                        <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Guard" value=0 /></div>
-    					<input type="hidden" name="attr_evasion" value=0 />
+<!-- END NPC Tab -->
+        <div class="displaySheetCharacter main width100">
+            <div class="row">
+         <!-- Left Column for Attributes -->
+           <!-- Attributes are setup so that clicking the name of the attribute will roll it -->
+            <input type="hidden" class="display_attributes_flag" name="attr_display_attributes_flag" value="show" />
+            <div class="third inlineBlock vertTop displayAttributes">
+                <div class="attributes padTop">
+                    <div class="width100 height5"></div>
+                    <div class="column width100 textLargest bold">Attributes</div>
+                </div>
+                <div class="row padBottom">
+                    <div class="column width30 inlineBlock textCenter vertBottom bold">Total Points</div>   <!-- Track how many points you have TO spend -->
+                    <div class="column width20 inlineBlock textCenter vertBottom inputNumber60"><input type="number" name="attr_attribute_points" value=40 /></div>
+                    <div class="column width30 inlineBlock textCenter vertBottom bold">Points Spent</div>   <!-- Track how many points you HAVE spent -->
+                    <div class="column width20 inlineBlock textCenter vertBottom inputNumber60"><input type="number" name="attr_attribute_points_spent" value=0 /></div>
+                </div>
+            <!-- Physical Attributes -->
+                <div class="column width100 textLeft bold textLarger gray">PHYSICAL</div>
+              <!-- Header Area -->
+                <div class="row width100">
+                    <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
                     </div>
-                    <div class="inlineBlock vertTop" style="width: 120px;">
-                        <div class="width100">
-                            <div class="column width100 height5"></div>
-    						<input type="hidden" name="attr_agility_display" value=0 />
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_agility_score" value="@{agility_display}" disabled="disabled" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock">Agility</div>
-    						<input type="hidden" name="attr_might_display" value=0 />
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_might_score" value="@{might_display}" disabled="disabled" /></div>
-                            <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Might</div>
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_armor" value=0 /></div>
-                            <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Armor</div>
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_evasion_other" value="0" /></div>
-                            <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Other</div>
+                </div>
+              <!-- Agility -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_agility_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="agility_display_sub_flag" name="attr_agility_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Agility Roll}} {{subTitle= @{character_name}}} {{roll= @{agility_dice_roll}}}">Agility</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_agility_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_agility_cost" value="@{agility_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_agility_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_agility_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="agility_display_settings_flag" name="attr_agility_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Dodge attacks, move with stealth, perform acrobatics, shoot a bow, pick a pocket</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_agility_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_agility_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_agility_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Agility.</div>
+                    </div>
+                </div>
+              <!-- Fortitude -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_fortitude_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="agility_display_sub_flag" name="attr_fortitude_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Fortitude Roll}} {{subTitle= @{character_name}}} {{roll= @{fortitude_dice_roll}}}">Fortitude</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_fortitude_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_fortitude_cost" value="@{fortitude_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_fortitude_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_fortitude_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="fortitude_display_settings_flag" name="attr_fortitude_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, survive in a desert, wear heavy armor</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_fortitude_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_fortitude_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_fortitude_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
+                    </div>
+                </div>
+              <!-- Might -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_might_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="agility_display_sub_flag" name="attr_might_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Might Roll}} {{subTitle= @{character_name}}} {{roll= @{might_dice_roll}}}">Might</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_might_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_might_cost" value="@{might_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_might_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_might_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="might_display_settings_flag" name="attr_might_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_might_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_might_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_might_substitution" value=0 />
+                        <div class="column width90 inlineBlock">Substitution affects Max Heavy Carry</div>
+                        <div class="column width10 inlineBlock"><input type="checkbox" class="checks25" name="attr_might_substitution_heavy" /></div>
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Might.</div>
+                    </div>
+                </div>
+            <!-- end of physical attributes -->
+            <!-- Mental Attributes -->
+                <div class="column width100 textLeft bold textLarger gray">MENTAL</div>
+              <!-- Header Area -->
+                <div class="row width100">
+                    <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
+                    </div>
+                </div>
+              <!-- Learning -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_learning_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="learning_display_sub_flag" name="attr_learning_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Learning Roll}} {{subTitle= @{character_name}}} {{roll= @{learning_dice_roll}}}">Learning</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_learning_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_learning_cost" value="@{learning_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_learning_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_learning_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="learning_display_settings_flag" name="attr_learning_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Recall facts about history, arcane magic, the natural world, or any information you picked up from an external source</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_learning_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_learning_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_learning_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Learning.</div>
+                    </div>
+                </div>
+              <!-- Logic -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_logic_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="logic_display_sub_flag" name="attr_logic_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Logic Roll}} {{subTitle= @{character_name}}} {{roll= @{logic_dice_roll}}}">Logic</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_logic_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_logic_cost" value="@{logic_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_logic_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_logic_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="logic_display_settings_flag" name="attr_logic_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Innovate a new crafting method, decipher a code, jury-rig a device, get the gist of a language you don’t speak</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_logic_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_logic_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_logic_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Logic.</div>
+                    </div>
+                </div>
+              <!-- Perception -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_perception_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="perception_display_sub_flag" name="attr_perception_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Perception Roll}} {{subTitle= @{character_name}}} {{roll= @{perception_dice_roll}}}">Perception</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_perception_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_perception_cost" value="@{perception_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_perception_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_perception_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="perception_display_settings_flag" name="attr_perception_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_perception_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_perception_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_perception_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Perception.</div>
+                    </div>
+                </div>
+              <!-- Will -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_will_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="will_display_sub_flag" name="attr_will_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Will Roll}} {{subTitle= @{character_name}}} {{roll= @{will_dice_roll}}}">Will</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_will_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_will_cost" value="@{will_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_will_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_will_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="will_display_settings_flag" name="attr_will_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Maintain your resolve, resist torture, study long hours, stay awake on watch, stave off insanity</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_will_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_will_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_will_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Will.</div>
+                    </div>
+                </div>
+            <!-- end mental attributes -->
+            <!-- Social Attributes -->
+                <div class="column width100 textLeft bold textLarger gray">SOCIAL</div>
+              <!-- Header Area -->
+                <div class="row width100">
+                    <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
+                    </div>
+                </div>
+              <!-- Deception -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_deception_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="deception_display_sub_flag" name="attr_deception_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Deception Roll}} {{subTitle= @{character_name}}} {{roll= @{deception_dice_roll}}}">Deception</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_deception_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_deception_cost" value="@{deception_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_deception_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_deception_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="deception_display_settings_flag" name="attr_deception_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Tell a lie, bluff at cards, disguise yourself, spread rumors, swindle a sucker</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_deception_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_deception_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_deception_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Deception.</div>
+                    </div>
+                </div>
+              <!-- Persuasion -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_persuasion_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="persuasion_display_sub_flag" name="attr_persuasion_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Persuasion Roll}} {{subTitle= @{character_name}}} {{roll= @{persuasion_dice_roll}}}">Persuasion</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_persuasion_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_persuasion_cost" value="@{persuasion_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_persuasion_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_persuasion_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="persuasion_display_settings_flag" name="attr_persuasion_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Negotiate a deal, convince someone, haggle a good price, pry information</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_persuasion_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_persuasion_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_persuasion_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Persuasion.</div>
+                    </div>
+                </div>
+              <!-- Presence -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_presence_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="presence_display_sub_flag" name="attr_presence_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Presence Roll}} {{subTitle= @{character_name}}} {{roll= @{presence_dice_roll}}}">Presence</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_presence_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_presence_cost" value="@{presence_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_presence_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_presence_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="presence_display_settings_flag" name="attr_presence_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Give a speech, sing a song, inspire an army, exert your force of personality, have luck smile upon you</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_presence_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_presence_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_presence_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Presence.</div>
+                    </div>
+                </div>
+            <!-- end of Social attributes -->
+            <!-- Extraordinary Attributes -->
+                <div class="column width100 textLeft bold textLarger gray">EXTRAORDINARY</div>
+              <!-- Header Area -->
+                <div class="row width100">
+                    <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Score</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Cost</div>
+                        <div class="column width1of3 inlineBlock textCenter bold italic">Dice</div>
+                    </div>
+                </div>
+              <!-- Alteration -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_alteration_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="alteration_display_sub_flag" name="attr_alteration_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Alteration Roll}} {{subTitle= @{character_name}}} {{roll= @{alteration_dice_roll}}}">Alteration</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_alteration_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_alteration_cost" value="@{alteration_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_alteration_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_alteration_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="alteration_display_settings_flag" name="attr_alteration_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Change shape, alter molecular structures, transmute one material into another</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_alteration_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_alteration_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_alteration_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Alteration.</div>
+                    </div>
+                </div>
+              <!-- Creation -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_creation_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="creation_display_sub_flag" name="attr_creation_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Creation Roll}} {{subTitle= @{character_name}}} {{roll= @{creation_dice_roll}}}">Creation</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_creation_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_creation_cost" value="@{creation_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_creation_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_creation_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="creation_display_settings_flag" name="attr_creation_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Channel higher powers, manifest something from nothing, regenerate, divinely bolster</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_creation_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_creation_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_creation_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Creation.</div>
+                    </div>
+                </div>
+              <!-- Energy -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_energy_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="energy_display_sub_flag" name="attr_energy_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Energy Roll}} {{subTitle= @{character_name}}} {{roll= @{energy_dice_roll}}}">Energy</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_energy_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_energy_cost" value="@{energy_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_energy_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_energy_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="energy_display_settings_flag" name="attr_energy_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Create and control the elements—fire, cold, electricity</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_energy_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_energy_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_energy_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Energy.</div>
+                    </div>
+                </div>
+              <!-- Entropy -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_entropy_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="entropy_display_sub_flag" name="attr_entropy_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Entropy Roll}} {{subTitle= @{character_name}}} {{roll= @{entropy_dice_roll}}}">Entropy</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_entropy_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_entropy_cost" value="@{entropy_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_entropy_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_entropy_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="entropy_display_settings_flag" name="attr_entropy_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Disintegrate matter, kill with a word, create undead, sicken others</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_entropy_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_entropy_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_entropy_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Entropy.</div>
+                    </div>
+                </div>
+              <!-- Influence -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_influence_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="influence_display_sub_flag" name="attr_influence_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Influence Roll}} {{subTitle= @{character_name}}} {{roll= @{influence_dice_roll}}}">Influence</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_influence_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_influence_cost" value="@{influence_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_influence_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_influence_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="influence_display_settings_flag" name="attr_influence_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Control the minds of others, speak telepathically, instill fear, create illusory figments, cloak with invisibility</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_influence_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_influence_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_influence_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Influence.</div>
+                    </div>
+                </div>
+              <!-- Movement -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_movement_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="movement_display_sub_flag" name="attr_movement_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Movement Roll}} {{subTitle= @{character_name}}} {{roll= @{movement_dice_roll}}}">Movement</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_movement_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_movement_cost" value="@{movement_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_movement_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_movement_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="movement_display_settings_flag" name="attr_movement_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Teleport, fly, hasten, telekinetically push</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_movement_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_movement_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_movement_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Movement.</div>
+                    </div>
+                </div>
+              <!-- Prescience -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_prescience_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="prescience_display_sub_flag" name="attr_prescience_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Prescience Roll}} {{subTitle= @{character_name}}} {{roll= @{prescience_dice_roll}}}">Prescience</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_prescience_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_prescience_cost" value="@{prescience_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_prescience_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_prescience_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="prescience_display_settings_flag" name="attr_prescience_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">See the future, read minds or auras, view from afar, detect magic or evil, communicate with extraplanar entities</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_prescience_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_prescience_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_prescience_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Prescience.</div>
+                    </div>
+                </div>
+              <!-- Protection -->
+                <div class="row width100">
+                    <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_protection_settings_flag" value="on" /><span>y</span></div>
+                    <input type="hidden" class="protection_display_sub_flag" name="attr_protection_display_sub_flag" value="hide" />
+                    <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
+                        <button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Protection Roll}} {{subTitle= @{character_name}}} {{roll= @{protection_dice_roll}}}">Protection</button>
+                    </div>
+                    <div class="width55 inlineBlock">
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_protection_score" value=0 /></div>
+                        <div class="column width1of3 inlineBlock textCenter inputNumber"><input type="number" name="attr_show_protection_cost" value="@{protection_cost}" disabled="disabled" /></div>
+                        <input type="hidden" name="attr_protection_dice_roll" value=0 />     <!-- hidden value of the roll button string -->
+                        <div class="column width1of3 inlineBlock textCenter inputDice"><input type="text" style="text-align: center;" name="attr_protection_dice" value=0 /></div>
+                    </div>
+                    <input type="hidden" class="protection_display_settings_flag" name="attr_protection_display_settings_flag" value="hide" />
+                    <div class="width100 displaySettings padBottom">
+                        <div class="column width95 inlineBlock boxShadow textSmall">Protect from damage, break supernatural influence, dispel magic, exile extradimensional beings</div>
+                        <div class="column width75 inlineBlock">Attribute Dice Size Bonus/Penalty:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_dice_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_cost_modifier" value=0 /></div>
+                        <div class="column width75 inlineBlock">Default (Dis)Advantage:</div>
+                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_default_advantage" value=0 /></div>
+                        <div class="column width60 inlineBlock">Your d20 (non-combat rolls):</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_protection_dice_d20">
+                                <option value="1d20!!" selected="selected">Normal</option>
+                                <option value="2d20!!kh1">Advantage</option>
+                                <option value="2d20!!kl1">Disadvantage</option>
+                            </select>
+                        </div>
+                        <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                        <div class="column width40 inlineBlock inputSelect">
+                            <select name="attr_protection_substitution_select">
+        						<optgroup label="Select Attribute">
+        							<option value="None" selected="selected">No Substitution</option>
+        						</optgroup>
+        						<optgroup label="Physical">
+        							<option value="Agility">Agility</option>
+        							<option value="Fortitude">Fortitude</option>
+        							<option value="Might">Might</option>
+        						</optgroup>
+        						<optgroup label="Mental">
+        							<option value="Learning">Learning</option>
+        							<option value="Logic">Logic</option>
+        							<option value="Perception">Perception</option>
+        							<option value="Will">Will</option>
+        						</optgroup>
+        						<optgroup label="Social">
+        							<option value="Deception">Deception</option>
+        							<option value="Persuasion">Persuasion</option>
+        							<option value="Presence">Presence</option>
+        						</optgroup>
+        						<optgroup label="Extraordinary">
+        							<option value="Alteration">Alteration</option>
+        							<option value="Creation">Creation</option>
+        							<option value="Energy">Energy</option>
+        							<option value="Entropy">Entropy</option>
+        							<option value="Influence">Influence</option>
+        							<option value="Movement">Movement</option>
+        							<option value="Prescience">Prescience</option>
+        							<option value="Protection">Protection</option>
+        						</optgroup>
+                            </select>
+                        </div>
+                        <input type="hidden" name="attr_protection_substitution" value=0 />
+                        <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+        				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Protection.</div>
+                    </div>
+                </div>
+            <!-- end of EXTRAORDINARY attributes -->
+            </div>
+         <!-- end of left column for Attributes -->
+        <div class="twoThird inlineBlock">
+         <!-- Middle column for defenses & actions -->
+            <input type="hidden" class="display_defenses_flag" name="attr_display_defenses_flag" value="show" />
+            <div class="third inlineBlock vertTop displayDefenses">
+           <!-- Guard information -->
+                <div class="width100 padAll">
+                    <div class="evasion vertTop padTop">
+                        <div class="inlineBlock vertTop" style="width: 155px;">
+                            <div class="column width100 textCenter resistButton">
+                                <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Guard</button>
+                            </div>
+                            <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
+                            <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Guard" value=0 /></div>
+        					<input type="hidden" name="attr_evasion" value=0 />
+                        </div>
+                        <div class="inlineBlock vertTop" style="width: 120px;">
+                            <div class="width100">
+                                <div class="column width100 height5"></div>
+        						<input type="hidden" name="attr_agility_display" value=0 />
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_agility_score" value="@{agility_display}" disabled="disabled" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock">Agility</div>
+        						<input type="hidden" name="attr_might_display" value=0 />
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_might_score" value="@{might_display}" disabled="disabled" /></div>
+                                <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Might</div>
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_armor" value=0 /></div>
+                                <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Armor</div>
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_evasion_other" value="0" /></div>
+                                <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Other</div>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-       <!-- End Guard -->
-       <!-- Toughness information -->
-            <div class="width100 padAll">
-                <div class="toughness vertTop padTop">
-                    <div class="inlineBlock vertTop" style="width: 155px;">
-                        <div class="column width100 textCenter resistButton">
-                            <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Toughness</button>
+           <!-- End Guard -->
+           <!-- Toughness information -->
+                <div class="width100 padAll">
+                    <div class="toughness vertTop padTop">
+                        <div class="inlineBlock vertTop" style="width: 155px;">
+                            <div class="column width100 textCenter resistButton">
+                                <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Toughness</button>
+                            </div>
+                            <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
+                            <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Toughness" value=0 /></div>
+        					<input type="hidden" name="attr_Toughness4Token" value=0 />
                         </div>
-                        <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
-                        <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Toughness" value=0 /></div>
-    					<input type="hidden" name="attr_Toughness4Token" value=0 />
-                    </div>
-                    <div class="inlineBlock vertTop" style="width: 120px;">
-                        <div class="width100 padTop">
-    						<input type="hidden" name="attr_fortitude_display" value=0 />
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_fortitude_score" value="@{fortitude_display}" disabled="true" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Fortitude</div>
-    						<input type="hidden" name="attr_will_display" value=0 />
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_toughness_other" value="0" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-       <!-- end toughness -->
-       <!-- Resolve information -->
-            <div class="width100 padAll">
-                <div class="resolve vertTop padTop">
-                    <div class="inlineBlock vertTop" style="width: 155px;">
-                        <div class="column width100 textCenter resistButton">
-                            <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Resolve</button>
-                        </div>
-                        <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
-                        <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Resolve" value=0 /></div>
-    					<input type="hidden" name="attr_Resolve4Token" value=0 />
-                    </div>
-                    <div class="inlineBlock vertTop" style="width: 120px;">
-                        <div class="width100 padTop">
-    						<input type="hidden" name="attr_presence_display" value=0 />
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_presence_score" value="@{presence_display}" disabled="true" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Presence</div>
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
-                            <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_resolve_other" value="0" /></div>
-                            <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
+                        <div class="inlineBlock vertTop" style="width: 120px;">
+                            <div class="width100 padTop">
+        						<input type="hidden" name="attr_fortitude_display" value=0 />
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_fortitude_score" value="@{fortitude_display}" disabled="true" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Fortitude</div>
+        						<input type="hidden" name="attr_will_display" value=0 />
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_toughness_other" value="0" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-       <!-- end Resolve -->
-        </div>
-     <!-- end Middle column for defenses & actions -->
-        <input type="hidden" class="display_healthspeed_flag" name="attr_display_healthspeed_flag" value="show" />
-        <div class="third inlineBlock vertTop displayHealthSpeed">
-     <!-- Right column for Health, speed, wealth, feats, perks, and flaws -->
-         <!-- Hit Points Section -->
-            <div class="width50 inlineBlock">
-                <div class="column width50 inlineBlock textCenter bold vertBottom">Level</div>
-                <div class="column width50 inlineBlock textCenter bold vertBottom">XP</div>
-            </div>
-            <div class="column width50 inlineBlock textCenter bold vertBottom">Legend Points</div>
-            <div class="width50 inlineBlock">
-                <div class="column width50 inlineBlock textCenter inputNumber30"><input type="number" name="attr_level" value=1 /></div>
-                <div class="column width50 inlineBlock textCenter inputLevel"><input type="number" name="attr_xp" value=0 /></div>
-            </div>
-            <div class="column width50 inlineBlock textCenter inputNumber60"><input type="number" name="attr_legend_points" value=0 /></div>
-            <div class="hitPoints padTop padBottom">
-                <div class="width100 height25"></div>
-                <div class="column width100 textLargest bold padTop">Hit Points</div>
-                <div class="column width100 textSmall italic bold">Fortitude, Presence, & Will</div>
-                <div class="width100">
-                    <div class="column width30 inlineBlock textLarge italic bold">Current</div>
-                    <div class="column width30 inlineBlock textLarge italic bold">Max</div>
-                    <div class="column width20 inlineBlock textLarge italic bold">Lethal</div>
-                    <div class="column width30 inlineBlock inputNumberLarge"><input type="number" name="attr_HP" value=10 /></div>
-                    <div class="column width30 inlineBlock inputNumberLarge"><input type="number" name="attr_HP_max" value=10 /></div>
-                    <div class="column width20 inlineBlock inputNumberLargeSkinny"><input type="number" name="attr_LethalDamage" value=0 /></div>
-    				<input type="hidden" name="attr_lethal_damage" value=0 />
-    				<input type="hidden" name="attr_hit_point" value=10 /><input type="hidden" name="attr_hit_point_max" value=0 />
-                    <div class="width25 inlineBlock"></div>
-                    <div class="column width30 inlineBlock bold">From Feats</div>
-                    <div class="column width10 inlineBlock inputNumber30"><input type="number" name="attr_hit_point_feats" value=0 /></div>
-                    <div class="width35 inlineBlock"></div>
-                    <div class="width25 inlineBlock"></div>
-                    <div class="column width30 inlineBlock bold">From Other</div>
-                    <div class="column width10 inlineBlock inputNumber30"><input type="number" name="attr_hit_point_other" value=0 /></div>
-                    <div class="width35 inlineBlock"></div>
+           <!-- end toughness -->
+           <!-- Resolve information -->
+                <div class="width100 padAll">
+                    <div class="resolve vertTop padTop">
+                        <div class="inlineBlock vertTop" style="width: 155px;">
+                            <div class="column width100 textCenter resistButton">
+                                <button type="roll" name="roll_resist_bane" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Resolve</button>
+                            </div>
+                            <div class="column width100 textCenter textSmall">Click to roll Resist Bane</div>
+                            <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_Resolve" value=0 /></div>
+        					<input type="hidden" name="attr_Resolve4Token" value=0 />
+                        </div>
+                        <div class="inlineBlock vertTop" style="width: 120px;">
+                            <div class="width100 padTop">
+        						<input type="hidden" name="attr_presence_display" value=0 />
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_presence_score" value="@{presence_display}" disabled="true" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Presence</div>
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
+                                <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_resolve_other" value="0" /></div>
+                                <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
+           <!-- end Resolve -->
             </div>
-         <!-- End Hit Points Section -->
-            <input type="hidden" class="display_sanity_flag" name="attr_display_sanity_flag" value="hide" />
-         <!-- Sanity -->
-    <!-- remove this Line to add Sanity back in (and corresponding 2 other areas)
-            <div class="third inlineBlock vertTop displaySanity">
-             <!-- Sanity Points Section -->
-    <!-- remove this to add Sanity back in (and corresponding 2 other areas)
-                <div class="hitPoints padTop padBottom black">
+         <!-- end Middle column for defenses & actions -->
+            <input type="hidden" class="display_healthspeed_flag" name="attr_display_healthspeed_flag" value="show" />
+            <div class="third inlineBlock vertTop displayHealthSpeed">
+         <!-- Right column for Health, speed, wealth, feats, perks, and flaws -->
+             <!-- Hit Points Section -->
+                <div class="width65 inlineBlock">
+                    <input type="hidden" class="display_sheet_type" name="attr_display_sheet_type" value="character" />
+                    <div class="column width20 inlineBlock textCenter bold vertBottom">Level</div>
+                    <div class="column width20 inlineBlock textCenter bold vertBottom">XP</div>
+                    <div class="displaySheetCompanion3 column width60 inlineBlock bold textCenter textSmall vertBottom">Feat Points Granted</div>
+                </div>
+                <div class="column width35 inlineBlock textCenter bold vertBottom">Legend Points</div>
+                <div class="width65 inlineBlock">
+                    <input type="hidden" class="display_sheet_type" name="attr_display_sheet_type" value="character" />
+                    <div class="column width20 inlineBlock textCenter inputNumber30"><input type="number" name="attr_level" value=1 /></div>
+                    <div class="column width20 inlineBlock textCenter inputLevel"><input type="number" name="attr_xp" value=0 /></div>
+                    <div class="displaySheetCompanion3 column width60 inlineBlock textCenter inputLevel"><input type="number" name="attr_companion_feat_given" value=0 /></div>
+                </div>
+                <div class="column width35 inlineBlock textCenter inputNumber60"><input type="number" name="attr_legend_points" value=0 /></div>
+                <div class="hitPoints padTop padBottom">
                     <div class="width100 height25"></div>
-                    <div class="column width100 textLargest bold padTop">Sanity Points</div>
-                    <div class="column width100 textSmall italic bold">Suggested: 2x(Logic + Presence + Will) + 40</div>
+                    <div class="column width100 textLargest bold padTop">Hit Points</div>
+                    <div class="column width100 textSmall italic bold">Fortitude, Presence, & Will</div>
                     <div class="width100">
-                        <div class="column width50 inlineBlock borderRight textLarge italic bold">Current</div>
-                        <div class="column width50 inlineBlock borderLeft textLarge italic bold">Max</div>
-                        <div class="column width50 inlineBlock borderRight inputNumberLarge"><input type="number" name="attr_sanity_point" value=0 /></div>
-                        <div class="column width50 inlineBlock borderLeft inputNumberLarge"><input type="number" name="attr_sanity_point_max" value=0 /></div>
-                        <div class="column width90 inlineBlock bold">This is Homebrew;<br />NOT officially Core Rules</div>
+                        <div class="column width30 inlineBlock textLarge italic bold">Current</div>
+                        <div class="column width30 inlineBlock textLarge italic bold">Max</div>
+                        <div class="column width20 inlineBlock textLarge italic bold">Lethal</div>
+                        <div class="column width30 inlineBlock inputNumberLarge"><input type="number" name="attr_HP" value=10 /></div>
+                        <div class="column width30 inlineBlock inputNumberLarge"><input type="number" name="attr_HP_max" value=10 /></div>
+                        <div class="column width20 inlineBlock inputNumberLargeLethal"><input type="number" name="attr_LethalDamage" value=0 /></div>
+        				<input type="hidden" name="attr_lethal_damage" value=0 />
+        				<input type="hidden" name="attr_hit_point" value=10 /><input type="hidden" name="attr_hit_point_max" value=0 />
+                        <div class="width25 inlineBlock"></div>
+                        <div class="column width30 inlineBlock bold">From Feats</div>
+                        <div class="column width10 inlineBlock inputNumber30"><input type="number" name="attr_hit_point_feats" value=0 /></div>
+                        <div class="width35 inlineBlock"></div>
+                        <div class="width25 inlineBlock"></div>
+                        <div class="column width30 inlineBlock bold">From Other</div>
+                        <div class="column width10 inlineBlock inputNumber30"><input type="number" name="attr_hit_point_other" value=0 /></div>
+                        <div class="width35 inlineBlock"></div>
                     </div>
                 </div>
-             <!-- End Sanity Points Section -->
-    <!-- remove this to add Sanity back in (and corresponding 2 other areas)
+             <!-- End Hit Points Section -->
+                <input type="hidden" class="display_sanity_flag" name="attr_display_sanity_flag" value="hide" />
+             <!-- Sanity -->
+        <!-- remove this Line to add Sanity back in (and corresponding 2 other areas)
+                <div class="third inlineBlock vertTop displaySanity">
+                 <!-- Sanity Points Section -->
+        <!-- remove this to add Sanity back in (and corresponding 2 other areas)
+                    <div class="hitPoints padTop padBottom black">
+                        <div class="width100 height25"></div>
+                        <div class="column width100 textLargest bold padTop">Sanity Points</div>
+                        <div class="column width100 textSmall italic bold">Suggested: 2x(Logic + Presence + Will) + 40</div>
+                        <div class="width100">
+                            <div class="column width50 inlineBlock borderRight textLarge italic bold">Current</div>
+                            <div class="column width50 inlineBlock borderLeft textLarge italic bold">Max</div>
+                            <div class="column width50 inlineBlock borderRight inputNumberLarge"><input type="number" name="attr_sanity_point" value=0 /></div>
+                            <div class="column width50 inlineBlock borderLeft inputNumberLarge"><input type="number" name="attr_sanity_point_max" value=0 /></div>
+                            <div class="column width90 inlineBlock bold">This is Homebrew;<br />NOT officially Core Rules</div>
+                        </div>
+                    </div>
+                 <!-- End Sanity Points Section -->
+        <!-- remove this to add Sanity back in (and corresponding 2 other areas)
+                </div>
+             <!-- Legend Points & Speed Section -->
+                <div class="column width100 textCenter textLargest bold padTop">Speed</div>
+                <div class="wealth">
+                    <div class="width100 height15"></div>
+                    <div class="column width100 inputNumber60 padTop"><input type="number" name="attr_Speed" value=30 /></div>
+                </div>
+                <div class="column width100 vertTop inputNumber30 textSmall bold">Base <input type="number" name="attr_base_speed" value=30 /> Armor Penalty(ft) <input type="number" name="attr_armor_penalty" value=0 /> Feat(ft) <input type="number" name="attr_armor_training" value=0 /></div>
+        		<input type="hidden" name="attr_Speed4Token" value=0 />
+                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlagInitiative" value="on" checked="checked" /><span>y</span></div>
+                <div class="column width35 inlineBlock textLarge speedButton"><button type="roll" name="roll_initiative" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Initiative Roll}} {{subTitle= @{character_name}}} {{subTitleAdd= @{select_initiative}}} {{roll= @{initiative}}} {{description= Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
+                <input type="hidden" class="displaySettingsFlagInitiative" name="attr_displaySettingsFlagInitiative" />
+                <div class="width100 displaySettingsInitiative padLeft">
+        			<div class="column width50 inlineBlock textSmall bold">Attribute</div>
+        			<div class="column width50 inlineBlock textSmall bold">Default (Dis)Advantage</div>
+                    <input type="hidden" name="attr_initiative" value="@{agility_initiative}" />
+        			<div class="column width50 inlineBlock inputSelect">
+        				<select name="attr_select_initiative">
+                            <optgroup label="Physical">
+        						<option value="Agility" selected="selected">Agility</option>
+        						<option value="Fortitude">Fortitude</option>
+        						<option value="Might">Might</option>
+        					</optgroup>
+                            <optgroup label="Mental">
+        						<option value="Learning">Learning</option>
+        						<option value="Logic">Logic</option>
+        						<option value="Perception">Perception</option>
+        						<option value="Will">Will</option>
+        					</optgroup>
+                            <optgroup label="Social">
+        						<option value="Deception">Deception</option>
+        						<option value="Persuasion">Persuasion</option>
+        						<option value="Presence">Presence</option>
+        					</optgroup>
+                            <optgroup label="Extraordinary">
+        						<option value="Alteration">Alteration</option>
+        						<option value="Creation">Creation</option>
+        						<option value="Energy">Energy</option>
+        						<option value="Entropy">Entropy</option>
+        						<option value="Influence">Influence</option>
+        						<option value="Movement">Movement</option>
+        						<option value="Prescience">Prescience</option>
+        						<option value="Protection">Protection</option>
+        					</optgroup>
+        				</select>
+        			</div>
+        			<div class="column width50 inlineBlock inputNumber30"><input type="number" name="attr_initiative_advantage" value=0 /></div>
+        		</div>
+             <!-- End Legend Points & Speed Section -->
+             <!-- Wealth Level Information -->
+                <div class="column width100 textLargest bold padTop">Wealth Level</div>
+                <div class="wealth">
+                    <div class="width100 height15"></div>
+                    <div class="column width100 inputNumber60 padTop"><input type="number" name="attr_wealth_level" value=2 /></div>
+                </div>
+             <!-- End Wealth Level Information -->
             </div>
-         <!-- Legend Points & Speed Section -->
-            <div class="column width100 textCenter textLargest bold padTop">Speed</div>
-            <div class="wealth">
-                <div class="width100 height15"></div>
-                <div class="column width100 inputNumber60 padTop"><input type="number" name="attr_Speed" value=30 /></div>
+            <input type="hidden" class="display_favoredactions_flag" name="attr_display_favoredactions_flag" value="show" />
+            <div class="third inlineBlock vertTop displayFavoredActions">
+           <!-- Actions Area -->
+                <div class="actionsTop padTop padLeft">
+                    <div class="column width100 textLargest bold textShadow padTop">Favored Actions</div>
+                    <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
+                </div>
+                <div class="actionsMiddle padTop padRight">
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_actions">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
+                                <div class="width85 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd=@{action_attribute} @{attribute_score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings padLeft">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                <!-- What kind of Action selection -->
+                                    <div class="column padTop">
+                                    <div class="inlineBlock">This Action is:</div>
+                                    <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                    <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                    <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+        
+                                    <input type="hidden" name="attr_dice_roll" value=0 />
+        							<input type="hidden" name="attr_attribute_score" value=0 />
+        
+                                    <div class="option-action attack width50 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall">Attack Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action boon width50 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall">Invoking Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action both width45 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock inputSelect">
+                                            <select name="attr_action_attribute">
+            									<optgroup label="Select Attribute">
+            										<option value="None" selected="selected">Select Attribute</option>
+            									</optgroup>
+            									<optgroup label="Physical">
+            										<option value="Agility">Agility</option>
+            										<option value="Fortitude">Fortitude</option>
+            										<option value="Might">Might</option>
+            									</optgroup>
+            									<optgroup label="Mental">
+            										<option value="Learning">Learning</option>
+            										<option value="Logic">Logic</option>
+            										<option value="Perception">Perception</option>
+            										<option value="Will">Will</option>
+            									</optgroup>
+            									<optgroup label="Social">
+            										<option value="Deception">Deception</option>
+            										<option value="Persuasion">Persuasion</option>
+            										<option value="Presence">Presence</option>
+            									</optgroup>
+            									<optgroup label="Extraordinary">
+            										<option value="Alteration">Alteration</option>
+            										<option value="Creation">Creation</option>
+            										<option value="Energy">Energy</option>
+            										<option value="Entropy">Entropy</option>
+            										<option value="Influence">Influence</option>
+            										<option value="Movement">Movement</option>
+            										<option value="Prescience">Prescience</option>
+            										<option value="Protection">Protection</option>
+            									</optgroup>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action attack width100"><div class="row">
+                                        <div class="column width100 bold italic textCenter">vs</div>
+                                        <div class="column width50 inlineBlock bold textSmall">Target Defense:</div>
+                                        <div class="column width45 inlineBlock inputSelect">
+                                            <select name="attr_action_target">
+                                                <option value="None" selected="selected">None</option>
+                                                <option value="Guard">Guard</option>
+                                                <option value="Toughness">Toughness</option>
+                                                <option value="Resolve">Resolve</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action both"><div class="row">
+            							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+            							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Attribute Dice Size Bonus/Penalty</div>
+                                    </div></div>
+        
+                                    <div class="option-action effect width100"><div class="row padTop">
+                                        <div class="column width90 inlineBlock borderAllDotted borderRound gray textSmall bold">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputSelect">
+                                            <select name="attr_effect_dice_type">
+                                                <option value="None" selected="selected">Dice Size</option>
+                                                <option value="d4!!">d4</option>
+                                                <option value="d6!!">d6</option>
+                                                <option value="d8!!">d8</option>
+                                                <option value="d10!!">d10</option>
+                                                <option value="d12!!">d12</option>
+                                                <option value="d20!!">d20</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action all width100"><div class="row padTop">
+                                        <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                        <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                    </div></div>
+        
+                                    <div class="option-action boon"><div class="row">
+                                        <input type="hidden" name="attr_power_level_low" value="0" />
+                                        <input type="hidden" name="attr_power_level_high" value="0" />
+                                        <div class="column width100 bold">Power Levels Available to Boon</div>
+                                        <div class="column width100 bold textLarge">
+                                            <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                            <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                            <div class="width100"></div>
+                                            <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                            <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                            <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                            <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                            <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                            <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                            <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                            <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                            <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                        </div>
+                                    </div></div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="actionsBottom"></div>
+           <!-- End Actions Area -->
             </div>
-            <div class="column width100 vertTop inputNumber30 textSmall bold">Base <input type="number" name="attr_base_speed" value=30 /> Armor Penalty(ft) <input type="number" name="attr_armor_penalty" value=0 /> Feat(ft) <input type="number" name="attr_armor_training" value=0 /></div>
-    		<input type="hidden" name="attr_Speed4Token" value=0 />
-            <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlagInitiative" value="on" checked="checked" /><span>y</span></div>
-            <div class="column width35 inlineBlock textLarge speedButton"><button type="roll" name="roll_initiative" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Initiative Roll}} {{subTitle= @{character_name}}} {{subTitleAdd= @{select_initiative}}} {{roll= @{initiative}}} {{description= Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
-            <input type="hidden" class="displaySettingsFlagInitiative" name="attr_displaySettingsFlagInitiative" />
-            <div class="width100 displaySettingsInitiative padLeft">
-    			<div class="column width50 inlineBlock textSmall bold">Attribute</div>
-    			<div class="column width50 inlineBlock textSmall bold">Default (Dis)Advantage</div>
-                <input type="hidden" name="attr_initiative" value="@{agility_initiative}" />
-    			<div class="column width50 inlineBlock inputSelect">
-    				<select name="attr_select_initiative">
-                        <optgroup label="Physical">
-    						<option value="Agility" selected="selected">Agility</option>
-    						<option value="Fortitude">Fortitude</option>
-    						<option value="Might">Might</option>
-    					</optgroup>
-                        <optgroup label="Mental">
-    						<option value="Learning">Learning</option>
-    						<option value="Logic">Logic</option>
-    						<option value="Perception">Perception</option>
-    						<option value="Will">Will</option>
-    					</optgroup>
-                        <optgroup label="Social">
-    						<option value="Deception">Deception</option>
-    						<option value="Persuasion">Persuasion</option>
-    						<option value="Presence">Presence</option>
-    					</optgroup>
-                        <optgroup label="Extraordinary">
-    						<option value="Alteration">Alteration</option>
-    						<option value="Creation">Creation</option>
-    						<option value="Energy">Energy</option>
-    						<option value="Entropy">Entropy</option>
-    						<option value="Influence">Influence</option>
-    						<option value="Movement">Movement</option>
-    						<option value="Prescience">Prescience</option>
-    						<option value="Protection">Protection</option>
-    					</optgroup>
-    				</select>
-    			</div>
-    			<div class="column width50 inlineBlock inputNumber30"><input type="number" name="attr_initiative_advantage" value=0 /></div>
-    		</div>
-         <!-- End Legend Points & Speed Section -->
-         <!-- Wealth Level Information -->
-            <div class="column width100 textLargest bold padTop">Wealth Level</div>
-            <div class="wealth">
-                <div class="width100 height15"></div>
-                <div class="column width100 inputNumber60 padTop"><input type="number" name="attr_wealth_level" value=2 /></div>
+            <input type="hidden" class="display_otheractions_flag" name="attr_display_otheractions_flag" value="show" />
+            <div class="third inlineBlock vertTop displayOtherActions">
+           <!-- Other Actions Area -->
+                <div class="actionsTop padTop padLeft">
+                    <div class="column width100 textLargest bold textShadow padTop">Other Actions</div>
+                    <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
+                </div>
+                <div class="actionsMiddle padTop padRight">
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_otheractions">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
+                                <div class="width85 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_action_other" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd=@{action_attribute} @{attribute_score}}} {{target=@{action_target}}} @{dice_roll} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings padLeft">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                <!-- What kind of Action selection -->
+                                    <div class="column padTop">
+                                    <div class="inlineBlock">This Action is:</div>
+                                    <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
+                                    <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
+                                    <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
+        
+                                    <input type="hidden" name="attr_dice_roll" value=0 />
+        							<input type="hidden" name="attr_attribute_score" value=0 />
+        
+                                    <div class="option-action attack width50 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall">Attack Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action boon width50 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock bold textSmall">Invoking Attribute:</div>
+                                    </div></div>
+                                    <div class="option-action both width45 inlineBlock"><div class="row padTop">
+                                        <div class="column width100 inlineBlock inputSelect">
+                                            <select name="attr_action_attribute">
+            									<optgroup label="Select Attribute">
+            										<option value="None" selected="selected">Select Attribute</option>
+            									</optgroup>
+            									<optgroup label="Physical">
+            										<option value="Agility">Agility</option>
+            										<option value="Fortitude">Fortitude</option>
+            										<option value="Might">Might</option>
+            									</optgroup>
+            									<optgroup label="Mental">
+            										<option value="Learning">Learning</option>
+            										<option value="Logic">Logic</option>
+            										<option value="Perception">Perception</option>
+            										<option value="Will">Will</option>
+            									</optgroup>
+            									<optgroup label="Social">
+            										<option value="Deception">Deception</option>
+            										<option value="Persuasion">Persuasion</option>
+            										<option value="Presence">Presence</option>
+            									</optgroup>
+            									<optgroup label="Extraordinary">
+            										<option value="Alteration">Alteration</option>
+            										<option value="Creation">Creation</option>
+            										<option value="Energy">Energy</option>
+            										<option value="Entropy">Entropy</option>
+            										<option value="Influence">Influence</option>
+            										<option value="Movement">Movement</option>
+            										<option value="Prescience">Prescience</option>
+            										<option value="Protection">Protection</option>
+            									</optgroup>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action attack width100"><div class="row">
+                                        <div class="column width100 bold italic textCenter">vs</div>
+                                        <div class="column width50 inlineBlock bold textSmall">Target Defense:</div>
+                                        <div class="column width45 inlineBlock inputSelect">
+                                            <select name="attr_action_target">
+                                                <option value="None" selected="selected">None</option>
+                                                <option value="Guard">Guard</option>
+                                                <option value="Toughness">Toughness</option>
+                                                <option value="Resolve">Resolve</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action both"><div class="row">
+            							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+            							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
+                                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
+                                        <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
+                                        <div class="column width75 textSmall bold textLeft inlineBlock"> Attribute Dice Size Bonus/Penalty</div>
+                                    </div></div>
+        
+                                    <div class="option-action effect width100"><div class="row padTop">
+                                        <div class="column width90 inlineBlock borderAllDotted borderRound gray textSmall bold">Effects is mainly for things like Persistent Damage, Healing from Regeneration, or other Non-Action rolls (no d20) so you can have simple output to display the roll.</div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
+                                        <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
+                                        <div class="column width30 inlineBlock inputSelect">
+                                            <select name="attr_effect_dice_type">
+                                                <option value="None" selected="selected">Dice Size</option>
+                                                <option value="d4!!">d4</option>
+                                                <option value="d6!!">d6</option>
+                                                <option value="d8!!">d8</option>
+                                                <option value="d10!!">d10</option>
+                                                <option value="d12!!">d12</option>
+                                                <option value="d20!!">d20</option>
+                                            </select>
+                                        </div>
+                                    </div></div>
+        
+                                    <div class="option-action all width100"><div class="row padTop">
+                                        <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
+                                        <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
+                                    </div></div>
+        
+                                    <div class="option-action boon"><div class="row">
+                                        <input type="hidden" name="attr_power_level_low" value="0" />
+                                        <input type="hidden" name="attr_power_level_high" value="0" />
+                                        <div class="column width100 bold">Power Levels Available to Boon</div>
+                                        <div class="column width100 bold textLarge">
+                                            <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
+                                            <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
+                                            <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
+                                            <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
+                                            <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
+                                            <div class="width100"></div>
+                                            <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
+                                            <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
+                                            <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
+                                            <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
+                                            <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
+                                            <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
+                                            <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
+                                            <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
+                                            <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
+                                        </div>
+                                    </div></div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="actionsBottom"></div>
+           <!-- End Other Actions Area -->
             </div>
-         <!-- End Wealth Level Information -->
         </div>
-        <input type="hidden" class="display_favoredactions_flag" name="attr_display_favoredactions_flag" value="show" />
-        <div class="third inlineBlock vertTop displayFavoredActions">
-       <!-- Actions Area -->
-            <div class="actionsTop padTop padLeft">
-                <div class="column width100 textLargest bold textShadow padTop">Favored Actions</div>
-                <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
-            </div>
-            <div class="actionsMiddle padTop padRight">
-            <!-- Headings for the actions -->
-                <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
-                <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
-            <!-- Add actions as needed Section (repeating fields) -->
-                <div class="column width100 vertTop padRight">
-                    <fieldset class="repeating_actions">
-                        <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
-                            <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
-                            <div class="width85 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_action" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd=@{action_attribute} @{attribute_score}}} {{target=@{action_target}}} {{roll=@{dice_roll}}} {{effect=[[@{effect_dice_number}@{effect_dice_type}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}} {{advantagedis={?{Do you have Advantage or Disadvantage?}}} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings padLeft">
-                                <div class="column width25 inlineBlock bold">Name: </div>
-                                <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
-                            <!-- What kind of Action selection -->
-                                <div class="column padTop">
-                                <div class="inlineBlock">This Action is:</div>
-                                <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
-                                <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
-                                <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
-    
-                                <input type="hidden" name="attr_dice_roll" value=0 />
-    							<input type="hidden" name="attr_attribute_score" value=0 />
-    
-                                <div class="option-action attack width50 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock bold textSmall">Attack Attribute:</div>
-                                </div></div>
-                                <div class="option-action boon width50 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock bold textSmall">Invoking Attribute:</div>
-                                </div></div>
-                                <div class="option-action both width45 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock inputSelect">
+            <!--
+            *
+            *
+            *
+            *
+            * visual space for editing and seeing quickly. This is stuff after Actions & Other Actions
+            *
+            *
+            *
+            -->
+            <input type="hidden" class="display_legendaryitems_flag" name="attr_display_legendaryitems_flag" value="show" />
+            <div class="third inlineBlock vertTop displayLegendaryItems">
+           <!-- Items Area -->
+                <div class="actionsTop padTop padLeft">
+                    <div class="column width100 textLargest bold textShadow padTop">Legendary Items</div>
+                    <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
+                </div>
+                <div class="actionsMiddle padTop padRight">
+                <!-- Headings for the actions -->
+                    <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
+                    <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
+                <!-- Add actions as needed Section (repeating fields) -->
+                    <div class="column width100 vertTop padRight">
+                        <fieldset class="repeating_legendary">
+                            <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
+                                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
+                                <div class="width85 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" name="roll_action" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd= @{action_attribute} @{dice_modifier}}} {{target= @{action_target}}} {{roll= @{dice_roll}}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}} {{advantagedis=?{Do you have Advantage or Disadvantage?}}} {{powertarget=@{power_target}}} {{powerlevel= @{power_level}}} {{powertargetmax= @{power_targetmax}}} {{powerlevelmax= @{power_levelmax}}} {{description= @{action_special}}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings padLeft">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
+                                    <div class="column width45 inlineBlock bold textSmall">Attribute</div>
+                                    <div class="column width10 inlineBlock bold textSmall">vs</div>
+                                    <div class="column width45 inlineBlock bold textSmall">Target</div>
+                                    <div class="column width45 inlineBlock inputSelect">
                                         <select name="attr_action_attribute">
-        									<optgroup label="Select Attribute">
-        										<option value="None" selected="selected">Select Attribute</option>
-        									</optgroup>
-        									<optgroup label="Physical">
-        										<option value="Agility">Agility</option>
-        										<option value="Fortitude">Fortitude</option>
-        										<option value="Might">Might</option>
-        									</optgroup>
-        									<optgroup label="Mental">
-        										<option value="Learning">Learning</option>
-        										<option value="Logic">Logic</option>
-        										<option value="Perception">Perception</option>
-        										<option value="Will">Will</option>
-        									</optgroup>
-        									<optgroup label="Social">
-        										<option value="Deception">Deception</option>
-        										<option value="Persuasion">Persuasion</option>
-        										<option value="Presence">Presence</option>
-        									</optgroup>
-        									<optgroup label="Extraordinary">
-        										<option value="Alteration">Alteration</option>
-        										<option value="Creation">Creation</option>
-        										<option value="Energy">Energy</option>
-        										<option value="Entropy">Entropy</option>
-        										<option value="Influence">Influence</option>
-        										<option value="Movement">Movement</option>
-        										<option value="Prescience">Prescience</option>
-        										<option value="Protection">Protection</option>
-        									</optgroup>
+                                            <option value="None" selected="selected">None</option>
+                                            <option value="Agility">Agility</option>
+                                            <option value="Fortitude">Fortitude</option>
+                                            <option value="Might">Might</option>
+                                            <option value="Deception">Deception</option>
+                                            <option value="Presence">Presence</option>
+                                            <option value="Persuasion">Persuasion</option>
+                                            <option value="Learning">Learning</option>
+                                            <option value="Logic">Logic</option>
+                                            <option value="Perception">Perception</option>
+                                            <option value="Will">Will</option>
+                                            <option value="Alteration">Alteration</option>
+                                            <option value="Creation">Creation</option>
+                                            <option value="Energy">Energy</option>
+                                            <option value="Entropy">Entropy</option>
+                                            <option value="Influence">Influence</option>
+                                            <option value="Movement">Movement</option>
+                                            <option value="Prescience">Prescience</option>
+                                            <option value="Protection">Protection</option>
                                         </select>
                                     </div>
-                                </div></div>
-    
-                                <div class="option-action attack width100"><div class="row">
-                                    <div class="column width100 bold italic textCenter">vs</div>
-                                    <div class="column width50 inlineBlock bold textSmall">Target Defense:</div>
+                                    <div class="column width10 inlineBlock bold italic textCenter">vs</div>
                                     <div class="column width45 inlineBlock inputSelect">
                                         <select name="attr_action_target">
                                             <option value="None" selected="selected">None</option>
@@ -4980,826 +9411,521 @@ on("change:repeating_featsLeft", function() {
                                             <option value="Resolve">Resolve</option>
                                         </select>
                                     </div>
-                                </div></div>
-    
-                                <div class="option-action both"><div class="row">
-        							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
-        							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
-                                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
-                                    <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
-                                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
-                                    <div class="column width75 textSmall bold textLeft inlineBlock"> Attribute Dice Size Bonus/Penalty</div>
-                                </div></div>
-    
-                                <div class="option-action effect width100"><div class="row padTop">
-                                    <div class="column width90 inlineBlock borderAllDotted borderRound red textSmall">Currently there is a pop-up for effects, but it doesn't affect anything, just click through. Will be fixed/removed in the next update.<br />Effects is mainly for things like Persistent Damage or Healing so you can have simple output to display the roll.</div>
-                                    <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
-                                    <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
-                                    <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
-                                    <div class="column width30 inlineBlock inputSelect">
-                                        <select name="attr_effect_dice_type">
-                                            <option value="None" selected="selected">Dice Size</option>
-                                            <option value="d4">d4</option>
-                                            <option value="d6">d6</option>
-                                            <option value="d8">d8</option>
-                                            <option value="d10">d10</option>
-                                            <option value="d12">d12</option>
-                                            <option value="d20">d20</option>
-                                        </select>
-                                    </div>
-                                </div></div>
-    
-                                <div class="option-action all width100"><div class="row padTop">
-                                    <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
-                                    <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
-                                </div></div>
-    
-                                <div class="option-action boon"><div class="row">
-                                    <input type="hidden" name="attr_power_level_low" value="0" />
-                                    <input type="hidden" name="attr_power_level_high" value="0" />
-                                    <div class="column width100 bold">Power Levels Available to Boon</div>
-                                    <div class="column width100 bold textLarge">
-                                        <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
-                                        <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
-                                        <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
-                                        <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
-                                        <div class="width100"></div>
-                                        <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
-                                        <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
-                                        <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
-                                        <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
-                                        <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
-                                        <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
-                                        <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
-                                        <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
-                                        <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
-                                    </div>
-                                </div></div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-            </div>
-            <div class="actionsBottom"></div>
-       <!-- End Actions Area -->
-        </div>
-        <input type="hidden" class="display_otheractions_flag" name="attr_display_otheractions_flag" value="show" />
-        <div class="third inlineBlock vertTop displayOtherActions">
-       <!-- Other Actions Area -->
-            <div class="actionsTop padTop padLeft">
-                <div class="column width100 textLargest bold textShadow padTop">Other Actions</div>
-                <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
-            </div>
-            <div class="actionsMiddle padTop padRight">
-            <!-- Headings for the actions -->
-                <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
-                <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
-            <!-- Add actions as needed Section (repeating fields) -->
-                <div class="column width100 vertTop padRight">
-                    <fieldset class="repeating_otheractions">
-                        <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
-                            <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
-                            <div class="width85 inlineBlock vertTop inputNameShort attributeButton silver"><button type="roll" name="roll_action_other" value="@{tab_chat}&{template:openLegend-@{tab_action}} {{border=@{template_border}}} {{title=@{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd=@{action_attribute} @{attribute_score}}} {{target=@{action_target}}} {{roll=@{dice_roll}}} {{effect=[[@{effect_dice_number}@{effect_dice_type}]]}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}} {{advantagedis=?{Do you have Advantage or Disadvantage?}}} {{description=@{action_special}}} {{powertarget=[[10 + (@{power_level_low}*2)]]}} {{PL1=@{pl1}}} {{PL1title=@{pl1_title}}} {{PL1roll=}} {{PL2=@{pl2}}} {{PL2title=@{pl2_title}}} {{PL2roll=}} {{PL3=@{pl3}}} {{PL3title=@{pl3_title}}} {{PL3roll=}} {{PL4=@{pl4}}} {{PL4title=@{pl4_title}}} {{PL4roll=}} {{PL5=@{pl5}}} {{PL5title=@{pl5_title}}} {{PL5roll=}} {{PL6=@{pl6}}} {{PL6title=@{pl6_title}}} {{PL6roll=}} {{PL7=@{pl7}}} {{PL7title=@{pl7_title}}} {{PL7roll=}} {{PL8=@{pl8}}} {{PL8title=@{pl8_title}}} {{PL8roll=}} {{PL9=@{pl9}}} {{PL9title=@{pl9_title}}} {{PL9roll=}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings padLeft">
-                                <div class="column width25 inlineBlock bold">Name: </div>
-                                <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
-                            <!-- What kind of Action selection -->
-                                <div class="column padTop">
-                                <div class="inlineBlock">This Action is:</div>
-                                <input class="tab-action attack" type="radio" name="attr_tab_action" checked="checked" value="attack"><span class="tab-action-text">Attack</span>
-                                <input class="tab-action boon" type="radio" name="attr_tab_action" value="boon"><span>Boon</span>
-                                <input class="tab-action effect" type="radio" name="attr_tab_action" value="effect"><span>Effect</span>
-    
-                                <input type="hidden" name="attr_dice_roll" value=0 />
-    							<input type="hidden" name="attr_attribute_score" value=0 />
-    
-                                <div class="option-action attack width50 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock bold textSmall">Attack Attribute:</div>
-                                </div></div>
-                                <div class="option-action boon width50 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock bold textSmall">Invoking Attribute:</div>
-                                </div></div>
-                                <div class="option-action both width45 inlineBlock"><div class="row padTop">
-                                    <div class="column width100 inlineBlock inputSelect">
-                                        <select name="attr_action_attribute">
-        									<optgroup label="Select Attribute">
-        										<option value="None" selected="selected">Select Attribute</option>
-        									</optgroup>
-        									<optgroup label="Physical">
-        										<option value="Agility">Agility</option>
-        										<option value="Fortitude">Fortitude</option>
-        										<option value="Might">Might</option>
-        									</optgroup>
-        									<optgroup label="Mental">
-        										<option value="Learning">Learning</option>
-        										<option value="Logic">Logic</option>
-        										<option value="Perception">Perception</option>
-        										<option value="Will">Will</option>
-        									</optgroup>
-        									<optgroup label="Social">
-        										<option value="Deception">Deception</option>
-        										<option value="Persuasion">Persuasion</option>
-        										<option value="Presence">Presence</option>
-        									</optgroup>
-        									<optgroup label="Extraordinary">
-        										<option value="Alteration">Alteration</option>
-        										<option value="Creation">Creation</option>
-        										<option value="Energy">Energy</option>
-        										<option value="Entropy">Entropy</option>
-        										<option value="Influence">Influence</option>
-        										<option value="Movement">Movement</option>
-        										<option value="Prescience">Prescience</option>
-        										<option value="Protection">Protection</option>
-        									</optgroup>
-                                        </select>
-                                    </div>
-                                </div></div>
-    
-                                <div class="option-action attack width100"><div class="row">
-                                    <div class="column width100 bold italic textCenter">vs</div>
-                                    <div class="column width50 inlineBlock bold textSmall">Target Defense:</div>
+                                    <input type="hidden" name="attr_dice_roll" value="[[d20!! + 1d4!!]]" />
+                                    <div class="column width55 inlineBlock">Attribute Dice:</div>
                                     <div class="column width45 inlineBlock inputSelect">
-                                        <select name="attr_action_target">
-                                            <option value="None" selected="selected">None</option>
-                                            <option value="Guard">Guard</option>
-                                            <option value="Toughness">Toughness</option>
-                                            <option value="Resolve">Resolve</option>
+                                        <select name="attr_dice_modifier">
+                                            <option value="1" selected="selected">Select Dice</option>
+                                            <option value="1">1 = 1d4</option>
+                                            <option value="2">2 = 1d6</option>
+                                            <option value="3">3 = 1d8</option>
+                                            <option value="4">4 = 1d10</option>
+                                            <option value="5">5 = 2d6</option>
+                                            <option value="6">6 = 2d8</option>
+                                            <option value="7">7 = 2d10</option>
+                                            <option value="8">8 = 3d8</option>
+                                            <option value="9">9 = 3d10</option>
+                                            <option value="10">10 = 4d8</option>
                                         </select>
                                     </div>
-                                </div></div>
-    
-                                <div class="option-action both"><div class="row">
-        							<div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
-        							<div class="column width75 textSmall bold textLeft inlineBlock"> Default (Dis)Advantage</div>
-                                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /></div>
-                                    <div class="column width75 textSmall bold textLeft inlineBlock"> Use Destructive Trance</div>
-                                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
-                                    <div class="column width75 textSmall bold textLeft inlineBlock"> Attribute Dice Size Bonus/Penalty</div>
-                                </div></div>
-    
-                                <div class="option-action effect width100"><div class="row padTop">
-                                    <div class="column width90 inlineBlock borderAllDotted borderRound red textSmall">Currently there is a pop-up for effects, but it doesn't affect anything, just click through. Will be fixed/removed in the next update.<br />Effects is mainly for things like Persistent Damage or Healing so you can have simple output to display the roll.</div>
-                                    <div class="column width65 inlineBlock textSmall bold textRight">Number of Dice to Roll:</div>
-                                    <div class="column width30 inlineBlock inputNumber30"><input type="number" name="attr_effect_dice_number" value=0 /></div>
-                                    <div class="column width65 inlineBlock textSmall bold textRight">Type of Dice to Roll:</div>
-                                    <div class="column width30 inlineBlock inputSelect">
-                                        <select name="attr_effect_dice_type">
-                                            <option value="None" selected="selected">Dice Size</option>
-                                            <option value="d4">d4</option>
-                                            <option value="d6">d6</option>
-                                            <option value="d8">d8</option>
-                                            <option value="d10">d10</option>
-                                            <option value="d12">d12</option>
-                                            <option value="d20">d20</option>
+                                    <div class="column width100"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /> Use Destructive Trance</div>
+                                    <input type="hidden" name="attr_dice_roll_d20" value="1d20!!" />
+                                    <input type="hidden" name="attr_attribute_score" value="0" />
+                                    <div class="column width50 textSmall bold inlineBlock">d20 for this action is</div>
+        							<div class="column width50 textSmall bold inlineBlock">Default (Dis)Advantage</div>
+                                    <div class="column width45 inlineBlock inputSelect">
+                                        <select name="attr_select_dice_d20">
+                                            <option value="Normal" selected="selected">Normal</option>
+                                            <option value="Advantage">Advantage</option>
+                                            <option value="Disadvantage">Disadvantage</option>
                                         </select>
                                     </div>
-                                </div></div>
-    
-                                <div class="option-action all width100"><div class="row padTop">
+        							<div class="column width50 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
+                                    <input type="hidden" name="attr_power_target" value="" />
+                                    <input type="hidden" name="attr_power_targetmax" value=0 />
+                                    <div class="column width50 inlineBlock textSmall bold">For a Boon</div>
+                                    <div class="column width25 inlineBlock textSmall bold">Minimum</div>
+                                    <div class="column width25 inlineBlock textSmall bold">Maximum</div>
+                                    <div class="column width50 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_power_level" value="Yes" /> Use Power level</div>
+                                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_power_level" value=0 /></div>
+                                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_power_levelmax" value=0 /></div>
                                     <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
                                     <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
-                                </div></div>
-    
-                                <div class="option-action boon"><div class="row">
-                                    <input type="hidden" name="attr_power_level_low" value="0" />
-                                    <input type="hidden" name="attr_power_level_high" value="0" />
-                                    <div class="column width100 bold">Power Levels Available to Boon</div>
-                                    <div class="column width100 bold textLarge">
-                                        <input type="hidden" name="attr_pl1" value="" /><input type="hidden" name="attr_pl1_title" value="Power Level 1 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl1" name="attr_use_power_level_1" value="1" /> 1&nbsp;&nbsp;&nbsp; 
-                                        <input type="hidden" name="attr_pl2" value="" /><input type="hidden" name="attr_pl2_title" value="Power Level 2 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl2" name="attr_use_power_level_2" value="1" /> 2&nbsp;&nbsp;&nbsp; 
-                                        <input type="hidden" name="attr_pl3" value="" /><input type="hidden" name="attr_pl3_title" value="Power Level 3 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl3" name="attr_use_power_level_3" value="1" /> 3&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl4" value="" /><input type="hidden" name="attr_pl4_title" value="Power Level 4 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl4" name="attr_use_power_level_4" value="1" /> 4&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl5" value="" /><input type="hidden" name="attr_pl5_title" value="Power Level 5 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl5" name="attr_use_power_level_5" value="1" /> 5<br />
-                                        <input type="hidden" name="attr_pl6" value="" /><input type="hidden" name="attr_pl6_title" value="Power Level 6 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl6" name="attr_use_power_level_6" value="1" /> 6&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl7" value="" /><input type="hidden" name="attr_pl7_title" value="Power Level 7 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl7" name="attr_use_power_level_7" value="1" /> 7&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl8" value="" /><input type="hidden" name="attr_pl8_title" value="Power Level 8 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl8" name="attr_use_power_level_8" value="1" /> 8&nbsp;&nbsp;&nbsp;
-                                        <input type="hidden" name="attr_pl9" value="" /><input type="hidden" name="attr_pl9_title" value="Power Level 9 Info" />
-                                        <input type="checkbox" class="checks25 display-boon pl9" name="attr_use_power_level_9" value="1" /> 9
-                                        <div class="width100"></div>
-                                        <div class="option-boon pl1 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl1" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 1 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl1}}}">PL 1 Info</button><textarea class="height50" name="attr_action_pl1"></textarea></div>
-                                        <div class="option-boon pl2 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl2" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 2 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl2}}}">PL 2 Info</button><textarea class="height50" name="attr_action_pl2"></textarea></div>
-                                        <div class="option-boon pl3 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl3" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 3 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl3}}}">PL 3 Info</button><textarea class="height50" name="attr_action_pl3"></textarea></div>
-                                        <div class="option-boon pl4 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl4" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 4 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl4}}}">PL 4 Info</button><textarea class="height50" name="attr_action_pl4"></textarea></div>
-                                        <div class="option-boon pl5 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl5" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 5 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl5}}}">PL 5 Info</button><textarea class="height50" name="attr_action_pl5"></textarea></div>
-                                        <div class="option-boon pl6 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl6" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 6 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl6}}}">PL 6 Info</button><textarea class="height50" name="attr_action_pl6"></textarea></div>
-                                        <div class="option-boon pl7 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl7" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 7 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl7}}}">PL 7 Info</button><textarea class="height50" name="attr_action_pl7"></textarea></div>
-                                        <div class="option-boon pl8 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl8" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 8 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl8}}}">PL 8 Info</button><textarea class="height50" name="attr_action_pl8"></textarea></div>
-                                        <div class="option-boon pl9 textSmall resizeVert inventoryButton"><button type="roll" name="roll_pl9" value="@{tab_chat}&{template:openLegend-effect}} {{border=@{template_border}}} {{title=Power Level 9 Info}} {{subTitle=@{action_name}}} {{emote=@{action_pl9}}}">PL 9 Info</button><textarea class="height50" name="attr_action_pl9"></textarea></div>
-                                    </div>
-                                </div></div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-            </div>
-            <div class="actionsBottom"></div>
-       <!-- End Other Actions Area -->
-        </div>
-    </div>
-        <!--
-        *
-        *
-        *
-        *
-        * visual space for editing and seeing quickly. This is stuff after Actions & Other Actions
-        *
-        *
-        *
-        -->
-        <input type="hidden" class="display_legendaryitems_flag" name="attr_display_legendaryitems_flag" value="hide" />
-        <div class="third inlineBlock vertTop displayLegendaryItems">
-       <!-- Items Area -->
-            <div class="actionsTop padTop padLeft">
-                <div class="column width100 textLargest bold textShadow padTop">Legendary Items</div>
-                <div class="column width100 italic marginTop">Attacks, Boons, & Banes</div>
-            </div>
-            <div class="actionsMiddle padTop padRight">
-            <!-- Headings for the actions -->
-                <div class="column width25 bold italic inlineBlock textCenter padLeft">Settings</div>
-                <div class="column width75 bold italic inlineBlock textCenter">Name (click to roll)</div>
-            <!-- Add actions as needed Section (repeating fields) -->
-                <div class="column width100 vertTop padRight">
-                    <fieldset class="repeating_legendary">
-                        <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
-                            <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
-                            <div class="width85 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" name="roll_action" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{action_name}}} {{subTitle=@{character_name}}} {{subTitleAdd= @{action_attribute} @{dice_modifier}}} {{target= @{action_target}}} {{roll= @{dice_roll}}} {{numberadvantage=?{# of Advantage/Disadvantage Dice}}} {{advantagedis=?{Do you have Advantage or Disadvantage?}}} {{powertarget=@{power_target}}} {{powerlevel= @{power_level}}} {{powertargetmax= @{power_targetmax}}} {{powerlevelmax= @{power_levelmax}}} {{description= @{action_special}}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings padLeft">
-                                <div class="column width25 inlineBlock bold">Name: </div>
-                                <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_action_name" /></div>
-                                <div class="column width45 inlineBlock bold textSmall">Attribute</div>
-                                <div class="column width10 inlineBlock bold textSmall">vs</div>
-                                <div class="column width45 inlineBlock bold textSmall">Target</div>
-                                <div class="column width45 inlineBlock inputSelect">
-                                    <select name="attr_action_attribute">
-                                        <option value="None" selected="selected">None</option>
-                                        <option value="Agility">Agility</option>
-                                        <option value="Fortitude">Fortitude</option>
-                                        <option value="Might">Might</option>
-                                        <option value="Deception">Deception</option>
-                                        <option value="Presence">Presence</option>
-                                        <option value="Persuasion">Persuasion</option>
-                                        <option value="Learning">Learning</option>
-                                        <option value="Logic">Logic</option>
-                                        <option value="Perception">Perception</option>
-                                        <option value="Will">Will</option>
-                                        <option value="Alteration">Alteration</option>
-                                        <option value="Creation">Creation</option>
-                                        <option value="Energy">Energy</option>
-                                        <option value="Entropy">Entropy</option>
-                                        <option value="Influence">Influence</option>
-                                        <option value="Movement">Movement</option>
-                                        <option value="Prescience">Prescience</option>
-                                        <option value="Protection">Protection</option>
-                                    </select>
                                 </div>
-                                <div class="column width10 inlineBlock bold italic textCenter">vs</div>
-                                <div class="column width45 inlineBlock inputSelect">
-                                    <select name="attr_action_target">
-                                        <option value="None" selected="selected">None</option>
-                                        <option value="Guard">Guard</option>
-                                        <option value="Toughness">Toughness</option>
-                                        <option value="Resolve">Resolve</option>
-                                    </select>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="actionsBottom"></div>
+           <!-- End Legendary Items Area -->
+            </div>
+            <input type="hidden" class="display_feats_flag" name="attr_display_feats_flag" value="show" />
+            <div class="third inlineBlock vertTop displayFeats">
+           <!-- Columns of Feats -->
+                <div class="actionsTop padTop padLeft padRight">
+                    <div class="column width100 textCenter bold textLargest textShadow vertTop padTop">Feats</div>
+               <!-- sub sections for feat points spent and total -->
+                    <div class="width50 inlineBlock vertTop padLeft">
+                        <div class="column width2of3 inlineBlock textRight bold italic">Total Points</div>
+                        <div class="column width1of3 inlineBlock inputNumber"><input type="number" name="attr_feat_total_points" value=6 /></div>
+                    </div>
+                    <div class="width50 inlineBlock vertTop padRight">
+                        <div class="column width2of3 inlineBlock textRight bold italic">Points Used</div>
+                        <input type="hidden" name="attr_featLeft_points_spent" value=0 />
+                        <input type="hidden" name="attr_featRight_points_spent" value=0 />
+                        <div class="column width1of3 inlineBlock inputNumber"><input type="number" name="attr_feat_points_spent" value="@{featLeft_points_spent}" disabled="disabled" /></div>
+                    </div>
+                </div>
+                <div class="actionsMiddle padTop padLeft padRight">
+                    <div class="column width95 vertTop padTop">
+                        <fieldset class="repeating_featsLeft">
+                            <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
+                                <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{feat_left_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Feat}} {{description= @{feat_left_description}}}"><input type="text" style="text-align: center;" name="attr_feat_left_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings">
+                                    <div class="column width75 inlineBlock bold textSmall">Name</div>
+                                    <div class="column width25 inlineBlock bold textSmall">Cost</div>
+                                    <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_feat_left_name" /></div>
+                                    <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_feat_left_cost" /></div>
+                                    <div class="column width100 bold textSmall">Description</div>
+                                    <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_feat_left_description"></textarea></div>
                                 </div>
-                                <input type="hidden" name="attr_dice_roll" value="[[d20!! + 1d4!!]]" />
-                                <div class="column width55 inlineBlock">Attribute Dice:</div>
-                                <div class="column width45 inlineBlock inputSelect">
-                                    <select name="attr_dice_modifier">
-                                        <option value="1" selected="selected">Select Dice</option>
-                                        <option value="1">1 = 1d4</option>
-                                        <option value="2">2 = 1d6</option>
-                                        <option value="3">3 = 1d8</option>
-                                        <option value="4">4 = 1d10</option>
-                                        <option value="5">5 = 2d6</option>
-                                        <option value="6">6 = 2d8</option>
-                                        <option value="7">7 = 2d10</option>
-                                        <option value="8">8 = 3d8</option>
-                                        <option value="9">9 = 3d10</option>
-                                        <option value="10">10 = 4d8</option>
-                                    </select>
+                            </div>
+                        </fieldset>
+                    </div>
+           <!-- End Columns of Feats -->
+                </div>
+                <div class="actionsBottom"></div>
+           <!-- End Feats, Perks, Flaws Area -->
+            </div>
+            <input type="hidden" class="display_feats_flag" name="attr_display_feats_flag" value="show" />
+            <div class="third inlineBlock vertTop displayFeats">
+        <!--    </div>
+            <input type="hidden" class="display_perksflaws_flag" name="attr_display_perksflaws_flag" value="show" />
+            <div class="third inlineBlock vertTop displayPerksFlaws">
+           <!-- Columns of Feats -->
+                <div class="actionsTop padTop padLeft padRight">
+           <!-- Column for Perks -->
+                    <div class="column width100 textCenter bold textLargest textShadow vertTop padTop padBottom">Perks</div>
+                </div>
+                <div class="actionsMiddle padTop padLeft padRight">
+                    <div class="column width95 vertTop">
+                        <fieldset class="repeating_perks">
+                            <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
+                                <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{perks_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Perk}} {{description= @{perks_description}}}"><input type="text" style="text-align: center;" name="attr_perks_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings">
+                                    <div class="column width100 bold textSmall">Name</div>
+                                    <div class="column width100 inputNameShort"><input type="text" name="attr_perks_name" /></div>
+                                    <div class="column width100 bold textSmall">Description</div>
+                                    <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_perks_description"></textarea></div>
                                 </div>
-                                <div class="column width100"><input type="checkbox" class="checks25" name="attr_use_destructive_trance" value="Yes" /> Use Destructive Trance</div>
-                                <input type="hidden" name="attr_dice_roll_d20" value="1d20!!" />
-                                <input type="hidden" name="attr_attribute_score" value="0" />
-                                <div class="column width50 textSmall bold inlineBlock">d20 for this action is</div>
-    							<div class="column width50 textSmall bold inlineBlock">Default (Dis)Advantage</div>
-                                <div class="column width45 inlineBlock inputSelect">
-                                    <select name="attr_select_dice_d20">
-                                        <option value="Normal" selected="selected">Normal</option>
-                                        <option value="Advantage">Advantage</option>
-                                        <option value="Disadvantage">Disadvantage</option>
-                                    </select>
+                            </div>
+                        </fieldset>
+                    </div>
+           <!-- end Column for Perks -->
+           <!-- Column for Flaws -->
+                    <div class="column width100 textCenter bold textLargest textShadow vertTop padTop padBottom">Flaws</div>
+                    <div class="column width95 vertTop">
+                        <fieldset class="repeating_flaws">
+                            <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
+                                <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
+                                <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{flaws_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Flaw}} {{description= @{flaws_description}}}"><input type="text" style="text-align: center;" name="attr_flaws_name" /></button></div>
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings">
+                                    <div class="column width100 bold textSmall">Name</div>
+                                    <div class="column width100 inputNameShort"><input type="text" name="attr_flaws_name" /></div>
+                                    <div class="column width100 bold textSmall">Description</div>
+                                    <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_flaws_description"></textarea></div>
                                 </div>
-    							<div class="column width50 inlineBlock inputNumber30"><input type="number" name="attr_default_advantage" value=0 /></div>
-                                <input type="hidden" name="attr_power_target" value="" />
-                                <input type="hidden" name="attr_power_targetmax" value=0 />
-                                <div class="column width50 inlineBlock textSmall bold">For a Boon</div>
-                                <div class="column width25 inlineBlock textSmall bold">Minimum</div>
-                                <div class="column width25 inlineBlock textSmall bold">Maximum</div>
-                                <div class="column width50 inlineBlock"><input type="checkbox" class="checks25" name="attr_use_power_level" value="Yes" /> Use Power level</div>
-                                <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_power_level" value=0 /></div>
-                                <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_power_levelmax" value=0 /></div>
-                                <div class="column width100 bold textSmall">Description/Special/Flavor Text</div>
-                                <div class="column width100 resizeVert vertTop"><textarea class="height50" name="attr_action_special"></textarea></div>
                             </div>
-                        </div>
-                    </fieldset>
+                        </fieldset>
+                    </div>
+           <!-- end Column for Flaws -->
                 </div>
+                <div class="actionsBottom"></div>
+           <!-- End Feats, Perks, Flaws Area -->
             </div>
-            <div class="actionsBottom"></div>
-       <!-- End Legendary Items Area -->
-        </div>
-        <input type="hidden" class="display_feats_flag" name="attr_display_feats_flag" value="show" />
-        <div class="third inlineBlock vertTop displayFeats">
-       <!-- Columns of Feats -->
-            <div class="actionsTop padTop padLeft padRight">
-                <div class="column width100 textCenter bold textLargest textShadow vertTop padTop">Feats</div>
-           <!-- sub sections for feat points spent and total -->
-                <div class="width50 inlineBlock vertTop padLeft">
-                    <div class="column width2of3 inlineBlock textRight bold italic">Total Points</div>
-                    <div class="column width1of3 inlineBlock inputNumber"><input type="number" name="attr_feat_total_points" value=6 /></div>
+         <!-- end Right column for Health, speed, wealth, feats, perks, and flaws -->
+         <!-- section for Other Inventory & Notes information -->
+            <input type="hidden" class="display_otherinventory_flag" name="attr_display_otherinventory_flag" value="hide" />
+            <div class="marginBottom displayOtherInventory inlineBlock third vertTop">
+               <!-- Other Area -->
+        		<div class="actionsTop padTop">
+                    <div class="column bold textLarge padTop">Non-Essential Inventory or Notes</div>
                 </div>
-                <div class="width50 inlineBlock vertTop padRight">
-                    <div class="column width2of3 inlineBlock textRight bold italic">Points Used</div>
-                    <input type="hidden" name="attr_featLeft_points_spent" value=0 />
-                    <input type="hidden" name="attr_featRight_points_spent" value=0 />
-                    <div class="column width1of3 inlineBlock inputNumber"><input type="number" name="attr_feat_points_spent" value="@{featLeft_points_spent}" disabled="disabled" /></div>
-                </div>
-            </div>
-            <div class="actionsMiddle padTop padLeft padRight">
-                <div class="column width95 vertTop padTop">
-                    <fieldset class="repeating_featsLeft">
-                        <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
-                            <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
-                            <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{feat_left_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Feat}} {{description= @{feat_left_description}}}"><input type="text" style="text-align: center;" name="attr_feat_left_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings">
-                                <div class="column width75 inlineBlock bold textSmall">Name</div>
-                                <div class="column width25 inlineBlock bold textSmall">Cost</div>
-                                <div class="column width75 inlineBlock inputNameShort"><input type="text" name="attr_feat_left_name" /></div>
-                                <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_feat_left_cost" /></div>
-                                <div class="column width100 bold textSmall">Description</div>
-                                <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_feat_left_description"></textarea></div>
+        		<div class="actionsMiddle padLeft">
+        		    <div class="column width95 vertTop">
+                		<fieldset class="repeating_OtherOne">
+                		    <div class="row">
+                			<!-- Roll to Chat & Expand -->
+                                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
+                                <div class="width85 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}"><input type="text" style="text-align: center;" name="attr_other_title" /></button></div>
+                			<!-- Hidden area -->
+                                <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
+                                <div class="width100 displaySettings">
+                                    <div class="column width25 inlineBlock bold">Name: </div>
+                    				<div class="column width70 inlineBlock padLeft inputName"><input type="text" name="attr_other_title" /></div>
+                    				<div class="column width100 bold italic textCenter">Content/Description</div>
+                                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
+                                </div>
                             </div>
-                        </div>
-                    </fieldset>
-                </div>
-       <!-- End Columns of Feats -->
-            </div>
-            <div class="actionsBottom"></div>
-       <!-- End Feats, Perks, Flaws Area -->
-        </div>
-        <input type="hidden" class="display_feats_flag" name="attr_display_feats_flag" value="show" />
-        <div class="third inlineBlock vertTop displayFeats">
-    <!--    </div>
-        <input type="hidden" class="display_perksflaws_flag" name="attr_display_perksflaws_flag" value="show" />
-        <div class="third inlineBlock vertTop displayPerksFlaws">
-       <!-- Columns of Feats -->
-            <div class="actionsTop padTop padLeft padRight">
-       <!-- Column for Perks -->
-                <div class="column width100 textCenter bold textLargest textShadow vertTop padTop padBottom">Perks</div>
-            </div>
-            <div class="actionsMiddle padTop padLeft padRight">
-                <div class="column width95 vertTop">
-                    <fieldset class="repeating_perks">
-                        <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
-                            <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
-                            <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{perks_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Perk}} {{description= @{perks_description}}}"><input type="text" style="text-align: center;" name="attr_perks_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings">
-                                <div class="column width100 bold textSmall">Name</div>
-                                <div class="column width100 inputNameShort"><input type="text" name="attr_perks_name" /></div>
-                                <div class="column width100 bold textSmall">Description</div>
-                                <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_perks_description"></textarea></div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-       <!-- end Column for Perks -->
-       <!-- Column for Flaws -->
-                <div class="column width100 textCenter bold textLargest textShadow vertTop padTop padBottom">Flaws</div>
-                <div class="column width95 vertTop">
-                    <fieldset class="repeating_flaws">
-                        <div class="row">   <!-- Fix for Mozilla squishing the +Add & Modify button text -->
-                            <div class="width10 inlineBlock vertTop"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
-                            <div class="width90 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{flaws_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= Flaw}} {{description= @{flaws_description}}}"><input type="text" style="text-align: center;" name="attr_flaws_name" /></button></div>
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings">
-                                <div class="column width100 bold textSmall">Name</div>
-                                <div class="column width100 inputNameShort"><input type="text" name="attr_flaws_name" /></div>
-                                <div class="column width100 bold textSmall">Description</div>
-                                <div class="column width95 resizeVert vertTop"><textarea class="height50" name="attr_flaws_description"></textarea></div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-       <!-- end Column for Flaws -->
-            </div>
-            <div class="actionsBottom"></div>
-       <!-- End Feats, Perks, Flaws Area -->
-        </div>
-     <!-- end Right column for Health, speed, wealth, feats, perks, and flaws -->
-     <!-- section for Other Inventory & Notes information -->
-        <input type="hidden" class="display_otherinventory_flag" name="attr_display_otherinventory_flag" value="hide" />
-        <div class="marginBottom displayOtherInventory inlineBlock third vertTop">
-           <!-- Other Area -->
-    		<div class="actionsTop padTop">
-                <div class="column bold textLarge padTop">Non-Essential Inventory or Notes</div>
-            </div>
-    		<div class="actionsMiddle padLeft">
-    		    <div class="column width95 vertTop">
-            		<fieldset class="repeating_OtherOne">
-            		    <div class="row">
-            			<!-- Roll to Chat & Expand -->
-                            <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>i</span></div>
-                            <div class="width85 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}"><input type="text" style="text-align: center;" name="attr_other_title" /></button></div>
-            			<!-- Hidden area -->
-                            <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
-                            <div class="width100 displaySettings">
-                                <div class="column width25 inlineBlock bold">Name: </div>
-                				<div class="column width70 inlineBlock padLeft inputName"><input type="text" name="attr_other_title" /></div>
-                				<div class="column width100 bold italic textCenter">Content/Description</div>
-                                <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
-                            </div>
-                        </div>
+                		</fieldset>
+                	</div>
+            	<div style="display: none;">	
+            		<fieldset class="repeating_OtherTwo">
+            			<!-- Headings for the actions -->
+            			<div class="column width100 bold textSmall textCenter inventoryButton"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}">Send Notes to Chat</button></div>
+        				<div class="column width100 textCenter padLeft inputName"><input type="text" name="attr_other_title" /></div>
+            			<!-- Add actions as needed Section (repeating fields) -->
+        				<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
+            		</fieldset>
+            		<fieldset class="repeating_OtherThree">
+        			<!-- Headings for the actions -->
+            			<div class="column width100 bold textSmall textCenter inventoryButton"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}">Send Notes to Chat</button></div>
+        				<div class="column width100 textCenter padLeft inputName"><input type="text" name="attr_other_title" /></div>
+        			<!-- Add actions as needed Section (repeating fields) -->
+        				<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
             		</fieldset>
             	</div>
-        	<div style="display: none;">	
-        		<fieldset class="repeating_OtherTwo">
-        			<!-- Headings for the actions -->
-        			<div class="column width100 bold textSmall textCenter inventoryButton"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}">Send Notes to Chat</button></div>
-    				<div class="column width100 textCenter padLeft inputName"><input type="text" name="attr_other_title" /></div>
-        			<!-- Add actions as needed Section (repeating fields) -->
-    				<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
-        		</fieldset>
-        		<fieldset class="repeating_OtherThree">
-    			<!-- Headings for the actions -->
-        			<div class="column width100 bold textSmall textCenter inventoryButton"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{other_title}}} {{subTitle= @{character_name}}} {{subTitleAdd= Notes}} {{description= @{other_contents}}}">Send Notes to Chat</button></div>
-    				<div class="column width100 textCenter padLeft inputName"><input type="text" name="attr_other_title" /></div>
-    			<!-- Add actions as needed Section (repeating fields) -->
-    				<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_other_contents"></textarea></div>
-        		</fieldset>
+        		</div>
+        		<div class="actionsBottom"></div>
         	</div>
-    		</div>
-    		<div class="actionsBottom"></div>
-    	</div>
-           <!-- End Other Area -->
-     <!-- end section for Other Inventory & Notes information -->
-     <!-- Equipment section -->
-        <input type="hidden" class="display_inventory_flag" name="attr_display_inventory_flag" value="show" />
-        <!-- new inventory section -->
-        <div class="inlineBlock third vertTop displayInventory">
-            <div class="actionsTop padTop">
-            <!-- Headings for Inventory -->
-                <div class="column bold textLarge width100 padTop">Important Inventory 1-10</div>
+               <!-- End Other Area -->
+         <!-- end section for Other Inventory & Notes information -->
+         <!-- Equipment section -->
+            <input type="hidden" class="display_inventory_flag" name="attr_display_inventory_flag" value="show" />
+            <!-- new inventory section -->
+            <div class="inlineBlock third vertTop displayInventory">
+                <div class="actionsTop padTop">
+                <!-- Headings for Inventory -->
+                    <div class="column bold textLarge width100 padTop"><span style="font-family: pictos; font-size: 1.5em;">n</span>Important Inventory 1-10</div>
+                </div>
+        		<div class="actionsMiddle padLeft padRight">
+            <!-- start item_1 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item1" value="on" checked="checked" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_1}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_1_contents}}}"><input type="text" style="text-align: center;" name="attr_item_1" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem1" name="attr_displaySettingsFlagItem1" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_1" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_1_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_1_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_1_contents"></textarea></div>
+                    </div>
+            <!-- end item_1 -->
+            <!-- start item_2 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item2" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_2}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_2_contents}}}"><input type="text" style="text-align: center;" name="attr_item_2" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem2" name="attr_displaySettingsFlagItem2" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_2" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_2_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_2_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_2_contents"></textarea></div>
+                    </div>
+            <!-- end item_2 -->
+            <!-- start item_3 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item3" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_3}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_3_contents}}}"><input type="text" style="text-align: center;" name="attr_item_3" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem3" name="attr_displaySettingsFlagItem3" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_3" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_3_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_3_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_3_contents"></textarea></div>
+                    </div>
+            <!-- end item_3 -->
+            <!-- start item_4 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item4" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_4}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_4_contents}}}"><input type="text" style="text-align: center;" name="attr_item_4" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem4" name="attr_displaySettingsFlagItem4" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_4" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_4_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_4_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_4_contents"></textarea></div>
+                    </div>
+            <!-- end item_4 -->
+            <!-- start item_5 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item5" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_5}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_5_contents}}}"><input type="text" style="text-align: center;" name="attr_item_5" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem5" name="attr_displaySettingsFlagItem5" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_5" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_5_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_5_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_5_contents"></textarea></div>
+                    </div>
+            <!-- end item_5 -->
+            <!-- start item_6 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item6" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_6}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_6_contents}}}"><input type="text" style="text-align: center;" name="attr_item_6" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem6" name="attr_displaySettingsFlagItem6" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_6" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_6_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_6_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_6_contents"></textarea></div>
+                    </div>
+            <!-- end item_6 -->
+            <!-- start item_7 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item7" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_7}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_7_contents}}}"><input type="text" style="text-align: center;" name="attr_item_7" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem7" name="attr_displaySettingsFlagItem7" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_7" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_7_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_7_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_7_contents"></textarea></div>
+                    </div>
+            <!-- end item_7 -->
+            <!-- start item_8 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item8" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_8}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_8_contents}}}"><input type="text" style="text-align: center;" name="attr_item_8" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem8" name="attr_displaySettingsFlagItem8" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_8" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_8_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_8_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_8_contents"></textarea></div>
+                    </div>
+            <!-- end item_8 -->
+            <!-- start item_9 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item9" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_9}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_9_contents}}}"><input type="text" style="text-align: center;" name="attr_item_9" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem9" name="attr_displaySettingsFlagItem9" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_9" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_9_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_9_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_9_contents"></textarea></div>
+                    </div>
+            <!-- end item_9 -->
+            <!-- start item_10 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item10" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_10}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_10_contents}}}"><input type="text" style="text-align: center;" name="attr_item_10" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem10" name="attr_displaySettingsFlagItem10" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_10" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_10_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_10_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_10_contents"></textarea></div>
+                    </div>
+            <!-- end item_10 -->
+        		</div>
+        		<div class="actionsBottom"></div>
             </div>
-    		<div class="actionsMiddle padLeft padRight">
-        <!-- start item_1 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item1" value="on" checked="checked" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_1}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_1_contents}}}"><input type="text" style="text-align: center;" name="attr_item_1" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem1" name="attr_displaySettingsFlagItem1" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_1" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_1_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_1_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_1_contents"></textarea></div>
+            <input type="hidden" class="display_inventory_flag" name="attr_display_inventory_flag" value="show" />
+            <!-- new inventory section -->
+            <div class="inlineBlock third vertTop displayInventory">
+                <div class="actionsTop padTop">
+                <!-- Headings for Inventory -->
+                    <div class="column bold textLarge width100 padTop"><span style="font-family: pictos; font-size: 1.5em;">n</span>Important Inventory 11-20</div>
                 </div>
-        <!-- end item_1 -->
-        <!-- start item_2 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item2" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_2}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_2_contents}}}"><input type="text" style="text-align: center;" name="attr_item_2" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem2" name="attr_displaySettingsFlagItem2" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_2" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_2_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_2_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_2_contents"></textarea></div>
-                </div>
-        <!-- end item_2 -->
-        <!-- start item_3 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item3" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_3}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_3_contents}}}"><input type="text" style="text-align: center;" name="attr_item_3" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem3" name="attr_displaySettingsFlagItem3" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_3" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_3_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_3_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_3_contents"></textarea></div>
-                </div>
-        <!-- end item_3 -->
-        <!-- start item_4 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item4" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_4}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_4_contents}}}"><input type="text" style="text-align: center;" name="attr_item_4" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem4" name="attr_displaySettingsFlagItem4" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_4" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_4_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_4_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_4_contents"></textarea></div>
-                </div>
-        <!-- end item_4 -->
-        <!-- start item_5 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item5" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_5}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_5_contents}}}"><input type="text" style="text-align: center;" name="attr_item_5" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem5" name="attr_displaySettingsFlagItem5" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_5" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_5_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_5_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_5_contents"></textarea></div>
-                </div>
-        <!-- end item_5 -->
-        <!-- start item_6 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item6" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_6}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_6_contents}}}"><input type="text" style="text-align: center;" name="attr_item_6" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem6" name="attr_displaySettingsFlagItem6" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_6" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_6_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_6_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_6_contents"></textarea></div>
-                </div>
-        <!-- end item_6 -->
-        <!-- start item_7 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item7" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_7}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_7_contents}}}"><input type="text" style="text-align: center;" name="attr_item_7" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem7" name="attr_displaySettingsFlagItem7" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_7" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_7_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_7_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_7_contents"></textarea></div>
-                </div>
-        <!-- end item_7 -->
-        <!-- start item_8 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item8" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_8}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_8_contents}}}"><input type="text" style="text-align: center;" name="attr_item_8" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem8" name="attr_displaySettingsFlagItem8" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_8" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_8_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_8_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_8_contents"></textarea></div>
-                </div>
-        <!-- end item_8 -->
-        <!-- start item_9 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item9" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_9}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_9_contents}}}"><input type="text" style="text-align: center;" name="attr_item_9" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem9" name="attr_displaySettingsFlagItem9" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_9" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_9_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_9_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_9_contents"></textarea></div>
-                </div>
-        <!-- end item_9 -->
-        <!-- start item_10 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item10" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_10}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_10_contents}}}"><input type="text" style="text-align: center;" name="attr_item_10" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem10" name="attr_displaySettingsFlagItem10" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_10" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_10_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_10_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_10_contents"></textarea></div>
-                </div>
-        <!-- end item_10 -->
-    		</div>
-    		<div class="actionsBottom"></div>
-        </div>
-        <input type="hidden" class="display_inventory_flag" name="attr_display_inventory_flag" value="show" />
-        <!-- new inventory section -->
-        <div class="inlineBlock third vertTop displayInventory">
-            <div class="actionsTop padTop">
-            <!-- Headings for Inventory -->
-                <div class="column bold textLarge width100 padTop">Important Inventory 11-20</div>
+        		<div class="actionsMiddle padLeft padRight">
+            <!-- start item_11 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item11" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_11}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_11_contents}}}"><input type="text" style="text-align: center;" name="attr_item_11" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem11" name="attr_displaySettingsFlagItem11" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_11" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_11_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_11_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_11_contents"></textarea></div>
+                    </div>
+            <!-- end item_11 -->
+            <!-- start item_12 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item12" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_12}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_12_contents}}}"><input type="text" style="text-align: center;" name="attr_item_12" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem12" name="attr_displaySettingsFlagItem12" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_12" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_12_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_12_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_12_contents"></textarea></div>
+                    </div>
+            <!-- end item_12 -->
+            <!-- start item_13 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item13" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_13}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_13_contents}}}"><input type="text" style="text-align: center;" name="attr_item_13" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem13" name="attr_displaySettingsFlagItem13" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_13" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_13_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_13_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_13_contents"></textarea></div>
+                    </div>
+            <!-- end item_13 -->
+            <!-- start item_14 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item14" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_14}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_14_contents}}}"><input type="text" style="text-align: center;" name="attr_item_14" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem14" name="attr_displaySettingsFlagItem14" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_14" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_14_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_14_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_14_contents"></textarea></div>
+                    </div>
+            <!-- end item_14 -->
+            <!-- start item_15 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item15" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_15}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_15_contents}}}"><input type="text" style="text-align: center;" name="attr_item_15" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem15" name="attr_displaySettingsFlagItem15" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_15" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_15_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_15_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_15_contents"></textarea></div>
+                    </div>
+            <!-- end item_15 -->
+            <!-- start item_16 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item16" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_16}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_16_contents}}}"><input type="text" style="text-align: center;" name="attr_item_16" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem16" name="attr_displaySettingsFlagItem16" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_16" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_16_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_16_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_16_contents"></textarea></div>
+                    </div>
+            <!-- end item_16 -->
+            <!-- start item_17 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item17" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_17}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_17_contents}}}"><input type="text" style="text-align: center;" name="attr_item_17" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem17" name="attr_displaySettingsFlagItem17" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_17" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_17_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_17_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_17_contents"></textarea></div>
+                    </div>
+            <!-- end item_17 -->
+            <!-- start item_18 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item18" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_18}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_18_contents}}}"><input type="text" style="text-align: center;" name="attr_item_18" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem18" name="attr_displaySettingsFlagItem18" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_18" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_18_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_18_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_18_contents"></textarea></div>
+                    </div>
+            <!-- end item_18 -->
+            <!-- start item_19 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item19" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_19}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_19_contents}}}"><input type="text" style="text-align: center;" name="attr_item_19" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem19" name="attr_displaySettingsFlagItem19" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_19" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_19_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_19_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_19_contents"></textarea></div>
+                    </div>
+            <!-- end item_19 -->
+            <!-- start item_20 -->
+                    <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item20" value="on" /><span>i</span></div>
+                    <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_20}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_20_contents}}}"><input type="text" style="text-align: center;" name="attr_item_20" /></button></div>
+                    <input type="hidden" class="displaySettingsFlagItem20" name="attr_displaySettingsFlagItem20" value="hide" />
+                    <div class="width100 displaySettings">
+                        <div class="column width25 inlineBlock bold">Name: </div>
+                        <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_20" /></div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_20_heavy" value="heavy" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
+                        <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_20_bulky" value="bulky" /></div>
+                        <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
+            			<div class="column width100 bold italic textCenter">Content/Description</div>
+                        <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_20_contents"></textarea></div>
+                    </div>
+            <!-- end item_20 -->
+        		</div>
+        		<div class="actionsBottom"></div>
             </div>
-    		<div class="actionsMiddle padLeft padRight">
-        <!-- start item_11 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item11" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_11}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_11_contents}}}"><input type="text" style="text-align: center;" name="attr_item_11" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem11" name="attr_displaySettingsFlagItem11" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_11" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_11_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_11_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_11_contents"></textarea></div>
-                </div>
-        <!-- end item_11 -->
-        <!-- start item_12 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item12" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_12}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_12_contents}}}"><input type="text" style="text-align: center;" name="attr_item_12" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem12" name="attr_displaySettingsFlagItem12" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_12" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_12_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_12_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_12_contents"></textarea></div>
-                </div>
-        <!-- end item_12 -->
-        <!-- start item_13 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item13" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_13}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_13_contents}}}"><input type="text" style="text-align: center;" name="attr_item_13" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem13" name="attr_displaySettingsFlagItem13" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_13" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_13_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_13_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_13_contents"></textarea></div>
-                </div>
-        <!-- end item_13 -->
-        <!-- start item_14 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item14" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_14}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_14_contents}}}"><input type="text" style="text-align: center;" name="attr_item_14" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem14" name="attr_displaySettingsFlagItem14" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_14" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_14_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_14_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_14_contents"></textarea></div>
-                </div>
-        <!-- end item_14 -->
-        <!-- start item_15 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item15" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_15}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_15_contents}}}"><input type="text" style="text-align: center;" name="attr_item_15" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem15" name="attr_displaySettingsFlagItem15" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_15" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_15_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_15_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_15_contents"></textarea></div>
-                </div>
-        <!-- end item_15 -->
-        <!-- start item_16 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item16" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_16}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_16_contents}}}"><input type="text" style="text-align: center;" name="attr_item_16" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem16" name="attr_displaySettingsFlagItem16" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_16" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_16_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_16_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_16_contents"></textarea></div>
-                </div>
-        <!-- end item_16 -->
-        <!-- start item_17 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item17" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_17}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_17_contents}}}"><input type="text" style="text-align: center;" name="attr_item_17" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem17" name="attr_displaySettingsFlagItem17" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_17" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_17_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_17_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_17_contents"></textarea></div>
-                </div>
-        <!-- end item_17 -->
-        <!-- start item_18 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item18" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_18}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_18_contents}}}"><input type="text" style="text-align: center;" name="attr_item_18" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem18" name="attr_displaySettingsFlagItem18" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_18" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_18_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_18_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_18_contents"></textarea></div>
-                </div>
-        <!-- end item_18 -->
-        <!-- start item_19 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item19" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_19}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_19_contents}}}"><input type="text" style="text-align: center;" name="attr_item_19" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem19" name="attr_displaySettingsFlagItem19" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_19" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_19_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_19_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_19_contents"></textarea></div>
-                </div>
-        <!-- end item_19 -->
-        <!-- start item_20 -->
-                <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag_item20" value="on" /><span>i</span></div>
-                <div class="width80 inlineBlock vertTop inputNameShort attributeButton gray"><button type="roll" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= @{item_20}}} {{subTitle= @{character_name}}} {{subTitleAdd= Inventory Item}} {{description= @{item_20_contents}}}"><input type="text" style="text-align: center;" name="attr_item_20" /></button></div>
-                <input type="hidden" class="displaySettingsFlagItem20" name="attr_displaySettingsFlagItem20" value="hide" />
-                <div class="width100 displaySettings">
-                    <div class="column width25 inlineBlock bold">Name: </div>
-                    <div class="column width70 inlineBlock inputNameShort"><input type="text" name="attr_item_20" /></div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_20_heavy" value="heavy" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Heavy</div>
-                    <div class="column width25 inlineBlock"><input type="checkbox" class="checks25" name="attr_item_20_bulky" value="bulky" /></div>
-                    <div class="column width25 inlineBlock textLeft textSmall bold">Bulky</div>
-        			<div class="column width100 bold italic textCenter">Content/Description</div>
-                    <div class="column width90 resizeVert vertTop padLeft"><textarea class="height100" name="attr_item_20_contents"></textarea></div>
-                </div>
-        <!-- end item_20 -->
-    		</div>
-    		<div class="actionsBottom"></div>
+        <!-- end Equipment section -->
         </div>
-    <!-- end Equipment section -->
+    <!-- End Main Charactersheet Section -->
     </div>
-<!-- End Main Charactersheet Section -->
+    <!-- End Main body of Character Sheet -->
 </div>
-<!-- End Main body of Character Sheet -->
-
 
 
 <!-- Roll Templates Area -->
@@ -6425,12 +10551,12 @@ on("change:repeating_featsLeft", function() {
         </div>
         {{/emote}}
       <!-- Display Boon roll -->
-        {{#effect}}
+        {{#roll}}
         <div class="row vertTop">
-            <div class="column textCenter width100 roll">{{effect}}</div>
+            <div class="column textCenter width100 roll">{{roll}}</div>
             <div class="column textCenter width100 bold">Effect</div>
         </div>
-        {{/effect}}
+        {{/roll}}
       <!-- Display description if provided -->
         {{#description}}
         <div class="row">

--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -4787,7 +4787,7 @@ on("change:repeating_featsLeft", function() {
     <div class="inlineBlock vertBottom" style="width: 110px;">      <!-- Right Third of 2/3 rows for info (Open Legend Logo) -->
         <div class="column width100 textCenter vertBottom"><img src="http://www.openlegendrpg.com/assets/img/open_legend_lg_logo.png" alt="Open Legend Open source roleplaying game" /></div>
     </div>
-    <div class="column textSmall inlineBlock padLeft vertMiddle bold">Version 1.9.5</div>
+    <div class="column textSmall inlineBlock padLeft vertMiddle bold">Version 1.9.6</div>
     <div class="row width100 padBottom"></div>
 <!-- Sheet Options, Change Logs, and Links -->
     <div class="option-main options width100 padTop marginTop">
@@ -4891,6 +4891,11 @@ on("change:repeating_featsLeft", function() {
     Might end up just removing the changelog, not sure it is really needed here -->
             <div class="width100 height150 scroll">
                 <div class="width90 inlineBlock boxShadow marginBottom marginTop">
+                    <div class="column width100 textLarge bold borderBottom textLeft">1.9.6 on 2018 May 14th</div>
+                    <div class="column width100 textLeft">Resist Rolls Update</div>
+                    <div class="column width100 textLeft padLeft">- Made Resist Roll buttons next to Speed</div>
+                    <div class="column width100 textLeft padLeft">- Updated look of Speed section on character sheet</div>
+                </div><div class="width90 inlineBlock boxShadow marginBottom marginTop">
                     <div class="column width100 textLarge bold borderBottom textLeft">1.9.5 on 2018 May 11th</div>
                     <div class="column width100 textLeft">Sheet Type Selection added</div>
                     <div class="column width100 textLeft padLeft">- Pick between: Primary Character, NPC/Summons, Alt form Tier 1 or 2, Companion Tier 1, 2, or 3</div>
@@ -5348,17 +5353,17 @@ on("change:repeating_featsLeft", function() {
                 <div class="third inlineBlock vertTop">
         <!-- Defenses (yep, HP is a defense) -->
                     <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
-                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width20">Guard</div>
                     <div class="column inlineBlock textCenter bold width25">Toughness</div>
-                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
-                    <div class="column inlineBlock textCenter bold width25">Resist</div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_guard" value=10 /></div>
+                    <div class="column inlineBlock textCenter bold width20">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width35">Resist</div>
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_guard" value=10 /></div>
                     <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_toughness" value=10 /></div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_resolve" value=10 /></div>
-                    <div class="column width25 inlineBlock speedButton vertBottom">
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc1_resolve" value=10 /></div>
+                    <div class="column width35 inlineBlock speedButton vertBottom">
                         <button type="roll" name="roll_npc1_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
-                        <button type="roll" name="roll_npc1_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
-                        <button type="roll" name="roll_npc1_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                        <button type="roll" name="roll_npc1_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                        <button type="roll" name="roll_npc1_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc1_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
                     </div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
@@ -5840,17 +5845,17 @@ on("change:repeating_featsLeft", function() {
                     <div class="third inlineBlock vertTop">
             <!-- Defenses (yep, HP is a defense) -->
                         <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
-                        <div class="column inlineBlock textCenter bold width25">Guard</div>
+                        <div class="column inlineBlock textCenter bold width20">Guard</div>
                         <div class="column inlineBlock textCenter bold width25">Toughness</div>
-                        <div class="column inlineBlock textCenter bold width25">Resolve</div>
-                        <div class="column inlineBlock textCenter bold width25">Resist</div>
-                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_guard" value=10 /></div>
+                        <div class="column inlineBlock textCenter bold width20">Resolve</div>
+                        <div class="column inlineBlock textCenter bold width35">Resist</div>
+                        <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_guard" value=10 /></div>
                         <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_toughness" value=10 /></div>
-                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_resolve" value=10 /></div>
-                        <div class="column width25 inlineBlock speedButton vertBottom">
+                        <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc2_resolve" value=10 /></div>
+                        <div class="column width35 inlineBlock speedButton vertBottom">
                             <button type="roll" name="roll_npc2_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
-                            <button type="roll" name="roll_npc2_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
-                            <button type="roll" name="roll_npc2_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                            <button type="roll" name="roll_npc2_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                            <button type="roll" name="roll_npc2_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc2_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
                         </div>
                         <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
                         <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
@@ -6332,17 +6337,17 @@ on("change:repeating_featsLeft", function() {
                 <div class="third inlineBlock vertTop">
         <!-- Defenses (yep, HP is a defense) -->
                     <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
-                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width20">Guard</div>
                     <div class="column inlineBlock textCenter bold width25">Toughness</div>
-                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
-                    <div class="column inlineBlock textCenter bold width25">Resist</div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_guard" value=10 /></div>
+                    <div class="column inlineBlock textCenter bold width20">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width35">Resist</div>
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_guard" value=10 /></div>
                     <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_toughness" value=10 /></div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_resolve" value=10 /></div>
-                    <div class="column width25 inlineBlock speedButton vertBottom">
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc3_resolve" value=10 /></div>
+                    <div class="column width35 inlineBlock speedButton vertBottom">
                         <button type="roll" name="roll_npc3_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
-                        <button type="roll" name="roll_npc3_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
-                        <button type="roll" name="roll_npc3_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                        <button type="roll" name="roll_npc3_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                        <button type="roll" name="roll_npc3_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc3_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
                     </div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
@@ -6824,17 +6829,17 @@ on("change:repeating_featsLeft", function() {
                     <div class="third inlineBlock vertTop">
             <!-- Defenses (yep, HP is a defense) -->
                         <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
-                        <div class="column inlineBlock textCenter bold width25">Guard</div>
+                        <div class="column inlineBlock textCenter bold width20">Guard</div>
                         <div class="column inlineBlock textCenter bold width25">Toughness</div>
-                        <div class="column inlineBlock textCenter bold width25">Resolve</div>
-                        <div class="column inlineBlock textCenter bold width25">Resist</div>
-                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_guard" value=10 /></div>
+                        <div class="column inlineBlock textCenter bold width20">Resolve</div>
+                        <div class="column inlineBlock textCenter bold width35">Resist</div>
+                        <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_guard" value=10 /></div>
                         <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_toughness" value=10 /></div>
-                        <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_resolve" value=10 /></div>
-                        <div class="column width25 inlineBlock speedButton vertBottom">
+                        <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc4_resolve" value=10 /></div>
+                        <div class="column width35 inlineBlock speedButton vertBottom">
                             <button type="roll" name="roll_npc4_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
-                            <button type="roll" name="roll_npc4_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
-                            <button type="roll" name="roll_npc4_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                            <button type="roll" name="roll_npc4_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                            <button type="roll" name="roll_npc4_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc4_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
                         </div>
                         <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
                         <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
@@ -7316,17 +7321,17 @@ on("change:repeating_featsLeft", function() {
                 <div class="third inlineBlock vertTop">
         <!-- Defenses (yep, HP is a defense) -->
                     <div class="column textCenter grey textLarger bold width95 marginCenter smallCaps">Defenses</div>
-                    <div class="column inlineBlock textCenter bold width25">Guard</div>
+                    <div class="column inlineBlock textCenter bold width20">Guard</div>
                     <div class="column inlineBlock textCenter bold width25">Toughness</div>
-                    <div class="column inlineBlock textCenter bold width25">Resolve</div>
-                    <div class="column inlineBlock textCenter bold width25">Resist</div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_guard" value=10 /></div>
+                    <div class="column inlineBlock textCenter bold width20">Resolve</div>
+                    <div class="column inlineBlock textCenter bold width35">Resist</div>
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_guard" value=10 /></div>
                     <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_toughness" value=10 /></div>
-                    <div class="column width25 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_resolve" value=10 /></div>
-                    <div class="column width25 inlineBlock speedButton vertBottom">
+                    <div class="column width20 inlineBlock inputNumberLargeNarrowShort"><input type="number" name="attr_Npc5_resolve" value=10 /></div>
+                    <div class="column width35 inlineBlock speedButton vertBottom">
                         <button type="roll" name="roll_npc5_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
-                        <button type="roll" name="roll_npc5_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Resilient</button>
-                        <button type="roll" name="roll_npc5_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Potent</button>
+                        <button type="roll" name="roll_npc5_resist_resilient" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                        <button type="roll" name="roll_npc5_resist_potent" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{npc5_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
                     </div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Current</div>
                     <div class="column inlineBlock textCenter bold width1of3">HP Max</div>
@@ -8967,13 +8972,22 @@ on("change:repeating_featsLeft", function() {
         <!-- remove this to add Sanity back in (and corresponding 2 other areas)
                 </div>
              <!-- Legend Points & Speed Section -->
-                <div class="column width100 textCenter textLargest bold padTop">Speed</div>
-                <div class="wealth">
-                    <div class="width100 height15"></div>
-                    <div class="column width100 inputNumber60 padTop"><input type="number" name="attr_Speed" value=30 /></div>
-                </div>
-                <div class="column width100 vertTop inputNumber30 textSmall bold">Base <input type="number" name="attr_base_speed" value=30 /> Armor Penalty(ft) <input type="number" name="attr_armor_penalty" value=0 /> Feat(ft) <input type="number" name="attr_armor_training" value=0 /></div>
-        		<input type="hidden" name="attr_Speed4Token" value=0 />
+                <div class="width25 inlineBlock vertTop">
+                    <div class="column width100 textCenter textLarge bold">Speed</div>
+                    <div class="column width100 inputNumberLargeNarrow"><input type="number" name="attr_Speed" value=30 /></div>
+                </div><div class="width40 inlineBlock textLeft vertBottom">
+                    <div class="column width100 vertTop inputNumber30 textSmall bold"><input type="number" name="attr_base_speed" value=30 /> Base</div>
+                    <div class="column width100 vertTop inputNumber30 textSmall bold"><input type="number" name="attr_armor_penalty" value=0 /> Penalty(ft)</div>
+                    <div class="column width100 vertTop inputNumber30 textSmall bold"><input type="number" name="attr_armor_training" value=0 /> Feat(ft)</div>
+            		<input type="hidden" name="attr_Speed4Token" value=0 />
+            	</div><div class="width35 inlineBlock vertTop">
+                    <div class="column width100 textCenter textLarge bold">Resist Bane</div>
+                    <div class="column width100 speedButton vertTop">
+                        <button type="roll" name="roll_npc1_resist" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{character_name}}} {{subTitleAdd=Normal}} {{roll=[[1d20!!]]}} {{description=10+ is successful resist}}">Normal</button>
+                        <button type="roll" name="roll_npc1_resist_advantage" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{character_name}}} {{subTitleAdd=with Advantage}} {{roll=[[2d20!!k1]]}} {{description=10+ is successful resist}}">Advantage</button>
+                        <button type="roll" name="roll_npc1_resist_disadvantage" value="@{tab_chat}&{template:openLegend} {{border=@{template_border}}} {{title=Resist Roll}} {{subTitle=@{character_name}}} {{subTitleAdd=with Disadvantage}} {{roll=[[2d20!!kl1]]}} {{description=10+ is successful resist}}">Disadvantage</button>
+                    </div>
+            	</div>
                 <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlagInitiative" value="on" checked="checked" /><span>y</span></div>
                 <div class="column width35 inlineBlock textLarge speedButton"><button type="roll" name="roll_initiative" value="@{tab_chat}&{template:openLegend@{template_border}} {{title= Initiative Roll}} {{subTitle= @{character_name}}} {{subTitleAdd= @{select_initiative}}} {{roll= @{initiative}}} {{description= Make sure you selected your token to have it automatically added to the turn order.}}">Initiative</button></div>
                 <input type="hidden" class="displaySettingsFlagInitiative" name="attr_displaySettingsFlagInitiative" />

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -4,6 +4,17 @@
 ## Tell YOUR story
 
 ### Changelog
+### 1.9.5 on 2018 May 13th
+* Sheet Type Selection added (and lots of backend coding)
+	- Pick between: Primary Character, NPC/Summons, Alternate Form Tier 1 or 2, Companion Tier 1, 2, or 3
+	- Changes the calculations for Attribute Points & Feat points based on what is selected
+	- Adds some entry fields were applicable (Companion Tier 3 Feat Points Granted)
+	- For NPC, shows a completely different sheet for "Quick" build (useful for summons as well)
+
+### 1.9.3 on 2018 May 10th
+* Fix for "Other Actions" section & Effects
+	- On Load function for Other Actions wasn't doing the Power Levels Correctly
+	- Forgot to make Effects dice explode (all dice in OL explode!!)
 
 ### 1.9.2 on 2018 May 8th
 * Added Whisper to GM option

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -4,6 +4,11 @@
 ## Tell YOUR story
 
 ### Changelog
+### 1.9.6 on 2018 May 14th
+* Resist Rolls Updated
+	- Made Resist Roll buttons next to Speed (to match what was on NPC section)
+	- Updated look of Speed section on character sheet
+
 ### 1.9.5 on 2018 May 13th
 * Sheet Type Selection added (and lots of backend coding)
 	- Pick between: Primary Character, NPC/Summons, Alternate Form Tier 1 or 2, Companion Tier 1, 2, or 3


### PR DESCRIPTION
### 1.9.5 on 2018 May 13th
* Sheet Type Selection added (and lots of backend coding)
	- Pick between: Primary Character, NPC/Summons, Alternate Form Tier 1 or 2, Companion Tier 1, 2, or 3
	- Changes the calculations for Attribute Points & Feat points based on what is selected
	- Adds some entry fields were applicable (Companion Tier 3 Feat Points Granted)
	- For NPC, shows a completely different sheet for "Quick" build (useful for summons as well)

### 1.9.3 on 2018 May 10th
* Fix for "Other Actions" section & Effects
	- On Load function for Other Actions wasn't doing the Power Levels Correctly
	- Forgot to make Effects dice explode (all dice in OL explode!!)