### PR TITLE
Create Warhammer40KWrathNGlory.html

### DIFF
--- a/Warhammer40KWrathNGlory/Warhammer40KWrathNGlory.html
+++ b/Warhammer40KWrathNGlory/Warhammer40KWrathNGlory.html
@@ -1,1007 +1,884 @@
-<!-- Warhammer 40,000 Wrath & Glory RPG, made from Only War -->
+<!-- Warhammer 40,000 Wrath & Glory RPG, made from the Only War character sheet -->
 <!-- Version 1.00 -->
 
-<div class="sheet-wrapper"><!-- Basic Character Information --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-<div class="sheet-3colrow">
+<div class="sheet-wrapper">
+<!-- Basic Character Information -->
+    <div class="sheet-3colrow">
 <!-- Left Column  -->
-<div class="sheet-col">
+        <div class="sheet-col">
 <!-- Character Name -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 35%;"><label>Character Name</label></div>
-<div class="sheet-item" style="width: 60%;"><input name="attr_character_name" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 35%;"><label>Character Name</label></div>
+                <div class="sheet-item" style="width: 60%;"><input name="attr_character_name" type="text" /></div>
+            </div>
 <!-- Player Name -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><label>Player Name</label></div>
-<div class="sheet-item" style="width: 65%;"><input name="attr_Player" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 30%;"><label>Player Name</label></div>
+                <div class="sheet-item" style="width: 65%;"><input name="attr_Player" type="text" /></div>
+            </div>
 <!-- Tier -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 25%;"><label>Tier</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_Tier" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 25%;"><label>Tier</label></div>
+                <div class="sheet-item" style="width: 70%;"><input name="attr_Tier" type="text" /></div>
+            </div>
 <!-- Rank and Rank Bonus -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 18%;"><label>Rank</label></div>
-<div class="sheet-item" style="width: 28%;"><input name="attr_Rank" type="text" /></div>
-<div class="sheet-item" style="width: 28%;"><label>Rank Bonus</label></div>
-<div class="sheet-item" style="width: 18%;"><input name="attr_RankBonus" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 18%;"><label>Rank</label></div>
+                <div class="sheet-item" style="width: 28%;"><input name="attr_Rank" type="text" /></div>
+                <div class="sheet-item" style="width: 28%;"><label>Rank Bonus</label></div>
+                <div class="sheet-item" style="width: 18%;"><input name="attr_RankBonus" type="text" /></div>
+            </div>
 <!-- Framework -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 25%;"><label>Framework</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_Framework" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 25%;"><label>Framework</label></div>
+                <div class="sheet-item" style="width: 70%;"><input name="attr_Framework" type="text" /></div>
+            </div>
 <!-- Keywords -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 25%;"><label>Keywords</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_Keywords1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 95%;"><input name="attr_Keywords2" type="text" /></div>
-</div>
-<fieldset class="repeating_Keywords">
-<div class="sheet-item" style="width: 95%;"><input name="attr_Keywords" type="text" /></div>
-</fieldset>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 25%;"><label>Keywords</label></div>
+                <div class="sheet-item" style="width: 70%;"><input name="attr_Keywords1" type="text" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_Keywords2" type="text" /></div>
+                <fieldset class="repeating_Keywords">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_Keywords" type="text" /></div>
+                </fieldset>
+            </div>
 <!-- Notes -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 15%;"><label>Notes</label></div>
-<div class="sheet-item" style="width: 80%;"><input name="attr_Notes1" type="text" /></div>
-</div>
-<fieldset class="repeating_Notes">
-<div class="sheet-item" style="width: 95%;"><input name="attr_Notes" type="text" /></div>
-</fieldset>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 15%;"><label>Notes</label></div>
+                <div class="sheet-item" style="width: 80%;"><input name="attr_Notes1" type="text" /></div>
+            </div>
+                <fieldset class="repeating_Notes">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_Notes" type="text" /></div>
+                </fieldset>
+        </div>
 <!-- Mid Column (Logo) -->
-<div class="sheet-col">
-<h2>Wrath & Glory</h2>
-<img src="http://i.imgur.com/WkHbDEv.png" alt="" />
-</div>
+        <div class="sheet-col">
+            <h2>Wrath & Glory</h2>
+            <img src="http://i.imgur.com/WkHbDEv.png" alt="" />
+        </div>
 <!-- Right Column  -->
-<div class="sheet-col">
+        <div class="sheet-col">
 <!-- Species -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 25%;"><label>Species</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_Species" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 25%;"><label>Species</label></div>
+                <div class="sheet-item" style="width: 70%;"><input name="attr_Species" type="text" /></div>
+            </div>
 <!-- Species Ability -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 40%;"><label>Species Ability</label></div>
-<div class="sheet-item" style="width: 55%;"><input name="attr_SpeciesAb1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb3" type="text" /></div>
-</div>
-<fieldset class="repeating_SpeciesAb">
-<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb" type="text" /></div>
-</fieldset>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 40%;"><label>Species Ability</label></div>
+                <div class="sheet-item" style="width: 55%;"><input name="attr_SpeciesAb1" type="text" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb2" type="text" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb3" type="text" /></div>
+                <fieldset class="repeating_SpeciesAb">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb" type="text" /></div>
+                </fieldset>
+            </div>
 <!-- Archetype -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 25%;"><label>Archetype</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_Archetype" type="text" /></div>
-</div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 25%;"><label>Archetype</label></div>
+                <div class="sheet-item" style="width: 70%;"><input name="attr_Archetype" type="text" /></div>
+            </div>
 <!-- Archetype Ability -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 40%;"><label>Archetype Ability</label></div>
-<div class="sheet-item" style="width: 55%;"><input name="attr_ArchetypeAb1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb3" type="text" /></div>
-</div>
-<fieldset class="repeating_ArchetypeAb">
-<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb" type="text" /></div>
-</fieldset>
-</div>
-</div>
-<!-- First Part = Attributes\Combat Traits\Mental Traits\Social Traits\Skills --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-<div class="sheet-2colrow"><!-- Left Side -->
-<div class="sheet-col">
-<div class="sheet-characteristics">
-<!-- Attributes -->
-<h3>Attributes</h3>
-<div class="sheet-2colrow">
-<!-- Left Column (Attributes) -->
-<div class="sheet-col">
-<!-- Strength (Str) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Str" type="roll" value="/em rolls Strength with [[1t[WrathDie]+(@{Strength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Strength<br />(Str)</label></button></div>
-<div class="sheet-col"><input name="attr_Strength" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseStrength">
-<option value="1">Base Strength: 1</option>
-<option value="2">Base Strength: 2</option>
-<option value="3">Base Strength: 3</option>
-<option value="4">Base Strength: 4</option>
-<option value="5">Base Strength: 5</option>
-<option value="6">Base Strength: 6</option>
-<option value="7">Base Strength: 7</option>
-</select></div>
-</div>
-<!-- Agility (Agl) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Agl" type="roll" value="/em rolls Agility with [[1t[WrathDie]+(@{Agilty}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Agility<br />(Agl)</label></button></div>
-<div class="sheet-col"><input name="attr_Agility" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseAgility">
-<option value="1">Base Agilty: 1</option>
-<option value="2">Base Agility: 2</option>
-<option value="3">Base Agility: 3</option>
-<option value="4">Base Agility: 4</option>
-<option value="5">Base Agility: 5</option>
-<option value="6">Base Agility: 6</option>
-<option value="7">Base Agility: 7</option>
-</select></div>
-</div>
-<!-- Toughness (Tou) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Toughness with [[1t[WrathDie]+(@{Toughness}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Toughness<br />(Tou)</label></button></div>
-<div class="sheet-col"><input name="attr_Toughness" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseToughness">
-<option value="1">Base Toughness: 1</option>
-<option value="2">Base Toughness: 2</option>
-<option value="3">Base Toughness: 3</option>
-<option value="4">Base Toughness: 4</option>
-<option value="5">Base Toughness: 5</option>
-<option value="6">Base Toughness: 6</option>
-<option value="7">Base Toughness: 7</option>
-</select></div>
-</div>
-<!-- Intellect (Int) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Intellect with [[1t[WrathDie]+(@{Intellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Intellect<br />(Int)</label></button></div>
-<div class="sheet-col"><input name="attr_Intellect" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseIntellect">
-<option value="1">Base Intellect: 1</option>
-<option value="2">Base Intellect: 2</option>
-<option value="3">Base Intellect: 3</option>
-<option value="4">Base Intellect: 4</option>
-<option value="5">Base Intellect: 5</option>
-<option value="6">Base Intellect: 6</option>
-<option value="7">Base Intellect: 7</option>
-</select></div>
-</div>
-</div>
-<!-- Attributes (Right Column) -->
-<div class="sheet-col">
-<!-- Willpower (Wil) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Wil" type="roll" value="/em rolls Willpower with [[1t[WrathDie]+(@{Willpower}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Willpower<br />(Wil)</label></button></div>
-<div class="sheet-col"><input name="attr_Willpower" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseWillpower">
-<option value="1">Base Willpower: 1</option>
-<option value="2">Base Willpower: 2</option>
-<option value="3">Base Willpower: 3</option>
-<option value="4">Base Willpower: 4</option>
-<option value="5">Base Willpower: 5</option>
-<option value="6">Base Willpower: 6</option>
-<option value="7">Base Willpower: 7</option>
-</select></div>
-</div>
-<!-- Fellowship (Fel) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Fel" type="roll" value="/em rolls Fellowship with [[1t[WrathDie]+(@{Fellowship}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Fellowship<br />(Fel)</label></button></div>
-<div class="sheet-col"><input name="attr_Fellowship" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseFellowship">
-<option value="1">Base Fellowship: 1</option>
-<option value="2">Base Fellowship: 2</option>
-<option value="3">Base Fellowship: 3</option>
-<option value="4">Base Fellowship: 4</option>
-<option value="5">Base Fellowship: 5</option>
-<option value="6">Base Fellowship: 6</option>
-<option value="7">Base Fellowship: 7</option>
-</select></div>
-</div>
-<!-- Initiative (Ini) -->
-<div class="sheet-2colrow">
-<div class="sheet-col"><button name="roll_Ini" type="roll" value="/em rolls Initiative with [[1t[WrathDie]+(@{Initiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Initiative<br />(Int)</label></button></div>
-<div class="sheet-col"><input name="attr_Initiative" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;">&nbsp;</div>
-<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseInitiative">
-<option value="1">Base Initiative: 1</option>
-<option value="2">Base Initiative: 2</option>
-<option value="3">Base Initiative: 3</option>
-<option value="4">Base Initiative: 4</option>
-<option value="5">Base Initiative: 5</option>
-<option value="6">Base Initiative: 6</option>
-<option value="7">Base Initiative: 7</option>
-</select></div>
-</div>
-</div>
-</div>
-</div>
-<br /> 
-<!-- Left Column (Combat Traits) -->
-<div class="sheet-2colrow">
-<div class="sheet-col sheet-fate">
-<!-- Combat Traits -->
-<h3>Combat Traits</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Trait</label></div>
-<div class="sheet-item" style="width: 25%;"><label>Rating</label></div>
-<div class="sheet-item" style="width: 25%;"><label>Current</label></div>
-</div>
-<!-- Defense -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Defense</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Defense" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"></div>
-</div>
-<!-- Resilience -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Resilience</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Resilience" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_ResilienceCurrent" type="number" /></div>
-</div>
-<!-- Soak -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Soak</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Soak" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"></div>
-</div>
-<!-- Speed -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Speed</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Speed" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"></div>
-</div>
-<!-- Shock -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Shock</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Shock" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_ShockCurrent" type="number" /></div>
-</div>
-<!-- Wounds -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 40%;"><label>Wounds</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Wounds" type="number" /></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_WoundsCurrent" type="number" /></div>
-</div>
-<br>
-<!-- Death Check -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 95%;"><label>At 0 Wounds</label></div>
-</div>
-<!-- Defiance Check -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;">&nbsp;</div>
-<div class="sheet-item" style="width: 70%;"><label>Defiance Check Fails</label></div>
-<div class="sheet-item" style="width: 25%;"><input name="attr_Defiance1" type="checkbox" /><input name="attr_Defiance2" type="checkbox" /><input name="attr_Defiance3" type="checkbox" /></div>
-</div>
-</div>
-<div class="sheet-col sheet-fate">
-<!-- Mental Traits -->
-<h3>Mental Traits</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
-<div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
-</div>
-<!-- Conviction -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Conviction</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Conviction" type="number" /></div>
-</div>
-<!-- Corruption -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Corruption</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Corruption" type="number" /></div>
-</div>
-<!-- Passive Awareness -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Passive Aware</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_PassiveAwareness" type="number" /></div>
-</div>
-<!-- Resolve -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Resolve</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Resolve" type="number" /></div>
-</div>
-<!-- Social Traits -->
-<h3>Social Traits</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
-<div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
-</div>
-<!-- Influence -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Influence</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Influence" type="number" /></div>
-</div>
-<!-- Wealth -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;"><label>Wealth</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Wealth" type="number" /></div>
-</div>
-</div>
-</div>
-<br>
-<!-- Wrath Points -->
-<h3>Wrath Points</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"><input name="attr_WrathPoints" type="number" /></div>
-<div class="sheet-item" style="width: 90%;"><label>Spend one Wrath to:</label></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;">* Re-roll failures once on a test</div>
-<div class="sheet-item" style="width: 50%;">* Add +1 to a Defiance Check</div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 50%;">* Make a narrative declaration</div>
-<div class="sheet-item" style="width: 50%;">* Restore 1d3+1 Shock</div>
-</div>
-
-</div>
-<!-- Right Side -->
-<div class="sheet-col">
-<!-- Right Column (Skills) -->
-<h3>Skills</h3>
-<div class="sheet-1colrow">
-<div class="sheet-col sheet-skills">
-<!-- Skills -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><label>Skill</label></div>
-<div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
-<div class="sheet-item" style="width: 25%;"><label>Linked To</label></div>
-<div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
-<div class="sheet-item" style="width: 15%;"><label>Total</label></div>
-</div>
-<!-- Athletics -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Athletics" type="roll" value="/em rolls Athletics with [[1t[WrathDie]+(@{AthleticsStrength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Athletics</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Athletics" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Strength </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Strength2" type="number" value="@{Strength}" disabled="true" /></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_AthleticsStrength" type="number" value="@{Athletics}+@{Strength}" disabled="true"/></div>
-</div>
-<!-- Awareness -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Awareness" type="roll" value="/em rolls Awareness with [[1t[WrathDie]+(@{AwarenessIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Awareness</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Awareness" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Intellect </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect2" type="number" value="@{Intellect}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_AwarenessIntellect" type="number" value="@{Awareness}+@{Intellect}" disabled="true"/></div>
-</div>
-<!-- Ballistic Skill -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Ballistic" type="roll" value="/em rolls Ballistic Skill with [[1t[WrathDie]+(@{BallisticAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Ballistic Skill</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Ballistic" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Agility </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Agility2" type="number" value="@{Agility}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_BallisticAgility" type="number"  value="@{Ballistic}+@{Agility}" disabled="true"/></div>
-</div>
-<!-- Cunning -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Cunning" type="roll" value="/em rolls Cunning with [[1t[WrathDie]+(@{CunningFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Cunning</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Cunning" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Fellowship </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship2" type="number" value="@{Fellowship}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_CunningFellow" type="number"  value="@{Cunning}+@{Fellowship}" disabled="true"/></dive>
-</div>
-<!-- Deception -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Deception" type="roll" value="/em rolls Deception with [[1t[WrathDie]+(@{DeceptionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Deception</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Deception" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Fellowship </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship3" type="number" value="@{Fellowship}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_DeceptionFellow" type="number" value="@{Deception}+@{Fellowship}" disabled="true"/></div>
-</div>
-<!-- Insight -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Insight" type="roll" value="/em rolls Insight with [[1t[WrathDie]+(@{InsightFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Insight</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Insight" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Fellowship </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship4" type="number" value="@{Fellowship}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_InsightFellow" type="number"  value="@{Insight}+@{Fellowship}" disabled="true"/></div>
-</div>
-<!-- Intimidation -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Intimidation" type="roll" value="/em rolls Intimidation with [[1t[WrathDie]+(@{IntimidationWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Intimidation</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intimidation" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Willpower </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower2" type="number" value="@{Willpower}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_IntimidationWill" type="number"  value="@{Intimidation}+@{Willpower}" disabled="true"/></div>
-</div>
-<!-- Investigation -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Investigation" type="roll" value="/em rolls Investigation with [[1t[WrathDie]+(@{InvestIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Investigation</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Investigation" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Intellect </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect3" type="number" value="@{Intellect}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_InvestIntellect" type="number" value="@{Investigation}+@{Intellect}" disabled="true"/></div>
-</div>
-<!-- Leadership -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Leadership" type="roll" value="/em rolls Leadership with [[1t[WrathDie]+(@{LeadershipWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Leadership</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Leadership" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Willpower </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower3" type="number" value="@{Willpower}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_LeadershipWill" type="number" value="@{Leadership}+@{Willpower}" disabled="true"/></div>
-</div>
-<!-- Medicae -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Medicae" type="roll" value="/em rolls Medicae with [[1t[WrathDie]+(@{MedicaeIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Medicae</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Medicae" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Intellect </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect4" type="number" value="@{Intellect}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_MedicaeIntellect" type="number" value="@{Medicae}+@{Intellect}" disabled="true"/></div>
-</div>
-<!-- Persuasion -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Persuasion" type="roll" value="/em rolls Persuasion with [[1t[WrathDie]+(@{PersuasionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Persuasion</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Persuasion" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Fellowship </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship5" type="number" value="@{Fellowship}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_PersuasionFellow" type="number" value="@{Persuasion}+@{Fellowship}" disabled="true"/></div>
-</div>
-<!-- Pilot -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Pilot" type="roll" value="/em rolls Pilot with [[1t[WrathDie]+(@{PilotAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Pilot</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Pilot" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Agility </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Agility3" type="number" value="@{Agility}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_PilotAgility" type="number" value="@{Pilot}+@{Agility}" disabled="true"/></div>
-</div>
-<!-- Psychic Mastery -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_PsychicMastery" type="roll" value="/em rolls Psychic Mastery with [[1t[WrathDie]+(@{PsychicWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Psychic Mastery</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_PsychicMastery" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Willpower </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower4" type="number" value="@{Willpower}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_PsychicWill" type="number" value="@{PsychicMastery}+@{Willpower}" disabled="true"/></div>
-</div>
-<!-- Scholar -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Scholar" type="roll" value="/em rolls Scholar with [[1t[WrathDie]+(@{ScholarIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Scholar</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Scholar" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Intellect </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect5" type="number" value="@{Intellect}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_ScholarIntellect" type="number" value="@{Scholar}+@{Intellect}" disabled="true"/></div>
-</div>
-<!-- Stealth -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Stealth" type="roll" value="/em rolls Stealth with [[1t[WrathDie]+(@{StealthAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Stealth</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Stealth" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Agility </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Agility4" type="number" value="@{Agility}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_StealthAgility" type="number" value="@{Stealth}+@{Agility}" disabled="true"/></div>
-</div>
-<!-- Survival -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Survival" type="roll" value="/em rolls Survival with [[1t[WrathDie]+(@{SurvivalWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Survival</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Survival" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Willpower </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower5" type="number" value="@{Willpower}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_SurvivalWill" type="number" value="@{Survival}+@{Willpower}" disabled="true"/></div>
-</div>
-<!-- Tech -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_Tech" type="roll" value="/em rolls Tech with [[1t[WrathDie]+(@{TechIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Tech</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Tech" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Intellect </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect6" type="number" value="@{Intellect}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_TechIntellect" type="number" value="@{Tech}+@{Intellect}" disabled="true"/></div>
-</div>
-<!-- Weapon Skill -->
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><button name="roll_WeaponSkill" type="roll" value="/em rolls Weapon Skill with [[1t[WrathDie]+(@{WeaponInitiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Weapon Skill</label> </button></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_WeaponSkill" type="number" /></div>
-<div class="sheet-item" style="width: 25%;">Initiative </div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_Initiative2" type="number" value="@{Initiative}" disabled="true"/></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_WeaponInitiative" type="number" value="@{WeaponSkill}+@{Initiative}" disabled="true"/></div>
-</div>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-
-<!-- Glory Points -->
-<h3>Glory Points</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"></div>
-<div class="sheet-item" style="width: 90%;"><label>Spend one Glory to:</label></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"></div>
-<div class="sheet-item" style="width: 90%;">* Add +1d to a test after any re-rolls</div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"></div>
-<div class="sheet-item" style="width: 90%;">* Add +1 bonus dice of damage to a successful attack</div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"></div>
-<div class="sheet-item" style="width: 90%;">* Increase the severity of a Critical Hit</div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"></div>
-<div class="sheet-item" style="width: 90%;">* Seize the Initiative</div>
-</div>
-
-
-</div>
-<div class="sheet-col sheet-skills">
-</div>
-</div>
-</div>
-</div>
-</div>
-<!-- Second Part = Aptitudes\Talents&Traits\Melee&Raged Weapons --> <br /><br /> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-<div class="sheet-2colrow">
-<div class="sheet-col">
-<!-- Talents -->
-<h3>Talents</h3>
-<div class="sheet-1colrow">
-<div class="sheet-col">
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent3" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent4" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent5" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent6" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent7" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent8" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent9" type="text" /></div>
-</div>
-<fieldset class="repeating_Talents">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Talent" type="text" /></div>
-</fieldset>
-</div>
-<!-- Background -->
-<h3>Background</h3>
-<div class="sheet-col">
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background3" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background4" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background5" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background6" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background7" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background8" type="text" /></div>
-</div>
-<fieldset class="repeating_Background">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Background" type="text" /></div>
-</fieldset>
-</div>
-<!-- Malignancies -->
-<h3>Malignancies</h3>
-<div class="sheet-col">
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies3" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies4" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies5" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies6" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies7" type="text" /></div>
-</div>
-<fieldset class="repeating_Malignancies">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies" type="text" /></div>
-</fieldset>
-</div>
-</div>
-<br />
-<h3>Melee Weapons</h3>
-<fieldset class="repeating_meleeweapons">
-<div class="sheet-quickborder">
-<div class="sheet-row">
-<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
-<div class="sheet-item" style="width: 55%;"><input name="attr_meleeweaponname" type="text" /></div>
-<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
-<div class="sheet-item" style="width: 19%;"><input name="attr_meleeweaponclass" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_meleeweapondamage" type="text" /></div>
-<div class="sheet-item" style="width: 12%;"><label>Type:</label></div>
-<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
-<div class="sheet-item" style="width: 16%;"><button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+@{MutS}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})"> <label>Damage</label> </button></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
-<div class="sheet-item" style="width: 70%;"><input name="attr_meleeweaponspecial" type="text" /> </div>
-<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} with [[ (([[@{WeaponSkill}+ ?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
-</div>
-</fieldset>
-<h3>Movement</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 20%;"><label>Half Move: </label></div>
-<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)+@{MutAg}+@{Size}" /></div>
-<div class="sheet-item" style="width: 20%;"><label>Full Move: </label></div>
-<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
-<div class="sheet-item" style="width: 16%;"><label>Charge: </label></div>
-<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
-<div class="sheet-item" style="width: 10%;"><label>Run: </label></div>
-<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 28%;"><label>Fatigue</label></div>
-<div class="sheet-item" style="width: 20%;"><label>Threshold:</label></div>
-<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FatigueThreshold" type="number" value="@{MutT}+floor(@{Toughness}/10)" /></div>
-<div class="sheet-item" style="width: 16%;"><label>Current: </label></div>
-<div class="sheet-item" style="width: 8%;"><input name="attr_Fatigue" type="number" /></div>
-</div>
-<br />
-<h3>Armour &amp; Defence</h3>
-<div class="sheet-2colrow">
-<div class="sheet-col">
-<div class="sheet-armourblock">&nbsp;</div>
-<div class="sheet-quickborder sheet-armourblock"><label>Head</label> <input name="attr_HArmour" type="number" /> <label>(1-10)</label> <input disabled="disabled" name="attr_HTotal" type="number" value="@{HArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-<br />
-<div class="sheet-quickborder sheet-armourblock"><label>AR</label> <input name="attr_ArArmour" type="number" /> <label>(11-20)</label> <input disabled="disabled" name="attr_ArTotal" type="number" value="@{ArArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-<div class="sheet-quickborder sheet-armourblock"><label>Body</label> <input name="attr_BArmour" type="number" /> <label>(31-70)</label> <input disabled="disabled" name="attr_BTotal" type="number" value="@{BArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-<div class="sheet-quickborder sheet-armourblock"><label>AL</label> <input name="attr_AlArmour" type="number" /> <label>(21-30)</label> <input disabled="disabled" name="attr_AlTotal" type="number" value="@{AlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LR</label> <input name="attr_LrArmour" type="number" /> <label>(71-85)</label> <input disabled="disabled" name="attr_LrTotal" type="number" value="@{LrArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LL</label> <input name="attr_LlArmour" type="number" /> <label>(86-00)</label> <input disabled="disabled" name="attr_LlTotal" type="number" value="@{LlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
-
-<br />
-<div class="sheet-row">
-    <div class="sheet-row"></div>
-<h3>Size</h3>
-<div class="sheet-item" style="width: 70%;"><select class="sizeselect" name="attr_Size">
-<option value="0">Average (4)</option>
-<option value="-3">Miniscule (1)</option>
-<option value="-2">Puny (2)</option>
-<option value="-1">Weedy (3)</option>
-<option value="1">Hulking (5)</option>
-<option value="2">Enormous (6)</option>
-<option value="3">Massive (7)</option>
-<option value="4">Immense (8)</option>
-<option value="5">Monumental (9)</option>
-<option value="6">Titanic (10)</option>
-</select>
-<br />
-</div>
-</div>
-
-</div>
-<div class="sheet-col sheet-fate">
-<h3>Wounds</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 65%;"><label>Total: </label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds_max" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 65%;"><label>Current: </label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 65%;"><label>Critical Damage: </label></div>
-<div class="sheet-item" style="width: 20%;"><input name="attr_Critical" type="number" /></div>
-</div>
-<h3>Conditions</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_1stCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_2ndCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_3rdCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_4thCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_5thCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_6thCondition" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_7thCondition" type="text" /></div>
-</div>
-</div>
-</div>
-</div>
-<div class="sheet-col">
-<!-- Objectives -->
-<h3>Objectives</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>D6</label></div>
-<div class="sheet-item" style="width: 95%;"><label>Roll Result</label></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>1</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>2</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>3</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>4</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>5</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><label>6</label></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6a" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6b" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"></div>
-<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6c" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 5%;"><input name="attr_ObjectiveAchieved" type="checkbox" /></div>
-<div class="sheet-item" style="width: 95%;">Objective Achieved</div>
-</div>
-<!-- Ascension Notes -->
-<h3>Ascension Notes</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension1" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension2" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension3" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension4" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension5" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension6" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension7" type="text" /></div>
-</div>
-<fieldset class="repeating_Ascension">
-<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension" type="text" /></div>
-</fieldset>
-<!-- Ranged Weapons -->
-<h3>Ranged Weapons</h3>
-<fieldset class="repeating_rangedweapons">
-<div class="sheet-quickborder">
-<div class="sheet-row">
-<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} with [[(([[@{BallisticSkill} + ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
-<div class="sheet-item" style="width: 12%;"><label>Name:</label></div>
-<div class="sheet-item" style="width: 73%;"><input name="attr_rangedweaponname" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 16%;"><button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})"> <label>Damage</label> </button></div>
-<div class="sheet-item" style="width: 24%;"><label>Base Damage:</label></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_rangedweapondamage" type="text" /></div>
-<div class="sheet-item" style="width: 5%;"><label> + </label></div>
-<div class="sheet-item" style="width: 8%;"><input name="attr_rangedweapontype" type="text" /></div>
-<div class="sheet-item" style="width: 16%;"><label> ED</label></div>
-<div class="sheet-item" style="width: 8%;"><label>AP:</label></div>
-<div class="sheet-item" style="width: 8%;"><input name="attr_rangedweaponpen" type="text" value="0" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 15%;"><label>Salvo:</label></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponsalvo" type="text" /></div>
-<div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
-<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponrange" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 13%;"><label>Traits:</label></div>
-<div class="sheet-item" style="width: 82%;"><input name="attr_rangedweapontraits" type="text" /></div>
-</div>
-</div>
-</fieldset>
-<h3>Gear</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 80%;"><input name="attr_Gear" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_GearWt" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_GearPage" type="number" /></div>
-</div>
-<fieldset class="repeating_Gears">
-<div class="sheet-item" style="width: 80%;"><input name="attr_Gears" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_GeasrWt" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_GearsPage" type="text" /></div>
-</fieldset>
-<div class="sheet-row">
-            <div class="sheet-item" style="width:40%">
-                <label>Max Carry WT (SB+TB): </label>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 40%;"><label>Archetype Ability</label></div>
+                <div class="sheet-item" style="width: 55%;"><input name="attr_ArchetypeAb1" type="text" /></div>
             </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_Carry_max" type="text">
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb2" type="text" /></div>
             </div>
-            <div class="sheet-item" style="width:30%">
-                                : <label style="width:10%">Current: </label>
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_Carry" type="text">
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb3" type="text" /></div>
+                <fieldset class="repeating_ArchetypeAb">
+                <div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb" type="text" /></div>
+                </fieldset>
             </div>
         </div>
+    </div>
+<!-- First Part = Attributes\Combat Traits\Mental Traits\Social Traits\Skills -->
+<div class="sheet-2colrow">
+<!-- Left Side -->
+    <div class="sheet-col">
+        <div class="sheet-characteristics">
+<!-- Attributes -->
+            <h3>Attributes</h3>
+            <div class="sheet-2colrow">
+<!-- Left Column (Attributes) -->
+                <div class="sheet-col">
+<!-- Strength (Str) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Str" type="roll" value="/em rolls Strength with [[1t[WrathDie]+(@{Strength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Strength<br />(Str)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Strength" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseStrength">
+                            <option value="1">Base Strength: 1</option>
+                            <option value="2">Base Strength: 2</option>
+                            <option value="3">Base Strength: 3</option>
+                            <option value="4">Base Strength: 4</option>
+                            <option value="5">Base Strength: 5</option>
+                            <option value="6">Base Strength: 6</option>
+                            <option value="7">Base Strength: 7</option>
+                        </select></div>
+                    </div>
+<!-- Agility (Agl) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Agl" type="roll" value="/em rolls Agility with [[1t[WrathDie]+(@{Agilty}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Agility<br />(Agl)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Agility" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseAgility">
+                            <option value="1">Base Agilty: 1</option>
+                            <option value="2">Base Agility: 2</option>
+                            <option value="3">Base Agility: 3</option>
+                            <option value="4">Base Agility: 4</option>
+                            <option value="5">Base Agility: 5</option>
+                            <option value="6">Base Agility: 6</option>
+                            <option value="7">Base Agility: 7</option>
+                        </select></div>
+                    </div>
+<!-- Toughness (Tou) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Toughness with [[1t[WrathDie]+(@{Toughness}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Toughness<br />(Tou)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Toughness" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseToughness">
+                            <option value="1">Base Toughness: 1</option>
+                            <option value="2">Base Toughness: 2</option>
+                            <option value="3">Base Toughness: 3</option>
+                            <option value="4">Base Toughness: 4</option>
+                            <option value="5">Base Toughness: 5</option>
+                            <option value="6">Base Toughness: 6</option>
+                            <option value="7">Base Toughness: 7</option>
+                        </select></div>
+                    </div>
+<!-- Intellect (Int) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Intellect with [[1t[WrathDie]+(@{Intellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Intellect<br />(Int)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Intellect" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseIntellect">
+                            <option value="1">Base Intellect: 1</option>
+                            <option value="2">Base Intellect: 2</option>
+                            <option value="3">Base Intellect: 3</option>
+                            <option value="4">Base Intellect: 4</option>
+                            <option value="5">Base Intellect: 5</option>
+                            <option value="6">Base Intellect: 6</option>
+                            <option value="7">Base Intellect: 7</option>
+                        </select></div>
+                    </div>
+                </div>
+<!-- Attributes (Right Column) -->
+                <div class="sheet-col">
+<!-- Willpower (Wil) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Wil" type="roll" value="/em rolls Willpower with [[1t[WrathDie]+(@{Willpower}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Willpower<br />(Wil)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Willpower" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseWillpower">
+                            <option value="1">Base Willpower: 1</option>
+                            <option value="2">Base Willpower: 2</option>
+                            <option value="3">Base Willpower: 3</option>
+                            <option value="4">Base Willpower: 4</option>
+                            <option value="5">Base Willpower: 5</option>
+                            <option value="6">Base Willpower: 6</option>
+                            <option value="7">Base Willpower: 7</option>
+                        </select></div>
+                    </div>
+<!-- Fellowship (Fel) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Fel" type="roll" value="/em rolls Fellowship with [[1t[WrathDie]+(@{Fellowship}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Fellowship<br />(Fel)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Fellowship" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseFellowship">
+                            <option value="1">Base Fellowship: 1</option>
+                            <option value="2">Base Fellowship: 2</option>
+                            <option value="3">Base Fellowship: 3</option>
+                            <option value="4">Base Fellowship: 4</option>
+                            <option value="5">Base Fellowship: 5</option>
+                            <option value="6">Base Fellowship: 6</option>
+                            <option value="7">Base Fellowship: 7</option>
+                        </select></div>
+                    </div>
+<!-- Initiative (Ini) -->
+                    <div class="sheet-2colrow">
+                        <div class="sheet-col"><button name="roll_Ini" type="roll" value="/em rolls Initiative with [[1t[WrathDie]+(@{Initiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Initiative<br />(Int)</label></button></div>
+                        <div class="sheet-col"><input name="attr_Initiative" type="number" /></div>
+                    </div>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 10%;">&nbsp;</div>
+                        <div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseInitiative">
+                            <option value="1">Base Initiative: 1</option>
+                            <option value="2">Base Initiative: 2</option>
+                            <option value="3">Base Initiative: 3</option>
+                            <option value="4">Base Initiative: 4</option>
+                            <option value="5">Base Initiative: 5</option>
+                            <option value="6">Base Initiative: 6</option>
+                            <option value="7">Base Initiative: 7</option>
+                        </select></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <br /> 
+<!-- Left Column (Combat Traits) -->
+    <div class="sheet-2colrow">
+        <div class="sheet-col sheet-fate">
+<!-- Combat Traits -->
+            <h3>Combat Traits</h3>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Trait</label></div>
+                    <div class="sheet-item" style="width: 25%;"><label>Rating</label></div>
+                    <div class="sheet-item" style="width: 25%;"><label>Current</label></div>
+                </div>
+<!-- Defense -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Defense</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Defense" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"></div>
+                </div>
+<!-- Resilience -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Resilience</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Resilience" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_ResilienceCurrent" type="number" /></div>
+                </div>
+<!-- Soak -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Soak</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Soak" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"></div>
+                </div>
+<!-- Speed -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Speed</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Speed" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"></div>
+                </div>
+<!-- Shock -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Shock</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Shock" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_ShockCurrent" type="number" /></div>
+                </div>
+<!-- Wounds -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 40%;"><label>Wounds</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Wounds" type="number" /></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_WoundsCurrent" type="number" /></div>
+                </div>
+                <br>
+<!-- Death Check -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 95%;"><label>At 0 Wounds</label></div>
+                </div>
+<!-- Defiance Check -->
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 5%;">&nbsp;</div>
+                    <div class="sheet-item" style="width: 70%;"><label>Defiance Check Fails</label></div>
+                    <div class="sheet-item" style="width: 25%;"><input name="attr_Defiance1" type="checkbox" /><input name="attr_Defiance2" type="checkbox" /><input name="attr_Defiance3" type="checkbox" /></div>
+                </div>
+            </div>
+            <div class="sheet-col sheet-fate">
+<!-- Mental Traits -->
+                <h3>Mental Traits</h3>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
+                        <div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
+                    </div>
+<!-- Conviction -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Conviction</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_Conviction" type="number" /></div>
+                    </div>
+<!-- Corruption -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Corruption</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_Corruption" type="number" /></div>
+                    </div>
+<!-- Passive Awareness -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Passive Aware</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_PassiveAwareness" type="number" /></div>
+                    </div>
+<!-- Resolve -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Resolve</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_Resolve" type="number" /></div>
+                    </div>
+<!-- Social Traits -->
+                <h3>Social Traits</h3>
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
+                        <div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
+                    </div>
+<!-- Influence -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Influence</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_Influence" type="number" /></div>
+                    </div>
+<!-- Wealth -->
+                    <div class="sheet-row">
+                        <div class="sheet-item" style="width: 50%;"><label>Wealth</label></div>
+                        <div class="sheet-item" style="width: 20%;"><input name="attr_Wealth" type="number" /></div>
+                    </div>
+                </div>
+            </div>
+        <br>
+<!-- Wrath Points -->
+            <h3>Wrath Points</h3>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 10%;"><input name="attr_WrathPoints" type="number" /></div>
+                    <div class="sheet-item" style="width: 90%;"><label>Spend one Wrath to:</label></div>
+                </div>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 50%;">* Re-roll failures once on a test</div>
+                    <div class="sheet-item" style="width: 50%;">* Add +1 to a Defiance Check</div>
+                </div>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 50%;">* Make a narrative declaration</div>
+                    <div class="sheet-item" style="width: 50%;">* Restore 1d3+1 Shock</div>
+                </div>
+            </div>
+<!-- Right Side -->
+            <div class="sheet-col">
+<!-- Right Column (Skills) -->
+                <h3>Skills</h3>
+                    <div class="sheet-1colrow">
+                    <div class="sheet-col sheet-skills">
+<!-- Skills -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><label>Skill</label></div>
+                            <div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
+                            <div class="sheet-item" style="width: 25%;"><label>Linked To</label></div>
+                            <div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
+                            <div class="sheet-item" style="width: 15%;"><label>Total</label></div>
+                        </div>
+<!-- Athletics -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Athletics" type="roll" value="/em rolls Athletics with [[1t[WrathDie]+(@{AthleticsStrength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Athletics</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Athletics" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Strength </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Strength2" type="number" value="@{Strength}" disabled="true" /></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_AthleticsStrength" type="number" value="@{Athletics}+@{Strength}" disabled="true"/></div>
+                        </div>
+<!-- Awareness -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Awareness" type="roll" value="/em rolls Awareness with [[1t[WrathDie]+(@{AwarenessIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Awareness</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Awareness" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Intellect </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intellect2" type="number" value="@{Intellect}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_AwarenessIntellect" type="number" value="@{Awareness}+@{Intellect}" disabled="true"/></div>
+                        </div>
+<!-- Ballistic Skill -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Ballistic" type="roll" value="/em rolls Ballistic Skill with [[1t[WrathDie]+(@{BallisticAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Ballistic Skill</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Ballistic" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Agility </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Agility2" type="number" value="@{Agility}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_BallisticAgility" type="number"  value="@{Ballistic}+@{Agility}" disabled="true"/></div>
+                        </div>
+<!-- Cunning -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Cunning" type="roll" value="/em rolls Cunning with [[1t[WrathDie]+(@{CunningFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Cunning</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Cunning" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Fellowship </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship2" type="number" value="@{Fellowship}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_CunningFellow" type="number"  value="@{Cunning}+@{Fellowship}" disabled="true"/></dive>
+                        </div>
+<!-- Deception -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Deception" type="roll" value="/em rolls Deception with [[1t[WrathDie]+(@{DeceptionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Deception</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Deception" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Fellowship </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship3" type="number" value="@{Fellowship}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_DeceptionFellow" type="number" value="@{Deception}+@{Fellowship}" disabled="true"/></div>
+                        </div>
+<!-- Insight -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Insight" type="roll" value="/em rolls Insight with [[1t[WrathDie]+(@{InsightFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Insight</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Insight" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Fellowship </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship4" type="number" value="@{Fellowship}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_InsightFellow" type="number"  value="@{Insight}+@{Fellowship}" disabled="true"/></div>
+                        </div>
+<!-- Intimidation -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Intimidation" type="roll" value="/em rolls Intimidation with [[1t[WrathDie]+(@{IntimidationWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Intimidation</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intimidation" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Willpower </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Willpower2" type="number" value="@{Willpower}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_IntimidationWill" type="number"  value="@{Intimidation}+@{Willpower}" disabled="true"/></div>
+                        </div>
+<!-- Investigation -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Investigation" type="roll" value="/em rolls Investigation with [[1t[WrathDie]+(@{InvestIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Investigation</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Investigation" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Intellect </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intellect3" type="number" value="@{Intellect}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_InvestIntellect" type="number" value="@{Investigation}+@{Intellect}" disabled="true"/></div>
+                        </div>
+<!-- Leadership -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Leadership" type="roll" value="/em rolls Leadership with [[1t[WrathDie]+(@{LeadershipWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Leadership</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Leadership" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Willpower </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Willpower3" type="number" value="@{Willpower}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_LeadershipWill" type="number" value="@{Leadership}+@{Willpower}" disabled="true"/></div>
+                        </div>
+<!-- Medicae -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Medicae" type="roll" value="/em rolls Medicae with [[1t[WrathDie]+(@{MedicaeIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Medicae</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Medicae" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Intellect </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intellect4" type="number" value="@{Intellect}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_MedicaeIntellect" type="number" value="@{Medicae}+@{Intellect}" disabled="true"/></div>
+                        </div>
+<!-- Persuasion -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Persuasion" type="roll" value="/em rolls Persuasion with [[1t[WrathDie]+(@{PersuasionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Persuasion</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Persuasion" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Fellowship </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship5" type="number" value="@{Fellowship}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_PersuasionFellow" type="number" value="@{Persuasion}+@{Fellowship}" disabled="true"/></div>
+                        </div>
+<!-- Pilot -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Pilot" type="roll" value="/em rolls Pilot with [[1t[WrathDie]+(@{PilotAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Pilot</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Pilot" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Agility </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Agility3" type="number" value="@{Agility}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_PilotAgility" type="number" value="@{Pilot}+@{Agility}" disabled="true"/></div>
+                        </div>
+<!-- Psychic Mastery -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_PsychicMastery" type="roll" value="/em rolls Psychic Mastery with [[1t[WrathDie]+(@{PsychicWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Psychic Mastery</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_PsychicMastery" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Willpower </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Willpower4" type="number" value="@{Willpower}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_PsychicWill" type="number" value="@{PsychicMastery}+@{Willpower}" disabled="true"/></div>
+                        </div>
+<!-- Scholar -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Scholar" type="roll" value="/em rolls Scholar with [[1t[WrathDie]+(@{ScholarIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Scholar</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Scholar" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Intellect </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intellect5" type="number" value="@{Intellect}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_ScholarIntellect" type="number" value="@{Scholar}+@{Intellect}" disabled="true"/></div>
+                        </div>
+<!-- Stealth -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Stealth" type="roll" value="/em rolls Stealth with [[1t[WrathDie]+(@{StealthAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Stealth</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Stealth" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Agility </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Agility4" type="number" value="@{Agility}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_StealthAgility" type="number" value="@{Stealth}+@{Agility}" disabled="true"/></div>
+                        </div>
+<!-- Survival -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Survival" type="roll" value="/em rolls Survival with [[1t[WrathDie]+(@{SurvivalWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Survival</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Survival" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Willpower </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Willpower5" type="number" value="@{Willpower}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_SurvivalWill" type="number" value="@{Survival}+@{Willpower}" disabled="true"/></div>
+                        </div>
+<!-- Tech -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_Tech" type="roll" value="/em rolls Tech with [[1t[WrathDie]+(@{TechIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Tech</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Tech" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Intellect </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Intellect6" type="number" value="@{Intellect}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_TechIntellect" type="number" value="@{Tech}+@{Intellect}" disabled="true"/></div>
+                        </div>
+<!-- Weapon Skill -->
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 30%;"><button name="roll_WeaponSkill" type="roll" value="/em rolls Weapon Skill with [[1t[WrathDie]+(@{WeaponInitiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Weapon Skill</label> </button></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_WeaponSkill" type="number" /></div>
+                            <div class="sheet-item" style="width: 25%;">Initiative </div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_Initiative2" type="number" value="@{Initiative}" disabled="true"/></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_WeaponInitiative" type="number" value="@{WeaponSkill}+@{Initiative}" disabled="true"/></div>
+                        </div>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+<!-- Glory Points -->
+                        <h3>Glory Points</h3>
+                            <div class="sheet-row">
+                                <div class="sheet-item" style="width: 10%;"></div>
+                                <div class="sheet-item" style="width: 90%;"><label>Spend one Glory to:</label></div>
+                            </div>
+                            <div class="sheet-row">
+                                <div class="sheet-item" style="width: 10%;"></div>
+                                <div class="sheet-item" style="width: 90%;">* Add +1d to a test after any re-rolls</div>
+                            </div>
+                            <div class="sheet-row">
+                                <div class="sheet-item" style="width: 10%;"></div>
+                                <div class="sheet-item" style="width: 90%;">* Add +1 bonus dice of damage to a successful attack</div>
+                            </div>
+                            <div class="sheet-row">
+                                <div class="sheet-item" style="width: 10%;"></div>
+                                <div class="sheet-item" style="width: 90%;">* Increase the severity of a Critical Hit</div>
+                            </div>
+                            <div class="sheet-row">
+                                <div class="sheet-item" style="width: 10%;"></div>
+                                <div class="sheet-item" style="width: 90%;">* Seize the Initiative</div>
+                            </div>
+                        </div>
+                    <div class="sheet-col sheet-skills">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<br />
+<br /> 
+<!-- Second Part = Aptitudes\Talents&Traits\Melee&Raged Weapons --> 
+    <div class="sheet-2colrow">
+        <div class="sheet-col">
+<!-- Talents -->
+            <h3>Talents</h3>
+                <div class="sheet-1colrow">
+                    <div class="sheet-col">
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent1" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent2" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent3" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent4" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent5" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent6" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent7" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent8" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent9" type="text" /></div>
+                        </div>
+                        <fieldset class="repeating_Talents">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Talent" type="text" /></div>
+                        </fieldset>
+                    </div>
+<!-- Background -->
+                <h3>Background</h3>
+                    <div class="sheet-col">
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background1" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background2" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background3" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background4" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background5" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background6" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background7" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background8" type="text" /></div>
+                        </div>
+                        <fieldset class="repeating_Background">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Background" type="text" /></div>
+                        </fieldset>
+                    </div>
+<!-- Malignancies -->
+                <h3>Malignancies</h3>
+                    <div class="sheet-col">
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies1" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies2" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies3" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies4" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies5" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies6" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies7" type="text" /></div>
+                        </div>
+                        <fieldset class="repeating_Malignancies">
+                            <div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies" type="text" /></div>
+                        </fieldset>
+                    </div>
+                </div>
+            <br />
+<!-- Melee Weapon -->
+            <h3>Melee Weapons</h3>
+                <fieldset class="repeating_meleeweapons">
+                    <div class="sheet-quickborder">
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/me uses @{meleeweaponname} with [[1t[WrathDie]+(@{WeaponInitiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Hit</label> </button></div>
+                            <div class="sheet-item" style="width: 12%;"><label>Name:</label></div>
+                            <div class="sheet-item" style="width: 73%;"><input name="attr_meleeweaponname" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 16%;"><button name="roll_meleedamage" type="roll" value="/me does [[@{meleebasedamage}+@{meleeweapondamage}t[PoolDice]]]"> <label>Damage</label> </button></div>
+                            <div class="sheet-item" style="width: 24%;"><label>Base Damage:</label></div>
+                            <div class="sheet-item" style="width: 10%;"><input name="attr_meleebasedamage" type="number" /></div>
+                            <div class="sheet-item" style="width: 5%;"><label> + </label></div>
+                            <div class="sheet-item" style="width: 8%;"><input name="attr_meleeweapondamage" type="number" /></div>
+                            <div class="sheet-item" style="width: 16%;"><label> ED</label></div>
+                            <div class="sheet-item" style="width: 8%;"><label>AP:</label></div>
+                            <div class="sheet-item" style="width: 8%;"><input name="attr_meleeweaponpen" type="number" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 15%;"><label>Salvo:</label></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_meleeweaponsalvo" type="number" /></div>
+                            <div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
+                            <div class="sheet-item" style="width: 15%;"><input name="attr_meleeweaponrange" type="text" /></div>
+                        </div>
+                        <div class="sheet-row">
+                            <div class="sheet-item" style="width: 13%;"><label>Traits:</label></div>
+                            <div class="sheet-item" style="width: 82%;"><input name="attr_meleeweapontraits" type="text" /></div>
+                        </div>
+                    </div>
+                </fieldset>
+            <br />
+<!-- Gear -->
+            <h3>Gear</h3>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width: 80%;"><input name="attr_Gear" type="text" /></div>
+                    <div class="sheet-item" style="width: 10%;"><input name="attr_GearWt" type="text" /></div>
+                    <div class="sheet-item" style="width: 10%;"><input name="attr_GearPage" type="number" /></div>
+                </div>
+                <fieldset class="repeating_Gears">
+                    <div class="sheet-item" style="width: 80%;"><input name="attr_Gears" type="text" /></div>
+                    <div class="sheet-item" style="width: 10%;"><input name="attr_GeasrWt" type="text" /></div>
+                    <div class="sheet-item" style="width: 10%;"><input name="attr_GearsPage" type="text" /></div>
+                </fieldset>
+                <div class="sheet-row">
+                    <div class="sheet-item" style="width:40%"><label>Max Carry WT: </label></div>
+                    <div class="sheet-item" style="width:10%"><input name="attr_Carry_max" type="text"></div>
+                    <div class="sheet-item" style="width:30%">: <label style="width:10%">Current: </label></div>
+                    <div class="sheet-item" style="width:10%">
+                <input name="attr_Carry" type="text">
+                </div>
+            </div>
 
-<h3 style="padding-top: 50px;">Psychic Powers</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 40%;"><label>Psy Rating:</label></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_PsyRating" type="number" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPower" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowerPage" type="text" /></div>
-</div>
-<fieldset class="repeating_PsyPowers">
-<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPowers" type="text" /></div>
-<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowersPage" type="text" /></div>
-</fieldset>
-<h3>Focus Power Test</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 55%;"><button name="roll_Fettered" type="roll" value="/em fetters their power with [[ ([[@{PsykerCharacteristic} + ceil(@{PsyRating}/2) *5 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Fettered</label> </button></div>
+        </div>
+    <div class="sheet-col">
+<!-- Objectives -->
+<h3>Objectives</h3>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label></label></div>
+        <div class="sheet-item" style="width: 25%;"><button name="roll_objective" type="roll" value="/me want to complete Objective #[[1d6]]"> <label>D6 Roll Result</label> </button></div>
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 5%;"><input name="attr_ObjectiveAchieved" type="checkbox" /></div>
+        <div class="sheet-item" style="width: 60%;">Objective Achieved</div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>1</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_1a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_1b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_1c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>2</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_2a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_2b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_2c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>3</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_3a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_3b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_3c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>4</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_4a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_4b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_4c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>5</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_5a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_5b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_5c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><label>6</label></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_6a" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_6b" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"></div>
+        <div class="sheet-item" style="width: 95%;"><input name="attr_D6_6c" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 5%;"><input name="attr_ObjectiveAchieved" type="checkbox" /></div>
+        <div class="sheet-item" style="width: 95%;">Objective Achieved</div>
+    </div>
+<br />
+<!-- Ascension Notes -->
+<h3>Ascension Notes</h3>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension1" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension2" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension3" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension4" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension5" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension6" type="text" /></div>
+    </div>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension7" type="text" /></div>
+    </div>
+    <fieldset class="repeating_Ascension">
+        <div class="sheet-item" style="width: 100%;"><input name="attr_Ascension" type="text" /></div>
+    </fieldset>
+<!-- Ranged Weapons -->
+<h3>Ranged Weapons</h3>
+    <fieldset class="repeating_rangedweapons">
+        <div class="sheet-quickborder">
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} with [[1t[WrathDie]+(@{BallisticAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Hit</label> </button></div>
+                <div class="sheet-item" style="width: 12%;"><label>Name:</label></div>
+                <div class="sheet-item" style="width: 73%;"><input name="attr_rangedweaponname" type="text" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 16%;"><button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedbasedamage}+@{rangedweapondamage}t[PoolDice]]]"> <label>Damage</label> </button></div>
+                <div class="sheet-item" style="width: 24%;"><label>Base Damage:</label></div>
+                <div class="sheet-item" style="width: 10%;"><input name="attr_rangedbasedamage" type="number" /></div>
+                <div class="sheet-item" style="width: 5%;"><label> + </label></div>
+                <div class="sheet-item" style="width: 8%;"><input name="attr_rangedweapondamage" type="number" /></div>
+                <div class="sheet-item" style="width: 16%;"><label> ED</label></div>
+                <div class="sheet-item" style="width: 8%;"><label>AP:</label></div>
+                <div class="sheet-item" style="width: 8%;"><input name="attr_rangedweaponpen" type="number" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 15%;"><label>Salvo:</label></div>
+                <div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponsalvo" type="number" /></div>
+                <div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
+                <div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponrange" type="text" /></div>
+            </div>
+            <div class="sheet-row">
+                <div class="sheet-item" style="width: 13%;"><label>Traits:</label></div>
+                <div class="sheet-item" style="width: 82%;"><input name="attr_rangedweapontraits" type="text" /></div>
+            </div>
+        </div>
+    </fieldset>
+<!-- Gear -->    
+    <h3>Gear</h3>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width: 80%;"><input name="attr_Gear" type="text" /></div>
+        <div class="sheet-item" style="width: 10%;"><input name="attr_GearWt" type="text" /></div>
+        <div class="sheet-item" style="width: 10%;"><input name="attr_GearPage" type="number" /></div>
+    </div>
+    <fieldset class="repeating_Gears">
+        <div class="sheet-item" style="width: 80%;"><input name="attr_Gears" type="text" /></div>
+        <div class="sheet-item" style="width: 10%;"><input name="attr_GeasrWt" type="text" /></div>
+        <div class="sheet-item" style="width: 10%;"><input name="attr_GearsPage" type="text" /></div>
+    </fieldset>
+    <div class="sheet-row">
+        <div class="sheet-item" style="width:40%"><label>Max Carry WT: </label></div>
+        <div class="sheet-item" style="width:10%"><input name="attr_Carry_max" type="text"></div>
+        <div class="sheet-item" style="width:30%">: <label style="width:10%">Current: </label></div>
+        <div class="sheet-item" style="width:10%">
+            <input name="attr_Carry" type="text">
+        </div>
+    </div>
 
-<div class="sheet-row">
-<div class="sheet-item" style="width: 55%;"><button name="roll_Unfettered" type="roll" value="/em focuses their unfettered power with [[ ([[@{PsykerCharacteristic} + 5*@{PsyRating} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Unfettered</label> </button></div>
-
-<div class="sheet-row">
-<div class="sheet-item" style="width: 55%;"><button name="roll_Push" type="roll" value="/em pushes their power to its limits with [[ ([[@{PsykerCharacteristic} + 5*(@{PsyRating}+?{Psy Push|0}) + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Push</label> </button></div>
-
-</div>
-</div>
-</div>
-
-<div class="sheet-row" style="padding-top: 60px;">
-<div class="sheet-item" style="width: 30%;"><select class="charaselect" name="attr_PsykerCharacteristic">
-    
-<option value="@{Perception}">(Perception)</option>
-<option value="@{Willpower}">(Willpower)</option>
-<option value="@{PsyniscienceCharacteristic} + -20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}">(Psyniscience)</option>
-</div>
-
-</div>
-
-<h3 style="padding-top: 50px;">Comrade</h3>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 20%;"><label>Name</label></div>
-<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_name" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 20%;"><label>Status</label></div>
-<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_Status" type="text" /></div>
-</div>
-<div class="sheet-row">
-<div class="sheet-item" style="width: 30%;"><label>Special Abilities</label></div>
-<div class="sheet-item" style="width: 65%;"><input name="attr_Comrade_Special_Abilities" type="text" /></div>
-</div>
-<fieldset class="repeating_Comrade_Special_Abilities">
-<div class="sheet-item" style="width: 95%;"><input name="attr_more_Comrade_Special_Abilities" type="text" /></div>
-</fieldset>
-
-</div>
-</div>
-</div>
+            </div>
+        </div>
+    </div>
 </div><br />
 
-       <h3 style="padding-top: 50px;">Special Weapon Dice Rolls</h3>
-<div class="sheet-item" style="width: 70%;">
-<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
-<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
-<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
-<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
-</div>

--- a/Warhammer40KWrathNGlory/Warhammer40KWrathNGlory.html
+++ b/Warhammer40KWrathNGlory/Warhammer40KWrathNGlory.html
@@ -1,0 +1,1007 @@
+<!-- Warhammer 40,000 Wrath & Glory RPG, made from Only War -->
+<!-- Version 1.00 -->
+
+<div class="sheet-wrapper"><!-- Basic Character Information --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-3colrow">
+<!-- Left Column  -->
+<div class="sheet-col">
+<!-- Character Name -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 35%;"><label>Character Name</label></div>
+<div class="sheet-item" style="width: 60%;"><input name="attr_character_name" type="text" /></div>
+</div>
+<!-- Player Name -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><label>Player Name</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_Player" type="text" /></div>
+</div>
+<!-- Tier -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Tier</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Tier" type="text" /></div>
+</div>
+<!-- Rank and Rank Bonus -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 18%;"><label>Rank</label></div>
+<div class="sheet-item" style="width: 28%;"><input name="attr_Rank" type="text" /></div>
+<div class="sheet-item" style="width: 28%;"><label>Rank Bonus</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_RankBonus" type="text" /></div>
+</div>
+<!-- Framework -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Framework</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Framework" type="text" /></div>
+</div>
+<!-- Keywords -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Keywords</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Keywords1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 95%;"><input name="attr_Keywords2" type="text" /></div>
+</div>
+<fieldset class="repeating_Keywords">
+<div class="sheet-item" style="width: 95%;"><input name="attr_Keywords" type="text" /></div>
+</fieldset>
+<!-- Notes -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Notes</label></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_Notes1" type="text" /></div>
+</div>
+<fieldset class="repeating_Notes">
+<div class="sheet-item" style="width: 95%;"><input name="attr_Notes" type="text" /></div>
+</fieldset>
+</div>
+<!-- Mid Column (Logo) -->
+<div class="sheet-col">
+<h2>Wrath & Glory</h2>
+<img src="http://i.imgur.com/WkHbDEv.png" alt="" />
+</div>
+<!-- Right Column  -->
+<div class="sheet-col">
+<!-- Species -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Species</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Species" type="text" /></div>
+</div>
+<!-- Species Ability -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 40%;"><label>Species Ability</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_SpeciesAb1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb3" type="text" /></div>
+</div>
+<fieldset class="repeating_SpeciesAb">
+<div class="sheet-item" style="width: 95%;"><input name="attr_SpeciesAb" type="text" /></div>
+</fieldset>
+<!-- Archetype -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Archetype</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Archetype" type="text" /></div>
+</div>
+<!-- Archetype Ability -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 40%;"><label>Archetype Ability</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_ArchetypeAb1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb3" type="text" /></div>
+</div>
+<fieldset class="repeating_ArchetypeAb">
+<div class="sheet-item" style="width: 95%;"><input name="attr_ArchetypeAb" type="text" /></div>
+</fieldset>
+</div>
+</div>
+<!-- First Part = Attributes\Combat Traits\Mental Traits\Social Traits\Skills --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-2colrow"><!-- Left Side -->
+<div class="sheet-col">
+<div class="sheet-characteristics">
+<!-- Attributes -->
+<h3>Attributes</h3>
+<div class="sheet-2colrow">
+<!-- Left Column (Attributes) -->
+<div class="sheet-col">
+<!-- Strength (Str) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Str" type="roll" value="/em rolls Strength with [[1t[WrathDie]+(@{Strength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Strength<br />(Str)</label></button></div>
+<div class="sheet-col"><input name="attr_Strength" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseStrength">
+<option value="1">Base Strength: 1</option>
+<option value="2">Base Strength: 2</option>
+<option value="3">Base Strength: 3</option>
+<option value="4">Base Strength: 4</option>
+<option value="5">Base Strength: 5</option>
+<option value="6">Base Strength: 6</option>
+<option value="7">Base Strength: 7</option>
+</select></div>
+</div>
+<!-- Agility (Agl) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Agl" type="roll" value="/em rolls Agility with [[1t[WrathDie]+(@{Agilty}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Agility<br />(Agl)</label></button></div>
+<div class="sheet-col"><input name="attr_Agility" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseAgility">
+<option value="1">Base Agilty: 1</option>
+<option value="2">Base Agility: 2</option>
+<option value="3">Base Agility: 3</option>
+<option value="4">Base Agility: 4</option>
+<option value="5">Base Agility: 5</option>
+<option value="6">Base Agility: 6</option>
+<option value="7">Base Agility: 7</option>
+</select></div>
+</div>
+<!-- Toughness (Tou) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Toughness with [[1t[WrathDie]+(@{Toughness}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Toughness<br />(Tou)</label></button></div>
+<div class="sheet-col"><input name="attr_Toughness" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseToughness">
+<option value="1">Base Toughness: 1</option>
+<option value="2">Base Toughness: 2</option>
+<option value="3">Base Toughness: 3</option>
+<option value="4">Base Toughness: 4</option>
+<option value="5">Base Toughness: 5</option>
+<option value="6">Base Toughness: 6</option>
+<option value="7">Base Toughness: 7</option>
+</select></div>
+</div>
+<!-- Intellect (Int) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Tou" type="roll" value="/em rolls Intellect with [[1t[WrathDie]+(@{Intellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Intellect<br />(Int)</label></button></div>
+<div class="sheet-col"><input name="attr_Intellect" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseIntellect">
+<option value="1">Base Intellect: 1</option>
+<option value="2">Base Intellect: 2</option>
+<option value="3">Base Intellect: 3</option>
+<option value="4">Base Intellect: 4</option>
+<option value="5">Base Intellect: 5</option>
+<option value="6">Base Intellect: 6</option>
+<option value="7">Base Intellect: 7</option>
+</select></div>
+</div>
+</div>
+<!-- Attributes (Right Column) -->
+<div class="sheet-col">
+<!-- Willpower (Wil) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Wil" type="roll" value="/em rolls Willpower with [[1t[WrathDie]+(@{Willpower}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Willpower<br />(Wil)</label></button></div>
+<div class="sheet-col"><input name="attr_Willpower" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseWillpower">
+<option value="1">Base Willpower: 1</option>
+<option value="2">Base Willpower: 2</option>
+<option value="3">Base Willpower: 3</option>
+<option value="4">Base Willpower: 4</option>
+<option value="5">Base Willpower: 5</option>
+<option value="6">Base Willpower: 6</option>
+<option value="7">Base Willpower: 7</option>
+</select></div>
+</div>
+<!-- Fellowship (Fel) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Fel" type="roll" value="/em rolls Fellowship with [[1t[WrathDie]+(@{Fellowship}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Fellowship<br />(Fel)</label></button></div>
+<div class="sheet-col"><input name="attr_Fellowship" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseFellowship">
+<option value="1">Base Fellowship: 1</option>
+<option value="2">Base Fellowship: 2</option>
+<option value="3">Base Fellowship: 3</option>
+<option value="4">Base Fellowship: 4</option>
+<option value="5">Base Fellowship: 5</option>
+<option value="6">Base Fellowship: 6</option>
+<option value="7">Base Fellowship: 7</option>
+</select></div>
+</div>
+<!-- Initiative (Ini) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Ini" type="roll" value="/em rolls Initiative with [[1t[WrathDie]+(@{Initiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"><label>Initiative<br />(Int)</label></button></div>
+<div class="sheet-col"><input name="attr_Initiative" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_BaseInitiative">
+<option value="1">Base Initiative: 1</option>
+<option value="2">Base Initiative: 2</option>
+<option value="3">Base Initiative: 3</option>
+<option value="4">Base Initiative: 4</option>
+<option value="5">Base Initiative: 5</option>
+<option value="6">Base Initiative: 6</option>
+<option value="7">Base Initiative: 7</option>
+</select></div>
+</div>
+</div>
+</div>
+</div>
+<br /> 
+<!-- Left Column (Combat Traits) -->
+<div class="sheet-2colrow">
+<div class="sheet-col sheet-fate">
+<!-- Combat Traits -->
+<h3>Combat Traits</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Trait</label></div>
+<div class="sheet-item" style="width: 25%;"><label>Rating</label></div>
+<div class="sheet-item" style="width: 25%;"><label>Current</label></div>
+</div>
+<!-- Defense -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Defense</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Defense" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"></div>
+</div>
+<!-- Resilience -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Resilience</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Resilience" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_ResilienceCurrent" type="number" /></div>
+</div>
+<!-- Soak -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Soak</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Soak" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"></div>
+</div>
+<!-- Speed -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Speed</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Speed" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"></div>
+</div>
+<!-- Shock -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Shock</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Shock" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_ShockCurrent" type="number" /></div>
+</div>
+<!-- Wounds -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 40%;"><label>Wounds</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Wounds" type="number" /></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_WoundsCurrent" type="number" /></div>
+</div>
+<br>
+<!-- Death Check -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 95%;"><label>At 0 Wounds</label></div>
+</div>
+<!-- Defiance Check -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 70%;"><label>Defiance Check Fails</label></div>
+<div class="sheet-item" style="width: 25%;"><input name="attr_Defiance1" type="checkbox" /><input name="attr_Defiance2" type="checkbox" /><input name="attr_Defiance3" type="checkbox" /></div>
+</div>
+</div>
+<div class="sheet-col sheet-fate">
+<!-- Mental Traits -->
+<h3>Mental Traits</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
+<div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
+</div>
+<!-- Conviction -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Conviction</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Conviction" type="number" /></div>
+</div>
+<!-- Corruption -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Corruption</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Corruption" type="number" /></div>
+</div>
+<!-- Passive Awareness -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Passive Aware</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_PassiveAwareness" type="number" /></div>
+</div>
+<!-- Resolve -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Resolve</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Resolve" type="number" /></div>
+</div>
+<!-- Social Traits -->
+<h3>Social Traits</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Trait</label></div>
+<div class="sheet-item" style="width: 20%;"><label>Rating</label></div>
+</div>
+<!-- Influence -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Influence</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Influence" type="number" /></div>
+</div>
+<!-- Wealth -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Wealth</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Wealth" type="number" /></div>
+</div>
+</div>
+</div>
+<br>
+<!-- Wrath Points -->
+<h3>Wrath Points</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"><input name="attr_WrathPoints" type="number" /></div>
+<div class="sheet-item" style="width: 90%;"><label>Spend one Wrath to:</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;">* Re-roll failures once on a test</div>
+<div class="sheet-item" style="width: 50%;">* Add +1 to a Defiance Check</div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;">* Make a narrative declaration</div>
+<div class="sheet-item" style="width: 50%;">* Restore 1d3+1 Shock</div>
+</div>
+
+</div>
+<!-- Right Side -->
+<div class="sheet-col">
+<!-- Right Column (Skills) -->
+<h3>Skills</h3>
+<div class="sheet-1colrow">
+<div class="sheet-col sheet-skills">
+<!-- Skills -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><label>Skill</label></div>
+<div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
+<div class="sheet-item" style="width: 25%;"><label>Linked To</label></div>
+<div class="sheet-item" style="width: 15%;"><label>Rating</label></div>
+<div class="sheet-item" style="width: 15%;"><label>Total</label></div>
+</div>
+<!-- Athletics -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Athletics" type="roll" value="/em rolls Athletics with [[1t[WrathDie]+(@{AthleticsStrength}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Athletics</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Athletics" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Strength </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Strength2" type="number" value="@{Strength}" disabled="true" /></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_AthleticsStrength" type="number" value="@{Athletics}+@{Strength}" disabled="true"/></div>
+</div>
+<!-- Awareness -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Awareness" type="roll" value="/em rolls Awareness with [[1t[WrathDie]+(@{AwarenessIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Awareness</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Awareness" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Intellect </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect2" type="number" value="@{Intellect}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_AwarenessIntellect" type="number" value="@{Awareness}+@{Intellect}" disabled="true"/></div>
+</div>
+<!-- Ballistic Skill -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Ballistic" type="roll" value="/em rolls Ballistic Skill with [[1t[WrathDie]+(@{BallisticAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Ballistic Skill</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Ballistic" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Agility </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Agility2" type="number" value="@{Agility}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_BallisticAgility" type="number"  value="@{Ballistic}+@{Agility}" disabled="true"/></div>
+</div>
+<!-- Cunning -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Cunning" type="roll" value="/em rolls Cunning with [[1t[WrathDie]+(@{CunningFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Cunning</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Cunning" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Fellowship </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship2" type="number" value="@{Fellowship}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_CunningFellow" type="number"  value="@{Cunning}+@{Fellowship}" disabled="true"/></dive>
+</div>
+<!-- Deception -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Deception" type="roll" value="/em rolls Deception with [[1t[WrathDie]+(@{DeceptionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Deception</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Deception" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Fellowship </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship3" type="number" value="@{Fellowship}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_DeceptionFellow" type="number" value="@{Deception}+@{Fellowship}" disabled="true"/></div>
+</div>
+<!-- Insight -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Insight" type="roll" value="/em rolls Insight with [[1t[WrathDie]+(@{InsightFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Insight</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Insight" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Fellowship </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship4" type="number" value="@{Fellowship}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_InsightFellow" type="number"  value="@{Insight}+@{Fellowship}" disabled="true"/></div>
+</div>
+<!-- Intimidation -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Intimidation" type="roll" value="/em rolls Intimidation with [[1t[WrathDie]+(@{IntimidationWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Intimidation</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intimidation" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Willpower </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower2" type="number" value="@{Willpower}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_IntimidationWill" type="number"  value="@{Intimidation}+@{Willpower}" disabled="true"/></div>
+</div>
+<!-- Investigation -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Investigation" type="roll" value="/em rolls Investigation with [[1t[WrathDie]+(@{InvestIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Investigation</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Investigation" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Intellect </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect3" type="number" value="@{Intellect}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_InvestIntellect" type="number" value="@{Investigation}+@{Intellect}" disabled="true"/></div>
+</div>
+<!-- Leadership -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Leadership" type="roll" value="/em rolls Leadership with [[1t[WrathDie]+(@{LeadershipWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Leadership</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Leadership" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Willpower </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower3" type="number" value="@{Willpower}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_LeadershipWill" type="number" value="@{Leadership}+@{Willpower}" disabled="true"/></div>
+</div>
+<!-- Medicae -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Medicae" type="roll" value="/em rolls Medicae with [[1t[WrathDie]+(@{MedicaeIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Medicae</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Medicae" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Intellect </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect4" type="number" value="@{Intellect}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_MedicaeIntellect" type="number" value="@{Medicae}+@{Intellect}" disabled="true"/></div>
+</div>
+<!-- Persuasion -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Persuasion" type="roll" value="/em rolls Persuasion with [[1t[WrathDie]+(@{PersuasionFellow}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Persuasion</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Persuasion" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Fellowship </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Fellowship5" type="number" value="@{Fellowship}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_PersuasionFellow" type="number" value="@{Persuasion}+@{Fellowship}" disabled="true"/></div>
+</div>
+<!-- Pilot -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Pilot" type="roll" value="/em rolls Pilot with [[1t[WrathDie]+(@{PilotAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Pilot</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Pilot" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Agility </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Agility3" type="number" value="@{Agility}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_PilotAgility" type="number" value="@{Pilot}+@{Agility}" disabled="true"/></div>
+</div>
+<!-- Psychic Mastery -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_PsychicMastery" type="roll" value="/em rolls Psychic Mastery with [[1t[WrathDie]+(@{PsychicWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Psychic Mastery</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_PsychicMastery" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Willpower </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower4" type="number" value="@{Willpower}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_PsychicWill" type="number" value="@{PsychicMastery}+@{Willpower}" disabled="true"/></div>
+</div>
+<!-- Scholar -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Scholar" type="roll" value="/em rolls Scholar with [[1t[WrathDie]+(@{ScholarIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Scholar</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Scholar" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Intellect </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect5" type="number" value="@{Intellect}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_ScholarIntellect" type="number" value="@{Scholar}+@{Intellect}" disabled="true"/></div>
+</div>
+<!-- Stealth -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Stealth" type="roll" value="/em rolls Stealth with [[1t[WrathDie]+(@{StealthAgility}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Stealth</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Stealth" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Agility </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Agility4" type="number" value="@{Agility}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_StealthAgility" type="number" value="@{Stealth}+@{Agility}" disabled="true"/></div>
+</div>
+<!-- Survival -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Survival" type="roll" value="/em rolls Survival with [[1t[WrathDie]+(@{SurvivalWill}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Survival</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Survival" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Willpower </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Willpower5" type="number" value="@{Willpower}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_SurvivalWill" type="number" value="@{Survival}+@{Willpower}" disabled="true"/></div>
+</div>
+<!-- Tech -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_Tech" type="roll" value="/em rolls Tech with [[1t[WrathDie]+(@{TechIntellect}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Tech</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Tech" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Intellect </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Intellect6" type="number" value="@{Intellect}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_TechIntellect" type="number" value="@{Tech}+@{Intellect}" disabled="true"/></div>
+</div>
+<!-- Weapon Skill -->
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><button name="roll_WeaponSkill" type="roll" value="/em rolls Weapon Skill with [[1t[WrathDie]+(@{WeaponInitiative}-1)t[PoolDice] + ?{Modifier|0}t[PoolDice]]] degree(s) of success!"> <label>Weapon Skill</label> </button></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_WeaponSkill" type="number" /></div>
+<div class="sheet-item" style="width: 25%;">Initiative </div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_Initiative2" type="number" value="@{Initiative}" disabled="true"/></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_WeaponInitiative" type="number" value="@{WeaponSkill}+@{Initiative}" disabled="true"/></div>
+</div>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+
+<!-- Glory Points -->
+<h3>Glory Points</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"></div>
+<div class="sheet-item" style="width: 90%;"><label>Spend one Glory to:</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"></div>
+<div class="sheet-item" style="width: 90%;">* Add +1d to a test after any re-rolls</div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"></div>
+<div class="sheet-item" style="width: 90%;">* Add +1 bonus dice of damage to a successful attack</div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"></div>
+<div class="sheet-item" style="width: 90%;">* Increase the severity of a Critical Hit</div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"></div>
+<div class="sheet-item" style="width: 90%;">* Seize the Initiative</div>
+</div>
+
+
+</div>
+<div class="sheet-col sheet-skills">
+</div>
+</div>
+</div>
+</div>
+</div>
+<!-- Second Part = Aptitudes\Talents&Traits\Melee&Raged Weapons --> <br /><br /> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-2colrow">
+<div class="sheet-col">
+<!-- Talents -->
+<h3>Talents</h3>
+<div class="sheet-1colrow">
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent3" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent4" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent5" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent6" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent7" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent8" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent9" type="text" /></div>
+</div>
+<fieldset class="repeating_Talents">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Talent" type="text" /></div>
+</fieldset>
+</div>
+<!-- Background -->
+<h3>Background</h3>
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background3" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background4" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background5" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background6" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background7" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background8" type="text" /></div>
+</div>
+<fieldset class="repeating_Background">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Background" type="text" /></div>
+</fieldset>
+</div>
+<!-- Malignancies -->
+<h3>Malignancies</h3>
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies3" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies4" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies5" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies6" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies7" type="text" /></div>
+</div>
+<fieldset class="repeating_Malignancies">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Malignancies" type="text" /></div>
+</fieldset>
+</div>
+</div>
+<br />
+<h3>Melee Weapons</h3>
+<fieldset class="repeating_meleeweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_meleeweaponname" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
+<div class="sheet-item" style="width: 19%;"><input name="attr_meleeweaponclass" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_meleeweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Type:</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 16%;"><button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+@{MutS}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})"> <label>Damage</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_meleeweaponspecial" type="text" /> </div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} with [[ (([[@{WeaponSkill}+ ?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+</div>
+</fieldset>
+<h3>Movement</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Half Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)+@{MutAg}+@{Size}" /></div>
+<div class="sheet-item" style="width: 20%;"><label>Full Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Charge: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Run: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 28%;"><label>Fatigue</label></div>
+<div class="sheet-item" style="width: 20%;"><label>Threshold:</label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FatigueThreshold" type="number" value="@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Current: </label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_Fatigue" type="number" /></div>
+</div>
+<br />
+<h3>Armour &amp; Defence</h3>
+<div class="sheet-2colrow">
+<div class="sheet-col">
+<div class="sheet-armourblock">&nbsp;</div>
+<div class="sheet-quickborder sheet-armourblock"><label>Head</label> <input name="attr_HArmour" type="number" /> <label>(1-10)</label> <input disabled="disabled" name="attr_HTotal" type="number" value="@{HArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<br />
+<div class="sheet-quickborder sheet-armourblock"><label>AR</label> <input name="attr_ArArmour" type="number" /> <label>(11-20)</label> <input disabled="disabled" name="attr_ArTotal" type="number" value="@{ArArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>Body</label> <input name="attr_BArmour" type="number" /> <label>(31-70)</label> <input disabled="disabled" name="attr_BTotal" type="number" value="@{BArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>AL</label> <input name="attr_AlArmour" type="number" /> <label>(21-30)</label> <input disabled="disabled" name="attr_AlTotal" type="number" value="@{AlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LR</label> <input name="attr_LrArmour" type="number" /> <label>(71-85)</label> <input disabled="disabled" name="attr_LrTotal" type="number" value="@{LrArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LL</label> <input name="attr_LlArmour" type="number" /> <label>(86-00)</label> <input disabled="disabled" name="attr_LlTotal" type="number" value="@{LlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+
+<br />
+<div class="sheet-row">
+    <div class="sheet-row"></div>
+<h3>Size</h3>
+<div class="sheet-item" style="width: 70%;"><select class="sizeselect" name="attr_Size">
+<option value="0">Average (4)</option>
+<option value="-3">Miniscule (1)</option>
+<option value="-2">Puny (2)</option>
+<option value="-1">Weedy (3)</option>
+<option value="1">Hulking (5)</option>
+<option value="2">Enormous (6)</option>
+<option value="3">Massive (7)</option>
+<option value="4">Immense (8)</option>
+<option value="5">Monumental (9)</option>
+<option value="6">Titanic (10)</option>
+</select>
+<br />
+</div>
+</div>
+
+</div>
+<div class="sheet-col sheet-fate">
+<h3>Wounds</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Total: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds_max" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Current: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Critical Damage: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Critical" type="number" /></div>
+</div>
+<h3>Conditions</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_4thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_5thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_6thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_7thCondition" type="text" /></div>
+</div>
+</div>
+</div>
+</div>
+<div class="sheet-col">
+<!-- Objectives -->
+<h3>Objectives</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>D6</label></div>
+<div class="sheet-item" style="width: 95%;"><label>Roll Result</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>1</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_1c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>2</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_2c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>3</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_3c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>4</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_4c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>5</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_5c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><label>6</label></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6a" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6b" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"></div>
+<div class="sheet-item" style="width: 95%;"><input name="attr_D6_6c" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;"><input name="attr_ObjectiveAchieved" type="checkbox" /></div>
+<div class="sheet-item" style="width: 95%;">Objective Achieved</div>
+</div>
+<!-- Ascension Notes -->
+<h3>Ascension Notes</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension1" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension2" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension3" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension4" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension5" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension6" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension7" type="text" /></div>
+</div>
+<fieldset class="repeating_Ascension">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ascension" type="text" /></div>
+</fieldset>
+<!-- Ranged Weapons -->
+<h3>Ranged Weapons</h3>
+<fieldset class="repeating_rangedweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} with [[(([[@{BallisticSkill} + ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0}]] - 1d100)/10)]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+<div class="sheet-item" style="width: 12%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 73%;"><input name="attr_rangedweaponname" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 16%;"><button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})"> <label>Damage</label> </button></div>
+<div class="sheet-item" style="width: 24%;"><label>Base Damage:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_rangedweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 5%;"><label> + </label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_rangedweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 16%;"><label> ED</label></div>
+<div class="sheet-item" style="width: 8%;"><label>AP:</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_rangedweaponpen" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Salvo:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponsalvo" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponrange" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 13%;"><label>Traits:</label></div>
+<div class="sheet-item" style="width: 82%;"><input name="attr_rangedweapontraits" type="text" /></div>
+</div>
+</div>
+</fieldset>
+<h3>Gear</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 80%;"><input name="attr_Gear" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearWt" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearPage" type="number" /></div>
+</div>
+<fieldset class="repeating_Gears">
+<div class="sheet-item" style="width: 80%;"><input name="attr_Gears" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GeasrWt" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearsPage" type="text" /></div>
+</fieldset>
+<div class="sheet-row">
+            <div class="sheet-item" style="width:40%">
+                <label>Max Carry WT (SB+TB): </label>
+            </div>
+            <div class="sheet-item" style="width:10%">
+                <input name="attr_Carry_max" type="text">
+            </div>
+            <div class="sheet-item" style="width:30%">
+                                : <label style="width:10%">Current: </label>
+            </div>
+            <div class="sheet-item" style="width:10%">
+                <input name="attr_Carry" type="text">
+            </div>
+        </div>
+
+<h3 style="padding-top: 50px;">Psychic Powers</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 40%;"><label>Psy Rating:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyRating" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPower" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowerPage" type="text" /></div>
+</div>
+<fieldset class="repeating_PsyPowers">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPowers" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowersPage" type="text" /></div>
+</fieldset>
+<h3>Focus Power Test</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Fettered" type="roll" value="/em fetters their power with [[ ([[@{PsykerCharacteristic} + ceil(@{PsyRating}/2) *5 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Fettered</label> </button></div>
+
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Unfettered" type="roll" value="/em focuses their unfettered power with [[ ([[@{PsykerCharacteristic} + 5*@{PsyRating} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Unfettered</label> </button></div>
+
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Push" type="roll" value="/em pushes their power to its limits with [[ ([[@{PsykerCharacteristic} + 5*(@{PsyRating}+?{Psy Push|0}) + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Push</label> </button></div>
+
+</div>
+</div>
+</div>
+
+<div class="sheet-row" style="padding-top: 60px;">
+<div class="sheet-item" style="width: 30%;"><select class="charaselect" name="attr_PsykerCharacteristic">
+    
+<option value="@{Perception}">(Perception)</option>
+<option value="@{Willpower}">(Willpower)</option>
+<option value="@{PsyniscienceCharacteristic} + -20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}">(Psyniscience)</option>
+</div>
+
+</div>
+
+<h3 style="padding-top: 50px;">Comrade</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Name</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_name" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Status</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_Status" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><label>Special Abilities</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_Comrade_Special_Abilities" type="text" /></div>
+</div>
+<fieldset class="repeating_Comrade_Special_Abilities">
+<div class="sheet-item" style="width: 95%;"><input name="attr_more_Comrade_Special_Abilities" type="text" /></div>
+</fieldset>
+
+</div>
+</div>
+</div>
+</div><br />
+
+       <h3 style="padding-top: 50px;">Special Weapon Dice Rolls</h3>
+<div class="sheet-item" style="width: 70%;">
+<option value=>Proven: {1d10, 0d1+3}kh1  "The ...0d1+X}kh1 where X is the Proven value"</option>
+<option value=>Tearing: 2d10d1  "The Xd10d1 where X is the number of dice +1 so tearing for an Eviscerator would be 3d10d1"  </option>
+<option value=>Primitive: {1d10, 7 + 0d0}dh1 "The {1d10, X + 0d0}dh1 where X is the Primitive value"</option>
+<option value=>1d5 weapons: ceil(1d10/2) "This dice roll mimics the game rules for righteous fury, you roll 1d10 and divide it by 2 rounding up."</option>
+</div>


### PR DESCRIPTION
New Character Sheet for the soon-to-be-released Warhammer 40,000 Wrath & Glory RPG. Still a work in progress. This Character Sheet requires two rollable tables: WrathDie and PoolDice. WrathDie has 6 entries:  #1 Weight 1 Value 0, #2 Weight 1 Value 0, #3 Weight 1 Value 0, #4 Weight 1 Value 1 (Icon), #5 Weight 1 Value 1 (Icon) and #6 Weight 1 Value 2 (Exalted Icon). PoolDice has 6 entries:  #1 Weight 1 Value 0, #2 Weight 1 Value 0, #3 Weight 1 Value 0, #4 Weight 1 Value 1 (Icon), #5 Weight 1 Value 1 (Icon) and #6 Weight 1 Value 2 (Exalted Icon). Personally, I put an image of dice pips 1 through 6 in each of the roll tables, with the WrathDie Red dice and PoolDice Green dice.