### PR TITLE
[Exalted3] Add support for quick characters.

### DIFF
--- a/Exalted 3/Ex3-Sheet.css
+++ b/Exalted 3/Ex3-Sheet.css
@@ -222,6 +222,10 @@ input, select, option, optgroup, textarea, .sheet-normal-caps, .btn:not([type=ro
 ::-moz-placeholder { font-style: italic; }
 :-ms-input-placeholder { font-style: italic; }
 
+.sheet-checklist > label {
+    display: block;
+}
+
 .sheet-trait > * {
     vertical-align: middle;
 }
@@ -229,6 +233,13 @@ input, select, option, optgroup, textarea, .sheet-normal-caps, .btn:not([type=ro
 .sheet-trait {
     position: relative;
     margin-bottom: 3px;
+}
+
+.sheet-trait > span:last-child,
+.sheet-trait > input:last-child {
+    position: absolute;
+    right: 0;
+    bottom: 0;
 }
 
 .sheet-6rows {
@@ -243,10 +254,11 @@ input, select, option, optgroup, textarea, .sheet-normal-caps, .btn:not([type=ro
     padding-left: 30px;
 }
 
+.sheet-trait input[type="number"],
 .sheet-motes input[type=number],
 .sheet-battle-group-row input[type=number] {
     width: 1.75em;
-    font-size: 16px;
+    font-size: 14px;
 }
 
 .sheet-motes:last-child input[type=number],
@@ -659,16 +671,33 @@ input.sheet-tab-settings-sheet:checked ~ div.sheet-tab-settings-sheet,
    display: block;
 }
 
+.sheet-quick-character[value="0"] ~ div.sheet-tab-character-sheet .sheet-qc-pools,
+.sheet-quick-character[value="0"] ~ div.sheet-tab-character-sheet .sheet-qc-defenses,
+.sheet-quick-character[value="0"] ~ div.sheet-tab-character-sheet .sheet-qc-health {
+    display: none;
+}
+
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet > .sheet-attributes,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-abilities,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-limit,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-experience,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-gear,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-health-defenses,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-health-header,
+.sheet-quick-character[value="1"] ~ div.sheet-tab-character-sheet .sheet-defenses {
+    display: none;
+}
+
 .sheet-battle-group[value="0"] ~ div.sheet-tab-character-sheet .sheet-battle-group-header,
 .sheet-battle-group[value="0"] ~ div.sheet-tab-character-sheet .sheet-battle-group-body {
     display: none;
 }
 
 .sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet > .sheet-health-track,
-.sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet > .sheet-health-header {
+.sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet > .sheet-health-header,
+.sheet-battle-group[value="1"] ~ div.sheet-tab-character-sheet h1.sheet-qc-health {
     display: none;
 }
-
 
 input.sheet-tab {
    width: 140px;

--- a/Exalted 3/Ex3-Sheet.html
+++ b/Exalted 3/Ex3-Sheet.html
@@ -550,6 +550,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
             <input class="sheet-tab sheet-tab-spells sheet-tab-spell-sheet" name="attr_sheet" title="Sorceries" type="radio" value="3">
             <input class="sheet-tab sheet-tab-settings sheet-tab-settings-sheet" name="attr_sheet" title="y" type="radio" value="4">
         </form>
+        <input class="sheet-quick-character" name="attr_qc" type="hidden" value="0">
         <input class="sheet-battle-group" name="attr_battlegroup" type="hidden" value="0">
         <div class="sheet-body sheet-tab-content sheet-tab-character-sheet">
             <div class="sheet-3colrow">
@@ -689,8 +690,8 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                 </div><!-- /sheet-col concept, animal, supernal -->
             </div><!-- /sheet-3colrow bio -->
 
-            <h1><span data-i18n="attributes">Attributes</span></h1>
-            <div class="sheet-3colrow">
+            <h1 class="sheet-attributes"><span data-i18n="attributes">Attributes</span></h1>
+            <div class="sheet-attributes sheet-3colrow">
                 <div class="sheet-col">
                     <div class="sheet-trait">
                         <label>
@@ -871,7 +872,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
             </div><!-- /sheet-3colrow attributes -->
 
             <div class="sheet-3colrow">
-                <div class="sheet-col">
+                <div class="sheet-abilities sheet-col">
                     <h1><span data-i18n="abilities">Abilities</span></h1>
                     <div class="sheet-trait">
                         <label>
@@ -1777,6 +1778,40 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                         </div>
                     </fieldset>
                 </div><!-- /sheet-col abilities -->
+                <div class="sheet-qc-pools sheet-col">
+                    <h1><span data-i18n="actions">Actions</span></h1>
+                    <div class="sheet-trait">
+                        <span data-i18n="join-battle">Join Battle</span>
+                        <input type="number" name="attr_qc-join">
+                    </div><!-- /sheet-trait qc-join -->
+                    <div class="sheet-trait">
+                        <span data-i18n="combat-movement">Combat Movement</span>
+                        <input type="number" name="attr_qc-move">
+                    </div><!-- /sheet-trait qc-move -->
+                    <fieldset class="repeating_qcactions">
+                        <div class="sheet-trait">
+                            <input type="text" name="attr_repqcactionname" data-i18n-placeholder="action-place" placeholder="Senses">
+                            <input type="number" name="attr_repqcactiondice">
+                        </div>
+                    </fieldset>
+                    <h1><span data-i18n="attacks">Attacks</span></h1>
+                    <div class="sheet-trait">
+                        <span data-i18n="grapple">Grapple</span>
+                        <span>
+                            <input type="number" name="attr_qc-grapple">
+                            <input type="number" name="attr_qc-grapple-control">
+                        </span>
+                    </div><!-- /sheet-trait qc-move -->
+                    <fieldset class="repeating_qcattacks">
+                        <div class="sheet-trait">
+                            <input type="text" name="attr_repqcattackname" data-i18n-placeholder="attack-place" placeholder="Self bow">
+                            <span>
+                                <input type="number" name="attr_repqcattackdice">
+                                <input type="number" name="attr_repqcattackdamage">
+                            </span>
+                        </div>
+                    </fieldset>
+                </div><!-- /sheet-col quick-pools -->
                 <div class="sheet-2col">
                     <h1 class="sheet-battle-group-header"><span data-i18n="battle-group">Battle Group</span></h1>
                     <div class="sheet-battle-group-body sheet-2colrow">
@@ -1912,8 +1947,8 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                             </div>
                         </div><!-- /sheet-col willpower/essence -->
                         <div class="sheet-col">
-                            <h1><span data-i18n="limit-break">Limit Break</span></h1>
-                            <div style="padding-left:6px;margin:9px 0 9px 0">
+                            <h1 class="sheet-limit"><span data-i18n="limit-break">Limit Break</span></h1>
+                            <div class="sheet-limit" style="padding-left:6px;margin:9px 0 9px 0">
                                 <div class="sheet-dots-full">
                                     <input type="radio" class="sheet-dots0" name="attr_limit" value="0" checked="checked"><span></span>
                                     <input type="radio" class="sheet-dots1" name="attr_limit" value="1"><span></span>
@@ -1928,13 +1963,44 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                                     <input type="radio" class="sheet-dots10" name="attr_limit" value="10"><span></span>
                                 </div>
                             </div>
-                            <h1><span data-i18n="limit-trigger">Limit Trigger</span></h1>
-                            <textarea name="attr_limittrigger" class="sheet-6rows" data-i18n-placeholder="limit-trigger-place"
+                            <h1 class="sheet-limit"><span data-i18n="limit-trigger">Limit Trigger</span></h1>
+                            <textarea name="attr_limittrigger" class="sheet-6rows sheet-limit" data-i18n-placeholder="limit-trigger-place"
                                 placeholder="Karal is insulted, belittled, or deliberately frustrated by another character."></textarea>
-                        </div><!-- /sheet-col limit -->
+                            <h1 class="sheet-qc-defenses"><span data-i18n="defenses">Defenses</span></h1>
+                            <div class="sheet-qc-defenses">
+                                <div class="sheet-trait">
+                                    <span data-i18n="appearance">Appearance</span>
+                                    <input type="number" name="attr_qc-appearance">
+                                </div><!-- /sheet-trait qc-appearance -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="guile">Guile</span>
+                                    <input type="number" name="attr_qc-guile">
+                                </div><!-- /sheet-trait qc-guile -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="resolve">Resolve</span>
+                                    <input type="number" name="attr_qc-resolve">
+                                </div><!-- /sheet-trait qc-resolve -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="parry">Parry</span>
+                                    <input type="number" name="attr_qc-parry">
+                                </div><!-- /sheet-trait qc-parry -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="evasion">Evasion</span>
+                                    <input type="number" name="attr_qc-evasion">
+                                </div><!-- /sheet-trait qc-evasion -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="soak">Soak</span>
+                                    <input type="number" name="attr_qc-soak">
+                                </div><!-- /sheet-trait qc-soak -->
+                                <div class="sheet-trait">
+                                    <span data-i18n="hardness">Hardness</span>
+                                    <input type="number" name="attr_qc-hardness">
+                                </div><!-- /sheet-trait qc-hardness -->
+                            </div><!-- /sheet-col limit -->
+                        </div>
                     </div><!-- /sheet-2colrow -->
-                    <h1><span data-i18n="experience-and-crafting">Experience & Crafting</span></h1>
-                    <div class="sheet-flexbox-h sheet-flexbox-inline">
+                    <h1><span class="sheet-experience" data-i18n="experience-and-crafting">Experience & Crafting</span></h1>
+                    <div class="sheet-experience sheet-flexbox-h sheet-flexbox-inline">
                         <label>
                             <span data-i18n="current-experience-points">Current XP:</span>
                             <input type="number" name="attr_xp">
@@ -1952,7 +2018,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                             <input type="number" name="attr_sxp_max">
                         </label>
                     </div><!-- /sheet-flexbox-h experience -->
-                    <div class="sheet-2colrow">
+                    <div class="sheet-experience sheet-2colrow">
                         <div class="sheet-col sheet-flexbox-h">
                             <label>
                                 <span data-i18n="silver-experience-points">Silver XP</span>:
@@ -1993,8 +2059,8 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                             </fieldset>
                         </div><!-- /sheet-col crafting projects -->
                     </div><!-- /sheet-2colrow -->
-                    <h1><span data-i18n="weapons-and-gear">Weapons & Gear</span></h1>
-                    <div class="sheet-table">
+                    <h1><span class="sheet-gear" data-i18n="weapons-and-gear">Weapons & Gear</span></h1>
+                    <div class="sheet-gear sheet-table">
                         <div class="sheet-table-header">
                             <div class="sheet-table-row">
                                 <div data-i18n="weapon" class="sheet-table-cell">Weapon</div>
@@ -2017,13 +2083,15 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                         </fieldset>
                     </div><!-- /sheet-table weapons-->
 
-                    <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="miscellaneous-items">Miscellaneous Items</strong></div>
-                    <fieldset class="repeating_gear">
-                        <input type="text" name="attr_repgear" style="width:100%" data-i18n-placeholder="miscellaneous-items-place" placeholder="Fancy scarf">
-                    </fieldset>
+                    <div class="sheet-gear">
+                        <div class="sheet-text-center sheet-txt-lg" style="margin-top:8px"><strong data-i18n="miscellaneous-items">Miscellaneous Items</strong></div>
+                        <fieldset class="repeating_gear">
+                            <input type="text" name="attr_repgear" style="width:100%" data-i18n-placeholder="miscellaneous-items-place" placeholder="Fancy scarf">
+                        </fieldset>
+                    </div>
 
-                    <h1><span data-i18n="armor">Armor</span></h1>
-                    <div class="sheet-table">
+                    <h1><span class="sheet-gear" data-i18n="armor">Armor</span></h1>
+                    <div class="sheet-gear sheet-table">
                         <div class="sheet-table-header">
                             <div class="sheet-table-row">
                                 <div data-i18n="armor" class="sheet-table-cell">Armor</div>
@@ -2048,8 +2116,9 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                 </div><!-- /sheet-2col -->
             </div><!-- /sheet-3colrow -->
 
-            <h1><span data-i18n="health-and-defense">Health & Defense</span></h1>
-            <div class="sheet-table sheet-txt-lg sheet-center-table sheet-80pct">
+            <h1 class="sheet-qc-health"><span data-i18n="health-levels">Health Levels</span></h1>
+            <h1 class="sheet-health-defenses"><span data-i18n="health-and-defense">Health & Defense</span></h1>
+            <div class="sheet-defenses sheet-table sheet-txt-lg sheet-center-table sheet-80pct">
                 <div class="sheet-table-body">
                     <div class="sheet-table-row">
                         <div class="sheet-table-cell sheet-text-right"><span data-i18n="natural-soak">Natural Soak</span>:</div>
@@ -2760,10 +2829,16 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
         </div><!-- /sheet-body -->
         <div class="sheet-body sheet-tab-content sheet-tab-settings-sheet">
             <h1><span data-i18n="character-type">Character Type</span></h1>
-            <label>
-                <input type="checkbox" name="attr_battlegroup" value="1"><span></span>
-                <span data-i18n="battle-group">battle group</span>
-            </label>
+            <div class="sheet-checklist">
+                <label>
+                    <input type="checkbox" name="attr_qc" value="1"><span></span>
+                    <span data-i18n="quick-character">quick character</span>
+                </label>
+                <label>
+                    <input type="checkbox" name="attr_battlegroup" value="1"><span></span>
+                    <span data-i18n="battle-group">battle group</span>
+                </label>
+            </div>
             <h1><span data-i18n="mote-pool-equations">Mote Pool Equations</span></h1>
             <label data-i18n="max-personal-motes">Max Personal Motes</label>
             <input type="text" name="attr_personal-equation" value="@{essence} * 3 + 10"><span> </span>

--- a/Exalted 3/translation.json
+++ b/Exalted 3/translation.json
@@ -237,5 +237,12 @@
     "elite": "Elite",
     "might": "Might",
     "character-type": "Character Type",
-    "battle-group": "Battle Group"
+    "battle-group": "Battle Group",
+    "combat-movement": "Combat Movement",
+    "grapple": "Grapple",
+    "join-battle": "Join Battle",
+    "actions": "Actions",
+    "attacks": "Attacks",
+    "defenses": "Defenses",
+    "quick-character": "Quick Character"
 }


### PR DESCRIPTION
Adds checkbox on settings page to toggle quick-character mode. This option hides sections of the sheet that aren't used by quick characters (or are calculated differently for them), and adds new sections for quick-character dice pools.