### PR TITLE
Re-added the spell prep checkbox to the sheet

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -783,6 +783,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -1912,6 +1914,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -2120,6 +2124,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -2317,6 +2323,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -2517,6 +2525,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -2714,6 +2724,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -2911,6 +2923,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -3111,6 +3125,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -3308,6 +3324,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -3505,6 +3523,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>
@@ -3702,6 +3722,8 @@
                             <div class="row">
                                 <span data-i18n="name:-u">NAME:</span>
                                 <input type="text" name="attr_spellname">
+                                <input type="checkbox" name="attr_spellprepared" value="1" checked="checked">
+                                <span data-i18n="prep-u">PREP</span>
                             </div>
                             <div class="row">
                                 <span data-i18n="school:-u">SCHOOL:</span>


### PR DESCRIPTION
The update for the charactermancer seemed to remove the spell prepared checkbox from all repeating spell sections. This update will put those back in place so that users can prepare/unprepare spells.