### PR TITLE
[Burning Wheel] Make Reputations and Affiliations an expandable list

### DIFF
--- a/Burning Wheel/Burning Wheel.html
+++ b/Burning Wheel/Burning Wheel.html
@@ -539,10 +539,10 @@
 
             <table class="page2">
                 <tr>
-                    <td colspan="2" style="text-align: center;" class="statname italic">Reputation:</td>
+                    <td colspan="3" style="text-align: center;" class="statname italic">Reputations:</td>
                 </tr>
                 <tr>
-                    <td colspan="2">
+                    <td colspan="3">
                         <fieldset class="repeating_reputation">
                             <input type="text" name="attr_reputation" class="underline full" />
                         </fieldset>
@@ -550,10 +550,10 @@
                 </tr>
                 <tr class="spacer"></tr>
                 <tr>
-                    <td colspan="2" style="text-align: center;" class="statname italic">Affiliation:</td>
+                    <td colspan="3" style="text-align: center;" class="statname italic">Affiliations:</td>
                 </tr>
                 <tr>
-                    <td colspan="2">
+                    <td colspan="3">
                         <fieldset class="repeating_affiliation">
                             <input type="text" name="attr_affiliation" class="underline full" />
                         </fieldset>

--- a/Burning Wheel/Burning Wheel.html
+++ b/Burning Wheel/Burning Wheel.html
@@ -539,23 +539,25 @@
 
             <table class="page2">
                 <tr>
-                    <td class="statname italic">Reputation</td><td><input type="text" class="underline full" name="attr_reputation1"></td>
+                    <td colspan="2" style="text-align: center;" class="statname italic">Reputation:</td>
                 </tr>
                 <tr>
-                    <td class="statname italic">Reputation</td><td><input type="text" class="underline full" name="attr_reputation2"></td>
-                </tr>
-                <tr>
-                    <td class="statname italic">Reputation</td><td><input type="text" class="underline full" name="attr_reputation3"></td>
+                    <td colspan="2">
+                        <fieldset class="repeating_reputation">
+                            <input type="text" name="attr_reputation" class="underline full" />
+                        </fieldset>
+                    </td>
                 </tr>
                 <tr class="spacer"></tr>
                 <tr>
-                    <td class="statname italic">Affiliation</td><td><input type="text" class="underline full" name="attr_affiliation1"></td>
+                    <td colspan="2" style="text-align: center;" class="statname italic">Affiliation:</td>
                 </tr>
                 <tr>
-                    <td class="statname italic">Affiliation</td><td><input type="text" class="underline full" name="attr_affiliation2"></td>
-                </tr>
-                <tr>
-                    <td class="statname italic">Affiliation</td><td><input type="text" class="underline full" name="attr_affiliation3"></td>
+                    <td colspan="2">
+                        <fieldset class="repeating_affiliation">
+                            <input type="text" name="attr_affiliation" class="underline full" />
+                        </fieldset>
+                    </td>
                 </tr>
             </table>
 


### PR DESCRIPTION
It was raised in the Burning Wheel discord, that people were having issue, only been allowed to have 3 of each. Updated this to now expand like sustained spells. 