### PR TITLE
[Burning Wheel] Fixed beginners luck difficulty calculations + Added Grey and White Grayscales to the Combat Page

### DIFF
--- a/Burning Wheel/Burning Wheel.html
+++ b/Burning Wheel/Burning Wheel.html
@@ -906,7 +906,7 @@
                             <tr>
                                 <td>
                                     <input type="text" class="underline long statname" name="attr_name">
-                                    <button type="roll" class="sheet-roll" name="roll_skill" title="roll_skill" value="&{template:bw} {{name=@{name}}} {{stat_name=@{name}}} {{stat=[[@{skill}]]}} {{shade=[[@{shade}]]}} {{openended=@{openended}}} {{mod=[[?{Modifiers|0}]]}} {{artha=[[?{Artha|0}]]}} {{wounddice=[[@{wounddice}]]}} {{ob=[[?{Base Obstacle|1}]]}} {{obpen=[[@{obstaclepenalties}]]}} {{successes=[[ {[[@{skill}+?{Modifiers|0}+?{Artha|0}-(@{wounddice})]]d6@{openended}}>@{shade}]]}} {{totalob=[[[[?{Base Obstacle|1}*2]]+[[@{obstaclepenalties}]]]]}} {{beinglearned=[[[[?{Base Obstacle|1}]]+[[@{obstaclepenalties}]]]]}} {{dice=[[@{skill}+?{Modifiers|0}-(@{wounddice})]]}} {{dice-1=[[@{skill}+?{Modifiers|0}-(@{wounddice})-(1)]]}} {{dice-2=[[@{skill}+?{Modifiers|0}-(@{wounddice})-(2)]]}}"></button>
+                                    <button type="roll" class="sheet-roll" name="roll_skill" title="roll_skill" value="&{template:bw} {{name=@{name}}} {{stat_name=@{name}}} {{stat=[[@{skill}]]}} {{shade=[[@{shade}]]}} {{openended=@{openended}}} {{mod=[[?{Modifiers|0}]]}} {{artha=[[?{Artha|0}]]}} {{wounddice=[[@{wounddice}]]}} {{ob=[[?{Base Obstacle|1}]]}} {{additional_complications=[[?{Additional Complications|0}]]}} {{obpen=[[@{obstaclepenalties}]]}} {{successes=[[ {[[@{skill}+?{Modifiers|0}+?{Artha|0}-(@{wounddice})]]d6@{openended}}>@{shade}]]}} {{totalob=[[[[?{Base Obstacle|1}*2+?{Additional Complications|0}]]+[[@{obstaclepenalties}]]]]}} {{beinglearned=[[[[?{Base Obstacle|1}]]+?{Additional Complications|0}]]}} {{dice=[[@{skill}+?{Modifiers|0}-(@{wounddice})]]}} {{dice-1=[[@{skill}+?{Modifiers|0}-(@{wounddice})-(1)]]}} {{dice-2=[[@{skill}+?{Modifiers|0}-(@{wounddice})-(2)]]}}"></button>
                                     <select class="box" name="attr_shade" title="@{shade}"><option value="4">B</option><option value="3">G</option><option value="2">W</option></select><input type="text" class="underline stat" name="attr_skill" title="@{skill}" disabled="disabled" value="10 - @{aptitutde}">
                                     <div class="opencontinaer">
                                         <input type="radio" class="openended unchecked" name="attr_openended" value="" checked="checked" title="Open Ended (D6 Explode)" />
@@ -1214,24 +1214,24 @@
                 </tr>
                 <tr>
                     <td style="background-color: black; color: white;">Coordinate</td>
-                    <td style="background-color: #787878;">B1</td>
-                    <td style="background-color: #808080;">B2</td>
-                    <td style="background-color: #888888;">B3</td>
-                    <td style="background-color: #909090;">B4</td>
-                    <td style="background-color: #989898;">B5</td>
-                    <td style="background-color: #A0A0A0;">B6</td>
-                    <td style="background-color: #A8A8A8;">B7</td>
-                    <td style="background-color: #B0B0B0;">B8</td>
-                    <td style="background-color: #B8B8B8;">B9</td>
-                    <td style="background-color: #C0C0C0;">B10</td>
-                    <td style="background-color: #C8C8C8;">B11</td>
-                    <td style="background-color: #D0D0D0;">B12</td>
-                    <td style="background-color: #D8D8D8;">B13</td>
-                    <td style="background-color: #E0E0E0;">B14</td>
-                    <td style="background-color: #E8E8E8;">B15</td>
-                    <td style="background-color: #F0F0F0;">B16</td>
+                    <td style="background-color: black; color: white;">B1</td>
+                    <td style="background-color: black; color: white;">B2</td>
+                    <td style="background-color: black; color: white;">B3</td>
+                    <td style="background-color: black; color: white;">B4</td>
+                    <td style="background-color: black; color: white;">B5</td>
+                    <td style="background-color: black; color: white;">B6</td>
+                    <td style="background-color: black; color: white;">B7</td>
+                    <td style="background-color: black; color: white;">B8</td>
+                    <td style="background-color: black; color: white;">B9</td>
+                    <td style="background-color: black; color: white;">B10</td>
+                    <td style="background-color: black; color: white;">B11</td>
+                    <td style="background-color: black; color: white;">B12</td>
+                    <td style="background-color: black; color: white;">B13</td>
+                    <td style="background-color: black; color: white;">B14</td>
+                    <td style="background-color: black; color: white;">B15</td>
+                    <td style="background-color: black; color: white;">B16</td>
                 </tr>
-                <tr>
+                <tr class="black_wounds">
                     <td>Injury</td>
                     <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_b1" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b1" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b1" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b1" value="3" /><span></span></td>
                     <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_b2" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b2" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b2" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b2" value="3" /><span></span></td>
@@ -1249,6 +1249,120 @@
                     <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_b14" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b14" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b14" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b14" value="3" /><span></span></td>
                     <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_b15" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b15" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b15" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b15" value="3" /><span></span></td>
                     <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_b16" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b16" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b16" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_b16" value="3" /><span></span></td>
+                </tr>
+                <tr>
+                    <td>Tolerance</td>
+                    <td><select name="attr_tolerance_g1"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g2"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g3"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g4"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g5"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g6"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g7"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g8"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g9"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g10"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g11"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g12"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g13"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g14"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g15"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_g16"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                </tr>
+                <tr>
+                    <td style="background-color: black; color: white;">Coordinate</td>
+                    <td style="background-color: #A0A0A0;">G1</td>
+                    <td style="background-color: #A0A0A0;">G2</td>
+                    <td style="background-color: #A0A0A0;">G3</td>
+                    <td style="background-color: #A0A0A0;">G4</td>
+                    <td style="background-color: #A0A0A0;">G5</td>
+                    <td style="background-color: #A0A0A0;">G6</td>
+                    <td style="background-color: #A0A0A0;">G7</td>
+                    <td style="background-color: #A0A0A0;">G8</td>
+                    <td style="background-color: #A0A0A0;">G9</td>
+                    <td style="background-color: #A0A0A0;">G10</td>
+                    <td style="background-color: #A0A0A0;">G11</td>
+                    <td style="background-color: #A0A0A0;">G12</td>
+                    <td style="background-color: #A0A0A0;">G13</td>
+                    <td style="background-color: #A0A0A0;">G14</td>
+                    <td style="background-color: #A0A0A0;">G15</td>
+                    <td style="background-color: #A0A0A0;">G16</td>
+                </tr>
+                <tr>
+                    <td>Injury</td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g1" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g1" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g1" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g1" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g2" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g2" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g2" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g2" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g3" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g3" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g3" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g3" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g4" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g4" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g4" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g4" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g5" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g5" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g5" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g5" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g6" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g6" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g6" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g6" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g7" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g7" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g7" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g7" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g8" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g8" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g8" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g8" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g9" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g9" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g9" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g9" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g10" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g10" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g10" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g10" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g11" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g11" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g11" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g11" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g12" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g12" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g12" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g12" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g13" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g13" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g13" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g13" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g14" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g14" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g14" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g14" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g15" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g15" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g15" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g15" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_g16" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g16" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g16" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_g16" value="3" /><span></span></td>
+                </tr>
+                <tr>
+                    <td>Tolerance</td>
+                    <td><select name="attr_tolerance_w1"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w2"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w3"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w4"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w5"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w6"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w7"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w8"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w9"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w10"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w11"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w12"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w13"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w14"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w15"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                    <td><select name="attr_tolerance_w16"><option value="*0*0" checked="checked">Br</option><option value="/3">Su</option><option value="*1">Li</option><option value="*2">Mi</option><option value="*3">Se</option><option value="*4">Tr</option><option value="*0">M</option></select></td>
+                </tr>
+                <tr>
+                    <td style="background-color: black; color: white;">Coordinate</td>
+                    <td style="background-color: white;">W1</td>
+                    <td style="background-color: white;">W2</td>
+                    <td style="background-color: white;">W3</td>
+                    <td style="background-color: white;">W4</td>
+                    <td style="background-color: white;">W5</td>
+                    <td style="background-color: white;">W6</td>
+                    <td style="background-color: white;">W7</td>
+                    <td style="background-color: white;">W8</td>
+                    <td style="background-color: white;">W9</td>
+                    <td style="background-color: white;">W10</td>
+                    <td style="background-color: white;">W11</td>
+                    <td style="background-color: white;">W12</td>
+                    <td style="background-color: white;">W13</td>
+                    <td style="background-color: white;">W14</td>
+                    <td style="background-color: white;">W15</td>
+                    <td style="background-color: white;">W16</td>
+                </tr>
+                <tr>
+                    <td>Injury</td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w1" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w1" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w1" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w1" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w2" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w2" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w2" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w2" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w3" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w3" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w3" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w3" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w4" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w4" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w4" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w4" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w5" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w5" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w5" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w5" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w6" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w6" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w6" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w6" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w7" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w7" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w7" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w7" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w8" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w8" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w8" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w8" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w9" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w9" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w9" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w9" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w10" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w10" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w10" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w10" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w11" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w11" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w11" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w11" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w12" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w12" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w12" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w12" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w13" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w13" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w13" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w13" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w14" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w14" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w14" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w14" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w15" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w15" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w15" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w15" value="3" /><span></span></td>
+                    <td><input type="radio" class="sheet-normal sheet-zero" name="attr_injury_w16" value="0" checked="checked" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w16" value="1" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w16" value="2" /><span></span><br><input type="radio" class="sheet-normal" name="attr_injury_w16" value="3" /><span></span></td>
                 </tr>
             </table>
 
@@ -3021,7 +3135,7 @@
 </div>  <!-- *** END CONTAINER *** -->
 
 <!-- *** BEGIN HIDDEN FIELDS *** -->
-<input type="hidden" name="attr_woundpenalty_total" value="(@{injury_b1}@{tolerance_b1})+(@{injury_b2}@{tolerance_b2})+(@{injury_b3}@{tolerance_b3})+(@{injury_b4}@{tolerance_b4})+(@{injury_b5}@{tolerance_b5})+(@{injury_b6}@{tolerance_b6})+(@{injury_b7}@{tolerance_b7})+(@{injury_b8}@{tolerance_b8})+(@{injury_b9}@{tolerance_b9})+(@{injury_b10}@{tolerance_b10})+(@{injury_b11}@{tolerance_b11})+(@{injury_b12}@{tolerance_b12})+(@{injury_b13}@{tolerance_b13})+(@{injury_b14}@{tolerance_b14})+(@{injury_b15}@{tolerance_b15})+(@{injury_b16}@{tolerance_b16})" />
+<input type="hidden" name="attr_woundpenalty_total" value="(@{injury_b1}@{tolerance_b1})+(@{injury_b2}@{tolerance_b2})+(@{injury_b3}@{tolerance_b3})+(@{injury_b4}@{tolerance_b4})+(@{injury_b5}@{tolerance_b5})+(@{injury_b6}@{tolerance_b6})+(@{injury_b7}@{tolerance_b7})+(@{injury_b8}@{tolerance_b8})+(@{injury_b9}@{tolerance_b9})+(@{injury_b10}@{tolerance_b10})+(@{injury_b11}@{tolerance_b11})+(@{injury_b12}@{tolerance_b12})+(@{injury_b13}@{tolerance_b13})+(@{injury_b14}@{tolerance_b14})+(@{injury_b15}@{tolerance_b15})+(@{injury_b16}@{tolerance_b16})+(@{injury_g1}@{tolerance_g1})+(@{injury_g2}@{tolerance_g2})+(@{injury_g3}@{tolerance_g3})+(@{injury_g4}@{tolerance_g4})+(@{injury_g5}@{tolerance_g5})+(@{injury_g6}@{tolerance_g6})+(@{injury_g7}@{tolerance_g7})+(@{injury_g8}@{tolerance_g8})+(@{injury_g9}@{tolerance_g9})+(@{injury_g10}@{tolerance_g10})+(@{injury_g11}@{tolerance_g11})+(@{injury_g12}@{tolerance_g12})+(@{injury_g13}@{tolerance_g13})+(@{injury_g14}@{tolerance_g14})+(@{injury_g15}@{tolerance_g15})+(@{injury_g16}@{tolerance_g16})+(@{injury_w1}@{tolerance_w1})+(@{injury_w2}@{tolerance_w2})+(@{injury_w3}@{tolerance_w3})+(@{injury_w4}@{tolerance_w4})+(@{injury_w5}@{tolerance_w5})+(@{injury_w6}@{tolerance_w6})+(@{injury_w7}@{tolerance_w7})+(@{injury_w8}@{tolerance_w8})+(@{injury_w9}@{tolerance_w9})+(@{injury_w10}@{tolerance_w10})+(@{injury_w11}@{tolerance_w11})+(@{injury_w12}@{tolerance_w12})+(@{injury_w13}@{tolerance_w13})+(@{injury_w14}@{tolerance_w14})+(@{injury_w15}@{tolerance_w15})+(@{injury_w16}@{tolerance_w16})" />
 <input type="hidden" name="attr_sheetversion" value="1.0" />
 <!-- *** END  HIDDEN FIELDS *** -->
 


### PR DESCRIPTION
These improvements were little bugbears we encountered during play. I am aware the Grayscales are quite large, I find them fairly useful when burning supernatural characters. The beginners luck issue still needs a bit more work with calculating obstacle penalties on the difficulty check, but it is much more solid. (if needed you can add those penalties as complications in the updated prompts)