### PR TITLE
[GURPS] Bug Fixes and added FoA

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -475,6 +475,8 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-melee-attacks .sheet-tooltip { margin-left: -100px; }
 .sheet-ranged-attacks .sheet-tooltip { margin-left: -100px; }
 .sheet-ranged-attacks .sheet-col1 .sheet-tooltip { margin-left: -40px; }
+.sheet-encumberance .sheet-tooltip { margin-left: -40px; }
+
 
 /* -- GENERAL -- */
 .sheet-attribute { width: 180px; }
@@ -580,12 +582,13 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-culture .sheet-col1 { width: 30px; }
 
 .sheet-traits { width: calc(100% - 0.4em); }
-.sheet-traits .sheet-col0 { width: calc(100% - 100px); }
+.sheet-traits .sheet-col0 { width: calc(100% - 117px); }
 .sheet-traits .sheet-col0 input { text-align:left; }
-.sheet-traits .sheet-col1 { width: 30px; }
-.sheet-traits .sheet-col2 { width: 30px; }
-.sheet-traits .sheet-col3 { width: 40px; }
-.sheet-traits .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 120px); }
+.sheet-traits .sheet-col1 { width: 25px; }
+.sheet-traits .sheet-col2 { width: 22px; }
+.sheet-traits .sheet-col3 { width: 30px; }
+.sheet-traits .sheet-col4 { width: 40px; }
+.sheet-traits .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 137px); }
 
 .sheet-disadvantages { width: calc(100% - 0.4em); }
 .sheet-disadvantages .sheet-col0 { width: calc(100% - 117px); }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -1130,13 +1130,39 @@
 						X-Heavy (4)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_4" value="10 * @{basic_lift}" disabled="disabled" />
+						<input type="number" name="attr_lift_4" value="10 * @{basic_lift}"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
 						<input type="number" name="attr_move_4" value="floor((@{basic_move}) * 0.2)" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
 						<input type="number" name="attr_dodge_4" value="@{dodge} - 4" disabled="disabled" />
+					</div>
+				</div> <!-- .sheet-row -->
+				<!-- Yes I realize encumbrance is spelled wrong here but the original authors misspelled it throughout the file so I did the same to stay backwards compatible. -->	
+				<div class="sheet-row sheet-row-encumberance-MAX">
+					<div class="sheet-cell sheet-col0 sheet-label">
+						<div class="sheet-popup">MAX Load*</div>
+						<span class="sheet-tooltip">
+							Carry on Back (B353) 15xBL. Thus, you can carry
+							<br />
+							more than you can lift by yourself . . . but 
+							<br />
+							every second that your encumbrance is over 10xBL
+							<br />
+							(that is Extra-Heavy encumbrance), you lose 1 FP.
+							<br />						
+						</span>
+					</div>
+
+					<div class="sheet-cell sheet-col1">
+						<input type="number" name="attr_lift_5" value="15 * @{basic_lift}"  disabled="disabled" />
+					</div>
+					<div class="sheet-cell sheet-col2">
+						<input type="number" name="attr_move_5" value="floor((@{basic_move}) * 0.2)" disabled="disabled" />
+					</div>
+					<div class="sheet-cell sheet-col3">
+						<input type="number" name="attr_dodge_5" value="@{dodge} - 4" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-load sheet-hr">
@@ -1263,9 +1289,24 @@
 			<div class="sheet-table">
 				<div class="sheet-header">
 					<div class="sheet-cell sheet-col0">Advantages (& Perks)</div>
-					<div class="sheet-cell sheet-col1"></div>
-					<div class="sheet-cell sheet-col2">Pts</div>
-					<div class="sheet-cell sheet-col3">Ref</div>
+					<div class="sheet-cell sheet-col1">
+						<div class="sheet-popup">FOA</div>
+						<span class="sheet-tooltip">
+							Frequency of Appearance
+							<br />
+							<table>
+								<tbody>
+									<tr><td>15 or less><td></td>
+									<tr><td>12 or less><td></td>
+									<tr><td>9 or less><td></td>
+									<tr><td>6 or less><td></td>
+								</tbody>
+							</table>
+						</span>
+					</div>
+					<div class="sheet-cell sheet-col2"></div>
+					<div class="sheet-cell sheet-col3">Pts</div>
+					<div class="sheet-cell sheet-col4">Ref</div>
 				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_traits">
 					<input class="sheet-toggle" type="checkbox" />
@@ -1275,12 +1316,15 @@
 							<input type="text" name="attr_name" />
 						</div>
 						<div class="sheet-cell sheet-col1">
-							
+							<input type="number" name="attr_foa" />
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_points" />
+							<button type="roll" value="@{roll} [[3d6]] @{VS} @{name} [[@{foa} + @{modifier}]]" name="roll_vsAFOA" />
 						</div>
 						<div class="sheet-cell sheet-col3">
+							<input type="number" name="attr_points" />
+						</div>
+						<div class="sheet-cell sheet-col4">
 							<input type="text" name="attr_ref" />
 						</div>
 					</div> <!-- .sheet-row -->
@@ -1306,14 +1350,16 @@
 					<div class="sheet-cell sheet-col1">
 						<div class="sheet-popup">SCN</div>
 						<span class="sheet-tooltip">
-							Self-control Number
+							Self-control Number OR
 							<br />
+							Frequency of Appearance
+							<br />							
 							<table>
 								<tbody>
-									<tr><td>6 or less</td><td>2x</td></tr>
-									<tr><td>9 or less</td><td>1.5x</td></tr>
-									<tr><td>12 or less</td><td>1x</td></tr>
-									<tr><td>15 or less</td><td>0.5x</td></tr>
+									<tr><td>15 or less</td></tr>
+									<tr><td>12 or less</td></tr>
+									<tr><td>9 or less</td></tr>
+									<tr><td>6 or less</td></tr>
 								</tbody>
 							</table>
 						</span>
@@ -1321,7 +1367,6 @@
 					<div class="sheet-cell sheet-col2"></div>
 					<div class="sheet-cell sheet-col3">Pts</div>
 					<div class="sheet-cell sheet-col4">Ref</div>	
-
 				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_disadvantages">
 					<input class="sheet-toggle" type="checkbox" />
@@ -1365,14 +1410,15 @@
 					<div class="sheet-cell sheet-col1">
 						<div class="sheet-popup">SCN</div>
 						<span class="sheet-tooltip">
-							Self-control Number
+							Self-control Number OR
 							<br />
+							Frequency of Appearance
 							<table>
 								<tbody>
-									<tr><td>6 or less</td><td>2x</td></tr>
-									<tr><td>9 or less</td><td>1.5x</td></tr>
-									<tr><td>12 or less</td><td>1x</td></tr>
-									<tr><td>15 or less</td><td>0.5x</td></tr>
+									<tr><td>15 or less</td></tr>
+									<tr><td>12 or less</td></tr>
+									<tr><td>9 or less</td></tr>
+									<tr><td>6 or less</td></tr>
 								</tbody>
 							</table>
 						</span>
@@ -2308,6 +2354,20 @@
 	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 
             Forum for now (Like Tom and I are doing) - perhaps later we can use GitHub.</p>
  
+	<h4>Version: 1.4.0</h4>
+
+	<p>Pull Request: 09/04/2018</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Fixed bug with calculating Current Move for Heavy and Extra Heavy Encumbrances and not using a Minimum of 1. Reported by Ray G (@raymond-g)  (UserID: 1600355)</li>
+		<li>Fixed bug with calculating Total Weight from Inventory which at times created a weigh of more than 3 decimal places.</li>
+		<li >Added a ‘FOA’ (Frequency of Appearance) field under Advantages (& Quirks) </li>
+		<li >Modified the Tool Tip for SCN under Disadvantages (& Quirks) and Racial Traits to include the wording ‘OR Frequency of Appearance’– Cosmetic Only</li>
+		<li>Added Max Load to the Encumbrance Table</li>
+	</ul>
+ 
+
 	<h4>Version: 1.3.9</h4>
 
 	<p>Pull Request: 08/21/2018</p>
@@ -2381,7 +2441,7 @@
 	</ul>
             
 	<h4>Version: 1.3.5</h4>
-            
+
 	<p>Pull Request: 7/17/2018</p>
             
 	<ul>
@@ -2509,7 +2569,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = '1.3.9';
+	var version = '1.4.0';
 
 	var modCascade = true;
 	var modCascadeAll = true;
@@ -2602,7 +2662,7 @@
 		});
 
 		sumRepeating('repeating_item', 'weighttotal', function (v) {
-			setAttrs({ total_weight: (v * 100) / 100 }, {silent: false}, thenEncumbrance);
+			setAttrs({ total_weight: (v * 1000) / 1000 }, {silent: false}, thenEncumbrance);
 		});
 
 		// Update attributes, then secondary characteristics, and so on...
@@ -2924,13 +2984,14 @@
 			var move = +v.basic_move;
 			var strength = +v.strength_base + +v.strength_mod;
 			if (v.encumbrance_level === 5) {
-				dodge = 0;
-				move = 0;
+				dodge = 1;
+				move = 1;
 			} else {
 				dodge = dodge - +v.encumbrance_level;
-				move = Math.floor(+v.basic_move * (1 - (0.2 * +v.encumbrance_level)));
-				dodge = dodge < 0 ? 0 : dodge;
-				move = move < 0 ? 0 : move;
+			// There is some math error when calculating Encumbrance which requires the modifier of 1.01 instead of 1 below
+				move = Math.floor(+v.basic_move * (1.01 - (0.2 * +v.encumbrance_level)));
+				dodge = dodge < 1 ? 1 : dodge;
+				move = move < 1 ? 1 : move;
 			}
 			if (+v.hit_points < +v.hit_points_max / 3) {
 				dodge = Math.ceil(dodge / 2);
@@ -3088,7 +3149,7 @@
 	// Update the total weight of all carried items.
 	on('change:repeating_item:weighttotal remove:repeating_item', function (e) {
 		sumRepeating('repeating_item', 'weighttotal', function(v) {
-			setAttrs({ total_weight: (v * 1000) / 1000 });
+			setAttrs({ total_weight: Math.round(v * 1000) / 1000 });
 		});
 	});
 


### PR DESCRIPTION
•	Fixed bug with calculating Current Move for Heavy and Extra Heavy Encumbrances and not using a Minimum of 1. Reported by Ray G (@raymond-g)  (UserID: 1600355).
•	 Fixed bug with calculating Total Weight from Inventory which at times created a weigh of more than 3 decimal places.
•	Added a ‘FOA’ (Frequency of Appearance) field under Advantages (& Quirks)
•	Modified the Tool Tip for SCN under Disadvantages (& Quirks) and Racial Traits to include the wording ‘OR Frequency of Appearance’– Cosmetic Only
•	Added Max Load to the Encumbrance table.