### PR TITLE
[Star Wars D6] Customization menu and NPC sheet added

### DIFF
--- a/D6StarWars/D6StarWars.css
+++ b/D6StarWars/D6StarWars.css
@@ -1,231 +1,6 @@
 /*-------------------------------------------*/
-/*------------- Header Styles ---------------*/
+/*------------- SWD6 Main CSS----------------*/
 /*-------------------------------------------*/
-.charsheet .sheet-main-settings .sheet-input-row label {
-	display: inline-block;
-	width: auto;
-}
-
-.charsheet .sheet-main-settings .sheet-input-row input {
-	margin-right: 15px;
-}
-
-.charsheet .sheet-main-settings .sheet-input-row select {
-	width: 45%;
-	margin-right: 15px;
-}
-
-/*-------------------------------------------*/
-/*------------- Header Styles ---------------*/
-/*-------------------------------------------*/
-
-div.sheet-main-settings {
-	display: none;
-	position: relative;
-	top: 40px;
-	margin-left: 0;
-}
-
-input.sheet-options-flag:checked ~ div.sheet-main-settings {
-	display: block;
-	width: 550px;
-	height: 800px;
-}
-
-input.sheet-options-flag:checked ~ div.sheet-main-container {
-	display: none;
-}
-
-input.sheet-selector-switch {
-	display: none;
-}
-/* all hide options using option menu checkboxes*/
-input.sheet-wild:checked ~ .sheet-master-container .sheet-wild-hide,
-input.sheet-nowild:checked ~ .sheet-master-container .sheet-nowild-hide,
-input.sheet-force:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-force-hide,
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-hide ,
-input.sheet-gmroll:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-gmroll-hide {
-	display: none;
-}
-
-/*-------------------------------------------*/
-/*------------- General Styles---------------*/
-/*-------------------------------------------*/
-
-input[type=number]::-webkit-inner-spin-button {}
-
-input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
-	display: none;
-}
-
-input.sheet-disabled {
-	pointer-events: none;
-}
-
-input[disabled] {
-	cursor: default;
-}
-
-.sheet-master-container {
-	position: relative;
-	padding: 0;
-	display: inline-block;
-	width: 880px;
-	background-image: url(https://cdn.pixabay.com/photo/2015/09/29/15/12/stars-964022_960_720.png); /*black space with tiny stars*/
-    background-color: black;
-    background-repeat: repeat;
-}
-
-.sheet-container {
-	padding: 15px;
-	margin-left: -25px;
-	position: relative;
-}
-
-.sheet-main-container {
-	display: inline-block;
-	padding-top: 50px;
-	margin-left: 0;
-}
-
-.sheet-clear,
-input.sheet-toc:checked ~ .sheet-master-container .sheet-toc-clear,
-input.sheet-nba:checked ~ .sheet-master-container .sheet-nba-clear {
-	clear: none !important;
-}
-
-/*-------------------------------------------*/
-/*------------- Options Toggles--------------*/
-/*-------------------------------------------*/
-
-input.sheet-options-flag,
-input.sheet-options-flag + span {
-	position: absolute;
-	top: 2px;
-	right: 2px;
-	width: 15px;
-	height: 15px;
-}
-
-input.sheet-options-flag {
-	z-index: 99;
-	opacity: 0;
-}
-
-input.sheet-options-flag + span {
-	margin-top: 0px;
-	display: none;
-	white-space: nowrap;
-	line-height: 15px;
-	font-size: 17px;
-	color: white;
-	cursor: pointer;
-}
-
-input.sheet-options-flag.sheet-main-options {
-	width: 30px;
-	height: 30px;
-	top: 20px;
-	left: 20px;
-	z-index: 3;
-}
-
-input.sheet-options-flag.sheet-main-options + span {
-	width: 30px;
-	height: 30px;
-	top: 20px;
-	left: 20px;
-	font-size: 34px;
-	z-index: 2;
-	line-height: 30px;
-	opacity: .5;
-	display: block;
-}
-
-input.sheet-options-flag.sheet-main-options:hover + span {
-	opacity: 1;
-}
-
-input.sheet-options-flag:checked + span {
-	color: white;
-	display: block;
-}
-
-input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options {
-	display: none;
-}
-
-input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-options {
-	display: block;
-}
-
-input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-display {
-	display: none;
-}
-
-.editmode .sheet-options-flag {
-	display: none;
-}
-
-.sheet-content .sheet-display input[type=text] {
-	border: 0;
-}
-
-/*-------------------------------------------*/
-/*------------ Repeating Buttons ------------*/
-/*-------------------------------------------*/
-
-.sheet-content input.sheet-edit + span,
-.sheet-content div.sheet-placeholder span::before,
-input.sheet-main-options.sheet-options-flag + span,
-.sheet-content .sheet-abilities input.sheet-free + span::before,
-.sheet-content .sheet-ability-edit p.sheet-mos-message span::before,
-input[type=radio]:checked ~ .sheet-master-container input.sheet-options-flag + span,
-input[type=radio]:checked ~ .sheet-master-container .repcontrol .repcontrol_add::before,
-input[type=radio]:checked ~ .sheet-master-container .repcontrol .repcontrol_edit::after,
-input[type=radio]:checked ~ .sheet-master-container .itemcontrol button.repcontrol_del,
-input[type=radio]:checked ~ .sheet-master-container .sheet-abilities-col input.sheet-mos {
-	font-family: pictos;
-	font-style: normal;
-}
-
-/*-------------------------------------------*/
-/*--------------- NPC Styles ----------------*/
-/*-------------------------------------------*/
-
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
-	display: inline-block;
-}
-
-input.sheet-npc:checked ~ input.sheet-toc:checked ~ .sheet-master-container .sheet-header {
-	display: none;
-}
-
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-full {
-	width: 100%;
-	float: left;
-	margin: 0;
-	padding-left: 0;
-	box-sizing: border-box;
-}
-
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-full div {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general,
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general .repcontrol,
-input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general .repcontainer {
-	width: 100%;
-	display: inline-block;
-}
-
-input.sheet-toc:checked ~ .sheet-master-container .sheet-section::before {
-	display: none;
-}
-
-/*------------------------------------SWD6 original CSS ------------------------------------------------- */
 .charsheet {
     /*background-position: center;*/ /*https://cdn.pixabay.com/photo/2017/01/02/11/10/sky-1946508_960_720.png more and brighter stars*/
 	background-image: url(https://cdn.pixabay.com/photo/2015/09/29/15/12/stars-964022_960_720.png); /*black space with tiny white stars*/
@@ -317,11 +92,6 @@ input.sheet-toc:checked ~ .sheet-master-container .sheet-section::before {
     margin-bottom: 10px;
 }
 
-.charsheet .sheet-forcebutton{
-    width:110px; 
-    padding-right:10px;
-}
-
 .charsheet .sheet-tdborder{
     border: 2px solid white;
     vertical-align:top;
@@ -367,20 +137,197 @@ input.sheet-toc:checked ~ .sheet-master-container .sheet-section::before {
 .charsheet label.sheet-areaLabel{
     margin:0px;
 }
-
+/*----------Roll Buttons ------------------*/
 .charsheet button[type=roll].sheet-d6-dice::before {	/*new die changes die roller to d6*/
 	font-family: 'dicefontd6',arial;
 	content: 'F ';
 	color: red;
 }
-/* gmrolls and section hiding*/
-
-
-.charsheet input.sheet-hidecheckbox {
-    float: left;
-}
-
-.charsheet input.sheet-hidecheckbox:checked ~ .sheet-body-to-hide {
-    display: none;
+.charsheet .sheet-forcebutton{
+    width:90px; 
+    padding-right:5px;
 }
 /*Original button :button[type=roll].sheet-blank-roll-button::before { content: ''; } */
+
+/*-------------------------------------------*/
+/*---Header Styles(from GUMSHOE Official)----*/
+/*-------------------------------------------*/
+.charsheet .sheet-main-settings .sheet-input-row label {
+	display: inline-block;
+	width: auto;
+}
+
+.charsheet .sheet-main-settings .sheet-input-row input {
+	margin-right: 15px;
+}
+
+.charsheet .sheet-main-settings .sheet-input-row select {
+	width: 45%;
+	margin-right: 15px;
+}
+
+/*-------------------------------------------*/
+/*-----Main Settings and hide classes--------*/
+/*-----------(from GUMSHOE Official)---------*/
+
+div.sheet-main-settings {
+	display: none;
+	position: relative;
+	top: 40px;
+	margin-left: 0;
+}
+
+input.sheet-options-flag:checked ~ div.sheet-main-settings {
+	display: block;
+	width: 550px;
+	height: 800px;
+}
+
+input.sheet-options-flag:checked ~ div.sheet-main-container {
+	display: none;
+}
+
+input.sheet-selector-switch {
+	display: none;
+}
+/* all hide options using option menu checkboxes*/
+input.sheet-wild:checked ~ .sheet-master-container .sheet-wild-hide,
+input.sheet-nowild:checked ~ .sheet-master-container .sheet-nowild-hide,
+input.sheet-background:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-background-hide,
+input.sheet-force:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-force-hide,
+input.sheet-equipment:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-equipment-hide,
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-hide ,
+input.sheet-gmroll:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-gmroll-hide {
+	display: none;
+}
+
+/*-------------------------------------------*/
+/*------------- General Styles---------------*/
+/*------------(from GUMSHOE Official)--------*/
+
+input[type=number]::-webkit-inner-spin-button {}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
+	display: none;
+}
+
+.sheet-master-container {
+	position: relative;
+	padding: 0;
+	display: inline-block;
+	width: 900px;
+	background-image: url(https://cdn.pixabay.com/photo/2015/09/29/15/12/stars-964022_960_720.png); /*black space with tiny stars*/
+    background-color: black;
+    background-repeat: repeat;
+}
+
+.sheet-container {
+	padding: 15px;
+	margin-left: -25px;
+	position: relative;
+}
+
+.sheet-main-container {
+	display: inline-block;
+	padding-top: 50px;
+	margin-left: 0;
+}
+
+/*-------------------------------------------*/
+/*------------- Options Toggles--------------*/
+/*-----------(from GUMSHOE Official)---------*/
+
+input.sheet-options-flag,
+input.sheet-options-flag + span {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	width: 15px;
+	height: 15px;
+}
+
+input.sheet-options-flag {
+	z-index: 99;
+	opacity: 0;
+}
+
+input.sheet-options-flag + span {
+	margin-top: 0px;
+	display: none;
+	white-space: nowrap;
+	line-height: 15px;
+	font-size: 17px;
+	color: white;
+	cursor: pointer;
+}
+
+input.sheet-options-flag.sheet-main-options {
+	width: 30px;
+	height: 30px;
+	top: 20px;
+	left: 20px;
+	z-index: 3;
+}
+
+input.sheet-options-flag.sheet-main-options + span {
+	width: 30px;
+	height: 30px;
+	top: 20px;
+	left: 20px;
+	font-size: 34px;
+	z-index: 2;
+	line-height: 30px;
+	opacity: .5;
+	display: block;
+}
+
+input.sheet-options-flag.sheet-main-options:hover + span {
+	opacity: 1;
+}
+
+input.sheet-options-flag:checked + span {
+	color: white;
+	display: block;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options {
+	display: none;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-options {
+	display: block;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-display {
+	display: none;
+}
+
+.editmode .sheet-options-flag {
+	display: none;
+}
+
+.sheet-content .sheet-display input[type=text] {
+	border: 0;
+}
+
+/*-------------------------------------------*/
+/*------------ Repeating Buttons ------------*/
+/*----------(from GUMSHOE Official)-----------*/
+
+.sheet-content input.sheet-edit + span,
+.sheet-content div.sheet-placeholder span::before,
+input.sheet-main-options.sheet-options-flag + span,
+.sheet-content .sheet-abilities input.sheet-free + span::before,
+.sheet-content .sheet-ability-edit p.sheet-mos-message span::before,
+input[type=radio]:checked ~ .sheet-master-container input.sheet-options-flag + span {
+	font-family: pictos;
+	font-style: normal;
+}
+
+/*-------------------------------------------*/
+/*--------------- NPC Styles ----------------*/
+/*---------(from GUMSHOE Official)-----------*/
+
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
+	display: inline-block;
+}

--- a/D6StarWars/D6StarWars.css
+++ b/D6StarWars/D6StarWars.css
@@ -1,3 +1,231 @@
+/*-------------------------------------------*/
+/*------------- Header Styles ---------------*/
+/*-------------------------------------------*/
+.charsheet .sheet-main-settings .sheet-input-row label {
+	display: inline-block;
+	width: auto;
+}
+
+.charsheet .sheet-main-settings .sheet-input-row input {
+	margin-right: 15px;
+}
+
+.charsheet .sheet-main-settings .sheet-input-row select {
+	width: 45%;
+	margin-right: 15px;
+}
+
+/*-------------------------------------------*/
+/*------------- Header Styles ---------------*/
+/*-------------------------------------------*/
+
+div.sheet-main-settings {
+	display: none;
+	position: relative;
+	top: 40px;
+	margin-left: 0;
+}
+
+input.sheet-options-flag:checked ~ div.sheet-main-settings {
+	display: block;
+	width: 550px;
+	height: 800px;
+}
+
+input.sheet-options-flag:checked ~ div.sheet-main-container {
+	display: none;
+}
+
+input.sheet-selector-switch {
+	display: none;
+}
+/* all hide options using option menu checkboxes*/
+input.sheet-wild:checked ~ .sheet-master-container .sheet-wild-hide,
+input.sheet-nowild:checked ~ .sheet-master-container .sheet-nowild-hide,
+input.sheet-force:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-force-hide,
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-hide ,
+input.sheet-gmroll:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-gmroll-hide {
+	display: none;
+}
+
+/*-------------------------------------------*/
+/*------------- General Styles---------------*/
+/*-------------------------------------------*/
+
+input[type=number]::-webkit-inner-spin-button {}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
+	display: none;
+}
+
+input.sheet-disabled {
+	pointer-events: none;
+}
+
+input[disabled] {
+	cursor: default;
+}
+
+.sheet-master-container {
+	position: relative;
+	padding: 0;
+	display: inline-block;
+	width: 880px;
+	background-image: url(https://cdn.pixabay.com/photo/2015/09/29/15/12/stars-964022_960_720.png); /*black space with tiny stars*/
+    background-color: black;
+    background-repeat: repeat;
+}
+
+.sheet-container {
+	padding: 15px;
+	margin-left: -25px;
+	position: relative;
+}
+
+.sheet-main-container {
+	display: inline-block;
+	padding-top: 50px;
+	margin-left: 0;
+}
+
+.sheet-clear,
+input.sheet-toc:checked ~ .sheet-master-container .sheet-toc-clear,
+input.sheet-nba:checked ~ .sheet-master-container .sheet-nba-clear {
+	clear: none !important;
+}
+
+/*-------------------------------------------*/
+/*------------- Options Toggles--------------*/
+/*-------------------------------------------*/
+
+input.sheet-options-flag,
+input.sheet-options-flag + span {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	width: 15px;
+	height: 15px;
+}
+
+input.sheet-options-flag {
+	z-index: 99;
+	opacity: 0;
+}
+
+input.sheet-options-flag + span {
+	margin-top: 0px;
+	display: none;
+	white-space: nowrap;
+	line-height: 15px;
+	font-size: 17px;
+	color: white;
+	cursor: pointer;
+}
+
+input.sheet-options-flag.sheet-main-options {
+	width: 30px;
+	height: 30px;
+	top: 20px;
+	left: 20px;
+	z-index: 3;
+}
+
+input.sheet-options-flag.sheet-main-options + span {
+	width: 30px;
+	height: 30px;
+	top: 20px;
+	left: 20px;
+	font-size: 34px;
+	z-index: 2;
+	line-height: 30px;
+	opacity: .5;
+	display: block;
+}
+
+input.sheet-options-flag.sheet-main-options:hover + span {
+	opacity: 1;
+}
+
+input.sheet-options-flag:checked + span {
+	color: white;
+	display: block;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options {
+	display: none;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-options {
+	display: block;
+}
+
+input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-content .sheet-options-flag:checked ~ .sheet-display {
+	display: none;
+}
+
+.editmode .sheet-options-flag {
+	display: none;
+}
+
+.sheet-content .sheet-display input[type=text] {
+	border: 0;
+}
+
+/*-------------------------------------------*/
+/*------------ Repeating Buttons ------------*/
+/*-------------------------------------------*/
+
+.sheet-content input.sheet-edit + span,
+.sheet-content div.sheet-placeholder span::before,
+input.sheet-main-options.sheet-options-flag + span,
+.sheet-content .sheet-abilities input.sheet-free + span::before,
+.sheet-content .sheet-ability-edit p.sheet-mos-message span::before,
+input[type=radio]:checked ~ .sheet-master-container input.sheet-options-flag + span,
+input[type=radio]:checked ~ .sheet-master-container .repcontrol .repcontrol_add::before,
+input[type=radio]:checked ~ .sheet-master-container .repcontrol .repcontrol_edit::after,
+input[type=radio]:checked ~ .sheet-master-container .itemcontrol button.repcontrol_del,
+input[type=radio]:checked ~ .sheet-master-container .sheet-abilities-col input.sheet-mos {
+	font-family: pictos;
+	font-style: normal;
+}
+
+/*-------------------------------------------*/
+/*--------------- NPC Styles ----------------*/
+/*-------------------------------------------*/
+
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-pc-hide {
+	display: inline-block;
+}
+
+input.sheet-npc:checked ~ input.sheet-toc:checked ~ .sheet-master-container .sheet-header {
+	display: none;
+}
+
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-full {
+	width: 100%;
+	float: left;
+	margin: 0;
+	padding-left: 0;
+	box-sizing: border-box;
+}
+
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-npc-full div {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general,
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general .repcontrol,
+input.sheet-npc:checked ~ input.sheet-selector-switch:checked ~ .sheet-master-container .sheet-abilities-col.sheet-general .repcontainer {
+	width: 100%;
+	display: inline-block;
+}
+
+input.sheet-toc:checked ~ .sheet-master-container .sheet-section::before {
+	display: none;
+}
+
+/*------------------------------------SWD6 original CSS ------------------------------------------------- */
 .charsheet {
     /*background-position: center;*/ /*https://cdn.pixabay.com/photo/2017/01/02/11/10/sky-1946508_960_720.png more and brighter stars*/
 	background-image: url(https://cdn.pixabay.com/photo/2015/09/29/15/12/stars-964022_960_720.png); /*black space with tiny white stars*/
@@ -6,7 +234,7 @@
     color:white;
 }
  
-.charsheet label, h3{
+.charsheet label, h1, h2, h3{
     color:white;
 }
  
@@ -53,6 +281,12 @@
     width:60px;
     margin:0px;
 }
+
+.charsheet input[type=text].sheet-mediumtext{
+    width:80px;
+    margin:0px;
+}
+
 .charsheet input[type=text].sheet-shorttext{
     padding-top:2px;
     padding-bottom:2px;
@@ -71,6 +305,11 @@
 
 .charsheet .sheet-left{
     float:left;
+}
+
+.charsheet .sheet-redtxt{
+    font-size: 6pt;
+    color: red;
 }
 
 .charsheet .sheet-bold{
@@ -134,12 +373,14 @@
 	content: 'F ';
 	color: red;
 }
+/* gmrolls and section hiding*/
 
-.charsheet input.sheet-hide {
+
+.charsheet input.sheet-hidecheckbox {
     float: left;
 }
 
-.charsheet input.sheet-hide:checked ~ div.sheet-body-to-hide {
+.charsheet input.sheet-hidecheckbox:checked ~ .sheet-body-to-hide {
     display: none;
 }
 /*Original button :button[type=roll].sheet-blank-roll-button::before { content: ''; } */

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -1,414 +1,1238 @@
-<div class="sheet-sheet" style=" position:relative;">
-    <div style="text-align: Center;"> <!-- id="header"-->
-        <img src="http://rs8.pbsrc.com/albums/a35/VPP3/d62_zpstllyo5ds.png?w=480&h=480&fit=clip" style="max-height: 60px;" />
-        <img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 90px;" />
-        <img src="http://rs8.pbsrc.com/albums/a35/VPP3/d61_zps5ef1qprz.png?w=480&h=480&fit=clip" style="max-height: 60px;" />
-    </div>
-    <div class="sheet-section"> <!-- id="Characterinfo"-->
-        <div class="sheet-2colrow">
-            <div class="sheet-col" style="display:inline-block;">
-                <label class="sheet-toppad">Character Name <input class="sheet-right sheet-shorttext" type="text" name="attr_charactername" style="width:65%"/></label>
-                <label class="sheet-toppad">Type <input class="sheet-right sheet-shorttext" type="text" name="attr_type" style="width:85%"/></label>
-                <label class="sheet-toppad;">Species <input class="sheet-right sheet-shorttext" style="width:80%;" type="text" name="attr_species"/></label>
-                <table style="margin-top:-10px; margin-left:-10px;">
-                    <tr>
-                        <td>
-                        <label class="sheet-toppad">Age <input  class="sheet-smalltext sheet-shorttext" type="text" name="attr_age"/></label>
-                        </td><td>
-                        <label>Height <input class="sheet-smalltext sheet-shorttext" type="text" name="attr_height"/></label>
-                        </td><td>
-                        <label>Weight <input class="sheet-smalltext sheet-shorttext" type="text" name="attr_weight"/></label>
-                        </td><td>
-                        <label>Gender <input class="sheet-smalltext sheet-shorttext" type="text" name="attr_gender"/></label>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="sheet-col">
-                <label>Credits <input type="number" min="0" class="sheet-credits" name="attr_credits" /></label>
-                <label>Physical Description</label>
-                <textarea name="attr_Physical_Description" style="height:4em;" ></textarea>
-            </div>
-        </div>
-    </div>
-    <div class="sheet-section"> <!-- id="Characternumbers" -->
-        <div class='sheet-3colrow'>
-            <div class='sheet-col'>
-                <label class="sheet-areaLabel">Special Abilities</label>
-                <textarea name="attr_specialAbilities" style="width:230px;height:9em;" ></textarea>
-            </div>            
-            <div class='sheet-col' >
-                <label>Move <input type="number" name="attr_move" class="sheet-smallshortnumber" min="0" value="10"/></label>
-                <label>
-                    Force Sensitive? <select name="attr_forceSensitive" class="sheet-smallselect">
-                      <option value="1">Yes</option>
-                      <option value="0" selected="selected">No</option>
-                    </select> 
-                </label>
-                <label>Force Points <input type="number" name="attr_forcePoints" class="sheet-smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 1 FP --->
-                <label>Dark Side Points <input type="number" name="attr_darkSidePoints" class="sheet-smallshortnumber" min="0" value="0"/></label>
-                <label>Character Points <input type="number" name="attr_characterPoints" class="sheet-smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 5 CP --->
-            </div>          
-            <div class='sheet-col'>
-                <label style="text-decoration:underline;">
-					Wound Level
-					<select name="attr_WoundLevel" class="sheet-mediumselect" class="sheet-left" >
-					  <option value="0" selected="selected">Healthy</option>
-					  <option value="-1">Stunned</option>
-					  <option value="-1">Wounded</option>
-					  <option value="-2">Wounded Twice</option>
-					  <option value="-10">Incapacitated</option> <!--You shouldn't even be able to make checks while incapacitated or Mortally wounded, hence -15. Later will include option to ignore wound penalties -->
-					  <option value="-15">Mortally Wounded</option>
-					</select> 
-				</label>
-				
-				<label>
-					Initiative bonus
-					<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-				</label>
-				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel}   + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative(select you token first)</button>
-				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>
-				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}">Extra Dice(no wild die)</button>
-				<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}">Character points roll</button>
-            </div>
-        </div>
-    </div>
-    <div class="sheet-section"> <!-- id="Attributes" -->
-        <table>
-            <tr>
-                <td class="sheet-tdborder"><div class="sheet-bold"><!---Perc Attribute --->
-                        <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Perception</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_perception" class="sheet-smallnumber"  min="1" value="3"/>D
-							+<input type="number" name="attr_perceptionpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
-                        </div>
-                    </div>
-					<fieldset class="repeating_perckills"> <!---Perc Skills --->
-						<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                          <input class="sheet-skilltext" type="text" name="attr_perckillname"/> <!-- Misspelled attr name iis to be left as it is, otherwise it wipes char sheets from perseption skills-->
-                          <div class="sheet-right">
-                          <input type="number" name="attr_perckilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D 
-                          +<input type="number" name="attr_perckillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
-                          </div>
-                    </fieldset>
-                </td>
-                <td class="sheet-tdborder"><div class="sheet-bold"><!---Str Attribute --->
-                        <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_strength" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_strengthpip" class="sheet-pipnumber" min="0" max="2" value="0"/>  
-                        </div>
-                    </div>
-                    <fieldset class="repeating_strskills"> <!---Str Skills --->
-                        <button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                          <input class="sheet-skilltext" type="text" name="attr_strskillname"/> 
-                          <div class="sheet-right">
-							<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_strskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
-                          </div>
-                    </fieldset>			
-                </td> 
-                <td class="sheet-tdborder"><div class="sheet-bold"><!---Tech Attribute --->
-                        <button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_technical" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_technicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>    
-                        </div>
-                    </div>
-                    <fieldset class="repeating_techskills">  <!---Tech Skills --->
-                        <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                          <input class="sheet-skilltext" type="text" name="attr_techskillname"/> 
-                          <div class="sheet-right">
-                          <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-						  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
-                          </div>
-                    </fieldset>
-                </td class="sheet-tdborder"> 
-            </tr>
-            <tr>
-                <td class="sheet-tdborder"><div class="sheet-bold"> <!---Dex Attribute --->
-                        <button class="sheet-d6-dice" type='roll'value='&{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_dexterity" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_dexteritypip" class="sheet-pipnumber" min="0" max="2" value="0"/>
-                        </div>
-                    </div>
-                    <fieldset class="repeating_dexskills"> <!---Dex Skills --->
-                        <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                          <input class="sheet-skilltext" type="text" name="attr_dexskillname"/>
-                          <div class="sheet-right">		
-                          <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-						  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-                          </div>
-                    </fieldset>
-                </td>
-                <td class="sheet-tdborder"><div class="sheet-bold"> <!---Know Attribute ---> 
-                        <button class="sheet-d6-dice" type='roll' value='&{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_knowledge" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_knowledgepip" class="sheet-pipnumber" min="0" max="2" value="0"/>
-                        </div>
-                    </div>
-                    <fieldset class="repeating_knowskills">  <!---Know Skills --->
-                        <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                          <input class="sheet-skilltext" type="text" name="attr_knowskillname"/> 
-                          <div class="sheet-right">
-                          <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-						  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
-                          </div>
-                    </fieldset>
-                </td> 
-                <td class="sheet-tdborder"><div class="sheet-bold"><!---Mech Attribute --->
-                        <button class="sheet-d6-dice"  type='roll' value='&{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Mechanical</button>
-                        <div style="float:right;">
-                            <input type="number" name="attr_mechanical" class="sheet-smallnumber" min="1" value="3"/>D
-							+<input type="number" name="attr_mechanicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
-                        </div>
-                    </div>
-                    <fieldset class="repeating_mechskills">  <!---Mech Skills --->      
-                        <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-                         <input class="sheet-skilltext" type="text" name="attr_mechskillname"/> 
-                         <div class="sheet-right">
-                         <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-						 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
-                         </div>
-                    </fieldset>
-                </td> 
-            </tr>
-        </table>    
-    </div>	
-	<div class="sheet-section"> <!-- id="Weapons" -->
-		<label style="text-align: center">Weapon Section</label>
-		<table>
-			<tr>
-				<td style="width:210px">Name</td>
-				<td style="width:70px">Skill Roll</td>
-				<td style="width:72px">Damage</td>
-				<td style="width:45px">Short</td>
-				<td style="width:50px">Med</td>
-				<td style="width:45px">Long</td>
-				<td style="width:35px">ROF</td>
-				<td style="width:30px;text-align:center;">Ammo</td>
-			</tr>
-		</table>	
-			<fieldset class="repeating_weapons">
-				<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_weapon"/>
-				<input type="number" name="attr_weaponskill" class="sheet-smallnumber" min="1" value="1"/>D+<input type="number" name="attr_weaponskillpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
-				<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_shortrange"/>
-				<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_medrange"/>
-				<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_longrange"/>
-				<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_ROF"/>
-				<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_Ammo"/>
+<input class="sheet-selector-switch sheet-npc" name="attr_npcswitch" type="checkbox" value="1">
+<input class="sheet-selector-switch sheet-gmroll" name="attr_gmrollswitch" type="checkbox" value="1">
+<input class="sheet-selector-switch sheet-force" name="attr_forceswitch" type="checkbox" value="1">
+<!-- -->
+<input class="selector-switch sheet-wild" name="attr_wildswitch" type="radio" value="wild" checked="true">
+<input class="selector-switch sheet-nowild" name="attr_wildswitch" type="radio" value="nowild">
 
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -1 +@{WoundLevel}   + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Atk</button>				
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Dmg</button>
-			</fieldset>
-					  
-    </div>
-	<div class="sheet-section"> <!--  id="Armor"-->
-		<table>
-			<tr>
-				<td style="width:200px"><label>Armor</label></td>
-				<td style="width:80px">Physical</td>
-				<td style="width:80px">Energy</td>
-				<td style="width:180px">Other</td>
-				<td style="width:180px">Damage Soak Rolls</td>
-			</tr>
-		</table>
-			<fieldset class="repeating_armors">
-				<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_armorname"/>
-				<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-				<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-				<input class="sheet-skilltext" type="text" name="attr_armor_other"/>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Physical</button>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Energy</button>
-				<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Str only</button>	  
-			</fieldset>
-	</div>
-    <div class="sheet-section"> <!-- id="Force" -->
-		<input type="checkbox" class="sheet-hide"><!-- Checkbox to hide force section -->
-		<label style="text-align: center">Force Section</label>
-		<div class='sheet-body-to-hide'>
-			<div class='sheet-2colrow'>
-			<div class='sheet-col'>
-                <table><th><label>Force Skills</label></th>
-                    <tr><!--Control -->
-                        <td style="width:260px;">
-                            <div class="sheet-bold">
-                                <button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' > Control</button>
-                                <div style="float:right;">
-                                    <input type="number" name="attr_control" class="sheet-smallnumber"  min="0" value="0"/>D 
-                                    +<input type="number" name="attr_controlpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr><!-- Sense -->
-                        <td style="width:260px;">
-                            <div class="sheet-bold">
-                                <button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' > Sense</button>
-                                <div style="float:right;">
-                                    <input type="number" name="attr_sense" class="sheet-smallnumber" style="margin-left=100px;"  min="0" value="0"/>D
-                                    +<input type="number" name="attr_sensepip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
-                                </div>
-                            </div>
-                        </td> 
-                    </tr>
-                    <tr><!-- Alter -->
-                        <td style="width:260px;">
-                            <div class="sheet-bold">
-                                <button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' > Alter</button>
-                                <div style="float:right;">
-                                    <input type="number" name="attr_alter" class="sheet-smallnumber" min="0" value="0"/>D 
-                                    +<input type="number" name="attr_alterpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
-                                </div>
-                            </div>
-                        </td> 
-                    </tr>
-                </table>
-				<table><th><label>Force Powers Active</label></th>
-					
-					<tr><td><!---Force Emptiness --->
-							<span style="padding-top:8px; padding-bottom:12px;" title="Force Emptiness adds +6 pips to all force skill rolls when active">Force Emptiness active?</span><!---Force Emptiness adds +6 pips to all force skill rolls when active --->
-								<select name="attr_Force_Emptiness" class="sheet-smallselect">
-								  <option value="0" selected="selected">No</option>
-								  <option value="6">Yes</option>
-								</select>
-					</td></tr>
-					<tr><td><!---Force Powers active --->
-						<span>Number of powers active?<!---gives penalty to all rolls thanks to concentration/distraction --->
-							<select name="attr_Force_Up" class="sheet-smallselect" title="The number of power active is subtracted from all roll as a MultiActionPenalty">
-							  <option value="0" selected="selected">0</option>
-							  <option value="-1">1</option>
-							  <option value="-2">2</option>
-							  <option value="-3">3</option>
-							  <option value="-4">4</option>
-							  <option value="-5">5</option>
-							</select>
-						</span>
-					</td></tr>
-					<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
-						This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
-						If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
-						this check could be added back. -Andreas.J 2017-12-3 
-						--->
-				</table>				
+<div class="sheet-master-container">
+	<input class="sheet-main-options sheet-options-flag" type="checkbox" name="attr_sheet-options-flag"><span>y</span>
+	<div class="sheet-main-settings sheet-container"><!-- Settings Menu-->
+		<h2 style="text-align: center">Settings</h2>
+		<div class="sheet-content">
+			<div class="sheet-input-row sheet-top-row"> 
+				<label>NPC sheet </label>
+				<input name="attr_npcswitch" type="checkbox" value="1">
 			</div>
-			
-			<div class='sheet-col'>
-				<div><!-- Force Power list -->
-					<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
-					<textarea name="attr_forcePowers" style="width:260px;height:17em"></textarea>
-				</div>				
+			<div class="sheet-input-row sheet-top-row">
+				<label>Hide GM Rolls? </label>
+				<input name="attr_gmrollswitch" type="checkbox" value="1">
 			</div>
-			</div>
-			<div class='sheet-col'>
-					<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
-					
-	                     <input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
-                         <div class="sheet-right">		
-                          <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-						  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-						<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
-						</div>
-						
-                         <div class="sheet-right">		
-                          <input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
-						  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-						  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
-						</div>		
+			<div class="sheet-input-row sheet-top-row">
+				<label>Hide Force Section? </label>
+				<input name="attr_forceswitch" type="checkbox" value="1">
 			</div>
 		</div>
 	</div>
-	<div class="sheet-section"> <!--id="Extendedinfo" -->
-		<input type="checkbox" class="sheet-hide"><!-- Checkbox to hide extended info section -->
-		<label style="text-align: center">Background and extended info</label>
-        <div class='sheet-body-to-hide'>
+
+	<div class="sheet-main-container sheet-container">
+		<div class="sheet-header sheet-npc-full">
+		<div style="text-align: Center;"> <!-- id="header"-->
+			<img class="sheet-npc-hide" src="http://rs8.pbsrc.com/albums/a35/VPP3/d62_zpstllyo5ds.png?w=480&h=480&fit=clip" style="max-height: 60px;"/>
+			<img class="sheet-npc-hide" src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 90px;"/>
+			<img class="sheet-npc-hide" src="http://rs8.pbsrc.com/albums/a35/VPP3/d61_zps5ef1qprz.png?w=480&h=480&fit=clip" style="max-height: 60px;"/>
+		</div>
+		</div>
+<!-- NPC Info ----------------------------------------->
+	<div class="sheet-npc-full sheet-pc-hide">
+		<div class="sheet-section"> <!-- "Characterinfo"-->
+			<h2 style="text-align: center">NPC Sheet</h2>
+			<div class="sheet-2colrow">
+				<div class="sheet-col" style="display:inline-block;">
+					<label class="sheet-toppad">NPC Name <input class="sheet-right sheet-shorttext" type="text" name="attr_charactername" style="width:65%"/></label>
+					<label style="text-decoration:underline;">
+						Wound Level
+						<select name="attr_WoundLevel" class="sheet-mediumselect" class="sheet-left" >
+						  <option value="0" selected="selected">Healthy</option>
+						  <option value="-1">Stunned</option>
+						  <option value="-1">Wounded</option>
+						  <option value="-2">Wounded Twice</option>
+						  <option value="-5">Incapacitated</option> <!--You shouldn't even be able to make checks while incapacitated or Mortally wounded, hence -15. Later will include option to ignore wound penalties -->
+						  <option value="-5">Mortally Wounded</option>
+						</select> 
+					</label>
+					<label>
+						Initiative bonus
+						<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					</label>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel}   + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative</button>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll<button>
+					<button class="sheet-d6-dice sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"><span class="sheet-redtxt">(GM)</span>Custom Roll<button>
+
+				</div>
+				<div class="sheet-col">
+					<label>Other Info</label>
+					<textarea name="attr_Physical_Description" style="height:6em;"></textarea>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-section"> <!-- id="Attributes" -->
 			<table>
 				<tr>
-					<td style="width:33.33%;"><label>Background</label>
-						<div>
-							<textarea name="attr_background"></textarea>
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Perc Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Perception</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_perception" class="sheet-smallnumber"  min="1" value="3"/>D
+								+<input type="number" name="attr_perceptionpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
 						</div>
+						<fieldset class="repeating_perckills"> <!---Perc Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_perckillname"/> <!-- Misspelled attr name iis to be left as it is, otherwise it wipes char sheets from perseption skills-->
+							  <div class="sheet-right">
+							  <input type="number" name="attr_perckilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D 
+							  +<input type="number" name="attr_perckillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
 					</td>
-					<td style="width:33.33%;">
-						<label>Personality</label>
-						<div>
-							<textarea name="attr_personality"></textarea>
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Str Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_strength" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_strengthpip" class="sheet-pipnumber" min="0" max="2" value="0"/>  
+							</div>
 						</div>
-					</td>
-					<td style="width:33.33%;">
-						<label>Objectives</label>
-						<div>
-							<textarea name="attr_objectives"></textarea>
+						<fieldset class="repeating_strskills"> <!---Str Skills --->
+							<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_strskillname"/> 
+							  <div class="sheet-right">
+								<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_strskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>			
+					</td> 
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Tech Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_technical" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_technicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>    
+							</div>
 						</div>
-					</td>
+						<fieldset class="repeating_techskills">  <!---Tech Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_techskillname"/> 
+							  <div class="sheet-right">
+							  <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
+					</td class="sheet-tdborder"> 
 				</tr>
 				<tr>
-					<td>
-						<label>Quotes</label>
-						<div>
-							<textarea name="attr_quotes"></textarea>
+					<td class="sheet-tdborder"><div class="sheet-bold"> <!---Dex Attribute --->
+							<button class="sheet-d6-dice" type='roll'value='&{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll'value='/w gm &{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_dexterity" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_dexteritypip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
 						</div>
+						<fieldset class="repeating_dexskills"> <!---Dex Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_dexskillname"/>
+							  <div class="sheet-right">		
+							  <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							  </div>
+						</fieldset>
 					</td>
-					<td>
-						<label>Connections to other characters</label>
-						<div>
-							<textarea name="attr_connections"></textarea>
+					<td class="sheet-tdborder"><div class="sheet-bold"> <!---Know Attribute ---> 
+							<button class="sheet-d6-dice" type='roll' value='&{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_knowledge" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_knowledgepip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
 						</div>
-					</td>
-					<td>
-						<label>Additional Notes</label>
-						<div>
-							<textarea name="attr_notes"></textarea>
+						<fieldset class="repeating_knowskills">  <!---Know Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_knowskillname"/> 
+							  <div class="sheet-right">
+							  <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
+					</td> 
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Mech Attribute --->
+							<button class="sheet-d6-dice"  type='roll' value='&{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Mechanical</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type='roll' value='/w gm &{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' ><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_mechanical" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_mechanicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
 						</div>
-					</td>
+						<fieldset class="repeating_mechskills">  <!---Mech Skills --->      
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							<input class="sheet-skilltext" type="text" name="attr_mechskillname"/> 
+							 <div class="sheet-right">
+							 <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							 </div>
+						</fieldset>
+					</td> 
+				</tr>
+			</table>    
+		</div>
+		<div class="sheet-section"> <!-- Weapons&Armor" -->
+			<label style="text-align: center">Weapon & Armor</label>
+			<table>
+				<tr>
+					<td style="width:210px">Name</td>
+					<td style="width:70px">Skill Roll</td>
+					<td style="width:72px">Damage</td>
+					<td style="width:45px">Short</td>
+					<td style="width:50px">Med</td>
+					<td style="width:45px">Long</td>
+					<td style="width:35px">ROF</td>
+					<td style="width:30px;text-align:center;">Ammo</td>
+				</tr>
+			</table>	
+				<fieldset class="repeating_weapons">
+					<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_weapon"/>
+					<input type="number" name="attr_weaponskill" class="sheet-smallnumber" min="1" value="1"/>D+<input type="number" name="attr_weaponskillpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_shortrange"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_medrange"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_longrange"/>
+					<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_ROF"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_Ammo"/>
+
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -1 +@{WoundLevel}   + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Atk</button>				
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Dmg</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -1 +@{WoundLevel}   + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>Atk</button>				
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}"><span class="sheet-redtxt">GM</span>Dmg</button>
+				</fieldset>
+			<table>
+				<tr>
+					<td style="width:200px"><label>Armor</label></td>
+					<td style="width:80px">Physical</td>
+					<td style="width:80px">Energy</td>
+					<td style="width:180px">Other</td>
+					<td style="width:180px">Damage Soak Rolls</td>
 				</tr>
 			</table>
+				<fieldset class="repeating_armors">
+					<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_armorname"/>
+					<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input class="sheet-skilltext" type="text" name="attr_armor_other"/>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Physical</button>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Energy</button>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Str only</button>	  
+	<!--GM rolls-->	<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>P</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>E</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>S</button>	  
+				</fieldset>
+		</div>		
+		<div class="sheet-section sheet-force-hide"> <!-- Force -->
+			<input type="checkbox" class="sheet-hidecheckbox"><!-- Checkbox to hide force section -->
+			<label style="text-align: center">Force Section</label>
+			<div class='sheet-body-to-hide'>
+				<div class='sheet-2colrow'>
+				<div class='sheet-col'>
+					<table><th><label>Force Skills</label></th>
+						<tr><!--Control -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_control" class="sheet-smallnumber"  min="0" value="0"/>D 
+										+<input type="number" name="attr_controlpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+									</div>
+								</div>
+							</td>
+						</tr>
+						<tr><!-- Sense -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_sense" class="sheet-smallnumber" style="margin-left=100px;"  min="0" value="0"/>D
+										+<input type="number" name="attr_sensepip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
+									</div>
+								</div>
+							</td> 
+						</tr>
+						<tr><!-- Alter -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_alter" class="sheet-smallnumber" min="0" value="0"/>D 
+										+<input type="number" name="attr_alterpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
+									</div>
+								</div>
+							</td> 
+						</tr>
+					</table>
+					<table><th><label>Force Powers Active</label></th>
+						
+						<tr><td><!---Force Emptiness --->
+								<span style="padding-top:8px; padding-bottom:12px;" title="Force Emptiness adds +6 pips to all force skill rolls when active">Force Emptiness active?</span><!---Force Emptiness adds +6 pips to all force skill rolls when active --->
+									<select name="attr_Force_Emptiness" class="sheet-smallselect">
+									  <option value="0" selected="selected">No</option>
+									  <option value="6">Yes,0 DSP</option>
+									  <option value="5">Yes,1 DSP</option>
+									  <option value="4">Yes,2 DSP</option>
+									  <option value="3">Yes,3 DSP</option>
+									  <option value="2">Yes,4 DSP</option>
+									  <option value="1">Yes,5 DSP</option>
+									</select>
+						</td></tr>
+						<tr><td><!---Force Powers active --->
+							<span>Number of powers active?<!---gives penalty to all rolls thanks to concentration/distraction --->
+								<select name="attr_Force_Up" class="sheet-smallselect" title="The number of power active is subtracted from all roll as a MultiActionPenalty">
+								  <option value="0" selected="selected">0</option>
+								  <option value="-1">1</option>
+								  <option value="-2">2</option>
+								  <option value="-3">3</option>
+								  <option value="-4">4</option>
+								  <option value="-5">5</option>
+								</select>
+							</span>
+						</td></tr>
+						<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
+							This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
+							If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
+							this check could be added back. -Andreas.J 2017-12-3 
+							--->
+					</table>				
+				</div>
+				
+				<div class='sheet-col'>
+					<div><!-- Force Power list -->
+						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
+						<textarea name="attr_forcePowers" style="width:300px;height:21em"></textarea>
+					</div>				
+				</div>
+				</div>
+				<div class='sheet-col'>
+						<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
+						
+							 <input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
+							 <div class="sheet-right">		
+							  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
+							</div>
+							
+							 <div class="sheet-right">		
+							  <input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
+							  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
+							</div>		
+				</div>
+			</div>
 		</div>
 	</div>
-	<div class="sheet-section"> <!-- id="Equipment"-->
-            <table>
-                <th></th>
-                <th><label>Equipment</label></th>
-                <th></th>
-                <tr>
-                    <td style="text-align: right;">
-                        <textarea name="attr_geartext1"></textarea>
-                        <textarea name="attr_geartext2"></textarea>
-                    </td>
-                    <td style="text-align: center;">
-                        <textarea name="attr_geartext3"></textarea>
-                        <textarea name="attr_geartext4"></textarea>
-                    </td>
-                    <td style="text-align: Left;">
-                        <textarea name="attr_geartext5"></textarea>
-                        <textarea name="attr_geartext6"></textarea>
-                    </td>
-                </tr>
-            </table>
-	</div>
-	<div class="sheet-section"> <!-- id="Ship"-->
-		<div class='sheet-2colrow'>
-			<div class='sheet-col'><!-- Vehicle -->
-				<div>
-					<label style="padding-top:8px; padding-bottom:12px;" >Vehicle</label>
-					<input class="sheet-skilltext" type="text"  style="width:100%" name="attr_vehiclename"/>
-					<textarea name="attr_vehicle" style="width:100%;height:17em"></textarea>
-				</div>				
-			</div>
-			<div class='sheet-col'><!-- Starship -->
-				<div>
-					<label style="padding-top:8px; padding-bottom:12px;" >Starship</label>
-					<input class="sheet-skilltext" type="text"  style="width:100%" name="attr_starshipname"/>
-					<textarea name="attr_starship" style="width:100%;height:17em"></textarea>
-				</div>				
+<!-- PC info --------------------------------------------->
+	<div class="sheet-npc-hide">
+		<div style=" position:relative;">
+		<div class="sheet-section"> <!-- id="Characterinfo"-->
+			<div class="sheet-2colrow">
+				<div class="sheet-col" style="display:inline-block;">
+					<label class="sheet-toppad">Character Name <input class="sheet-right sheet-shorttext" type="text" name="attr_charactername" style="width:65%"/></label>
+					<label class="sheet-toppad">Type <input class="sheet-right sheet-shorttext" type="text" name="attr_type" style="width:85%"/></label>
+					<label class="sheet-toppad;">Species <input class="sheet-right sheet-shorttext" style="width:80%;" type="text" name="attr_species"/></label>
+					<table style="margin-top:-10px; margin-left:-10px;">
+						<tr>
+							<td>
+							<label class="sheet-toppad">Age <input  class="sheet-smalltext sheet-shorttext" type="text" name="attr_age"/></label>
+							</td><td>
+							<label>Height <input class="sheet-smalltext sheet-shorttext" type="text" name="attr_height"/></label>
+							</td><td>
+							<label>Weight <input class="sheet-smalltext sheet-shorttext" type="text" name="attr_weight"/></label>
+							</td><td>
+							<label>Gender <input class="sheet-mediumtext sheet-shorttext" type="text" name="attr_gender"/></label>
+							</td>
+						</tr>
+					</table>
+				</div>
+				<div class="sheet-col">
+					<label>Credits <input type="number" min="0" class="sheet-credits" name="attr_credits" /></label>
+					<label>Physical Description</label>
+					<textarea name="attr_Physical_Description" style="height:6em;" ></textarea>
+				</div>
 			</div>
 		</div>
+		<div class="sheet-section"> <!-- id="Characternumbers" -->
+			<div class='sheet-3colrow'>
+				<div class='sheet-col'>
+					<label class="sheet-areaLabel">Special Abilities</label>
+					<textarea name="attr_specialAbilities" style="width:230px;height:14em" ></textarea>
+				</div>            
+				<div class='sheet-col' >
+					<label>Move <input type="number" name="attr_move" class="sheet-smallshortnumber" min="0" value="10"/></label>
+					<label>
+						Force Sensitive? <select name="attr_forceSensitive" class="sheet-smallselect">
+						  <option value="1">Yes</option>
+						  <option value="0" selected="selected">No</option>
+						</select> 
+					</label>
+					<label>Force Points <input type="number" name="attr_forcePoints" class="sheet-smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 1 FP --->
+					<label>Dark Side Points <input type="number" name="attr_darkSidePoints" class="sheet-smallshortnumber" min="0" value="0"/></label>
+					<label>Character Points <input type="number" name="attr_characterPoints" class="sheet-smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 5 CP --->
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"><span class="sheet-redtxt">(GM)</span>Custom Roll<button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}"><span class="sheet-redtxt">(GM)</span>Extra Dice</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}"><span class="sheet-redtxt">(GM)</span>Char pt</button>
+				</div>          
+				<div class='sheet-col'>
+					<label style="text-decoration:underline;">
+						Wound Level
+						<select name="attr_WoundLevel" class="sheet-mediumselect" class="sheet-left" >
+						  <option value="0" selected="selected">Healthy</option>
+						  <option value="-1">Stunned</option>
+						  <option value="-1">Wounded</option>
+						  <option value="-2">Wounded Twice</option>
+						  <option value="-5">Incapacitated</option> <!--You shouldn't even be able to make checks while incapacitated or Mortally wounded, hence -15. Later will include option to ignore wound penalties -->
+						  <option value="-5">Mortally Wounded</option>
+						</select> 
+					</label>
+					<label>
+						Initiative bonus
+						<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					</label>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel}   + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative</button>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}">Extra Dice(no wild die)</button>
+					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}">Character points roll</button>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-section"> <!-- id="Attributes" -->
+			<table>
+				<tr>
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Perc Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Perception</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Perception}} {{Roll=[[(@{perception} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perceptionpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_perception" class="sheet-smallnumber"  min="1" value="3"/>D
+								+<input type="number" name="attr_perceptionpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
+						</div>
+						<fieldset class="repeating_perckills"> <!---Perc Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_perckillname"/> <!-- Misspelled attr name iis to be left as it is, otherwise it wipes char sheets from perseption skills-->
+							  <div class="sheet-right">
+							  <input type="number" name="attr_perckilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D 
+							  +<input type="number" name="attr_perckillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
+					</td>
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Str Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Strength}} {{Roll=[[(@{strength} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_strength" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_strengthpip" class="sheet-pipnumber" min="0" max="2" value="0"/>  
+							</div>
+						</div>
+						<fieldset class="repeating_strskills"> <!---Str Skills --->
+							<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type="roll" value="/w gm &{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_strskillname"/> 
+							  <div class="sheet-right">
+								<input type="number" name="attr_strskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_strskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>			
+					</td> 
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Tech Attribute --->
+							<button class="sheet-d6-dice" type='roll' class="astext" value='&{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Technical}} {{Roll=[[(@{technical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_technical" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_technicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>    
+							</div>
+						</div>
+						<fieldset class="repeating_techskills">  <!---Tech Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_techskillname"/> 
+							  <div class="sheet-right">
+							  <input type="number" name="attr_techskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_techskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
+					</td class="sheet-tdborder"> 
+				</tr>
+				<tr>
+					<td class="sheet-tdborder"><div class="sheet-bold"> <!---Dex Attribute --->
+							<button class="sheet-d6-dice" type='roll'value='&{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll'value='/w gm &{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_dexterity" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_dexteritypip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
+						</div>
+						<fieldset class="repeating_dexskills"> <!---Dex Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_dexskillname"/>
+							  <div class="sheet-right">		
+							  <input type="number" name="attr_dexskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_dexskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							  </div>
+						</fieldset>
+					</td>
+					<td class="sheet-tdborder"><div class="sheet-bold"> <!---Know Attribute ---> 
+							<button class="sheet-d6-dice" type='roll' value='&{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_knowledge" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_knowledgepip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
+						</div>
+						<fieldset class="repeating_knowskills">  <!---Know Skills --->
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							  <input class="sheet-skilltext" type="text" name="attr_knowskillname"/> 
+							  <div class="sheet-right">
+							  <input type="number" name="attr_knowskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_knowskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							  </div>
+						</fieldset>
+					</td> 
+					<td class="sheet-tdborder"><div class="sheet-bold"><!---Mech Attribute --->
+							<button class="sheet-d6-dice"  type='roll' value='&{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Mechanical</button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type='roll' value='/w gm &{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' ><span class="sheet-redtxt">GM</span></button>
+							<div style="float:right;">
+								<input type="number" name="attr_mechanical" class="sheet-smallnumber" min="1" value="3"/>D
+								+<input type="number" name="attr_mechanicalpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+							</div>
+						</div>
+						<fieldset class="repeating_mechskills">  <!---Mech Skills --->      
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span></button>
+							<input class="sheet-skilltext" type="text" name="attr_mechskillname"/> 
+							 <div class="sheet-right">
+							 <input type="number" name="attr_mechskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							 +<input type="number" name="attr_mechskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/> 
+							 </div>
+						</fieldset>
+					</td> 
+				</tr>
+			</table>    
+		</div>	
+		<div class="sheet-section"> <!-- id="Weapons" -->
+			<label style="text-align: center">Weapon Section</label>
+			<table>
+				<tr>
+					<td style="width:210px">Name</td>
+					<td style="width:70px">Skill Roll</td>
+					<td style="width:72px">Damage</td>
+					<td style="width:45px">Short</td>
+					<td style="width:50px">Med</td>
+					<td style="width:45px">Long</td>
+					<td style="width:35px">ROF</td>
+					<td style="width:30px;text-align:center;">Ammo</td>
+				</tr>
+			</table>	
+				<fieldset class="repeating_weapons">
+					<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_weapon"/>
+					<input type="number" name="attr_weaponskill" class="sheet-smallnumber" min="1" value="1"/>D+<input type="number" name="attr_weaponskillpip" class="sheet-pipnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_damagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="1"/>D+<input type="number" name="attr_damagepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_shortrange"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_medrange"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_longrange"/>
+					<input class="sheet-smallnumber sheet-shortnumber" type="number" name="attr_ROF"/>
+					<input class="sheet-mediumnumber sheet-shortnumber" type="number" name="attr_Ammo"/>
+
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -1 +@{WoundLevel}   + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Atk</button>				
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Dmg</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -1 +@{WoundLevel}   + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>Atk</button>				
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}"><span class="sheet-redtxt">GM</span>Dmg</button>
+				</fieldset>
+						  
+		</div>
+		<div class="sheet-section"> <!--  id="Armor"-->
+			<table>
+				<tr>
+					<td style="width:200px"><label>Armor</label></td>
+					<td style="width:80px">Physical</td>
+					<td style="width:80px">Energy</td>
+					<td style="width:180px">Other</td>
+					<td style="width:180px">Damage Soak Rolls</td>
+				</tr>
+			</table>
+				<fieldset class="repeating_armors">
+					<input class="sheet-skilltext" type="text"  style="width:200px" name="attr_armorname"/>
+					<input type="number" name="attr_armorPhDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input type="number" name="attr_armorEnDice" class="sheet-smallnumber sheet-shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<input class="sheet-skilltext" type="text" name="attr_armor_other"/>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}">Physical</button>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}">Energy</button>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}">Str only</button>	  
+	<!--GM rolls-->	<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} + @{armorPhDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorPhPip} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>P</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} + @{armorEnDice} +@{WoundLevel} - 1)d6cf0cs7 + @{armorEnPip} + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>E</button>
+					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>S</button>	  
+				</fieldset>
+		</div>
+		<div class='sheet-force-hide'> <!-- id="Force" -->
+			<div class="sheet-section">
+				<label style="text-align: center">Force Section</label>
+				<div class='sheet-2colrow'>
+				<div class='sheet-col'>
+					<table><th><label>Force Skills</label></th>
+						<tr><!--Control -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_control" class="sheet-smallnumber"  min="0" value="0"/>D 
+										+<input type="number" name="attr_controlpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
+									</div>
+								</div>
+							</td>
+						</tr>
+						<tr><!-- Sense -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_sense" class="sheet-smallnumber" style="margin-left=100px;"  min="0" value="0"/>D
+										+<input type="number" name="attr_sensepip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
+									</div>
+								</div>
+							</td> 
+						</tr>
+						<tr><!-- Alter -->
+							<td style="width:260px;">
+								<div class="sheet-bold">
+									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div style="float:right;">
+										<input type="number" name="attr_alter" class="sheet-smallnumber" min="0" value="0"/>D 
+										+<input type="number" name="attr_alterpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
+									</div>
+								</div>
+							</td> 
+						</tr>
+					</table>
+					<table><th><label>Force Powers Active</label></th>		
+						<tr><td><!---Force Emptiness --->
+								<span style="padding-top:8px; padding-bottom:12px;" title="Force Emptiness adds +6 pips to all force skill rolls when active">Force Emptiness active?</span><!---Force Emptiness adds +6 pips to all force skill rolls when active --->
+									<select name="attr_Force_Emptiness" class="sheet-smallselect">
+									  <option value="0" selected="selected">No</option>
+									  <option value="6">Yes,0 DSP</option>
+									  <option value="5">Yes,1 DSP</option>
+									  <option value="4">Yes,2 DSP</option>
+									  <option value="3">Yes,3 DSP</option>
+									  <option value="2">Yes,4 DSP</option>
+									  <option value="1">Yes,5 DSP</option>
+									</select>
+						</td></tr>
+						<tr><td><!---Force Powers active --->
+							<span>Number of powers active?<!---gives penalty to all rolls thanks to concentration/distraction --->
+								<select name="attr_Force_Up" class="sheet-smallselect" title="The number of power active is subtracted from all roll as a MultiActionPenalty">
+								  <option value="0" selected="selected">0</option>
+								  <option value="-1">1</option>
+								  <option value="-2">2</option>
+								  <option value="-3">3</option>
+								  <option value="-4">4</option>
+								  <option value="-5">5</option>
+								</select>
+							</span>
+						</td></tr>
+						<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
+							This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
+							If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
+							this check could be added back. -Andreas.J 2017-12-3 
+							--->
+					</table>				
+				</div>
+				
+				<div class='sheet-col'>
+					<div><!-- Force Power list -->
+						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
+						<textarea name="attr_forcePowers" style="width:300px;height:21em"></textarea>
+					</div>				
+				</div>
+				</div>
+				<div class='sheet-col'>
+						<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
+						
+							 <input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
+							 <div class="sheet-right">		
+							  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+							  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
+							</div>
+							
+							 <div class="sheet-right">		
+							  <input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
+							  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+							  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
+							</div>		
+				</div>
+			</div>
+		</div>
+		<div class="sheet-section"> <!--id="Extendedinfo" -->
+			<input type="checkbox" class="sheet-hidecheckbox"><!-- Checkbox to hide extended info section -->
+			<label style="text-align: center">Background and extended info</label>
+			<div class='sheet-body-to-hide'>
+				<table>
+					<tr>
+						<td style="width:33.33%;"><label>Background</label>
+							<div>
+								<textarea name="attr_background"></textarea>
+							</div>
+						</td>
+						<td style="width:33.33%;">
+							<label>Personality</label>
+							<div>
+								<textarea name="attr_personality"></textarea>
+							</div>
+						</td>
+						<td style="width:33.33%;">
+							<label>Objectives</label>
+							<div>
+								<textarea name="attr_objectives"></textarea>
+							</div>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<label>Quotes</label>
+							<div>
+								<textarea name="attr_quotes"></textarea>
+							</div>
+						</td>
+						<td>
+							<label>Connections to other characters</label>
+							<div>
+								<textarea name="attr_connections"></textarea>
+							</div>
+						</td>
+						<td>
+							<label>Additional Notes</label>
+							<div>
+								<textarea name="attr_notes"></textarea>
+							</div>
+						</td>
+					</tr>
+				</table>
+			</div>
+		</div>
+		<div class="sheet-section"> <!-- id="Equipment"-->
+				<table>
+					<th></th>
+					<th><label>Equipment</label></th>
+					<th></th>
+					<tr>
+						<td style="text-align: right;">
+							<textarea name="attr_geartext1"></textarea>
+							<textarea name="attr_geartext2"></textarea>
+						</td>
+						<td style="text-align: center;">
+							<textarea name="attr_geartext3"></textarea>
+							<textarea name="attr_geartext4"></textarea>
+						</td>
+						<td style="text-align: Left;">
+							<textarea name="attr_geartext5"></textarea>
+							<textarea name="attr_geartext6"></textarea>
+						</td>
+					</tr>
+				</table>
+		</div>
+		<div class="sheet-section"> <!-- id="Ship"-->
+			<div class='sheet-2colrow'>
+				<div class='sheet-col'><!-- Vehicle -->
+					<div>
+						<label style="padding-top:8px; padding-bottom:12px;" >Vehicle</label>
+						<input class="sheet-skilltext" type="text"  style="width:100%" name="attr_vehiclename"/>
+						<textarea name="attr_vehicle" style="width:100%;height:17em"></textarea>
+					</div>				
+				</div>
+				<div class='sheet-col'><!-- Starship -->
+					<div>
+						<label style="padding-top:8px; padding-bottom:12px;" >Starship</label>
+						<input class="sheet-skilltext" type="text"  style="width:100%" name="attr_starshipname"/>
+						<textarea name="attr_starship" style="width:100%;height:17em"></textarea>
+					</div>				
+				</div>
+			</div>
+		</div>
+		</div>
 	</div>
-	<div class="sheet-section" style="text-align: Center; padding-top:10px;"> <!-- id="footer"-->
-		<img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 100px;" />
-		<p style="text-align: center;" ><small>Author: Timothy O'Driscoll | Editor: Andreas J. (Roll20user: 1223200)</small></p>
+		
+	<div class="sheet-section" style="text-align: Center; padding-top:10px;"> <!-- footer-->
+			<img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 100px;" />
+			<p style="text-align: center;" ><small>Author: Timothy O'Driscoll | Editor: Andreas J. (Roll20user: 1223200)</small></p>
+	</div>
+
 	</div>
 </div>
+
+<script type="text/worker">
+//changes: occult -> occult-studies; Assess Honesty -> Bullshit Detector; Outdoorsman -> Outdoor Survival; Explosives -> Explosive Devices;
+// Mechanical Repair -> Mechanics; 
+var currentAbilities = {},
+	reverseAbilities = {},
+	allAbilities = ["accounting", "anthropology", "archaeology", "architecture", "art", "art-history", "art-hsitory", "assess-honesty", "astronomy", "athletics", "bargain", "biology", "bullshit-detector", "bureaucracy", "chemistry", "conceal", "cop-talk", "cover", "craft", "credit-rating", "criminology", "cryptography", "cthulhu-mythos", "data-recovery", "diagnosis", "digital-intrusion", "disguise", "driving", "electrical-repair", "electronic-surveillance", "evidence-collection", "explosive-devices", "explosives", "filch", "firearms", "first-aid", "flattery", "fleeing", "flirting", "forensic-pathology", "forensics", "forgery", "gambling", "geology", "hand-to-hand", "health", "high-society", "history", "human-terrain", "hypnosis", "infiltration", "interrogation", "intimidation", "languages", "law", "library-use", "locksmith", "mechanical-repair", "mechanics", "medic", "medicine", "military-science", "negotiation", "network", "notice", "occult", "occult-studies", "oral-history", "outdoorsman", "outdoor-survival", "pharmacy", "photography", "physics", "piloting", "preparedness", "psychoanalysis", "reassurance", "research", "riding", "sanity", "scuffling", "sense-trouble", "shadowing", "shooting", "shrink", "stability", "stealth", "streetwise", "surveillance", "theology", "tradecraft", "traffic-analysis", "urban-survival", "vampirology"],
+	system = 'toc',
+	npc = false,
+	sections = ['academic', 'interpersonal', 'technical', 'general'],
+	pointChange = ['inc', 'dec', 'max-inc', 'max-dec', '', 'max'],
+	maxChange = ['occupation', 'max', 'free'],
+
+	changeString = function(elementList, endings = [""], repeating = false) {
+		let string = '';
+		if(repeating) {
+			_.each(elementList, function(element) {
+				_.each(endings, function(ending) {
+					string += ' change:repeating_' + element + ':r-' + element;
+					string += (ending == '') ? '' : '_' + ending;
+				});
+			});
+		} else {
+			_.each(elementList, function(element) {
+				_.each(endings, function(ending) {
+					string += ' change:' + element;
+					string += (ending == '') ? '' : '_' + ending;
+				});
+			});
+		}
+		return string;
+	},
+
+	getAbility = function(trigger) {
+		return trigger ? trigger.split("_") : false;
+	},
+
+	abilityList = function(elementList, endings, repeating = false) {
+		let returnList = [],
+			prefix = repeating ? repeating : '';
+		_.each(elementList, function(element) {
+			_.each(endings, function(ending) {
+				let underscore = ending == '' ? '' : '_';
+				returnList.push(prefix + element + underscore + ending);
+			});
+		});
+		return returnList;
+	},
+
+	returnInt = function(x) {
+		return isNaN(x) ? "" : parseInt(x);
+	},
+
+	makeRepeatingArray = function(section, repIds) {
+		let result = [];
+
+		_.each(repIds, function(repId) {
+			result.push('repeating_' + section + '_' + repId + '_r-' + section);
+		});
+		return result;
+	},
+
+	getSectionTotal = function(secs = {}, eventInfo = {category: false}, repeating = false) {
+		let aList = [],
+			pointList = abilityList(sections, ['points']);
+		pointList = pointList.concat(abilityList(sections, ['points'], 'r-'));
+
+		if(eventInfo.category) {
+			aList = aList.concat(abilityList(secs, maxChange.concat([""])));
+		} else {
+			_.each(sections, function(sec) {
+				aList = aList.concat(abilityList(currentAbilities[sec], maxChange));
+			});
+		}
+
+		getAttrs(aList.concat(pointList), function(values) {
+			let result = {},
+				current = repeating ? 'r-' + eventInfo.category + '_points' : eventInfo.category + '_points',
+
+				computePoints = function(abilities) {
+					let result = 0;
+					_.each(abilities, function(ability) {
+						let max = parseInt(values[ability + "_max"]),
+							occupation = values[ability + "_occupation"];
+						if(ability == 'fleeing') {
+							let ath = values['athletics_max'] ? parseInt(values['athletics_max']) : 0;
+							if(ath < max) {
+								result += ath;
+								max -= ath;
+								occupation = 0.5;
+							}
+						} else {
+							max = Math.max(max - values[ability + "_free"], 0);
+						}
+						occupation = system == 'toc' ? occupation : 0;
+						result += max ? Math.ceil(max * (1 - occupation)) : 0;
+					});
+
+					return result;
+				},
+
+				setResult = function() {
+					result['inv_points'] = 0;
+					result['gen_points'] = 0;
+					_.each(['academic', 'interpersonal', 'technical'], function(sec) {
+						result['inv_points'] += parseInt(result[sec + '_points']) + parseInt(result['r-' + sec + '_points']);
+					});
+					result['gen_points'] += parseInt(result['general_points']) + parseInt(result['r-general_points']);
+					setAttrs(result);
+				};
+
+			if(eventInfo.category) {
+				_.each(pointList, function(sec) {
+					result[sec] = parseInt(values[sec]);
+				});
+				result[current] = 0;
+
+				result[current] = computePoints(secs);
+
+				if(eventInfo.sourceAttribute.substr(-4) == 'free') {
+					let oldVal = 0, diff = 0,
+						trigger = eventInfo.sourceAttribute.slice(0,-5),
+						newVal = parseInt(values[trigger + '_free']);
+
+					if(eventInfo.previousValue) {
+						oldVal = parseInt(eventInfo.previousValue);
+						if(oldVal == newVal) {
+							oldVal = 0;
+						}
+					}
+
+					diff = newVal - oldVal;
+
+					result[trigger + '_max'] = Math.max(parseInt(values[trigger + '_max']) + diff, 0);
+					result[trigger] = Math.max(parseInt(values[trigger]) + diff, 0);
+				}
+				setResult(result);
+
+			} else {
+				let idResult = [];
+
+				result = secs;
+
+				_.each(pointList, function(sec) {
+					result[sec] = 0;
+				});
+
+				_.each(sections, function(sec) {
+					result[sec + '_points'] += computePoints(currentAbilities[sec]);
+				});
+
+				getRepeating(sections, function(resultArray) {
+					getAttrs(abilityList(resultArray, maxChange), function(vals) {
+						_.each(resultArray, function(rAbility) {
+							let max = vals[rAbility + "_max"],
+								occupation = vals[rAbility + "_occupation"];
+
+							occupation = system == 'toc' ? occupation : 0;
+							result[rAbility.split('_')[3] + '_points'] += max ? Math.ceil(max * (1 - occupation)) : 0;
+						});
+						setResult();
+					});
+				});
+
+			}
+		});
+	},
+
+	abilityChange = function(trigger, repeating = false) {
+		if (trigger == false) {
+			return;
+		}
+
+		let ability = trigger[0],
+			source = trigger[1],
+			max = ability + "_max",
+			constraint = ability + "_constraint",
+			free = ability + "_free",
+			noCherry = ["health", "stability", "cover", "network"];
+
+		getAttrs([ability, max, free, "cherry-branch-height"], function(values) {
+			let change = {},
+				maxMin = npc ? 0 : parseInt(values[free]),
+				min = ["health", "stability"].indexOf(ability) == -1 ? 0 : -12;
+
+			change[ability] = returnInt(values[ability]);
+			change[max] = returnInt(values[max]);
+			change[constraint] = " ";
+
+			if(source == "inc") {
+				change[ability] = change[ability] ? change[ability] + 1 : 1;
+			}
+			if(source == "dec") {
+				change[ability] -= 1;
+			}
+
+			if(source == "max-inc") {
+				change[max] = change[max] ? change[max] : 0;
+				change[ability] = change[ability] ? change[ability] : 0;
+				if(change[ability] == change[max]) {
+					change[ability] = change[max] + 1;
+				}
+				change[max] += 1;
+			}
+			if(source == "max-dec") {
+				if(change[ability] == change[max]) {
+					change[ability] = change[max] - 1;
+				}
+				change[max] -= 1;
+			}
+
+			if(change[max] <= maxMin) {
+				change[constraint] += "d";
+				change[max] = maxMin ? maxMin : "";
+			}
+			if(change[ability] >= change[max]) {
+				change[constraint] += "a";
+			}
+			if(change[ability] <= min) {
+				change[constraint] += "b";
+				change[ability] = change[max] ? min : "";
+			}
+
+			if(values[ability] == "" && values[max] == 0) {
+				change[ability] = change[max];
+			}
+
+			if(ability == 'athletics' && !npc) {
+				change['hit-rating'] = change[max] >= 8 ? 4 : 3;
+			}
+
+			if(change[ability] <= -10) {
+				change[constraint] += 's';
+			}
+
+			if(parseInt(change[ability]) > 0) {
+				change[ability + "_dice"] = "@{point_query}";
+			} else {
+				change[ability + "_dice"] = "@{basic_roll}";
+			}
+
+			if(npc) {
+				change[ability] = change[ability] == "" ? 0 : change[ability];
+			}
+
+			if(change[ability] >= values["cherry-branch-height"] && noCherry.indexOf(ability) == -1) {
+				change[constraint] += "x";
+			}
+
+			setAttrs(change);
+
+		});
+	};
+
+on("sheet:opened change:sheetsettings", function(eventInfo) {
+	let systemAbilities = {
+			tocAcademic: ['accounting', 'anthropology', 'archaeology', 'architecture', 'art-history', 'biology', 'cthulhu-mythos', 'cryptography', 'geology', 'history', 'languages', 'law', 'library-use', 'medicine', 'occult', 'physics', 'theology'],
+			tocInterpersonal: ['assess-honesty', 'bargain', 'bureaucracy', 'cop-talk', 'credit-rating', 'flattery', 'interrogation', 'intimidation', 'oral-history', 'reassurance', 'streetwise'],
+			tocTechnical: ['art', 'astronomy', 'chemistry', 'craft', 'evidence-collection', 'forensics', 'locksmith', 'outdoorsman', 'pharmacy', 'photography'],
+			tocGeneral: ['athletics', 'conceal', 'disguise', 'driving', 'electrical-repair', 'explosives', 'filch', 'firearms', 'first-aid', 'fleeing', 'health', 'hypnosis', 'mechanical-repair', 'piloting', 'preparedness', 'psychoanalysis', 'riding', 'sanity', 'scuffling', 'sense-trouble', 'shadowing', 'stability', 'stealth', 'weapons'],
+			nbaAcademic: ['accounting', 'archaeology', 'architecture', 'art-history', 'criminology', 'diagnosis', 'history', 'human-terrain', 'languages', 'law', 'military-science', 'occult-studies', 'research', 'vampirology'],
+			nbaInterpersonal: ['bullshit-detector', 'bureaucracy', 'cop-talk', 'flattery', 'flirting', 'high-society', 'interrogation', 'intimidation', 'negotiation', 'reassurance', 'streetwise', 'tradecraft'],
+			nbaTechnical: ['astronomy', 'chemistry', 'cryptography', 'data-recovery', 'electronic-surveillance', 'forensic-pathology', 'forgery', 'notice', 'outdoor-survival', 'pharmacy', 'photography', 'traffic-analysis', 'urban-survival'],
+			nbaGeneral: ['athletics', 'conceal', 'cover', 'digital-intrusion', 'disguise', 'driving', 'explosive-devices', 'filch', 'gambling', 'hand-to-hand', 'health', 'infiltration', 'mechanics', 'medic', 'network', 'piloting', 'preparedness', 'sense-trouble', 'shooting', 'shrink', 'stability', 'surveillance', 'weapons']};
+
+	getAttrs(["health_default", "stability_default", "sanity_default", "cover_default", "network_default", "sheetsettings", "firstopen"], function(values) {
+		let updates = {version: 0.5};
+
+		system = values.sheetsettings;
+		_.each(sections, function(section) {
+			tempArray = systemAbilities[system + section[0].toUpperCase() + section.substr(1)];
+			currentAbilities[section] = tempArray;
+			_.each(tempArray, function(ability) {
+				reverseAbilities[ability] = section;
+			});
+		});
+
+		if(!values.firstopen) {
+			_.each(["health", "stability", "sanity", "cover", "network"], function(ability) {
+				updates[ability + '_free'] = values[ability + "_default"];
+				if(!npc) {
+					updates[ability + '_max'] = updates[ability + "_free"];
+					updates[ability] = updates[ability + "_free"];
+				}
+			});
+			updates.sanity_marker = updates.sanity_free;
+			updates.firstopen = 1;
+		}
+
+		if(system == "toc") {
+			updates.vampswitch = 0;
+		}
+
+		updates.sheetswitch = values.sheetsettings;
+		setAttrs(updates, {}, function() {
+			getSectionTotal();
+		}
+		
+		updates.wildswitch = values.wildsettings;
+		setAttrs(updates, {}, function() {
+			getSectionTotal();
+		});
+	});
+});
+
+
+on("change:npcswitch", function(eventInfo) {
+	let abilities = ["aberrance", "athletics", "conceal", "driving", "firearms", "hand-to-hand", "health", "medic", "scuffling", "shooting", "weapons"],
+		abilityVal = 0,
+		updates = {};
+
+	if(parseInt(eventInfo.newValue) == 1) {
+		updates["edit-abilities"] = 0;
+		npc = true;
+	} else {
+		updates["edit-abilities"] = 1;
+		abilityVal = "";
+		npc = false;
+	}
+
+	_.each(abilities, function(x) {
+		updates[x] = abilityVal;
+	});
+
+	if(npc) {
+		setAttrs(updates);
+	} else {
+		getAttrs(abilityList(abilities, ["free"]), function(values) {
+			_.each(abilities, function(ability) {
+				if(values[ability + '_free']) {
+					updates[ability + '_max'] = values[ability + '_free'];
+					updates[ability] = values[ability + '_free'];
+				}
+			});
+			setAttrs(updates);
+		});
+	}
+});
+
+on(changeString(allAbilities) + " change:spinner", function(eventInfo) {
+	let trigger = eventInfo.sourceAttribute,
+		resetAbilities = function(sectionArray) {
+			getRepeating(sectionArray, function(resultArray, returnedSecs) {
+				let secAbilities = [],
+					fullList = []; //resultArray.concat(allAbilities);
+
+				_.each(returnedSecs, function(sec) {
+					secAbilities = secAbilities.concat(currentAbilities[sec]);
+				});
+
+				fullList = resultArray.concat(secAbilities);
+
+				getAttrs(abilityList(fullList, ['max', '']), function(vals) {
+					let results = {},
+						noReset = ["sanity", "health", "stability", "cover", "network"];
+
+					_.each(fullList, function(ability) {
+						if(vals[ability] != vals[ability + '_max'] && vals[ability + '_max'] != "0") {
+							if(noReset.indexOf(ability) == -1) {
+								results[ability] = vals[ability + '_max'];
+							}
+						}
+					});
+
+					setAttrs(results);
+				});
+			});
+		};
+
+	if(trigger) {
+		if(trigger == "spinner") {
+			getAttrs(["spinner"], function(values) {
+				setAttrs({spinner: ""}, {silent: true});
+				if(values.spinner == "reset-inv") {
+					resetAbilities(["academic", "interpersonal", "technical"]);
+				} else if(values.spinner == "reset-gen") {
+					resetAbilities(["general"]);
+				}
+				else {
+					abilityChange(getAbility(values.spinner));
+				}
+			});
+		} else {
+			abilityChange(getAbility(trigger));
+		}
+	}
+});
+
+on(changeString(sections, pointChange, true), function(eventInfo) {
+	let triggerArray = eventInfo.sourceAttribute.split('_'),
+		trigger = triggerArray.pop();
+	triggerArray.splice(2, 1);
+	abilityChange([triggerArray.join('_'), trigger], true);
+});
+
+on(changeString(allAbilities, maxChange), function(eventInfo) {
+	eventInfo.category = reverseAbilities[eventInfo.sourceAttribute.split('_')[0]];
+	if(!npc) {
+		getSectionTotal(currentAbilities[eventInfo.category], eventInfo);
+	}
+});
+
+on(changeString(sections, maxChange, true), function(eventInfo) {
+	eventInfo.category = eventInfo.sourceAttribute.split('_')[1];
+	if(!npc) {
+		getSectionIDs(eventInfo.category, function(repIds) {
+			let nameArray = makeRepeatingArray(eventInfo.category, repIds);
+			getSectionTotal(nameArray, eventInfo, true);
+		});
+	}
+});
+
+
+on(changeString(["sanity", "cthulhu-mythos"], ["max"]), function() {
+	getAttrs(["sanity", "sanity_max", "cthulhu-mythos_max"], function(values) {
+		let result = {};
+		if(!values["cthulhu-mythos_max"]) {
+			values["cthulhu-mythos_max"] = 0;
+		}
+		result["sanity_marker"] = parseInt(values["sanity_max"]);
+		if(parseInt(values["cthulhu-mythos_max"]) > 0) {
+			result["sanity_marker"] = Math.min(parseInt(values["sanity_max"]), 10 - parseInt(values["cthulhu-mythos_max"]));
+		}
+		result["sanity_marker"] = Math.max(result["sanity_marker"], 0);
+		result["sanity_marker"] = Math.min(result["sanity_marker"], 15);
+		setAttrs(result);
+	});
+});
+
+on("change:repeating_general:r-mos", function(eventInfo) {
+	if(eventInfo.newValue == "1") {
+		let updates = {mos: "blank"};
+
+		getSectionIDs("repeating_general", function(idArray) {
+			console.log(idArray);
+			_.each(idArray, function(abilityID){
+				if(eventInfo.sourceAttribute != "repeating_general_" + abilityID + "_r-mos") {
+					updates["repeating_general_" + abilityID + "_r-mos"] = 0;
+				}
+			});
+			setAttrs(updates, {silent: true});
+		});
+	}
+});
+
+on("change:mos", function(eventInfo) {
+	let updates = {};
+
+	getSectionIDs("repeating_general", function(idArray) {
+		_.each(idArray, function(abilityID){
+			updates["repeating_general_" + abilityID + "_r-mos"] = 0;
+		});
+		console.log(updates);
+		setAttrs(updates, {silent: true});
+	});
+});
+
+</script>

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -1,6 +1,8 @@
 <input class="sheet-selector-switch sheet-npc" name="attr_npcswitch" type="checkbox" value="1">
 <input class="sheet-selector-switch sheet-gmroll" name="attr_gmrollswitch" type="checkbox" value="1">
 <input class="sheet-selector-switch sheet-force" name="attr_forceswitch" type="checkbox" value="1">
+<input class="sheet-selector-switch sheet-background" name="attr_backgroundswitch" type="checkbox" value="1">
+<input class="sheet-selector-switch sheet-equipment" name="attr_equipmentswitch" type="checkbox" value="1">
 <!-- -->
 <input class="selector-switch sheet-wild" name="attr_wildswitch" type="radio" value="wild" checked="true">
 <input class="selector-switch sheet-nowild" name="attr_wildswitch" type="radio" value="nowild">
@@ -21,6 +23,14 @@
 			<div class="sheet-input-row sheet-top-row">
 				<label>Hide Force Section? </label>
 				<input name="attr_forceswitch" type="checkbox" value="1">
+			</div>
+			<div class="sheet-input-row sheet-top-row">
+				<label>Hide Background Section? </label>
+				<input name="attr_backgroundswitch" type="checkbox" value="1">
+			</div>
+			<div class="sheet-input-row sheet-top-row">
+				<label>Hide Equipment Section? </label>
+				<input name="attr_equipmentswitch" type="checkbox" value="1">
 			</div>
 		</div>
 	</div>
@@ -61,12 +71,12 @@
 
 				</div>
 				<div class="sheet-col">
-					<label>Other Info</label>
+					<label>Physical Description & Other Info</label>
 					<textarea name="attr_Physical_Description" style="height:6em;"></textarea>
 				</div>
 			</div>
 		</div>
-		<div class="sheet-section"> <!-- id="Attributes" -->
+		<div class="sheet-section"> <!-- Attributes&Skills -->
 			<table>
 				<tr>
 					<td class="sheet-tdborder"><div class="sheet-bold"><!---Perc Attribute --->
@@ -182,11 +192,11 @@
 				</tr>
 			</table>    
 		</div>
-		<div class="sheet-section"> <!-- Weapons&Armor" -->
+		<div class="sheet-section"> <!-- Weapons&Armor -->
 			<label style="text-align: center">Weapon & Armor</label>
 			<table>
 				<tr>
-					<td style="width:210px">Name</td>
+					<td style="width:210px"><label>Weapon</label></td>
 					<td style="width:70px">Skill Roll</td>
 					<td style="width:72px">Damage</td>
 					<td style="width:45px">Short</td>
@@ -234,51 +244,42 @@
 				</fieldset>
 		</div>		
 		<div class="sheet-section sheet-force-hide"> <!-- Force -->
-			<input type="checkbox" class="sheet-hidecheckbox"><!-- Checkbox to hide force section -->
 			<label style="text-align: center">Force Section</label>
-			<div class='sheet-body-to-hide'>
-				<div class='sheet-2colrow'>
+			<div class='sheet-2colrow'>
 				<div class='sheet-col'>
 					<table><th><label>Force Skills</label></th>
 						<tr><!--Control -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_control" class="sheet-smallnumber"  min="0" value="0"/>D 
 										+<input type="number" name="attr_controlpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
 									</div>
-								</div>
 							</td>
 						</tr>
 						<tr><!-- Sense -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_sense" class="sheet-smallnumber" style="margin-left=100px;"  min="0" value="0"/>D
 										+<input type="number" name="attr_sensepip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
 									</div>
-								</div>
 							</td> 
 						</tr>
 						<tr><!-- Alter -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_alter" class="sheet-smallnumber" min="0" value="0"/>D 
 										+<input type="number" name="attr_alterpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
 									</div>
-								</div>
 							</td> 
 						</tr>
 					</table>
-					<table><th><label>Force Powers Active</label></th>
-						
+					<table><th><label>Force Powers Active</label></th>		
 						<tr><td><!---Force Emptiness --->
 								<span style="padding-top:8px; padding-bottom:12px;" title="Force Emptiness adds +6 pips to all force skill rolls when active">Force Emptiness active?</span><!---Force Emptiness adds +6 pips to all force skill rolls when active --->
 									<select name="attr_Force_Emptiness" class="sheet-smallselect">
@@ -303,44 +304,83 @@
 								</select>
 							</span>
 						</td></tr>
-						<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
-							This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
-							If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
-							this check could be added back. -Andreas.J 2017-12-3 
-							--->
 					</table>				
 				</div>
-				
 				<div class='sheet-col'>
 					<div><!-- Force Power list -->
-						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
+						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers</label>
 						<textarea name="attr_forcePowers" style="width:300px;height:21em"></textarea>
 					</div>				
 				</div>
-				</div>
-				<div class='sheet-col'>
-						<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
-						
-							 <input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
-							 <div class="sheet-right">		
-							  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-							  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
-							</div>
-							
-							 <div class="sheet-right">		
-							  <input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
-							  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-							  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
-							</div>		
-				</div>
+			</div>
+			<div class='sheet-col'>
+					<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
+					<input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
+					<div class="sheet-right">		
+					  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+					  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
+					</div>
+					<div class="sheet-right">		
+					<input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
+					  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
+					</div>		
 			</div>
 		</div>
+		<div class="sheet-section sheet-background-hide"> <!--Background & Extendedinfo -->
+			<label style="text-align: center">Background and extended info</label>
+			<table>
+				<tr>
+					<td style="width:33.33%;"><label>Background</label>
+						<div>
+							<textarea name="attr_background"></textarea>
+						</div>
+					</td>
+					<td style="width:33.33%;">
+						<label>Personality</label>
+						<div>
+							<textarea name="attr_personality"></textarea>
+						</div>
+					</td>
+					<td style="width:33.33%;">
+						<label>Objectives</label>
+						<div>
+							<textarea name="attr_objectives"></textarea>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<label>Quotes</label>
+						<div>
+							<textarea name="attr_quotes"></textarea>
+						</div>
+					</td>
+					<td>
+						<label>Connections to other characters</label>
+						<div>
+							<textarea name="attr_connections"></textarea>
+						</div>
+					</td>
+					<td>
+						<label>Additional Notes</label>
+						<div>
+							<textarea name="attr_notes"></textarea>
+						</div>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<div class="sheet-section sheet-equipment-hide"><!-- Equipment-->
+			<label style="text-align: center">Equipment</label>
+			<textarea name="attr_geartext1"></textarea>
+		</div>
 	</div>
-<!-- PC info --------------------------------------------->
+<!--------------------------- PC info --------------->
 	<div class="sheet-npc-hide">
 		<div style=" position:relative;">
-		<div class="sheet-section"> <!-- id="Characterinfo"-->
+		<div class="sheet-section"> <!-- Characterinfo-->
 			<div class="sheet-2colrow">
 				<div class="sheet-col" style="display:inline-block;">
 					<label class="sheet-toppad">Character Name <input class="sheet-right sheet-shorttext" type="text" name="attr_charactername" style="width:65%"/></label>
@@ -367,7 +407,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="sheet-section"> <!-- id="Characternumbers" -->
+		<div class="sheet-section"> <!-- Characternumbers -->
 			<div class='sheet-3colrow'>
 				<div class='sheet-col'>
 					<label class="sheet-areaLabel">Special Abilities</label>
@@ -375,8 +415,8 @@
 				</div>            
 				<div class='sheet-col' >
 					<label>Move <input type="number" name="attr_move" class="sheet-smallshortnumber" min="0" value="10"/></label>
-					<label>
-						Force Sensitive? <select name="attr_forceSensitive" class="sheet-smallselect">
+					<label>Force Sensitive? 
+						<select name="attr_forceSensitive" class="sheet-smallselect">
 						  <option value="1">Yes</option>
 						  <option value="0" selected="selected">No</option>
 						</select> 
@@ -400,8 +440,7 @@
 						  <option value="-5">Mortally Wounded</option>
 						</select> 
 					</label>
-					<label>
-						Initiative bonus
+					<label>Initiative bonus
 						<input type="number" name="attr_initiative" class="sheet-smallnumber sheet-shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
 					</label>
 					<button class="sheet-d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} + @{WoundLevel}   + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative</button>
@@ -411,7 +450,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="sheet-section"> <!-- id="Attributes" -->
+		<div class="sheet-section"> <!-- Attributes&Skills -->
 			<table>
 				<tr>
 					<td class="sheet-tdborder"><div class="sheet-bold"><!---Perc Attribute --->
@@ -527,7 +566,7 @@
 				</tr>
 			</table>    
 		</div>	
-		<div class="sheet-section"> <!-- id="Weapons" -->
+		<div class="sheet-section"> <!-- Weapons-->
 			<label style="text-align: center">Weapon Section</label>
 			<table>
 				<tr>
@@ -558,7 +597,7 @@
 				</fieldset>
 						  
 		</div>
-		<div class="sheet-section"> <!--  id="Armor"-->
+		<div class="sheet-section"> <!-- Armor-->
 			<table>
 				<tr>
 					<td style="width:200px"><label>Armor</label></td>
@@ -581,46 +620,39 @@
 					<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} +@{WoundLevel} - 1)d6cf0cs7 + 1d6!cf1cs6]]}}"><span class="sheet-redtxt">GM</span>S</button>	  
 				</fieldset>
 		</div>
-		<div class='sheet-force-hide'> <!-- id="Force" -->
-			<div class="sheet-section">
-				<label style="text-align: center">Force Section</label>
-				<div class='sheet-2colrow'>
+		<div class="sheet-section sheet-force-hide"> <!-- Force -->
+			<label style="text-align: center">Force Section</label>
+			<div class='sheet-2colrow'>
 				<div class='sheet-col'>
 					<table><th><label>Force Skills</label></th>
 						<tr><!--Control -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Control</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Control}} {{Roll=[[(@{control} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{controlpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_control" class="sheet-smallnumber"  min="0" value="0"/>D 
 										+<input type="number" name="attr_controlpip" class="sheet-smallnumber" min="0" max="2" value="0"/>
 									</div>
-								</div>
 							</td>
 						</tr>
 						<tr><!-- Sense -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Sense</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Sense}} {{Roll=[[(@{sense} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{sensepip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_sense" class="sheet-smallnumber" style="margin-left=100px;"  min="0" value="0"/>D
 										+<input type="number" name="attr_sensepip" class="sheet-smallnumber" min="0" max="2" value="0"/>  
 									</div>
-								</div>
 							</td> 
 						</tr>
 						<tr><!-- Alter -->
 							<td style="width:260px;">
-								<div class="sheet-bold">
-									<button class="sheet-d6-dice" class="sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
-									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" class="sheet-forcebutton" type='roll' class="astext" value='/w gm &{template:default} {{name=Force: Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
-									<div style="float:right;">
+									<button class="sheet-d6-dice sheet-forcebutton" type='roll' class="astext" value='&{template:default} {{name=Force:Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Alter</button>
+									<button class="sheet-d6-dice sheet-gmroll sheet-gmroll-hide" type='roll' class="astext" value='/w gm &{template:default} {{name=Force:Alter}} {{Roll=[[(@{alter} -1 +@{WoundLevel} + @{Force_Up} + ?{Dice mods|0})d6cf0cs7 + @{alterpip} + @{Force_Emptiness}+ ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="sheet-redtxt">GM</span></button>
+									<div class="sheet-bold" style="float:right;">
 										<input type="number" name="attr_alter" class="sheet-smallnumber" min="0" value="0"/>D 
 										+<input type="number" name="attr_alterpip" class="sheet-smallnumber" min="0" max="2" value="0"/>    
 									</div>
-								</div>
 							</td> 
 						</tr>
 					</table>
@@ -649,87 +681,75 @@
 								</select>
 							</span>
 						</td></tr>
-						<!---Force Control pain/ resist stun , could not make it work, thanks to order of precedence https://wiki.roll20.net/Dice_Reference#Math_Operators_and_Functions
-							This version result in abs(-1) being put into the roll, where the -1 is replaced by char's woundlevel.
-							If a way to get the attr_Force_ControlPain_ResistStun be equal to a positive value of attr_WoundLevel
-							this check could be added back. -Andreas.J 2017-12-3 
-							--->
 					</table>				
 				</div>
-				
 				<div class='sheet-col'>
 					<div><!-- Force Power list -->
-						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers </label>
+						<label style="padding-top:8px; padding-bottom:12px;" >Force Powers</label>
 						<textarea name="attr_forcePowers" style="width:300px;height:21em"></textarea>
 					</div>				
 				</div>
-				</div>
-				<div class='sheet-col'>
-						<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
-						
-							 <input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
-							 <div class="sheet-right">		
-							  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
-							  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-							<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
-							</div>
-							
-							 <div class="sheet-right">		
-							  <input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
-							  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
-							  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
-							</div>		
-				</div>
+			</div>
+			<div class='sheet-col'>
+					<label style="padding-top:8px; padding-bottom:12px;" >Lightsaber Combat</label>
+					<input class="sheet-skilltext" type="text" name="attr_lightsaberskill"/>
+					<div class="sheet-right">		
+					  <input type="number" name="attr_lightsaberskilldice" class="sheet-smallnumber sheet-shortnumber" min="1" value="3"/>D
+					  +<input type="number" name="attr_lightsaberskillpip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					<button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill}}} {{Roll=[[(@{lightsaberskilldice} -1 +@{WoundLevel} + @{Force_Up} + @{sense} -1 + ?{Dice mods|0})d6cf0cs7 + @{lightsaberskillpip} + @{sensepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Lightsaber Combat</button>
+					</div>
+					<div class="sheet-right">		
+					<input type="number" name="attr_lightsaberdamagedice" class="sheet-smallnumber sheet-shortnumber" min="1" value="6"/>D
+					  +<input type="number" name="attr_lightsaberdamagepippip" class="sheet-pipnumber sheet-shortnumber" min="0" max="2" value="0"/>
+					  <button class="sheet-d6-dice"  type="roll" value="&{template:default} {{name=@{lightsaberskill} damage}} {{Roll=[[(@{lightsaberdamagedice}- 1)d6cf0cs7 + @{lightsaberdamagepip} + (1d6!cf1cs6)]]}}">Lightsaber Combat Damage</button>
+					</div>		
 			</div>
 		</div>
-		<div class="sheet-section"> <!--id="Extendedinfo" -->
-			<input type="checkbox" class="sheet-hidecheckbox"><!-- Checkbox to hide extended info section -->
+		<div class="sheet-section sheet-background-hide"> <!--Extendedinfo -->
 			<label style="text-align: center">Background and extended info</label>
-			<div class='sheet-body-to-hide'>
-				<table>
-					<tr>
-						<td style="width:33.33%;"><label>Background</label>
-							<div>
-								<textarea name="attr_background"></textarea>
-							</div>
-						</td>
-						<td style="width:33.33%;">
-							<label>Personality</label>
-							<div>
-								<textarea name="attr_personality"></textarea>
-							</div>
-						</td>
-						<td style="width:33.33%;">
-							<label>Objectives</label>
-							<div>
-								<textarea name="attr_objectives"></textarea>
-							</div>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<label>Quotes</label>
-							<div>
-								<textarea name="attr_quotes"></textarea>
-							</div>
-						</td>
-						<td>
-							<label>Connections to other characters</label>
-							<div>
-								<textarea name="attr_connections"></textarea>
-							</div>
-						</td>
-						<td>
-							<label>Additional Notes</label>
-							<div>
-								<textarea name="attr_notes"></textarea>
-							</div>
-						</td>
-					</tr>
-				</table>
-			</div>
+			<table>
+				<tr>
+					<td style="width:33.33%;"><label>Background</label>
+						<div>
+							<textarea name="attr_background"></textarea>
+						</div>
+					</td>
+					<td style="width:33.33%;">
+						<label>Personality</label>
+						<div>
+							<textarea name="attr_personality"></textarea>
+						</div>
+					</td>
+					<td style="width:33.33%;">
+						<label>Objectives</label>
+						<div>
+							<textarea name="attr_objectives"></textarea>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<label>Quotes</label>
+						<div>
+							<textarea name="attr_quotes"></textarea>
+						</div>
+					</td>
+					<td>
+						<label>Connections to other characters</label>
+						<div>
+							<textarea name="attr_connections"></textarea>
+						</div>
+					</td>
+					<td>
+						<label>Additional Notes</label>
+						<div>
+							<textarea name="attr_notes"></textarea>
+						</div>
+					</td>
+				</tr>
+			</table>
 		</div>
-		<div class="sheet-section"> <!-- id="Equipment"-->
+		<div class="sheet-section sheet-equipment-hide"> <!-- Equipment-->
 				<table>
 					<th></th>
 					<th><label>Equipment</label></th>
@@ -750,7 +770,7 @@
 					</tr>
 				</table>
 		</div>
-		<div class="sheet-section"> <!-- id="Ship"-->
+		<div class="sheet-section"> <!-- Ship&Vehicle section-->
 			<div class='sheet-2colrow'>
 				<div class='sheet-col'><!-- Vehicle -->
 					<div>
@@ -770,10 +790,8 @@
 		</div>
 		</div>
 	</div>
-		
 	<div class="sheet-section" style="text-align: Center; padding-top:10px;"> <!-- footer-->
-			<img src="http://a.dilcdn.com/bl/wp-content/uploads/sites/6/2012/11/sw_logo_lg_default-small.jpg" style="max-height: 100px;" />
-			<p style="text-align: center;" ><small>Author: Timothy O'Driscoll | Editor: Andreas J. (Roll20user: 1223200)</small></p>
+			<p style="text-align: center;" ><small>Sheet Version 1.6 | Original Author: Timothy O'Driscoll | Main Editor: Andreas J. (Roll20user: 1223200)</small></p>
 	</div>
 
 	</div>

--- a/D6StarWars/README.md
+++ b/D6StarWars/README.md
@@ -9,9 +9,17 @@ The text areas are expandable for additional info.
 Wiki page for the sheet:
 		--------------->https://wiki.roll20.net/Star_Wars_WEG_D6_character_sheet<-------------
 
+		
+Version 1.6 (2018-07-10):
+	-sheet customization menu added with these options:
+		-pc/npc sheet switch 							(condenced basic info block & equipment sections)
+		-hide/show gmroll buttons option 				(these rolls are whispered to GM)
+		-show/hide options for Force, Background & Equipment section
+	-Fixed Force Emptiness tracker						(now able to change it's strength according to DSP)
+	-minor formatting
+	-some code cleanup
 
-Recent improvements (2017-2018):
-
+Prior v1.6:
 	-Weapon section roll fixed (2018-02)
 	-Vehicle/Ship text blocks have been added to the bottom of the sheet(2018-02)
 	-"Lightsaber Combat" option added to the Force section so you can have your attack and damage rolls preset for "Lightsaber Combat" (2018-02)


### PR DESCRIPTION
**Added:**
- option menu to customize sheet with following options:
                 - pc/npc sheet switch
                 - hide/show gmroll buttons
                 - show/hide option for Force, Background & Equipment sections
- fixed Force Emptiness, can now adjust Emptiness bonus according to your DSP
- minor formatting changes
- updated readme
- code cleanup, some comments added

ATM showing the gmroll button doesn't align that well with the existing content but I have the intention to adjust them further.

**Comments:**
- The NPC sheet is partially duplicated from the original sheet, will trim code later 
- I haven't manage to remove all unnecessary scripts nor css as I don't fully understand how much of the scripts are relevant to the new features, but will over time trim it away. 
- seem to have gained some extra mini-buttons that doesn't seem to do anything, but haven't figured how to remove yet