### PR TITLE
Free Spacer  - Removed Pulldown for Trivial traits to increase flexibility

### DIFF
--- a/Free Spacer/FreeSpacer.html
+++ b/Free Spacer/FreeSpacer.html
@@ -350,7 +350,7 @@
 						<select name="attr_Consumption" class="sheet-full sheet-aspect">
 							<option></option>
 							<option>Hemovore</option>
-							<option>Detritivores</option>
+							<option>Detritivore</option>
 							<option>Herbivore</option>
 							<option>Omnivore</option>
 							<option>Carnivore</option>
@@ -1387,19 +1387,8 @@
 								<option>Strong</option>
 								<option>Natural weapons</option>
 							</optgroup>
-							<optgroup label="Trival">
-								<option>Android</option>
-								<option>Ancient</option>
-								<option>Plant-like</option>
-								<option>Symbiote</option>
-								<option>Uplifted</option>
-								<option>Variant</option>
-							</optgroup>
 						</select>
-						<select name="attr_TraitRating" class="sheet-FittingAdv sheet-fifth">
-							<option value=0></option>
-							<option value=2>JJ</option>
-						</select>
+						<em class="sheet-FittingAdv sheet-fifth">JJ</em>
 					</fieldset>
 					<h4>Survival Traits</h4>
 					<fieldset class="repeating_SurvivalTraits">
@@ -1413,6 +1402,8 @@
 						</select>
 						<input type="checkbox" class="sheet-armourConditionSlot" name="attr_TraitArmourConditionSlot1" value="damaged" /><span></span>
 					</fieldset>
+					<h4>Trivial Trait</h4>
+					<input type="text" name="attr_trivalTrait" lass="sheet-threeQuarters">
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
- Replaced a pulldown for Trivial traits with a seperate flexable text field.
- Replaced a dice pulldown that is no longer required with text.
- Fixed a tense issue in consumption.