### PR TITLE
Update readme.md for Wrath & Glory v2

### DIFF
--- a/Wrath and Glory API/readme.md
+++ b/Wrath and Glory API/readme.md
@@ -9,7 +9,7 @@ Please note that the inline dice roll macros do not fully enable the type of dic
 If you have any questions, comments, or feedback (all welcome) please contact Barry at btsnyder@gmail.com
 
 ### Current Version
-Version 2.0 (August 16th, 2018) 
+Version 2.0 (August 20th, 2018) 
 
 ### Thanks	
 Many thanks to my players (Dave, Brian, Charles, Matt, and Tyler) for their patience as I evolved the sheet and die roller (sometimes in the middle of play) over the past several weeks.
@@ -33,23 +33,23 @@ v5.0. Automate all calculated fields for performance and speed of character crea
 ** August 20th, 2018: version 2.0 - Base Rule Alignment Changes** 
 
 Updates:
-    1. Changed XP labels to BP and tweaked layout on the progression tab; still same effect.
-    2. Updated NPC Type list (added Elite and renamed Monster to Monstrous Creature).
-    3. Added Assets to Gear Label so now it is Gear & Assets.
-    4. Changed NPC Size to a drop down populated with the size categories.
-    5. Updated Tier to a dropdown and added a note section for ascension notes.
-    6. Removed Rank Bonus (redundant) and added the rank description as a drop down.
-    7. Added a custom field for Tier; the rules talk about GM's having tiers higher than 5.
-    8. Removed dice rolling for Passive Awareness and Wealth; neither have dice rolls per core rules.
-    9. Added Passive Awareness and Conviction to NPC's.
-    10. Added empty checkbox to weapons on both PC and NPC tables to track when you use your last reload and you have not emptied the weapon yet.  On the next complication or other event the weapon is out of ammo.
-    11. Added a seventh tab and reorganized content - Abilities, talents, and psychic power are on the 'Powers' tab; Gear & Assets, vehicles, and voidships will be on the 'Equipment' tab; objectives, background, malignancies, and alliances are on the 'Personal' tab.
-    12. Moved ascension notes to the Abilities tab as an expanded note by Tier.
-    13. Added section for entering psychic powers.
-    14. Added a section for listing multiple vehicles and voidships under Equipment for PC/Adversary view.
-    15. Added section in Powers for Psychic powers with the ability to roll a test, push the test, and roll damage.
-    16. Added a new column to skills with an assist roll; assist rolls do not include wrath dice.
-    17. Created a view for vehicles and voidships; these views include fields for entering a pool of dice for rolls. Players can also make the appropriate tests from their character sheet.
+1. Changed XP labels to BP and tweaked layout on the progression tab; still same effect.
+2. Updated NPC Type list (added Elite and renamed Monster to Monstrous Creature).
+3. Added Assets to Gear Label so now it is Gear & Assets.
+4. Changed NPC Size to a drop down populated with the size categories.
+5. Updated Tier to a dropdown and added a note section for ascension notes.
+6. Removed Rank Bonus (redundant) and added the rank description as a drop down.
+7. Added a custom field for Tier; the rules talk about GM's having tiers higher than 5.
+8. Removed dice rolling for Passive Awareness and Wealth; neither have dice rolls per core rules.
+9. Added Passive Awareness and Conviction to NPC's.
+10. Added empty checkbox to weapons on both PC and NPC tables to track when you use your last reload and you have not emptied the weapon yet.  On the next complication or other event the weapon is out of ammo.
+11. Added a seventh tab and reorganized content - Abilities, talents, and psychic power are on the 'Powers' tab; Gear & Assets, vehicles, and voidships will be on the 'Equipment' tab; objectives, background, malignancies, and alliances are on the 'Personal' tab.
+12. Moved ascension notes to the Abilities tab as an expanded note by Tier.
+13. Added section for entering psychic powers.
+14. Added a section for listing multiple vehicles and voidships under Equipment for PC/Adversary view.
+15. Added section in Powers for Psychic powers with the ability to roll a test, push the test, and roll damage.
+16. Added a new column to skills with an assist roll; assist rolls do not include wrath dice.
+17. Created a view for vehicles and voidships; these views include fields for entering a pool of dice for rolls. Players can also make the appropriate tests from their character sheet.
 
 Note:  No existing attributes were changed or removed.  Existing functionality was expanded.
 
@@ -60,4 +60,4 @@ Fixes:
 - resubmitted on August 6th due to roll20 packaging error.
 
 ### Known Issues
-1. Inline rolls do not show two successes on a 2 and die modifier is not added; this functionality is not core within the Roll20 capabilities and an expanded formula needs to be created.
+1. Inline rolls do not show two successes on a 6 and die modifier is not added; this functionality is not core within the Roll20 capabilities and an expanded formula needs to be created.


### PR DESCRIPTION
corrected number list and rewrote known issue (referenced a roll of a 2 when it should have been a 6).