### PR TITLE
Fix textfield background-color

### DIFF
--- a/Unknown Armies 3e/UnknownArmies3e.html
+++ b/Unknown Armies 3e/UnknownArmies3e.html
@@ -414,7 +414,7 @@
     </div>
 <div class="sheet-supernatural">
     <h5 class="sheet-idlabel">I have</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity1}! [[d100]] VS [[@{identity1val}]]" type="roll" style="width: 63%;"><span name="attr_identity1"></span></button><h5 class="sheet-idlabel">, which gives me</h5><input type="text" name="attr_identity1cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Vague Protection/Influence/Whatever"><input type="number" name="attr_identity1val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<textarea style="width: 97%;height: 72px; border: 0px; background-color: #00000000; resize: none;" placeholder="Notes" name="attr_identity1notes"></textarea>
+<textarea style="width: 97%;height: 72px; border: 0px; background-color: rgba(0, 0, 0, 0); resize: none;" placeholder="Notes" name="attr_identity1notes"></textarea>
 </div>
 <div class="sheet-adept">
     <h5 class="sheet-idlabel">I'm a</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity1}! [[d100]] VS [[@{identity1val}]]" type="roll" style="width: 66%;"><span name="attr_identity1"></span></button><h5 class="sheet-idlabel">, so I mess with</h5><input type="text" name="attr_identity1cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Domain"><input type="number" name="attr_identity1val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
@@ -426,7 +426,7 @@
 </div>
 <div class="sheet-avatar">
     <h5 class="sheet-idlabel">I'm an Avatar of</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity1}! [[d100]] VS [[@{identity1val}]]" type="roll" style="width: 72%;"><span name="attr_identity1"></span></button><input type="text" name="attr_identity1cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Symbols"><input type="number" name="attr_identity1val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<input type="text" name="attr_identity1taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: #00000000;resize: none;" placeholder="Notes" name="attr_identity1notes"></textarea>
+<input type="text" name="attr_identity1taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: rgba(0, 0, 0, 0);resize: none;" placeholder="Notes" name="attr_identity1notes"></textarea>
 
 
 
@@ -464,7 +464,7 @@
     </div>
 <div class="sheet-supernatural">
     <h5 class="sheet-idlabel">I have</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity2}! [[d100]] VS [[@{identity2val}]]" type="roll" style="width: 63%;"><span name="attr_identity2"></span></button><h5 class="sheet-idlabel">, which gives me</h5><input type="text" name="attr_identity2cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Vague Protection/Influence/Whatever"><input type="number" name="attr_identity2val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<textarea style="width: 97%;height: 72px; border: 0px; background-color: #00000000; resize: none;" placeholder="Notes" name="attr_identity2notes"></textarea>
+<textarea style="width: 97%;height: 72px; border: 0px; background-color: rgba(0, 0, 0, 0); resize: none;" placeholder="Notes" name="attr_identity2notes"></textarea>
 </div>
 <div class="sheet-adept">
     <h5 class="sheet-idlabel">I'm a</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity2}! [[d100]] VS [[@{identity2val}]]" type="roll" style="width: 66%;"><span name="attr_identity2"></span></button><h5 class="sheet-idlabel">, so I mess with</h5><input type="text" name="attr_identity2cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Domain"><input type="number" name="attr_identity2val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
@@ -476,7 +476,7 @@
 </div>
 <div class="sheet-avatar">
     <h5 class="sheet-idlabel">I'm an Avatar of</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity2}! [[d100]] VS [[@{identity2val}]]" type="roll" style="width: 72%;"><span name="attr_identity2"></span></button><input type="text" name="attr_identity2cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Symbols"><input type="number" name="attr_identity2val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<input type="text" name="attr_identity2taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: #00000000;resize: none;" placeholder="Notes" name="attr_identity2notes"></textarea>
+<input type="text" name="attr_identity2taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: rgba(0, 0, 0, 0);resize: none;" placeholder="Notes" name="attr_identity2notes"></textarea>
 
 
 
@@ -518,7 +518,7 @@
     </div>
 <div class="sheet-supernatural">
     <h5 class="sheet-idlabel">I have</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity3}! [[d100]] VS [[@{identity3val}]]" type="roll" style="width: 63%;"><span name="attr_identity3"></span></button><h5 class="sheet-idlabel">, which gives me</h5><input type="text" name="attr_identity3cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Vague Protection/Influence/Whatever"><input type="number" name="attr_identity3val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<textarea style="width: 97%;height: 72px; border: 0px; background-color: #00000000; resize: none;" placeholder="Notes" name="attr_identity3notes"></textarea>
+<textarea style="width: 97%;height: 72px; border: 0px; background-color: rgba(0, 0, 0, 0); resize: none;" placeholder="Notes" name="attr_identity3notes"></textarea>
 </div>
 <div class="sheet-adept">
     <h5 class="sheet-idlabel">I'm a</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity3}! [[d100]] VS [[@{identity3val}]]" type="roll" style="width: 66%;"><span name="attr_identity3"></span></button><h5 class="sheet-idlabel">, so I mess with</h5><input type="text" name="attr_identity3cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Domain"><input type="number" name="attr_identity3val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
@@ -530,7 +530,7 @@
 </div>
 <div class="sheet-avatar">
     <h5 class="sheet-idlabel">I'm an Avatar of</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity3}! [[d100]] VS [[@{identity3val}]]" type="roll" style="width: 72%;"><span name="attr_identity3"></span></button><input type="text" name="attr_identity3cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Symbols"><input type="number" name="attr_identity3val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<input type="text" name="attr_identity3taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: #00000000;resize: none;" placeholder="Notes" name="attr_identity3notes"></textarea>
+<input type="text" name="attr_identity3taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: rgba(0, 0, 0, 0);resize: none;" placeholder="Notes" name="attr_identity3notes"></textarea>
 
 
 
@@ -568,7 +568,7 @@
     </div>
 <div class="sheet-supernatural">
     <h5 class="sheet-idlabel">I have</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity4}! [[d100]] VS [[@{identity4val}]]" type="roll" style="width: 63%;"><span name="attr_identity4"></span></button><h5 class="sheet-idlabel">, which gives me</h5><input type="text" name="attr_identity4cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Vague Protection/Influence/Whatever"><input type="number" name="attr_identity4val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<textarea style="width: 97%;height: 72px; border: 0px; background-color: #00000000; resize: none;" placeholder="Notes" name="attr_identity4notes"></textarea>
+<textarea style="width: 97%;height: 72px; border: 0px; background-color: rgba(0, 0, 0, 0); resize: none;" placeholder="Notes" name="attr_identity4notes"></textarea>
 </div>
 <div class="sheet-adept">
     <h5 class="sheet-idlabel">I'm a</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity4}! [[d100]] VS [[@{identity4val}]]" type="roll" style="width: 66%;"><span name="attr_identity4"></span></button><h5 class="sheet-idlabel">, so I mess with</h5><input type="text" name="attr_identity4cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Domain"><input type="number" name="attr_identity4val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
@@ -580,7 +580,7 @@
 </div>
 <div class="sheet-avatar">
     <h5 class="sheet-idlabel">I'm an Avatar of</h5><button class="btn ui-draggable" value="/me rolls their identity as @{identity4}! [[d100]] VS [[@{identity4val}]]" type="roll" style="width: 72%;"><span name="attr_identity4"></span></button><input type="text" name="attr_identity4cap" style="border-bottom: 1px solid black;width: 86%;margin-right: 1%;" placeholder="Symbols"><input type="number" name="attr_identity4val" style="border-bottom: 1px solid black;width: 3em;"><label style="display: inline-block;font-size: 8pt;font-family: courier new, monospace;width: 0px;">%</label>
-<input type="text" name="attr_identity4taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: #00000000;resize: none;" placeholder="Notes" name="attr_identity4notes"></textarea>
+<input type="text" name="attr_identity4taboo" style="border-bottom: 1px solid black;width: 97%;margin-right: 1%;" placeholder="Taboo"><textarea style="width: 97%;height: 45px;border: 0px;background-color: rgba(0, 0, 0, 0);resize: none;" placeholder="Notes" name="attr_identity4notes"></textarea>
 
 
 


### PR DESCRIPTION
Turns out "#00000000" doesn't work for setting transparency in roll20. Switching it out for "rgb(0, 0, 0, 0)", which worked at the top of the sheet.