### PR TITLE
[GURPS] Inventory and Language Box reformatted

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -688,20 +688,25 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-items .sheet-col0 { width: calc(100% - 0.4em); }
 
 .sheet-items { width: calc(100% - 0.4em); }
-.sheet-items .sheet-col0 { width: calc(100% - 270px); }
+.sheet-items .sheet-col0 { width: calc(100% - 350px); }
 .sheet-items .sheet-col0 input { text-align:left; }
-.sheet-items .sheet-col1 { width: 20px; }
-.sheet-items .sheet-col1 input { text-align:left; }
+.sheet-items .sheet-col1 { width: 30px; }
 .sheet-items .sheet-col2 { width: 50px; }
-.sheet-items .sheet-col3 { width: 50px; }
+.sheet-items .sheet-col3 { width: 20px; }
+.sheet-items .sheet-col3 input { text-align:left; }
 .sheet-items .sheet-col4 { width: 50px; }
 .sheet-items .sheet-col5 { width: 50px; }
+.sheet-items .sheet-col5 input { text-align:right; }
 .sheet-items .sheet-col6 { width: 50px; }
-.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 290px); }
-.sheet-items .sheet-row-totals .sheet-col0 { width: calc(100% - 300px); }
+.sheet-items .sheet-col6 input { text-align:right; }
+.sheet-items .sheet-col7 { width: 50px; }
+.sheet-items .sheet-col8 { width: 50px; }
+.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 370px); }
+.sheet-items .sheet-row-totals .sheet-col0 { width: calc(100% - 380px); }
 .sheet-items .sheet-row-totals .sheet-col1 { width: 100px; }
 .sheet-items .sheet-row-totals .sheet-col2 { width: 100px; }
 .sheet-items .sheet-row-totals .sheet-col3 { width: 100px; }
+
 
 /* -- SPELLS -- */
 .sheet-spells { width: calc(100% - 0.4em); }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -2310,7 +2310,7 @@
  
 	<h4>Version: 1.3.9</h4>
 
-	<p>Pull Request: ##/##/2018</p>
+	<p>Pull Request: 08/21/2018</p>
 
 	<ul>
 		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -1167,21 +1167,41 @@
 		<div class="sheet-box sheet-language">
 			<div class="sheet-table">
 				<div class="sheet-header">
-					<div class="sheet-cell sheet-col0">Languages</div>
+					<div class="sheet-cell sheet-col0">Native Language</div>
 					<div class="sheet-cell sheet-col1">Spoken</div>
 					<div class="sheet-cell sheet-col2">Written</div>
 					<div class="sheet-cell sheet-col3">Pts</div>
 				</div> <!-- .sheet-header -->
 				<div class="sheet-row sheet-row-native-language">
 					<div class="sheet-cell sheet-col0 sheet-label">
-						<input type="text" style="font-weight:bold;" name="attr_name_native_language" value="-Enter Native Language here"  />
+						<input type="text" style="font-weight:bold;" name="attr_name_native_language" placeholder="-Enter Native Language here">
 					</div>
-					<div class="sheet-header">
-						<div class="sheet-cell sheet-col1">Native</div>
-						<div class="sheet-cell sheet-col2">Native</div>
-						<div class="sheet-cell sheet-col3">0</div>
-					</div> <!-- .sheet-header -->
+					<div class="sheet-cell sheet-col1">
+						<select name="attr_native_language_spoken">
+							<option value="0" selected>Native</option>
+							<option value="-1">Accented</option>
+							<option value="-2">Broken</option>
+							<option value="-3">None</option>
+						</select>
+					</div>
+					<div class="sheet-cell sheet-col2">
+						<select name="attr_native_language_written">
+							<option value="0" selected>Native</option>
+							<option value="-1">Accented</option>
+							<option value="-2">Broken</option>
+							<option value="-3">None</option>
+						</select>
+					</div>
+					<div class="sheet-cell sheet-col3">
+						<input type="text" name="attr_native_language_points" value="@{native_language_spoken} + @{native_language_written}" disabled="disabled" />
+					</div>
 				</div> <!-- .sheet-row -->
+				<div class="sheet-header">
+					<div class="sheet-cell sheet-col0">Learned Languages</div>
+					<div class="sheet-cell sheet-col1">Spoken</div>
+					<div class="sheet-cell sheet-col2">Written</div>
+					<div class="sheet-cell sheet-col3">Pts</div>
+				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_languages">
 					<div class="sheet-row sheet-row-stats">
 						<div class="sheet-cell sheet-col0">
@@ -1191,7 +1211,6 @@
 							<select name="attr_spoken">
 								<option value="3">Native</option>
 								<option value="2">Accented</option>
-								<option value="1.0">One-Way</option>
 								<option value="1">Broken</option>
 								<option value="0" selected>None</option>
 							</select>
@@ -1200,7 +1219,6 @@
 							<select name="attr_written">
 								<option value="3">Native</option>
 								<option value="2">Accented</option>
-								<option value="1.0">One-Way</option>
 								<option value="1">Broken</option>
 								<option value="0" selected>None</option>
 							</select>
@@ -2095,7 +2113,9 @@
 			<div class="sheet-table">
 				<div class="sheet-header">
 					<div class="sheet-cell sheet-col0">Possessions</div>
-					<div class="sheet-cell sheet-col1">
+					<div class="sheet-cell sheet-col1">TL</div>
+					<div class="sheet-cell sheet-col2">Ref</div>
+					<div class="sheet-cell sheet-col3">
 						<div class="sheet-popup">On</div>
 						<span class="sheet-tooltip">
 							Carried
@@ -2103,11 +2123,11 @@
 							Is the item being carried at the moment?
 						</span>
 					</div>
-					<div class="sheet-cell sheet-col2">#</div>
-					<div class="sheet-cell sheet-col3">$</div>
-					<div class="sheet-cell sheet-col4">W</div>
-					<div class="sheet-cell sheet-col5">$+</div>
-					<div class="sheet-cell sheet-col6">W+</div>
+					<div class="sheet-cell sheet-col4">#</div>
+					<div class="sheet-cell sheet-col5">$</div>
+					<div class="sheet-cell sheet-col6">W</div>
+					<div class="sheet-cell sheet-col7">$+</div>
+					<div class="sheet-cell sheet-col8">W+</div>
 				</div>
 				<fieldset class="repeating_item">
 					<input class="sheet-toggle" type="checkbox" />
@@ -2117,21 +2137,27 @@
 							<input type="text" name="attr_name" />
 						</div>
 						<div class="sheet-cell sheet-col1">
-							<input class="sheet-boolean" type="checkbox" name="attr_carried" value="1" checked />
+							<input type="text" name="attr_tl" />
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_count" value="1" />
+							<input type="text" name="attr_ref" />
 						</div>
 						<div class="sheet-cell sheet-col3">
-							<input type="number" name="attr_cost" value="0" />
+							<input class="sheet-boolean" type="checkbox" name="attr_carried" value="1" checked />
 						</div>
 						<div class="sheet-cell sheet-col4">
-							<input type="number" name="attr_weight" value="0" step="any" />
+							<input type="number" name="attr_count" value="1" />
 						</div>
 						<div class="sheet-cell sheet-col5">
-							<span name="attr_costtotal" value="0" />
+							<input type="number" name="attr_cost" value="0.00" step="0.01" />
 						</div>
 						<div class="sheet-cell sheet-col6">
+							<input type="number" name="attr_weight" value="0" step="0.001" />
+						</div>
+						<div class="sheet-cell sheet-col7" style="text-align: right">
+							<span name="attr_costtotal" value="0.00" />
+						</div>
+						<div class="sheet-cell sheet-col8" style="text-align: right"> 
 							<span name="attr_weighttotal" value="0" />
 						</div>
 					</div> <!-- .sheet-row -->
@@ -2263,122 +2289,134 @@
     <!-- ===== ===== ===== ===== Revision History TAB ===== ===== ===== ===== -->
 	<div class="sheet-tab7">
 
-        <div>
-           <h3>Known Issues</h3>
+	<div>
+	<h3>Known Issues</h3>
+	<ul>
+		<li>Unable to delete a Technique - UPDATE</li>
+		<li>The issue is the 'Max' value for the Technique. If any value was placed in there, the row will not delete. So in this PULL I have blocked values from being placed there so that new Techniques can be deleted if need be. Existing Techniques that you are unable to delete – the Devs are looking into that issue and will advise me. </li>
+		<li>NOTE: Techniques, as it is now on the character sheet, does not really work well – that section will most likely be completely rewritten (I plan on doing it when I get some time and my skills at HTML improve).</li>
+	</ul>
 
-            <ul>
-               <li>Unable to delete a Technique - UPDATE</li>
-               <li>The issue is the ‘Max’ value for the Technique. If any value was placed in there, the row will not delete. So in this PULL I have blocked values from being placed there so that new Techniques can be deleted if need be. Existing Techniques that you are unable to delete – the Devs are looking into that issue and will advise me. </li>
-               <li>NOTE: Techniques, as it is now on the character sheet, does not really work well – that section will most likely be completely rewritten (I plan on doing it when I get some time and my skills at HTML improve).</li>
-            </ul>
-
-           <h3>Revision History</h3>
+	<h3>Revision History</h3>
                   
-            <p>To report an Issues or a Suggestion, please use the Roll20 forum under Character Sheets & Compendium. 
-            I have created a thread named: [GURPS] - Sheet #1 - Thread 1 (that seems to be similar to the naming
-            convention used by other sheets).</p>
-
-            <p> https://app.roll20.net/forum/post/6616836/gurps-sheet-number-1-thread-1/?pageforid=6644122#post-6644122</p>
+	<p>To report an Issues or a Suggestion, please use the Roll20 forum under Character Sheets & Compendium. U  I have created a thread named: [GURPS] - Sheet #1 - Thread 1 (that seems to be similar to the naming convention used by other sheets).</p>
+	
+	<p> https://app.roll20.net/forum/post/6616836/gurps-sheet-number-1-thread-1/?pageforid=6644122#post-6644122</p>
             
-            <p>In your post, please specify if it is an Issue or Suggestion with as much detail information as possible. 
-            Screen shots help a lot! I am just learning to work with HTML and CSS so I may not be able to do everything 
-            requested. I make no promises on how fast I may be able to implement a Fix or a Suggestion - so please be 
-            patient. -Thanks, Mike W.</p>
+	<p>In your post, please specify if it is an Issue or Suggestion with as much detail information as possible. Screen shots help a lot! I am just learning to work with HTML and CSS so I may not be able to do everything requested. I make no promises on how fast I may be able to implement a Fix or a Suggestion - so please be patient. -Thanks, Mike W.</p>
 
-            <p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 
+	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 
             Forum for now (Like Tom and I are doing) - perhaps later we can use GitHub.</p>
  
-            <h4>Version: 1.3.8</h4>
+	<h4>Version: 1.3.9</h4>
+
+	<p>Pull Request: ##/##/2018</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Updated the Language Box format – Cosmetic Only</li>
+		<li>Added additional options for Native Language in regards to Spoken and Written levels as a Disadvantage</li>
+		<li>Updated the Inventory Box format – Cosmetic Only</li>
+		<li>Added fields of ‘TL’ (Tech Level) and ‘Ref’ (Reference) to the Inventory repeating section</li>
+		<li>Fixed bug for Single Modifier Prompt and Extended Modifier Prompts if a ‘+’ is used for a positive modifier entry</li>
+		<li> </li>
+		<li> </li>
+		<li> </li>
+		<li> </li>
+		<li> </li>
+		<li> </li>
+	</ul>
+
+	<h4>Version: 1.3.8</h4>
             
-            <p>Pull Request: 08/08/2018</p>
+ 	<p>Pull Request: 08/08/2018</p>
             
-            <ul>
-               <li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
-               <li>Added the Speed-Range table image to the Combat Tab - Requested by CaptainJoy (UserID: GitHub) </li>
-               <li>Set the character sheet to always open to the Updates Tab</li>
-               <li>Fixed BUG where Basic Lift calculations for ST 7 or less was incorrectly rounding for Light, Medium, and Heavy Encumbrances </li>
-               <li>Renamed Notes to Weapon Notes under Melee Attacks and Ranged Attacks – Cosmetic Only</li>
-               <li>Added Damage Notes with an attribute under Melee Attacks and Ranged Attacks</li>
-               <li>Changed Tool Tip for Damage, for Melee attacks and Ranged Attacks, to indicate using the Damage Notes field – Cosmetic Only</li>
-               <li>Changed Armour Divisor to Armor Divisor – Cosmetic Only</li>
-               <li> Changed the output of the Attack Macros for Melee and Ranged attacks to include the Weapons Notes attribute – Cosmetic Only</li>
-               <li>Changed the output of the Damage Macros for Melee and Ranged attacks to include the Damage Notes attribute – Cosmetic Only</li>
-            </ul>
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Added the Speed-Range table image to the Combat Tab - Requested by CaptainJoy (UserID: GitHub) </li>
+		<li>Set the character sheet to always open to the Updates Tab</li>
+		<li>Fixed BUG where Basic Lift calculations for ST 7 or less was incorrectly rounding for Light, Medium, and Heavy Encumbrances </li>
+		<li>Renamed Notes to Weapon Notes under Melee Attacks and Ranged Attacks – Cosmetic Only</li>
+		<li>Added Damage Notes with an attribute under Melee Attacks and Ranged Attacks</li>
+		<li>Changed Tool Tip for Damage, for Melee attacks and Ranged Attacks, to indicate using the Damage Notes field – Cosmetic Only</li>
+		<li>Changed Armour Divisor to Armor Divisor – Cosmetic Only</li>
+		<li> Changed the output of the Attack Macros for Melee and Ranged attacks to include the Weapons Notes attribute – Cosmetic Only</li>
+		<li>Changed the output of the Damage Macros for Melee and Ranged attacks to include the Damage Notes attribute – Cosmetic Only</li>
+	</ul>
 
 
-            <h4>Version: 1.3.7</h4>
+	<h4>Version: 1.3.7</h4>
             
-            <p>Pull Request: 08/01/2018</p>
+	<p>Pull Request: 08/01/2018</p>
             
-            <ul>
-                <li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
-                <li>Fixed alignment issue with the Notes field Under Skills not Left Justified – Cosmetic Only </li>
-                <li>Changed Hit Location box to have an additional Header identifying User Created Locations – Cosmetic Only</li>
-                <li>Changed all fields in the Hit Location box to be editable. This will enable you to change the name of any of the default Locations and the To Hit Penalty - Request from Valter (User id: 285013)</li>
-                <li> Fixed Bug where some Hit Locations did not save their DR values</li>
-                <li>Removed and Deleted the CR Label and attr_control_rating for Advantages. The correct terminology is Self-control Number and this is not used for Advantages</li>
-                <li>Added an attribute for Native Language. Nothing fancy just a direct input - Requested by Flemmerr (User id: 1515009)</li>
-                <li>Added the Recoil attribute to the chat results for the Ranged Attacks macro – Cosmetic only</li>
-                <l>Changed the Label of “Disadvantages” to “Disadvantages (&Quirks)” – Cosmetic Only </li>
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Fixed alignment issue with the Notes field Under Skills not Left Justified – Cosmetic Only </li>
+		<li>Changed Hit Location box to have an additional Header identifying User Created Locations – Cosmetic Only</li>
+		<li>Changed all fields in the Hit Location box to be editable. This will enable you to change the name of any of the default Locations and the To Hit Penalty - Request from Valter (User id: 285013)</li>
+		<li> Fixed Bug where some Hit Locations did not save their DR values</li>
+		<li>Removed and Deleted the CR Label and attr_control_rating for Advantages. The correct terminology is Self-control Number and this is not used for Advantages</li>
+		<li>Added an attribute for Native Language. Nothing fancy just a direct input - Requested by Flemmerr (User id: 1515009)</li>
+		<li>Added the Recoil attribute to the chat results for the Ranged Attacks macro – Cosmetic only</li>
+		<l>Changed the Label of “Disadvantages” to “Disadvantages (&Quirks)” – Cosmetic Only </li>
 		<l>Changed the Label of “Advantages” to “Advantages (& Perks)” – Cosmetic Only </li>
-                <li>Fixed many miscellaneous issues to existing table fieldsets</li>
-            </ul>
+		<li>Fixed many miscellaneous issues to existing table fieldsets</li>
+	</ul>
 
 
-            <h4>Version: 1.3.6</h4>
+	<h4>Version: 1.3.6</h4>
             
-            <p>Pull Request: 07/25/2018</p>
+	<p>Pull Request: 07/25/2018</p>
             
-            <ul>
-                <li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
-                <li>Corrected spelling of Miscellaneous on the General page – Cosmetic only</li>
-                <li>Updated Tool Tip for Type under Melee Attacks and Ranged, removed the Multiplier information as it is irrelevant, also fixed the alignment – Cosmetic only</li>
-                <li>Added missing information from Type drop down for Ranged Attacks – missing was Affliction and Special</li>
-                <li>Changed the Label of ‘Quick Inventory’ to ‘Quick Inventory & Wealth’ and the Label left justified – Cosmetic only</li>
-                <li>Changed the Melee Attacks and Ranged Attacks macros to include the Notes attribute in the results in Chat – Cosmetic only </li>
-                <li>Changed all Die Macros to apply Bold to the Character Name in the results in Chat – Cosmetic only</li>
-                <li>Change when adding a new Skill, Technique, or Spell, the Points defaults to 0 instead of blank</li>
-                <li>Fixed minor spelling errors – Cosmetic only</li>
-                <li>Renamed Header of CR to SCN under Disadvantages and Racial Trains to reflect correct terminology – Cosmetic only</li>        
-                <li>Fixed Tool Tip of SCN (formerly CR) under Disadvantages and Racial Trains to reflect correct terminology – changed from ‘Control Rating’ to ‘Self-control Number’ – Cosmetic only</li>
-                <li>Added Macro for Self-control Number Roll within Disadvantages and Racial Traits</li>
-                <li>Changes and Adds requested by Mike W (@mike-w) (UserID: 1414610)</li>
-                <li>Spelling correction requested by Rabulias (@rabulias) (UserID: 4692)</li>
-            </ul>
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Corrected spelling of Miscellaneous on the General page – Cosmetic only</li>
+		<li>Updated Tool Tip for Type under Melee Attacks and Ranged, removed the Multiplier information as it is irrelevant, also fixed the alignment – Cosmetic only</li>
+		<li>Added missing information from Type drop down for Ranged Attacks – missing was Affliction and Special</li>
+		<li>Changed the Label of ‘Quick Inventory’ to ‘Quick Inventory & Wealth’ and the Label left justified – Cosmetic only</li>
+		<li>Changed the Melee Attacks and Ranged Attacks macros to include the Notes attribute in the results in Chat – Cosmetic only </li>
+		<li>Changed all Die Macros to apply Bold to the Character Name in the results in Chat – Cosmetic only</li>
+		<li>Change when adding a new Skill, Technique, or Spell, the Points defaults to 0 instead of blank</li>
+		<li>Fixed minor spelling errors – Cosmetic only</li>
+		<li>Renamed Header of CR to SCN under Disadvantages and Racial Trains to reflect correct terminology – Cosmetic only</li>        
+		<li>Fixed Tool Tip of SCN (formerly CR) under Disadvantages and Racial Trains to reflect correct terminology – changed from ‘Control Rating’ to ‘Self-control Number’ – Cosmetic only</li>
+		<li>Added Macro for Self-control Number Roll within Disadvantages and Racial Traits</li>
+ 		<li>Changes and Adds requested by Mike W (@mike-w) (UserID: 1414610)</li>
+  		<li>Spelling correction requested by Rabulias (@rabulias) (UserID: 4692)</li>
+	</ul>
             
-            <h4>Version: 1.3.5</h4>
+	<h4>Version: 1.3.5</h4>
             
-            <p>Pull Request: 7/17/2018</p>
+	<p>Pull Request: 7/17/2018</p>
             
-            <ul>
-                <li>Changes made by Tom S</li>
-                <li>Changed the word Fear to Fright (Visibility only - no attributes where changed)</li>
-                <li>Changed the Macro result from vs. Will to vs. Fright</li>
-                <li>Changed the Hit Location DR input to accept text (so that you can add DR entries like 2* or 3/1*)</li>
-                <li>Changed the visible width of the DR field making it wider</li>
-                <li>Fixed bug in Hit Location Penalty not saving for added custom location</li>
-                <li>Added a Tool Tip for Pen header in Hit Location</li>
-                <li>Requested by Mike W (@mike-w) (UserID: 1414610) see: https://app.roll20.net/forum/post/6572120/</li>
-            </ul>
+	<ul>
+		<li>Changes made by Tom S</li>
+		<li>Changed the word Fear to Fright (Visibility only - no attributes where changed)</li>
+		<li>Changed the Macro result from vs. Will to vs. Fright</li>
+		<li>Changed the Hit Location DR input to accept text (so that you can add DR entries like 2* or 3/1*)</li>
+		<li>Changed the visible width of the DR field making it wider</li>
+		<li>Fixed bug in Hit Location Penalty not saving for added custom location</li>
+		<li>Added a Tool Tip for Pen header in Hit Location</li>
+		<li>Requested by Mike W (@mike-w) (UserID: 1414610) see: https://app.roll20.net/forum/post/6572120/</li>
+	</ul>
             
-            <h4>Version: 1.3.4</h4>
+	<h4>Version: 1.3.4</h4>
             
-            <p>Pull Request: 3/7/2018</p>
-            
-            <ul>
+	<p>Pull Request: 3/7/2018</p>
+	<ul>
 		<li>Changes made by MadCoder https://github.com/MadCoder253/roll20-character-sheets/issues</li>
                 <li>Add Revision History Tab</li>
                 <li>Changed roll buttons to use dicefontd6 (requested by Mike W 
                 (@mike-w) (UserID: 1414610) see: https://app.roll20.net/forum/post/5845539/</li>
                 <li>Fix lift & encumbrance rounding error for low ST. Round to whole number. 
                 (requested by Lucy (@lucy) (UserID: 359497) see: https://app.roll20.net/forum/permalink/5142954/</li>
-            </ul>
+	</ul>
             
-            <h4>Version 1.3.3</h4>
+	<h4>Version 1.3.3</h4>
             
-            <p>Pull Request: 3/1/2018</p>
+	<p>Pull Request: 3/1/2018</p>
             
-            <ul>
+	<ul>
 		<li>Changes made by MadCoder https://github.com/MadCoder253/roll20-character-sheets/issues</li>
                 <li>Restyled tabs to work with Firefox and MS Edge</li>
                 <li>Traits tab -> disadvantages section: slight changes to column spacing</li>
@@ -2399,7 +2437,7 @@
 				<span class="sheet-tooltip">
 					Rolls will be made immediately with no prompt.
 				</span>
-				<br /><input type="radio" name="attr_modifier" value="?{Modifier|0}" />
+				<br /><input type="radio" name="attr_modifier" value="[[?{Modifier|0}]]" />
 				<span class="sheet-popup">Single Modifier Prompt</span>
 				<span class="sheet-tooltip">
 					Ask for a bonus or penalty to be added to dice rolls.
@@ -2407,7 +2445,7 @@
 					This will not affect damage rolls.
 				</span>
 				<br />
-				<input type="radio" name="attr_modifier" value="?{Modifier|0} + ?{Shock|0} + ?{Reeling or Staggered|0} + ?{Off-Hand|0} + ?{Familiarity|0}" />
+				<input type="radio" name="attr_modifier" value="[[?{Modifier|0}]] +[[?{Shock|0}]] + [[?{Reeling or Staggered|0}]] + [[?{Off-Hand|0}]] + [[?{Familiarity|0}]]" />
 				<span class="sheet-popup">Extended Modifier Prompts</span>
 				<span class="sheet-tooltip">
 					Instead of a single modifier, rolls will ask for a series of modifiers,<br />
@@ -2476,7 +2514,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = '1.3.4';
+	var version = '1.3.9';
 
 	var modCascade = true;
 	var modCascadeAll = true;
@@ -2487,8 +2525,20 @@
 	 */
 	on('sheet:opened', function() {
 		console.log('********* Sheet Opened *********');
+		console.log('** Setting default TAB to Updates  **');
 		/* When the sheet is opened, it opens to the Update tab */
 			setAttrs({tab:7});
+		/* For Bug Fix v1.3.9 : Need to convert the Value of the Modifier Prompt*/
+		console.log('** Attribute Modifier new values v1.3.9 **');
+		getAttrs(['modifier'], function(v){
+			const setObj = {};
+			if(v.modifier==='?{Modifier|0}'){
+				setObj.modifier = '[[?{Modifier|0}]]'
+			}else if(v.modifier==='?{Modifier|0} + ?{Shock|0} + ?{Reeling or Staggered|0} + ?{Off-Hand|0} + ?{Familiarity|0}'){
+				setObj.modifier = '[[?{Modifier|0}]] +[[?{Shock|0}]] + [[?{Reeling or Staggered|0}]] + [[?{Off-Hand|0}]] + [[?{Familiarity|0}]]'
+			}
+			setAttrs(setObj,{silent:true});
+		});
 		getAttrs(['sheet_version', 'mod_cascade', 'modCascade', 'modCascadeAll'], function(v) {
 			if (v.modCascade && v.modCascadeAll) {
 				modCascade = v.modCascade;
@@ -2498,7 +2548,7 @@
 				// Set sheet version:
 				setAttrs({ sheet_version: version });
 
-				// initalize any empty fields in repeating sections since the default values were removed.
+				// initialize any empty fields in repeating sections since the default values were removed.
 				loadRepeating('repeating_languages', 'spoken', 0);
 				loadRepeating('repeating_languages', 'written', 0);
 				loadRepeating('repeating_skills', 'points', 1);
@@ -2786,11 +2836,11 @@
 		});
 	}
 
-	// Updage Willpower, Fear (This is actually called Fright Chec - the General page reflects this)
+	// Updage Willpower, Fear (This is actually called Fright Check - the General page reflects this)
 	on('change:intelligence change:willpower_points change:willpower_mod change:fear_check_points change:fear_check_mod', function (e) {
 		updateWill();
 	});
-	// Updage Willpower, Fear (This is actually called Fright Chec - the General page reflects this)
+	// Updage Willpower, Fear (This is actually called Fright Check - the General page reflects this)
 	function updateWill() {
 		console.log('********* updateWill *********');
 		getAttrs(['intelligence', 'intelligence_base', 'willpower_points', 'willpower_mod', 'fear_check_points', 'fear_check_mod'], function(v) {
@@ -2947,10 +2997,18 @@
 	}
 
 	// Update the total cost of Languages
-	on('change:repeating_languages:spoken change:repeating_languages:written remove:repeating_languages', function (e) {
+	on('change:native_language_spoken change:native_language_written change:repeating_languages:spoken change:repeating_languages:written remove:repeating_languages', function (e) {
+		console.log('**** Languages Changed ****');
 		var total = 0;
 		var tally = _.after(2, function () {
 			setAttrs({ languages_points: total });
+		});
+		getAttrs(['native_language_spoken', 'native_language_written'], function(v) {
+			console.log('Native Language Spoken: ' + v.native_language_spoken);
+			console.log('Native Language Written: ' + v.native_language_written);
+			total += +v.native_language_spoken;
+			total += +v.native_language_written;
+			tally();
 		});
 		sumRepeating('repeating_languages', 'spoken', function(v) {
 			console.log('Spoken: ' + v);
@@ -3026,7 +3084,7 @@
 	on('change:repeating_item:count change:repeating_item:cost change:repeating_item:carried change:repeating_item:weight', function (e) {
 		getAttrs(['repeating_item_count', 'repeating_item_cost', 'repeating_item_weight', 'repeating_item_carried'], function (item) {
 			setAttrs({
-				repeating_item_weighttotal: Math.round(item.repeating_item_count * item.repeating_item_weight * item.repeating_item_carried * 100) / 100,
+				repeating_item_weighttotal: Math.round(item.repeating_item_count * item.repeating_item_weight * item.repeating_item_carried * 1000) / 1000,
 				repeating_item_costtotal: Math.round(item.repeating_item_count * item.repeating_item_cost * 100) / 100
 			});
 		});
@@ -3035,7 +3093,7 @@
 	// Update the total weight of all carried items.
 	on('change:repeating_item:weighttotal remove:repeating_item', function (e) {
 		sumRepeating('repeating_item', 'weighttotal', function(v) {
-			setAttrs({ total_weight: (v * 100) / 100 });
+			setAttrs({ total_weight: (v * 1000) / 1000 });
 		});
 	});
 

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -2319,12 +2319,7 @@
 		<li>Updated the Inventory Box format – Cosmetic Only</li>
 		<li>Added fields of ‘TL’ (Tech Level) and ‘Ref’ (Reference) to the Inventory repeating section</li>
 		<li>Fixed bug for Single Modifier Prompt and Extended Modifier Prompts if a ‘+’ is used for a positive modifier entry</li>
-		<li> </li>
-		<li> </li>
-		<li> </li>
-		<li> </li>
-		<li> </li>
-		<li> </li>
+
 	</ul>
 
 	<h4>Version: 1.3.8</h4>


### PR DESCRIPTION
•	Updated the Language Box format – Cosmetic Only.
•	Added additional options for Native Language in regards to Spoken and Written levels as a Disadvantage.
•	Updated the Inventory Box format – Cosmetic Only.
•	Added fields for ‘TL’ (Tech Level) and ‘Ref’ (Reference) to the Inventory repeating section.
•	Fixed bug for Single Modifier Prompt and Extended Modifier Prompts if a ‘+’ is used for a positive modifier entry.