### PR TITLE
Free Spacer: Bug and clarity fixes

### DIFF
--- a/Free Spacer/FreeSpacer.html
+++ b/Free Spacer/FreeSpacer.html
@@ -46,7 +46,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Gender Identity:</td>
+					<td>Pronouns:</td>
 					<td>
 						<input type="text" name="attr_GenderIndentity" class="sheet-full sheet-aspect" />
 					</td>
@@ -230,7 +230,7 @@
 							<option>Fame</option>
 							<option>Greed</option>
 							<option>Idealism</option>
-							<option>Open Source</option>
+							<option>Liberation</option>
 							<option>Order</option>
 							<option>Science</option>
 						</select>
@@ -265,12 +265,12 @@
 					<td>
 						<select name="attr_Build" class="sheet-full sheet-aspect">
 							<option></option>
-							<option>Thin(Micro 0.01-0.2 g0)</option>
-							<option>Slim(Low 0.2-0.8 g0)</option>
-							<option>Average(Std 0.8-1.3 g0)</option>
-							<option>Broad(High 1.3-2 g0)</option>
-							<option>Squat(Heavy 2-3 g0)</option>
-							<option>Square(Extreme 3-4 g0)</option>
+							<option>Thin(Micro g0)</option>
+							<option>Slim(Low g0)</option>
+							<option>Average(Std g0)</option>
+							<option>Broad(High g0)</option>
+							<option>Squat(Heavy g0)</option>
+							<option>Square(Extreme g0)</option>
 						</select>
 					</td>
 				</tr>
@@ -360,7 +360,7 @@
 				</tr>
 				<tr>
 					<td>
-						Sex Strategy:
+						Differentiation:
 					</td>
 					<td>
 						<select name="attr_SexStrategy" class="sheet-full sheet-aspect">
@@ -1558,6 +1558,7 @@
 						<option>(Adversary)</option>
 						<option>(Business)</option>
 						<option>(Family)</option>
+						<option>(Patron Commissionaire)</option>
 						<option>(Friend)</option>
 						<option>(Rival)</option>
 						<option>(Subordinate)</option>
@@ -1652,30 +1653,7 @@
 						Designation:
 					</td>
 					<td>
-						<select name="attr_designationPrefix" class="sheet-fifth sheet-aspect">
-							<optgroup label="Any Flag">
-								<option>FSS</option>
-								<option>ICV</option>
-							</optgroup>
-							<optgroup label="Agent Flag">
-								<option>IDC</option>
-							</optgroup>
-							<optgroup label="Bounty Hunter Flag">
-								<option>LRS</option>
-							</optgroup>
-							<optgroup label="Courier Flag">
-								<option>CCV</option>
-							</optgroup>
-							<optgroup label="Mercenary Flag">
-								<option>PMC</option>
-							</optgroup>
-							<optgroup label="Scout Flag">
-								<option>FRS</option>
-							</optgroup>
-							<optgroup label="Technician Flag">
-								<option>CSV</option>
-							</optgroup>
-						</select>
+						<input type="text" name="attr_designationPrefix" class="sheet-fifth sheet-aspect"/>
 						<input type="text" name="attr_name" class="sheet-threeQuarters sheet-aspect" />
 					</td>
 				</tr>
@@ -1993,7 +1971,7 @@
 				<tr class="sheet-specialty">
 					<td>Multi-field:</td>
 					<td class="sheet-right">
-						<input type="radio" class="sheet-D10 sheet-ZeroDie" name="attr_shipShieldsMultifield:" value="0" checked="checked" /><span></span>
+						<input type="radio" class="sheet-D10 sheet-ZeroDie" name="attr_shipShieldsMultifield" value="0" checked="checked" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_shipShieldsMultifield" value="1" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_shipShieldsMultifield" value="2" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_shipShieldsMultifield" value="3" /><span></span>
@@ -2009,6 +1987,7 @@
 		<div class="sheet-columnLeft">
 			<h3>Laboratories</h3>
 			<p>Projects / Vignettes</p>
+			<p>&emsp;</p>
 			<table class="sheet-quarterPage">
 				<tr>
 					<th>
@@ -2067,6 +2046,7 @@
 		<div class="sheet-column225">
 			<h3>Hydroponics</h3>
 			<p>Life Support / Foodstuff (6)</p>
+			<p>&emsp;</p>
 			<h4>Fittings</h4>
 			<table class="sheet-quarterPage">
 				<tr class="sheet-specialty">
@@ -2074,7 +2054,7 @@
 						1
 					</td>
 					<td>
-						Passanger/Day
+						Passenger/Day
 					</td>
 				</tr>
 			</table>
@@ -2178,6 +2158,7 @@
 		<div class="sheet-columnLeft">
 			<h3><input type="checkbox" name="attr_brig" class="sheet-checkbox" value="active" /><span></span> Brig</h3>
 			<p>Holding Cells</p>
+			<p>&emsp;</p>
 			<h4>Fittings</h4>
 			<table class="sheet-quarterPage">
 				<tr class="sheet-specialty">
@@ -2194,7 +2175,7 @@
 						2
 					</td>
 					<td>
-						Life Support / Day
+						Prisoner/Day
 					</td>
 				</tr>
 				<tr class="sheet-specialty">
@@ -2212,6 +2193,7 @@
 		<div class="sheet-column225">
 			<h3><input type="checkbox" name="attr_compartments" class="sheet-checkbox" value="active" /><span></span> Compartments</h3>
 			<p>Concealed Hold [10 tonne]</p>
+			<p>&emsp;</p>
 			<h4>Fittings</h4>
 			<table class="sheet-quarterPage">
 				<tr class="sheet-specialty">
@@ -2219,7 +2201,7 @@
 						2
 					</td>
 					<td>
-						Support Passenger / Day
+						Passenger/Day
 					</td>
 					<td>&emsp;</td>
 				</tr>
@@ -2818,7 +2800,7 @@
 				<tr class="sheet-specialty">
 					<td>Multi-field:</td>
 					<td class="sheet-right">
-						<input type="radio" class="sheet-D10 sheet-ZeroDie" name="attr_launchShieldsMultifield:" value="0" checked="checked" /><span></span>
+						<input type="radio" class="sheet-D10 sheet-ZeroDie" name="attr_launchShieldsMultifield" value="0" checked="checked" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_launchShieldsMultifield" value="1" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_launchShieldsMultifield" value="2" /><span></span>
 						<input type="radio" class="sheet-D10" name="attr_launchShieldsMultifield" value="3" /><span></span>


### PR DESCRIPTION
Fixed bug in Ship and Launch Shields: Removed ":" from attribute name that kept stat from displaying.

Removed pull down for prefix and replaced it with a text field for flexibility.

Changed Gender Identity to Pronouns for clarity

Changed Open Source to Liberation in Drive pulldown. Will not effect Drive until it changes. Attribute changes every session- will have no effect on play.

Shortened and fixed spelling in descriptions for consistancy.

Added spacing to tools for layout.