### PR TITLE
Fixes the Dice box position

### DIFF
--- a/OpenLegend_Minimalist/open_legend_minimalist.css
+++ b/OpenLegend_Minimalist/open_legend_minimalist.css
@@ -13,6 +13,10 @@ input[type=number]::-webkit-outer-spin-button {
   margin: 0; 
 }
 
+input[type=number] {
+    -moz-appearance: textfield;
+}
+
 input[type="text"] {
     text-align: center;
 }
@@ -449,6 +453,7 @@ button:hover ~ .sheet-advantage-disadvantage,
     margin: 0;
     width: 2.5em;
     -webkit-appearance: none;
+    -moz-appearance: none;
 }
 
 .sheet-attribute-group input {
@@ -772,6 +777,7 @@ button:hover ~ .sheet-advantage-disadvantage,
     text-align: right;
     width: 2.5em;
     -webkit-appearance: none;
+    -moz-appearance: none;
 }
 
 .sheet-actions .repeating_actions .sheet-dice select,

--- a/OpenLegend_Minimalist/open_legend_minimalist.css
+++ b/OpenLegend_Minimalist/open_legend_minimalist.css
@@ -444,6 +444,7 @@ button:hover ~ .sheet-advantage-disadvantage,
     border-bottom-left-radius: 0;
     border-left: 0;
     height: 2.1em;
+    vertical-align:top;
     line-height: 1em;
     margin: 0;
     width: 2.5em;


### PR DESCRIPTION
A simple one line fix to fix the positioning of the attribute dice size box due to the changes that Roll20 made. I had been working with the other collaborator before he too vanished. It's a small fix though and hopefully can be passed easily.