### PR TITLE
Shadowrun Anarchy: Fixes & Refactor

### DIFF
--- a/ShadowrunAnarchy/SR Anarchy.css
+++ b/ShadowrunAnarchy/SR Anarchy.css
@@ -6,37 +6,29 @@
 	****/
 
 button {
-	font-family: Helvetica, Arial, sans-serif;
-	font-size: 0.8rem;
-	font-weight: bold;
-	border: none;
-	border-color: transparent;
+	background-color: transparent;
 	background-image: none;
-	background-color: transparent;
-	text-shadow: none;
+	border-color: transparent;
+	border: none;
 	box-shadow: none;
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 0.8em;
+	font-weight: bold;
+	text-shadow: none;
 }
 
-button[type="roll"] {
-	padding: 2px 0px !important;
-	margin: 0px 0px 0px 0px !important;
-}
-
-button:hover {
+button:hover,
+button:focus {
 	background-color: transparent;
+}
+
+.ui-dialog .charsheet button[type=roll] {
+	margin: 0px 0px 0px 0px;
+	padding: 2px 0px;
 }
 
 button:before {
 	display: none;
-}
-
-h1, h2, h3, h4 {
-	font-family: monospace;
-	text-transform: uppercase;
-}
-
-h1, h3 {
-	color: #ffffff;
 }
 
 h1 {
@@ -48,28 +40,24 @@ h2 {
 	text-align: center;
 }
 
-input {
-	-webkit-box-shadow: none;
-	border-bottom: 1px solid;
-	border-radius: 0px;
-	font-size: 0.8rem;
+h1, h3 {
+	color: #ffffff;
+}
+
+h1, h2, h3, h4 {
+	font-family: monospace;
+	text-transform: uppercase;
 }
 
 img {
 	margin-bottom: -4px;
 }
 
-textarea,
-textarea::-webkit-input-placeholder {
-	background: transparent;
-	resize: vertical;
-	border: 0px;
-	height: inherit;
-	font-size: 0.8rem;
-	/*overflow: hidden;*/
-	overflow-wrap: break-word;
-	white-space: pre-line;
-	/*border: 1.5px dotted #4f7da7;*/
+input {
+	-webkit-box-shadow: none;
+	border-bottom: 1px solid;
+	border-radius: 0px;
+	font-size: 0.8em;
 }
 
 input[type="checkbox"],
@@ -79,7 +67,25 @@ input[type="radio"] {
     position: relative;
 }
 
-/**** Removes the arrows for increase numbers ****/
+input[type="number"],
+input[type="text"] {
+	font-size: 1em;
+	font-weight: bold;
+	text-align: center;
+}
+
+textarea,
+textarea::-webkit-input-placeholder {
+	background: transparent;
+	resize: vertical;
+	border: 0px;
+	height: inherit;
+	font-size: 0.8em;
+	overflow-wrap: break-word;
+	white-space: pre-line;
+}
+
+/**** emoves the arrows for increase numbers ****/
 
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button,
@@ -96,7 +102,7 @@ img.sheet-header {
 	width: 850px;
 }
 
-/**** Repeating Weapons Styled ****/
+/**** Repeating Sections Styled ****/
 
 .repcontrol {
 	display: inline-block;
@@ -116,26 +122,18 @@ img.sheet-header {
 }
 
 .sheet-bubblerow .repcontainer {
-	clear: both;
-	margin-top: -15px;
+	margin-bottom: -20px;
 }
 
 .sheet-bubblerow .repcontainer .repitem {
-	width: 32%;
+	height: auto;
+	margin-bottom: 5px;
 	vertical-align: top;
+	width: 32%;
 }
 
 .sheet-bubblerow .repcontrol {
 	margin-top: 25px;
-}
-
-.sheet-skillrow .repcontainer {
-	margin-top: -5px;
-}
-
-.sheet-skillrow .repcontainer .repitem,
-.sheet-amprow .repcontainer .repitem {
-	margin-bottom: -25px;
 }
 
 .sheet-weaponsection .repcontainer {
@@ -147,7 +145,7 @@ img.sheet-header {
 	font-family: Helvetica, Arial, sans-serif;
 	font-size: 10px;
     color: white;
-    letter-spacing: .12rem;
+    letter-spacing: .12em;
     background: #59595b;
     border: none;
 }
@@ -208,7 +206,7 @@ img.sheet-header {
 .sheet-row-name {
 	display: inline-block;
 	border: 1px solid #000000;
-	border-radius: 0rem 0rem 1rem 1rem;
+	border-radius: 0em 0em 1em 1em;
 }
 
 .sheet-tan {
@@ -228,10 +226,8 @@ img.sheet-header {
     background: none;
     height: 35px;
     border: none;
-    text-align: center;
     text-transform: uppercase;
     font-size: 2em;
-    font-weight: bold;
     margin-left: 120px;
     box-shadow: none;
     color: #000000;
@@ -255,18 +251,21 @@ img.sheet-header {
 /**** Format the Attribute area ****/
 
 .sheet-attribute {
-	height: 7.5rem;
-	text-align: center;
+	height: 9em;
 }
 
 .sheet-attribute .sheet-col {
-	width: 15%;
-	border-radius: 0px 0px 0px 0px;
-	margin: 0px 2px 0px 1px;
+	text-align: center;
+	width: 15.5%;
+}
+
+.sheet-attribute .sheet-col:nth-child(1) {
+	margin-left: -5px;
+	margin-right: -5px;
 }
 
 .sheet-attribute h1 {
-	font-size: 1.6rem;
+	font-size: 1.5em;
 }
 
 .sheet-attribute h1:hover {
@@ -275,16 +274,14 @@ img.sheet-header {
 }
 
 .sheet-attribute input[type="number"] {
-	width: 1.5em;
-	background: white;
+	background: transparent;
 	border: none;
-	text-align: center;
+	box-shadow: none;
 	color: white;
 	font-size: 4em;
-	margin: 0rem 0rem .2rem 0rem;
+	margin: 0em 0em .2em 0em;
 	text-shadow: 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000, -1px 0 0 #000;
-	background: transparent;
-	box-shadow: none;
+	width: 1.5em;
 }
 
 /**** Format the Toggle Gears ****/
@@ -295,17 +292,16 @@ img.sheet-header {
 }
 
 .sheet-toggle input[type="checkbox"] + span {
-	position: relative;
 	font-family: pictos;
-	text-align: center;
 	font-size: 16px;
+	position: relative;
 }
 
 /**** Inputs for Karma ****/
 
 .sheet-karma {
 	display: inline-flex;
-	margin: -1rem 0rem -4rem 40rem;
+	margin: -1em 0em -4em 40em;
 	float: right;
 }
 
@@ -319,21 +315,19 @@ img.sheet-header {
 	font-weight: bold;
 	border: 1px solid black;
 	border-radius: 10px 10px 10px 10px;
-	margin: 0rem 1rem 0rem 0rem;
+	margin: 0em 1em 0em 0em;
 }
 
-.sheet-karma-bubbles input {
+.sheet-karma-bubbles input[type="number"] {
 	border: none;
-	text-align: center;
-	height: 0.8rem;
-	width: 5.5rem !important;
-	font-weight: bold;
-	margin-top: -1.5rem;
+	height: 1.5em;
+	margin-top: -1.8em;
+	width: 5em;
 }
 
 .sheet-karma label {
+	font-size: 0.9em;
 	text-align: center;
-	font-size: 0.6rem;
 }
 
 /**** Dispositions Customizations ****/
@@ -344,11 +338,11 @@ img.sheet-header {
 }
 
 .sheet-dispositionsrow h2 {
-	width: 30%;
-	position: relative;
-	margin-top: -15px;
-	margin-bottom: 10px;
 	left: 37%;
+	margin-bottom: 10px;
+	margin-top: -15px;
+	position: relative;
+	width: 30%;
 }
 
 .sheet-dispositionsrow .sheet-textbox,
@@ -357,14 +351,12 @@ img.sheet-header {
 }
 
 .sheet-dispositions input {
-	text-align: center;
-	font-weight: bold;
 	width: 45%;
 	display: inline-block;
 	border: none;
 	border-bottom: 1px solid black;
 	border-radius: 0px 0px 0px 0px;
-	margin: 0rem 0rem 0rem 1.5rem;
+	margin: 0em 0em 0em 1.5em;
 }
 
 /**** Format the Skill Capsules ****/
@@ -374,10 +366,10 @@ img.sheet-header {
 }
 
 .sheet-skillrow h2 {
-	width: 30%;
-	position: relative;
-	top: -20px;
 	left: 34.5%;
+	position: relative;
+	top: -40px;
+	width: 30%;
 }
 
 .sheet-skillbox {
@@ -396,26 +388,25 @@ img.sheet-header {
 
 
 .sheet-skillbox input {
-	text-align: center;
-	font-size: .8rem;
-	font-weight: bold;
 	border: none;
 	border-bottom: 1px solid black;
 	border-radius: 0px 0px 0px 0px;
 }
 
-.sheet-skillbox input[type="text"] {width: 65%;}
+.sheet-skillbox input[type="text"] {width: 75%;}
+
+.sheet-skillbox input[type="text"]:last-child {width: 85%;}
 
 .sheet-skillbox input[type="number"],
 .sheet-ampbox input[type="number"] {width: 10%;}
 
 .sheet-skillname {
 	color: black;
-	font-weight: bolder;
+	font-size: 0.65em;
+	font-weight: bold;
+	line-height: 35px;
 	text-shadow: none;
 	text-transform: uppercase;
-	font-size: 0.6rem;
-	line-height: 35px;
 }
 
 span.sheet-skillname:hover {
@@ -424,13 +415,18 @@ span.sheet-skillname:hover {
 }
 
 .sheet-skillheader {
-	display: inline;
-	width: 45%;
+	display: inline-block;
+	width: 80%;
+}
+
+.sheet-skillheader button[type="roll"] {
+	padding: 0px;
+	margin: 0px;
 }
 
 .sheet-skillcontainer {
-	width: 30%;
-	margin-top: 0.5rem;
+	width: 20%;
+	margin-top: 0.5em;
 	float: right;
 }
 
@@ -440,19 +436,18 @@ span.sheet-skillname:hover {
 	text-shadow: 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000, -1px 0 0 #000;
 }
 
-.sheet-skillcontainer span {font-size: 1.5rem;}
+.sheet-skillcontainer span {font-size: 1.5em;}
 
 .sheet-skillbox select {
-	width: 60%;
-	text-align:center;
-	height: inherit;
-	font-size: 1.5rem;
+	background-color: transparent;
 	border: none;
 	box-shadow: none;
-	background-color: transparent;
-	margin-top: -8px;
-	margin-right: -15px;
+	font-size: 1.5em;
+	height: inherit;
 	margin-left: -5px;
+	margin-top: -8px;
+	text-align: center;
+	width: 76%;
 }
 
 .sheet-option {color: black;}
@@ -480,18 +475,17 @@ span.sheet-skillname:hover {
 .sheet-essence-box h3 {margin-left: 2%;}
 
 .sheet-essence-input {
-	color: #ffffff;
-	width: 2rem !important;
-	font-size: 1rem;
 	background: none;
-	border: none;
-	margin-right: 5px;
-	margin-bottom: 3px;
 	border: 1px solid #ffffff2b;
+	color: #ffffff;
+	font-size: 1em;
+	margin-bottom: 3px;
+	margin-right: 5px;
+	width: 2em !important;
 }
 
 .sheet-essence-note {
-	width: 14rem;
+	width: 14em;
 	background: #ffffff;
 	border: 1px solid #000000;
 	border-radius: 5px 5px 5px 5px;
@@ -523,7 +517,7 @@ span.sheet-skillname:hover {
 	margin-left: -14px;
 	margin-top: 10px;
 	float: left;
-	font-size: 0.8rem;
+	font-size: 0.8em;
 }
 
 .sheet-amprating span {
@@ -541,7 +535,7 @@ span.sheet-skillname:hover {
 	margin-top: -12px;
 	font-weight: normal;
 	font-style: italic;
-	font-size: 0.7rem;
+	font-size: 0.9em;
 	overflow: hidden;
 	overflow-wrap: break-word;
 	white-space: pre-line;
@@ -552,16 +546,16 @@ span.sheet-skillname:hover {
 
 .sheet-cues,
 .sheet-gear {
-	min-height: 35px;
-	width: 46%;
-	display: inline-block;
+	-webkit-box-shadow: none;
 	background-color: #ffffff;
 	background-image: repeating-linear-gradient(transparent, transparent 29px, #000000 30px, #000000 20px, white 31px);
-	resize: none;
-	-webkit-box-shadow: none;
-	text-align: left;
+	display: inline-block;
 	margin: 0px 10px 10px 15px;
+	min-height: 35px;
+	resize: none;
+	text-align: left;
 	vertical-align: top;
+	width: 46%;
 }
 
 .sheet-gear {
@@ -571,7 +565,7 @@ span.sheet-skillname:hover {
 .sheet-textbox textarea,
 .sheet-cues span,
 .sheet-gear span {
-	font-size: 0.8rem;
+	font-size: 1em;
 	line-height: 2.45em;
 	font-weight: normal;
 	padding: 8px 5px;
@@ -603,8 +597,8 @@ span.sheet-skillname:hover {
 
 .sheet-dispositionsrow input[type="checkbox"],
 .sheet-dispositionsrow input[type="checkbox"] + span {
-	top: -20px;
 	left: 61%;
+	top: -20px;
 }
 
 .sheet-dispositionsrow input[type="checkbox"] + span {
@@ -612,29 +606,30 @@ span.sheet-skillname:hover {
 }
 
 .sheet-cuerow input[type="checkbox"] {
-	top: -23px;
 	left: 53%;
+	top: -23px;
 }
 
 .sheet-cuerow input[type="checkbox"] + span {
-	top: -23px;
 	left: 50%;
+	top: -23px;
 }
 
 .sheet-bubblerow .sheet-toggle input[type="checkbox"],
 .sheet-bubblerow .sheet-toggle input[type="checkbox"] + span  {
-	top: 25px;
-	left: 94%;
+	position: absolute;
+	left: 95%;
+	top: 5px;
 }
 
 .sheet-bubblerow .sheet-toggle input[type="checkbox"] + span {
-	left: 86%;
+	left: 97%;
 }
 
 .sheet-unarmedbox input[type="checkbox"],
 .sheet-unarmedbox input[type="checkbox"] + span {
-	top: -35px;
 	left: 50%;
+	top: -35px;
 }
 
 .sheet-unarmedbox input[type="checkbox"] + span {
@@ -642,19 +637,19 @@ span.sheet-skillname:hover {
 }
 
 .sheet-weaponbox input[type="checkbox"] {
-	top: 0px;
 	left: 78%;
+	top: 0px;
 }
 
 .sheet-weaponbox input[type="checkbox"] + span {
-	top: 0px;
 	left: 69%;
+	top: 0px;
 }
 
 .sheet-armorsection .sheet-toggle input[type="checkbox"],
 .sheet-armorsection .sheet-toggle input[type="checkbox"] + span {
-	top: -25px;
 	left: 155px;
+	top: -25px;
 }
 
 .sheet-armorsection .sheet-toggle input[type="checkbox"] + span {
@@ -665,8 +660,8 @@ span.sheet-skillname:hover {
 .sheet-geartoggle input[type="checkbox"] + span,
 .sheet-contacttoggle input[type="checkbox"],
 .sheet-contacttoggle input[type="checkbox"] + span {
-	top: -7px;
 	left: 27%;
+	top: -7px;
 }
 
 .sheet-geartoggle input[type="checkbox"] + span {
@@ -698,22 +693,19 @@ span.sheet-skillname:hover {
 /**** Qualities ****/
 
 .sheet-ampbox {
-	min-height: 35px;
-	width: 95%;
-	display: inline-block;
 	background: #ffffff;
-	resize: none;
-	box-shadow: none;
-	border: 1.4px solid #000000;
 	border-radius: 15px 15px 15px 15px;
-	text-align: center;
+	border: 1.4px solid #000000;
+	box-shadow: none;
+	display: inline-block;
 	margin: 0px 0px 5px 8px;
+	min-height: 35px;
+	resize: none;
+	text-align: center;
+	width: 95%;
 }
 
 .sheet-ampbox input  {
-	text-align: center;
-	font-size: .8rem;
-	font-weight: bold;
 	border: none;
 	border-bottom: 1px solid black;
 	border-radius: 0px 0px 0px 0px;
@@ -770,7 +762,6 @@ span.sheet-skillname:hover {
 
 .sheet-weaponrow {
 	border-top: 1px solid #000;
-	margin-bottom: 10px;
 }
 
 .sheet-weaponrow h2 {
@@ -825,21 +816,28 @@ span.sheet-skillname:hover {
 	margin-left: 5px;
 }
 
-.sheet-unarmedheader h4 {font-size: 1rem;}
+.sheet-unarmedheader h4 {font-size: 1em;}
 
 .sheet-unarmeddamagebox {
 	width: 66%;
 	margin: -35px 0px 0px 75px;
 }
 
-.sheet-damagename {
+.sheet-weaponsubtitlesbox label {
+	display: inline-block;
+	padding: 0px;
+	width: 22%;
+}
+
+.sheet-weaponlabels {
 	display: inline-block;
 	width: 21%;
 }
 
-.sheet-damagename label {
+.sheet-weaponsubtitlesbox label,
+.sheet-weaponlabels label {
 	color: #59595b;
-	font-size: 0.6rem;
+	font-size: 0.7em;
 	text-align: center;
 	margin-bottom: 15px;
 	margin-top: 2px;
@@ -864,22 +862,20 @@ span.sheet-skillname:hover {
 
 .sheet-unarmeddamagebox input[type="text"],
 .sheet-weapondamagebox input[type="text"] {
-	width: 20%;
-	font-size: 9px;
-	text-align: center;
-	text-transform: uppercase;
-	padding: 0px;
+	font-size: 1em;
 	margin-right: 2px;
+	padding: 0px;
+	text-transform: uppercase;
+	width: 20%;
 }
 
 .sheet-weapondamagebox input[type="text"] {
 	width: 21%;
 }
 
-.sheet-weaponsubtitlesbox .sheet-damagename label {
-	font-size: 0.5rem;
+.sheet-weaponsubtitlesbox .sheet-weaponslabel label {
+	font-size: 0.7em;
 	margin-bottom: 0px;
-	margin-left: 5px;
 }
 
 .sheet-weaponsubtitlesbox {
@@ -893,23 +889,23 @@ span.sheet-skillname:hover {
 }
 
 .sheet-weaponheader input[type="text"] {
-	width: 100%;
-	margin-bottom: 5px;
 	float: left;
+	margin-bottom: 5px;
 	text-transform: none;
-}
-
-.sheet-display .sheet-weaponheader div.sheet-damagename {
 	width: 100%;
 }
 
-.sheet-weapontype {
-	font-size: 0.7rem;
+.sheet-display .sheet-weaponheader div.sheet-weaponslabel {
+	width: 100%;
+}
+
+.sheet-weaponheader span:last-child {
+	font-size: 0.7em;
 	font-weight: normal;
 }
 
 .sheet-weaponbody {
-	width: 45%;
+	width: 50%;
 	display: inline-block;
 	vertical-align: top;
 }
@@ -926,7 +922,7 @@ span.sheet-skillname:hover {
 	width: 40%;
 	font-size: 25px;
 	position: relative;
-	top: -25px;
+	top: -30px;
 	left: 31%;
 }
 
@@ -999,13 +995,13 @@ img.sheet-conrightdec {
 
 .sheet-armorsection input[type="text"] {
 	border: none;
-	width: 70%;
 	border-bottom: 1px solid;
-	vertical-align: top;
 	font-weight: bold;
-	text-align: right;
-	margin-top: 5px;
 	margin-left: 5px;
+	margin-top: 5px;
+	text-align: right;
+	vertical-align: top;
+	width: 70%;
 }
 
 .sheet-armorsection input[type="number"] {
@@ -1029,10 +1025,10 @@ img.sheet-conrightdec {
 
 .sheet-armorcircles input[type="radio"] {
 	height: 25px;
-	width: 25px;
-	top: -7px;
 	left: 1px;
 	margin-right: -3px;
+	top: -7px;
+	width: 25px;
 }
 
 .sheet-armor {
@@ -1081,10 +1077,10 @@ img.sheet-conrightdec {
 
 .sheet-conditioncircles input[type="radio"],
 .sheet-edgecircles input[type="radio"] {
-	width: 20px;
 	height: 20px;
-	top: -7px;
 	left: 2px;
+	top: -7px;
+	width: 20px;
 }
 
 .sheet-edgecircles input[type="radio"] {
@@ -1094,23 +1090,23 @@ img.sheet-conrightdec {
 .sheet-armorcircles input[type="radio"] + span,
 .sheet-conditioncircles input[type="radio"] + span,
 .sheet-edgecircles input[type="radio"] + span {
-	display: inline-block;
-	width: 20px;
-	height: 20px;
 	background: #ffffff;
 	border-radius: 50%;
 	border: 1px solid #000;
+	display: inline-block;
+	height: 20px;
 	margin-left: -20px;
+	width: 20px;
 }
 
 .sheet-armorcircles input[type="radio"] + span {
-	font-size: 0.8rem;
+	font-size: 0.8em;
 }
 
 .sheet-edgecircles input[type="radio"],
 .sheet-edgecircles input[type="radio"] + span {
-	width: 15px;
 	height: 15px;
+	width: 15px;
 }
 
 .sheet-edgecircles input[type="radio"] + span {
@@ -1151,23 +1147,23 @@ input.sheet-radio-header-small:checked ~ .sheet-edgecircles input[type="radio"] 
 }
 
 input.sheet-radio-header-armor {
-	width: 80px;
 	height: 20px;
 	left: 65%;
 	top: -60px;
+	width: 80px;
 }
 
 input.sheet-radio-header-physical,
 input.sheet-radio-header-small {
-	width: 80px;
 	height: 15px;
 	left: 17%;
 	top: 24px;
+	width: 80px;
 }
 
 input.sheet-radio-header-small {
-	width: 50px;
 	left: 30%;
+	width: 50px;
 }
 
 input.sheet-radio-header-armor:hover + h1,
@@ -1228,12 +1224,12 @@ div.sheet-gearback.sheet-contact  {
 /**** Roll Toggles in the Skills section ****/
 
 .sheet-roll-toggles {
-	width: 42%;
-	font-size: 1.6rem;
-	font-family: "pictos";
 	color: #000;
+	font-family: "pictos";
+	font-size: 18px;
 	position: relative;
-	top: 32px;
+	top: 35px;
+	width: 42%;
 }
 
 .sheet-roll-toggles input {
@@ -1244,16 +1240,16 @@ div.sheet-gearback.sheet-contact  {
 .sheet-toggle-buttons {
 	display: inline-block;
 	width: 54%;
-	margin-right: 7px;
 }
 
 .sheet-toggle-toggles {
 	display: inline-block;
-	width: 40%;
+	font-size: 23px;
+	left: -10px;
 	letter-spacing: -12px;
 	position: relative;
 	top: -4px;
-	left: -10px;
+	width: 40%;
 }
 
 span.sheet-pictosC {
@@ -1261,11 +1257,11 @@ span.sheet-pictosC {
 }
 
 span.sheet-lightening {
-	font-family: "pictos";
 	color: #8c9180;
-	font-size: 0.9rem;
+	font-family: "pictos";
+	font-size: 0.7em;
+	left: -15px;
 	position: relative;
-	left: -13px;
 	top: -4px;
 }
 
@@ -1296,8 +1292,8 @@ span.sheet-wound-flag {
 }
 
 span.sheet-wound-line {
-	font-size: 1rem;
 	color: #8c9180;
+	font-size: 0.8em;
 	left: -5%;
 	top: -2px;
 }
@@ -1331,12 +1327,11 @@ input.sheet-modifier-flag {
 	text-shadow: 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000, -1px 0 0 #000;
 }
 
-.sheet-roll-toggles button {
-	font-family: "pictos";
+.sheet-roll-toggles button[type="roll"] {
 	color: #000;
-	font-size: 1.5rem !important;
-	margin-left: 5px !important;
-	margin-top: -4px !important;
+	font-family: "pictos";
+	font-size: 1.5em;
+	margin: 0px;
 }
 
 .sheet-roll-toggles button:hover {
@@ -1354,124 +1349,122 @@ input.sheet-modifier-flag {
 	border-left: 1px solid #fff;
 }
 
-.sheet-dispo-trapezoid,
-.sheet-dispo-trapezoid-white,
-.sheet-skill-trapezoid,
-.sheet-skill-trapezoid-tan {
+.sheet-trapezoid,
+.sheet-trapezoid-white,
+.sheet-trapezoid-tan {
 	border-bottom: 20px solid #000;
 	border-left: 15px solid transparent;
 	border-right: 15px solid transparent;
 	position: relative;
 }
 
-.sheet-amps-trapezoid,
-.sheet-amps-trapezoid-tan,
-.sheet-cues-trapezoid,
-.sheet-cues-trapezoid-white,
-.sheet-weapon-trapezoid,
-.sheet-weapon-trapezoid-tan,
-.sheet-con-trapezoid,
-.sheet-con-trapezoid-tan   {
+.sheet-amprow .sheet-trapezoid,
+.sheet-amprow .sheet-trapezoid-tan,
+.sheet-cuerow .sheet-trapezoid,
+.sheet-cuerow .sheet-trapezoid-white,
+.sheet-weaponrow .sheet-trapezoid,
+.sheet-weaponrow .sheet-trapezoid-tan,
+.sheet-conrow .sheet-trapezoid,
+.sheet-conrow .sheet-trapezoid-tan   {
 	border-bottom: 15px solid #000;
 	border-left: 25px solid transparent;
 	border-right: 25px solid transparent;
 	position: relative;
 }
 
-.sheet-dispo-trapezoid,
-.sheet-dispo-trapezoid-white {
-	width: 25%;
-	top: 2px;
+.sheet-dispositionsrow .sheet-trapezoid,
+.sheet-dispositionsrow .sheet-trapezoid-white {
 	left: 37%;
 	margin-top: -20px;
+	width: 25%;
 }
 
-.sheet-dispo-trapezoid-white {
+.sheet-trapezoid-white {
 	border-bottom-color: #fff;
-	top: 4px;
+	top: 2px;
 }
 
-.sheet-skill-trapezoid,
-.sheet-skill-trapezoid-tan {
-	width: 15%;
-	top: 25px;
+.sheet-skillrow .sheet-trapezoid,
+.sheet-skillrow .sheet-trapezoid-tan {
 	left: 40%;
+	top: -23px;
+	width: 15%;
 }
 
-.sheet-skill-trapezoid-tan {
+.sheet-skillrow .sheet-trapezoid-tan {
 	border-bottom-color: #8c9180;
-	top: 27px;
 	margin-top: -20px;
+	top: -20px;
 }
 
-.sheet-amps-trapezoid,
-.sheet-amps-trapezoid-tan,
-.sheet-cues-trapezoid,
-.sheet-cues-trapezoid-white  {
+.sheet-amprow .sheet-trapezoid,
+.sheet-amprow .sheet-trapezoid-tan,
+.sheet-cuerow .sheet-trapezoid,
+.sheet-cuerow  .sheet-trapezoid-white  {
 	width: 60%;
 	top: 0px;
 	left: 20%;
 	margin-top: -15px;
 }
 
-.sheet-amps-trapezoid-tan,
-.sheet-weapon-trapezoid-tan  {
+.sheet-amprow .sheet-trapezoid-tan,
+.sheet-weaponrow .sheet-trapezoid-tan  {
 	border-bottom-color: #8c9180;
 	top: 2px;
 }
 
-.sheet-cues-trapezoid-white {
+.sheet-cuerow  .sheet-trapezoid-white {
 	border-bottom-color: #fff;
 	top: 2px;
 }
 
-.sheet-weapon-trapezoid,
-.sheet-weapon-trapezoid-tan {
+.sheet-weaponrow .sheet-trapezoid,
+.sheet-weaponrow .sheet-trapezoid-tan {
 	width: 40%;
 	top: 1px;
 	left: 25%;
 	margin-top: -15px;
 }
 
-.sheet-weapon-trapezoid-tan {
+.sheet-weaponrow  .sheet-trapezoid-tan {
 	border-bottom-color: #8c9180;
 	top: 2px;
 }
 
-.sheet-con-trapezoid,
-.sheet-con-trapezoid-tan {
+.sheet-conrow .sheet-trapezoid,
+.sheet-conrow .sheet-trapezoid-tan {
 	width: 30%;
 	left: 33%;
-	margin-top: -15px;
+	margin-top: -12px;
 }
 
-.sheet-con-trapezoid {
-	top: -9px;
+.sheet-conrow .sheet-trapezoid {
+	top: -8px;
 }
 
-.sheet-con-trapezoid-tan {
+.sheet-conrow .sheet-trapezoid-tan {
 	border-bottom-color: #8c9180;
-	top: -7px;
+	top: -10px;
 }
 
-.sheet-conmon-trapezoid,
-.sheet-conmon-trapezoid-tan {
-	width: 65%;
-	left: 15%;
+.sheet-conrow .sheet-trapezoid:nth-child(1),
+.sheet-conrow .sheet-trapezoid-tan:nth-child(2) {
 	border-bottom: 10px solid #000;
 	border-left: 25px solid transparent;
 	border-right: 25px solid transparent;
+	left: 15%;
 	position: relative;
-	margin-top: -15px;
+	top: 2px;
+	width: 65%;
 }
 
-.sheet-conmon-trapezoid {
-	top: -5px;
+.sheet-conrow .sheet-trapezoid:nth-child(2) {
+	top: 5px;
 }
 
-.sheet-conmon-trapezoid-tan {
+.sheet-conrow .sheet-trapezoid-tan:nth-child(2) {
 	border-bottom-color: #8c9180;
-	top: 1px;
+	top: 5px;
 }
 
 .sheet-arrow-left {
@@ -1525,8 +1518,8 @@ div.sheet-col.sheet-toggle span {
 }
 
 .sheet-indent-row {
-	padding-left: 1.5rem; 
-	text-indent: -1.5rem;
+	padding-left: 1.5em; 
+	text-indent: -1.5em;
 }
 
 .sheet-npc button:hover {
@@ -1605,20 +1598,16 @@ div.sheet-col.sheet-toggle span {
 }
 
 input.sheet-npc-desc {
-	width: 100%;
 	margin-left: 0px !important;
+	width: 100%;
 }
 
 .sheet-npc .sheet-weaponsubtitlesbox {
 	width: 50%;
 	position: relative;
-	left: 3%;
+	left: 5%;
 }
 
-.sheet-npc .sheet-damagename {
-	width: 20%;
-	margin-right: 8px;
-}
 
 .sheet-npc-name {
 	width: 50%;
@@ -1632,7 +1621,7 @@ input.sheet-npc-desc {
 	background-color: #e4bc34;
 	text-transform: uppercase;
 	font-weight: bolder;
-	font-size: 1.3rem;
+	font-size: 1.3em;
 	padding: 5px 8px 5px 8px;
 }
 
@@ -1642,20 +1631,20 @@ input.sheet-npc-desc {
 }
 
 .sheet-npc-name input {
-	margin-left: 25%;
 	margin-bottom: 5px;
+	margin-left: 25%;
 }
 
 .sheet-npc-attribute {
 	background-color: #3f4144;
-	width: 100%;
 	height: 70px;
+	width: 100%;
 }
 
 .sheet-npc-attribute label,
 .sheet-npc-attribute button {
 	display: inline-block;
-	width: 15%;
+	width: 14%;
 	color: #fff;
 	text-align: center;
 	text-transform: uppercase;
@@ -1677,7 +1666,7 @@ input.sheet-npc-desc {
 
 .sheet-npc-attr-num {
 	margin-left: 50px;
-	margin-right: 36px;
+	margin-right: 39px;
 	padding-top: 10px;
 	font-weight: bolder;
 	font-size: 16px;
@@ -1688,16 +1677,16 @@ input.sheet-npc-desc {
 }
 
 .sheet-npc-body span {
-	font-size: 0.8rem;
+	font-size: 13px;
 }
 
 .sheet-npc-amps {
-	padding-left: 3.7rem; 
-	text-indent: -2.5rem;
+	padding-left: 3.7em; 
+	text-indent: -2.5em;
 }
 
-.sheet-npc-amps button[type=roll] {
-	font-size: 0.8rem !important;
+.sheet-npc-amps button[type="roll"] {
+	font-size: 0.9em !important;
 }
 
 .sheet-npc-ampbox input[type="checkbox"] {
@@ -1719,10 +1708,6 @@ input.sheet-npc-desc {
 	width: 63%;
 }
 
-.sheet-bolder {
-	font-weight: bolder;
-}
-
 .sheet-caps {
 	text-transform: uppercase;
 }
@@ -1732,13 +1717,21 @@ input.sheet-npc-desc {
 }
 
 .sheet-npc-weapons h2 {
+	font-size: 1.5em;
 	margin-top: 5px;
-	font-size: 1.5rem;
+	text-align: left;
 }
 
-.sheet-npc-weapons h2,
 .sheet-npc .sheet-weaponheader {
 	text-align: left;
+}
+
+.sheet-npc .sheet-weaponheader span {
+	font-size: 1em;
+	font-weight: bolder;
+	margin-right: 8px;
+	text-align: left;
+	width: 20%;
 }
 
 .sheet-npc .sheet-weaponbox {
@@ -1753,7 +1746,7 @@ input.sheet-npc-desc {
 }
 
 .sheet-indent {
-	text-indent: 1.5rem;
+	text-indent: 1.5em;
 }
 
 .sheet-npc .sheet-conditioncircles {
@@ -1799,7 +1792,7 @@ input.sheet-npc-desc {
 	display: inline;
 	position: relative;
 	top: 0px;
-	left: 320px;
+	left: 48%;
 }
 
 .sheet-npc .sheet-toggle-toggles {
@@ -1811,7 +1804,7 @@ input.sheet-npc-desc {
 .sheet-npc .sheet-toggle-toggles input[type="checkbox"] + span {
 	display: inline;
 	left: -17%;
-	font-size: 1.5rem;
+	font-size: 1em;
 }
 
 .sheet-npc .sheet-roll-toggles button {
@@ -1831,8 +1824,8 @@ input.sheet-npc-desc {
 
 .sheet-npc span.sheet-wound-line {
 	color: #fff;
-	font-size: 1rem;
-	left: -16%;
+	font-size: 1em;
+	left: -18%;
 }
 
 .sheet-npc .sheet-radio-header-armor {
@@ -1866,6 +1859,10 @@ input.sheet-npc-desc {
 	left: 4%;
 }
 
+.sheet-npc .sheet-npc-consection span:first-child {
+  font-weight: bolder;
+}
+
 .sheet-npc .sheet-radio-header-armor:hover + span,
 .sheet-npc .sheet-radio-header-physical:hover + span,
 .sheet-npc .sheet-radio-header-small:hover + span {
@@ -1878,7 +1875,7 @@ input.sheet-npc-desc {
 	border: none;
 	border-bottom: 1px solid #3f4144;
 	border-radius: 0px;
-	font-size: 0.8rem;
+	font-size: 0.8em;
 }
 
 .sheet-npc .sheet-essence-input {
@@ -1906,7 +1903,7 @@ input.sheet-npc-desc {
 .sheet-footer {
 	width: 850px;
 	text-align: left;
-	font-size: 0.55rem;
+	font-size: 0.55em;
 	line-height: 15px;
 	border: none;
 }
@@ -1986,5 +1983,5 @@ input.sheet-npc-desc {
 }
 
 .sheet-rolltemplate-sAnarchy .sheet-template-desc {
-	font-size: 1rem;
+	font-size: 1em;
 }

--- a/ShadowrunAnarchy/SR Anarchy.html
+++ b/ShadowrunAnarchy/SR Anarchy.html
@@ -115,7 +115,7 @@
 						<div class="skillbox">
 							<input type="text" name="attr_skill" placeholder="Skill Name">
 							<input type="number" name="attr_skill_rank" placeholder="0"><br />
-							<input type="text" name="attr_skill_specialization" placeholder="Specialization">
+							<input type="text" name="attr_skill_specalization" placeholder="Specialization">
 						</div>
 					</div>
 					<div class="display">
@@ -124,7 +124,7 @@
 								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{attr=@{attribute_name}}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Name">
 									<span class="skillname" name="attr_skill_display"></span>
 								</button>
-								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{spec=@{skill_specialization}}}{{attr=@{attribute_name}}}{{wound=[[@{wound_toggle}]]}}{{mod=[[@{modifier_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Specilization Roll">
+								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{spec=@{skill_specalization}}}{{attr=@{attribute_name}}}{{wound=[[@{wound_toggle}]]}}{{mod=[[@{modifier_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Specilization Roll">
 									<span class="skillname" name="attr_skill_spec_display"></span>
 								</button>
 							</div>
@@ -1138,11 +1138,11 @@ on("change:repeating_skills:skill_attribute", function() {
 });
 
     //Put () around Skill specializations
-on("change:repeating_skills:skill_specialization", function() {
-    getAttrs(["repeating_skills_skill_specialization"], function(v){
-        var ski = "(" + (v.repeating_skills_skill_specialization) + ")";
+on("change:repeating_skills:skill_specalization", function() {
+    getAttrs(["repeating_skills_skill_specalization"], function(v){
+        var ski = "(" + (v.repeating_skills_skill_specalization) + ")";
         var emp = "";
-        if (v.repeating_skills_skill_specialization === '') {
+        if (v.repeating_skills_skill_specalization === '') {
         	setAttrs({repeating_skills_skill_spec_display: emp});
         } else {setAttrs({repeating_skills_skill_spec_display: ski});
         };
@@ -1296,9 +1296,9 @@ on("change:vehicle_weapons", function() {
 
 	//Repeating active for PC sheet
 on("change:repeating_skills", function() {
-	getAttrs(["repeating_skills_skill", "repeating_skills_skill_specialization"], function(v) {
+	getAttrs(["repeating_skills_skill", "repeating_skills_skill_specalization"], function(v) {
 		const skill = (v.repeating_skills_skill);
-		const spec = (v.repeating_skills_skill_specialization);
+		const spec = (v.repeating_skills_skill_specalization);
 
 		console.log(skill.length + "skill");
 		console.log(spec.length + "spec");

--- a/ShadowrunAnarchy/SR Anarchy.html
+++ b/ShadowrunAnarchy/SR Anarchy.html
@@ -1,7 +1,7 @@
 <!-- ~~~~~~~~ Shadowrun Anarchy Character sheet  ~~~~~~~~ -->
 <div class="container">
 	<input type="hidden" class="npc-toggle" name="attr_npc_toggle" />
-	<img class="header" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/ShadowrunHeader.png" style="width:100%" "border:1px solid black;"/>
+	<img class="header" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/ShadowrunHeader.png" style="width:100%" "border:1px solid black;" alt="Shadowrun logo" />
 	<div class="pc">	
 		<!-- The "Shadowrun" logo -->
 		<div class="row row-name">
@@ -17,37 +17,35 @@
 			</div>
 		</div>
 	<!-- ~~~~~~~~ Attribute  ~~~~~~~~ -->
-		<div class="tan">
-			<div class="attribute tan">
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Strength}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Strength Roll"><h1 data-i18n="strength">STRENGTH</h1></button>
-					<input type="number" name="attr_strength" value="1" title="@{strength}" />
-				</div>
-				<div class="vertdeco"></div>
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Agility}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Agility Roll"><h1 data-i18n="agility">AGILITY</h1></button>
-					<input type="number" name="attr_agility" value="1" title="@{agility}" />
-				</div>
-				<div class="vertdeco"></div>
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Willpower}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Willpower Roll"><h1 data-i18n="willpower">WILLPOWER</h1></button>
-					<input type="number" name="attr_willpower" value="1" title="@{willpower}" />
-				</div>
-				<div class="vertdeco"></div>
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Logic}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Logic Roll"><h1 data-i18n="logic">LOGIC</h1></button>
-					<input type="number" name="attr_logic" value="1" title="@{logic}" />
-				</div>
-				<div class="vertdeco"></div>
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Charisma}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Charisma Roll"><h1 data-i18n="charisma">CHARISMA</h1></button>
-					<input type="number" name="attr_charisma" value="1" title="@{charisma}" />
-				</div>
-				<div class="vertdeco"></div>
-				<div class="sheet-col">
-					<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Edge}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Edge Roll"><h1 data-i18n="edge">EDGE</h1></button>
-					<input type="number" name="attr_edge" value="1" title="@{edge}" />
-				</div>
+		<div class="tan attribute">
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Strength}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Strength Roll"><h1 data-i18n="strength">STRENGTH</h1></button>
+				<input type="number" name="attr_strength" value="1" title="@{strength}" />
+			</div>
+			<div class="vertdeco"></div>
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Agility}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Agility Roll"><h1 data-i18n="agility">AGILITY</h1></button>
+				<input type="number" name="attr_agility" value="1" title="@{agility}" />
+			</div>
+			<div class="vertdeco"></div>
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Willpower}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Willpower Roll"><h1 data-i18n="willpower">WILLPOWER</h1></button>
+				<input type="number" name="attr_willpower" value="1" title="@{willpower}" />
+			</div>
+			<div class="vertdeco"></div>
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Logic}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Logic Roll"><h1 data-i18n="logic">LOGIC</h1></button>
+				<input type="number" name="attr_logic" value="1" title="@{logic}" />
+			</div>
+			<div class="vertdeco"></div>
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Charisma}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Charisma Roll"><h1 data-i18n="charisma">CHARISMA</h1></button>
+				<input type="number" name="attr_charisma" value="1" title="@{charisma}" />
+			</div>
+			<div class="vertdeco"></div>
+			<div class="sheet-col">
+				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Edge}}{{attr=Attribute}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{strength}+(?{Attribute|Strength,@{strength}|Agility,@{agility}|Willpower,@{willpower}|Logic,@{logic}|Charisma,@{charisma}|Edge,@{edge}})+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}]]}}" title="Edge Roll"><h1 data-i18n="edge">EDGE</h1></button>
+				<input type="number" name="attr_edge" value="1" title="@{edge}" />
 			</div>
 		</div><!--End Attributes-->
 	<!-- ~~~~~~~~ Karma Input  ~~~~~~~~ -->
@@ -62,9 +60,9 @@
 			</div>
 		</div><!-- End Karma Inputs  -->
 	<!-- ~~~~~~~~ Dispositions  ~~~~~~~~ -->
-		<div class="dispo-trapezoid"></div>
-		<div class="dispo-trapezoid-white"></div>
 		<div class="row dispositionsrow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-white"></div>
 			<h2 data-i18n="dispositions">DISPOSITIONS</h2>
 			<div class="textbox toggle">
 				<input type="checkbox" class="options-flag" name="attr_disposition_toggle" checked="checked" /><span>y</span>
@@ -87,8 +85,6 @@
 			</div>
 		</div><!--End Dispositions Row -->
 	<!-- ~~~~~~~~ Skills  ~~~~~~~~ -->
-		<div class="skill-trapezoid"></div>
-		<div class="skill-trapezoid-tan"></div>
 		<div class="roll-toggles">
 			<div class="toggle-buttons">
 				<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=Perception}}{{attr=Wil+Log}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{willpower}+@{logic}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Perception Roll"><span class="pictos">E</span></button>
@@ -107,6 +103,8 @@
 			</div>
 		</div>
 		<div class="tan bubblerow skillrow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-tan"></div>
 			<h2 data-i18n="skills">SKILLS</h2>
 			<fieldset class="repeating_skills">
 				<input type="hidden" name="attr_skill_spec_display">
@@ -117,16 +115,16 @@
 						<div class="skillbox">
 							<input type="text" name="attr_skill" placeholder="Skill Name">
 							<input type="number" name="attr_skill_rank" placeholder="0"><br />
-							<input type="text" name="attr_skill_specalization" placeholder="Specialization">
+							<input type="text" name="attr_skill_specialization" placeholder="Specialization">
 						</div>
 					</div>
 					<div class="display">
 						<div class="skillbox">
 							<div class="skillheader">
-								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{attr=@{attribute_name}}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Roll">
-									<span class="skillname" name="attr_skill"></span>
+								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{attr=@{attribute_name}}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Name">
+									<span class="skillname" name="attr_skill_display"></span>
 								</button>
-								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{spec=@{skill_specalization}}}{{attr=@{attribute_name}}}{{wound=[[@{wound_toggle}]]}}{{mod=[[@{modifier_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Specilization Roll">
+								<button type='roll' value="@{gm_toggle} &{template:sAnarchy}{{header=@{skill}}}{{spec=@{skill_specialization}}}{{attr=@{attribute_name}}}{{wound=[[@{wound_toggle}]]}}{{mod=[[@{modifier_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{skill_rank}+@{skill_attribute}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}" title="Skill Specilization Roll">
 									<span class="skillname" name="attr_skill_spec_display"></span>
 								</button>
 							</div>
@@ -148,9 +146,9 @@
 			</fieldset>
 		</div><!-- End Skills Row -->
 	<!-- ~~~~~~~~ Shadow Amps  ~~~~~~~~ -->
-		<div class="amps-trapezoid"></div>
-		<div class="amps-trapezoid-tan"></div>
 		<div class="tan bubblerow amprow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-tan"></div>
 			<div class="essence-box">
 				<h2 data-i18n="shadowamps">SHADOW AMPS</h2>
 				<h3 data-i18n="essence">ESSENCE</h3><span style="color:white">: </span>
@@ -178,9 +176,9 @@
 			</fieldset>
 		</div><!-- End Shadow Amps -->
 	<!-- ~~~~~~~~ Cues  ~~~~~~~~ -->
-		<div class="cues-trapezoid"></div>
-		<div class="cues-trapezoid-white"></div>
 		<div class="row cuerow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-white"></div>
 			<h2 data-i18n="cues">CUES</h2>
 			<div class="textbox toggle">
 				<input type="checkbox" class="options-flag" name="attr_cue_toggle" checked="checked" /><span>y</span>
@@ -228,9 +226,9 @@
 			</fieldset>
 		</div><!-- End Qualities  -->
 	<!-- ~~~~~~~~ Weapons!! ~~~~~~~~ -->
-		<div class="weapon-trapezoid"></div>
-		<div class="weapon-trapezoid-tan"></div>
 		<div class="tan weaponrow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-tan"></div>
 			<h2 data-i18n="weapons">WEAPONS</h2>
 			<div class="weaponsection">
 			<!-- Unarmed Boxs-->
@@ -239,10 +237,10 @@
 						<h4 data-i18n="unarmed">UNARMED</h4>
 					</div>
 					<div class="unarmeddamagebox">
-						<div class="damagename"><label>DAM</label></div>
-						<div class="damagename"><label data-i18n="close">CLOSE</label></div>
-						<div class="damagename"><label data-i18n="near">NEAR</label></div>
-						<div class="damagename"><label data-i18n="far">FAR</label></div>
+						<div class="weaponlabels"><label>DAM</label></div>
+						<div class="weaponlabels"><label data-i18n="close">CLOSE</label></div>
+						<div class="weaponlabels"><label data-i18n="near">NEAR</label></div>
+						<div class="weaponlabels"><label data-i18n="far">FAR</label></div>
 					</div>
 					<input type="checkbox" class="options-flag" name="attr_unarmed_toggle" checked="checked" /><span>i</span>
 					<div class="options unarmeddamagebox">
@@ -252,10 +250,10 @@
 						<input type="text" name="attr_unarmed_far" value="-" placeholder="-" />
 					</div>
 					<div class="display unarmeddamagebox">
-						<div class="damagename"><span name="attr_unarmed_dmg"></span></div>
-						<div class="damagename"><span name="attr_unarmed_close"></span></div>
-						<div class="damagename"><span name="attr_unarmed_near"></span></div>
-						<div class="damagename"><span name="attr_unarmed_far"></span></div>
+						<div class="weaponlabels"><span name="attr_unarmed_dmg"></span></div>
+						<div class="weaponlabels"><span name="attr_unarmed_close"></span></div>
+						<div class="weaponlabels"><span name="attr_unarmed_near"></span></div>
+						<div class="weaponlabels"><span name="attr_unarmed_far"></span></div>
 					</div>
 				</div>
 				<br />
@@ -264,10 +262,10 @@
 					<div class="weaponbox toggle ">
 						<input type="checkbox" class="options-flag" name="attr_weapon_toggle" checked="checked" /><span>y</span>
 						<div class="weaponsubtitlesbox">
-							<div class="damagename"><label>DAM</label></div>
-							<div class="damagename"><label data-i18n="close">CLOSE</label></div>
-							<div class="damagename"><label data-i18n="near">NEAR</label></div>
-							<div class="damagename"><label data-i18n="far">FAR</label></div>
+							<label>DAM</label>
+							<label data-i18n="close">CLOSE</label>
+							<label data-i18n="near">NEAR</label>
+							<label data-i18n="far">FAR</label>
 						</div>
 						<div class="options weapondamagebox">
 							<div class="weaponheader">
@@ -283,14 +281,14 @@
 						</div>
 						<div class="display weapondamagebox">
 							<div class="weaponheader">
-								<div class="damagename"><span name="attr_weapon_name"></span></div><br />
-								<div class="damagename weapontype"><span name="attr_weapon_type"></span></div>
+								<span name="attr_weapon_name"></span><br />
+								<span name="attr_weapon_type"></span>
 							</div>
 							<div class="weaponbody">
-								<div class="damagename"><span name="attr_weapon_dmg"></span></div>
-								<div class="damagename"><span name="attr_weapon_close"></span></div>
-								<div class="damagename"><span name="attr_weapon_near"></span></div>
-								<div class="damagename"><span name="attr_weapon_far"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_dmg"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_close"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_near"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_far"></span></div>
 							</div>
 						</div>
 					</div>
@@ -298,11 +296,11 @@
 			</div>
 		</div><!--End Weapons!! -->
 	<!-- ~~~~~~~~  Condition Monitor  ~~~~~~~~ -->
-		<div class="conmon-trapezoid"></div>
-		<div class="conmon-trapezoid-tan"></div>
-		<div class="con-trapezoid"></div>
-		<div class="con-trapezoid-tan"></div>
 		<div class="tan conrow">
+			<div class="trapezoid"></div>
+			<div class="trapezoid-tan"></div>
+			<div class="trapezoid"></div>
+			<div class="trapezoid-tan"></div>
 			<h1 data-i18n="condition">CONDITION MONITOR</h1>
 		<!-- ~~~~~~~~  Armor  ~~~~~~~~ -->	
 			<div class="armorbox">
@@ -321,7 +319,7 @@
 					</div>
 					<input type="radio" class="radio-header-armor" name="attr_armor_damage" value="0" title="Armor Reset" checked="checked" />
 					<h1 data-i18n="armor">ARMOR</h1>
-					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/CatalystLogo.png">
+					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/CatalystLogo.png" alt="Catalyst & Anarchy Logo">
 					<div class="armorcircles">
 						<input type="hidden" name="attr_armor_1_enabled" value="true"/>
 						<input type="radio" name="attr_armor_damage" value="1" /><span></span>
@@ -357,9 +355,9 @@
 				</div>
 			</div>
 		<!-- Middle area with condition monitor -->
-		<img class="conleftdec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/SideDecor.png">
-		<img class="conmiddec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/MidDecor.png">
-		<img class="conrightdec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/SideDecor.png">
+		<img class="conleftdec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/SideDecor.png" alt="Straight line with circle at the top facing left.">
+		<img class="conmiddec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/MidDecor.png" alt="Straight line with circle at both ends">
+		<img class="conrightdec" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ShadowrunAnarchy/SideDecor.png" alt="Straight line with circle at the top facing right.">
 			<div class="conditionbox">
 			<!-- Physical Damage Circles -->
 				<div class="conditionsection">
@@ -520,7 +518,7 @@
 					<span>CHA </span><input type="number" name="attr_charisma" value="1" title="@{charisma}" />
 					<span>EDG </span><input type="number" name="attr_edge" value="1" placeholder="0" title="@{edge}" />
 				</div>
-				<div class="row"><label data-i18n="skills">SKILLS</label></div>
+				<div class="row"><label data-i18n="skills" style="font-weight: bolder">SKILLS</label></div>
 				<div class="col">
 					<div class="row"><span data-i18n="astralcombat">Astral Combat</span><input type="number" name="attr_astral_combat" value="0" placeholder="0" title="@{astral_combat}" /></div>
 					<div class="row"><span data-i18n="athletics">Athletics</span><input type="number" name="attr_athletics" value="0" placeholder="0" title="@{athletics}" /></div>
@@ -552,7 +550,7 @@
 					<div class="row"><span data-i18n="vehicleweapons">Vehicle Weapons</span><input type="number" name="attr_vehicle_weapons" value="0" placeholder="0" title="@{vehicle_weapons}" /></div>
 				</div>
 				<br />
-				<label data-i18n="condition">CONDITION MONITOR</label>
+				<label data-i18n="condition" style="font-weight: bolder">CONDITION MONITOR</label>
 				<div class="row">
 					<span data-i18n="armor">ARMOR</span>
 					<input type="number" name="attr_armor" value="9" placeholder="9"><input type="text" name="attr_armor_name" value="Natural Armor" placeholder="Natural Armor">
@@ -599,7 +597,7 @@
 					</div>
 				</div>
 				<div class="npc-body">
-					<div class="indent-row"><span class="bolder caps" data-i18n="skills">SKILLS</span><span>: </span>
+					<div class="indent-row"><span class="bolder caps" data-i18n="skills" style="font-weight: bolder">SKILLS</span><span>: </span>
 						<!-- ~~~~~~~~ astralcombat  ~~~~~~~~ -->
 						<input type="hidden" class="optional-flag0" name="attr_astralcombat_flag" value="0">
 						<span class="optional"><button type="roll" value="@{gm_toggle} &{template:sAnarchy}{{header=Astral Combat}}{{attr=Willpower}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{astral_combat}+@{willpower}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>@{edge_threshold}cs0]]}}"><span data-i18n="astralcombat">Astral Combat</span><span> </span><span name="attr_astral_combat"></span><span>+W</span></button>,</span>
@@ -697,7 +695,7 @@
 							<span data-i18n="vehicleweapons">Vehicle Weapons</span><span> </span><span name="attr_vehicle_weapons"></span><span>+A</span></button></span>
 					</div>
 				</div>
-				<div class="indent-row"><span class="bolder caps" data-i18n="shadowamps">SHADOW AMPS</span><span>: </span>
+				<div class="indent-row"><span class="caps" data-i18n="shadowamps" style="font-weight: bolder">SHADOW AMPS</span><span>: </span>
 					<span data-i18n="essence">Essence</span><span>: </span>
 					<input class="essence-input" type="text" name="attr_essence" value="6" placeholder="6" title="@{essence}" /> 
 					<input class="essence-note" type="text" name="attr_essence_penalty" value="" placeholder="0 penalty to magic/healing tests" title="@{essence_penalty}" />
@@ -723,10 +721,10 @@
 				<div class="npc-weapons">
 					<h2>Weapons</h2>
 					<div class="weaponsubtitlesbox">
-						<div class="damagename"><span data-i18n="damage">Damage</span></div>
-						<div class="damagename"><span data-i18n="close">Close</span></div>
-						<div class="damagename"><span data-i18n="near">Near</span></div>
-						<div class="damagename"><span data-i18n="far">Far</span></div>
+						<div class="weaponlabels"><span data-i18n="damage">Damage</span></div>
+						<div class="weaponlabels"><span data-i18n="close">Close</span></div>
+						<div class="weaponlabels"><span data-i18n="near">Near</span></div>
+						<div class="weaponlabels"><span data-i18n="far">Far</span></div>
 					</div>
 					<fieldset class="repeating_weapons">
 					<div class="weaponbox toggle">
@@ -744,13 +742,13 @@
 						</div>
 						<div class="display weapondamagebox">
 							<div class="weaponheader">
-								<div class="damagename"><span class="bolder" name="attr_weapon_name"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_name"></span></div>
 							</div>
 							<div class="weaponbody">
-								<div class="damagename"><span name="attr_weapon_dmg"></span></div>
-								<div class="damagename"><span name="attr_weapon_close"></span></div>
-								<div class="damagename"><span name="attr_weapon_near"></span></div>
-								<div class="damagename"><span name="attr_weapon_far"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_dmg"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_close"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_near"></span></div>
+								<div class="weaponlabels"><span name="attr_weapon_far"></span></div>
 							</div>
 						</div>
 					</div>
@@ -759,7 +757,7 @@
 				<div class="npc-body">
 					<div class="indent">
 						<input type="radio" class="radio-header-armor" name="attr_npc_armor_damage" value="0" title="@{armor_damage}" checked="checked" />
-						<span class="bolder" data-i18n="armor">Armor</span><span>: </span><span name="attr_armor"></span> [<span name="attr_armor_name"></span>]
+						<span class="bolder" data-i18n="armor" style="font-weight: bolder;">Armor</span><span>: </span><span name="attr_armor"></span> [<span name="attr_armor_name"></span>]
 						<div class="armorcircles">
 							<input type="hidden" name="attr_npc_armor_1_enabled" value="true"/>
 							<input type="radio" name="attr_npc_armor_damage" value="1" /><span></span>
@@ -793,10 +791,10 @@
 							<input type="radio" name="attr_npc_armor_damage" value="15" /><span></span>
 						</div>
 					</div>
-					<div class="indent"><span class="bolder" data-i18n="condition">Condition Monitors (P/S)</span><span>: </span><span name="attr_physical_max"></span>/<span name="attr_stun_max"></span>
+					<div class="indent"><span data-i18n="condition" style="font-weight: bolder;">Condition Monitors (P/S)</span><span>: </span><span name="attr_physical_max"></span>/<span name="attr_stun_max"></span>
 						<div class="npc-consection">
 							<input type="radio" class="radio-header-physical" name="attr_npc_physical" value="0" title="@{physical}" checked="checked" />
-							<span class="bolder" data-i18n="physical">Physical</span><span>: </span>
+							<span data-i18n="physical">Physical</span><span>: </span>
 							<div class="conditioncircles">
 								<input type="hidden" name="attr_npc_physical_1_enabled" value="true"/>
 								<input type="radio" name="attr_npc_physical" value="1" /><span></span><div class="arrow-left"></div>
@@ -832,7 +830,7 @@
 						</div>
 						<div class="npc-consection">
 							<input type="radio" class="radio-header-small" name="attr_npc_stun" value="0" title="@{stun}" checked="checked" />
-							<span class="bolder" data-i18n="stun">Stun</span><span>: </span>
+							<span data-i18n="stun">Stun</span><span>: </span>
 							<div class="conditioncircles">
 								<input type="hidden" name="attr_npc_stun_1_enabled" value="true"/>
 								<input type="radio" name="attr_npc_stun" value="1" /><span></span><div class="arrow-left"></div>
@@ -869,7 +867,7 @@
 					</div>
 					<div class="indent">
 						<input type="radio" class="radio-header-small" name="attr_npc_edge_pool" value="0" title="@{edge}" checked="checked" />
-						<span class="bolder" data-i18n="edge">Edge</span><span>: </span>
+						<span data-i18n="edge" style="font-weight: bolder;">Edge</span><span>: </span>
 						<div class="edgecircles">
 							<input type="hidden" name="attr_npc_edge_1_enabled" value="true"/>
 							<input type="radio" name="attr_npc_edge_pool" value="1" /><span></span>
@@ -892,7 +890,7 @@
 </div>
 
 <input type="hidden" class="npc-toggle" name="attr_npc_toggle" />
-<div class="footer" data-i18n="topps">The Topps Company, Inc. has sole ownership of the names, logo, artwork, marks, photographs, sounds, audio, video and/or any proprietary material used in connection with the game Shadowrun. The Topps Company, Inc. has granted permission to use such names, logos, artwork, marks and/or any proprietary materials for promotional and informational purposes on its website but does not endorse, and is not affiliated with any official capacity whatsoever.</div>
+<div class="footer" data-i18n="topps">The Topps Company, Inc. has sole ownership of the names, logo, artwork, marks, photographs, sounds, audio, video and/or any proprietary material used in connection with the game Shadowrun. The Topps Company, Inc. has granted permission to use such names, logos, artwork, marks and/or any proprietary materials for promotional and informational purposes on its website but does not endorse, and is not affiliated with any official capacity whatsoever.<br />Sheet: Version 1.5</div>
 
 
 <div class="rolltemplates">
@@ -1139,12 +1137,12 @@ on("change:repeating_skills:skill_attribute", function() {
    });
 });
 
-    //Put () around Skill Specalizations
-on("change:repeating_skills:skill_specalization", function() {
-    getAttrs(["repeating_skills_skill_specalization"], function(v){
-        var ski = "(" + (v.repeating_skills_skill_specalization) + ")";
+    //Put () around Skill specializations
+on("change:repeating_skills:skill_specialization", function() {
+    getAttrs(["repeating_skills_skill_specialization"], function(v){
+        var ski = "(" + (v.repeating_skills_skill_specialization) + ")";
         var emp = "";
-        if (v.repeating_skills_skill_specalization === '') {
+        if (v.repeating_skills_skill_specialization === '') {
         	setAttrs({repeating_skills_skill_spec_display: emp});
         } else {setAttrs({repeating_skills_skill_spec_display: ski});
         };
@@ -1295,5 +1293,34 @@ on("change:vehicle_weapons", function() {
 	var skl = parseInt(v.vehicle_weapons) || 0;
 	if (skl > 0) {setAttrs({vehicle_weapons_flag: 1});} else {
 	setAttrs({vehicle_weapons_flag: 0});}});});
+
+	//Repeating active for PC sheet
+on("change:repeating_skills", function() {
+	getAttrs(["repeating_skills_skill", "repeating_skills_skill_specialization"], function(v) {
+		const skill = (v.repeating_skills_skill);
+		const spec = (v.repeating_skills_skill_specialization);
+
+		console.log(skill.length + "skill");
+		console.log(spec.length + "spec");
+
+		if (spec === "") {
+
+			(skill.length > 0 && skill.length <= 24) ? setAttrs({repeating_skills_skill_display: skill}) : 
+				(skill.length > 24 ) ? setAttrs({repeating_skills_skill_display: skill.slice(0, 24) + "..."}) :
+				setAttrs({repeating_skills_skill_display: " "});
+
+		} else {
+
+			(skill.length > 0 && skill.length <= 15) ? setAttrs({repeating_skills_skill_display: skill}) : 
+				(skill.length > 12 ) ? setAttrs({repeating_skills_skill_display: skill.slice(0, 12) + "..."}) :
+				setAttrs({repeating_skills_skill_display: " "});
+
+			(spec.length > 0 && spec.length <= 12) ? setAttrs({repeating_skills_skill_spec_display: "(" + spec + ")"}) : 
+				(spec.length > 12 ) ? setAttrs({repeating_skills_skill_spec_display: "(" + spec.slice(0, 12) + "..." + ")"}) :
+				setAttrs({repeating_skills_skill_spec_display: " "});	
+		};
+	});
+});
+
 
 </script>

--- a/ShadowrunAnarchy/sheet.json
+++ b/ShadowrunAnarchy/sheet.json
@@ -5,5 +5,6 @@
 	"roll20userid": "557736",
 	"patreon": "https://www.patreon.com/emeraldgrid",
 	"preview": "Anarchy_preview.PNG",
+	"version": "Version 1.5",
 	"instructions": "The Topps Company, Inc. has sole ownership of the names, logo, artwork, marks, photographs, sounds, audio, video and/or any proprietary material used in connection with the game Shadowrun. The Topps Company, Inc. has granted permission to use such names, logos, artwork, marks and/or any proprietary materials for promotional and informational purposes on its website but does not endorse, and is not affiliated with any official capacity whatsoever."
 }


### PR DESCRIPTION
Fix: Removed all REMs which broke after last update
Refactor:
- Removed & renamed excess classes. Replaced with selectors.
- Added Alts for images
- Fixed spelling error for skill specializations
- Added a Version for the sheet in the footer
- Added sheet worker  & display for Skills & Skill Specs so they will be shortened when excessively long