### PR TITLE
[Vampire Dark Ages 20th] attribute fix

### DIFF
--- a/CWOD-DAV20/DAV20.css
+++ b/CWOD-DAV20/DAV20.css
@@ -203,4 +203,3 @@ input.sheet-CorC2:checked ~ h4.sheet-CorC2
 {
     display: none;
 }
-

--- a/CWOD-DAV20/DAV20.html
+++ b/CWOD-DAV20/DAV20.html
@@ -72,12 +72,12 @@
         <h4>Wits</h4>
     </div>
     <div class="sheet-col" style="width:150px">
-        <input type="radio" name="attr_Perception" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Perception" value="2" /><span></span>    <input type="radio" name="attr_Perception" value="3" /><span></span>    <input type="radio" name="attr_Perception" value="4" /><span></span>    <input type="radio" name="attr_Perception" value="5" /><span></span>
+        <input type="radio" name="attr_Perception" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Perception" value="2" /><span></span>    <input type="radio" name="attr_Perception" value="3" /><span></span>    <input type="radio" name="attr_Perception" value="4" /><span></span>    <input type="radio" name="attr_Perception" value="5" /><span></span> <input type="radio" name="attr_Perception" value="6" /><span></span>    <input type="radio" name="attr_Perception" value="7" /><span></span>    <input type="radio" name="attr_Perception" value="8" /><span></span>
         <div class="sheet-row">
-            <input type="radio" name="attr_Intelligence" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Intelligence" value="2" /><span></span>    <input type="radio" name="attr_Intelligence" value="3" /><span></span>    <input type="radio" name="attr_Intelligence" value="4" /><span></span>    <input type="radio" name="attr_Intelligence" value="5" /><span></span>
+            <input type="radio" name="attr_Intelligence" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Intelligence" value="2" /><span></span>    <input type="radio" name="attr_Intelligence" value="3" /><span></span>    <input type="radio" name="attr_Intelligence" value="4" /><span></span>    <input type="radio" name="attr_Intelligence" value="5" /><span></span> <input type="radio" name="attr_Intelligence" value="6" /><span></span>    <input type="radio" name="attr_Intelligence" value="7" /><span></span>    <input type="radio" name="attr_Intelligence" value="8" /><span></span>
         </div>
         <div class="sheet-row">
-            <input type="radio" name="attr_Wits" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Wits" value="2" /><span></span>    <input type="radio" name="attr_Wits" value="3" /><span></span>    <input type="radio" name="attr_Wits" value="4" /><span></span>    <input type="radio" name="attr_Wits" value="5" /><span></span>
+            <input type="radio" name="attr_Wits" value="1" checked="checked" /><span></span>    <input type="radio" name="attr_Wits" value="2" /><span></span>    <input type="radio" name="attr_Wits" value="3" /><span></span>    <input type="radio" name="attr_Wits" value="4" /><span></span>    <input type="radio" name="attr_Wits" value="5" /><span></span> <input type="radio" name="attr_Wits" value="6" /><span></span>    <input type="radio" name="attr_Wits" value="7" /><span></span>    <input type="radio" name="attr_Wits" value="8" /><span></span>
         </div>
     </div>
 </div>

--- a/CWOD-DAV20/sheet.json
+++ b/CWOD-DAV20/sheet.json
@@ -1,8 +1,8 @@
 {
 	"html": "DAV20.html",
 	"css": "DAV20.css",
-	"authors": "Invincible Spleen, based on Matt Zaldivar's V20 character sheet",
-    "roll20userid": 901082,
+	"authors": "Invincible Spleen",
+    "roll20userid": "901082",
 	"preview": "DAV20.png",
-	"instructions": "# Vampire: The Dark Ages Character Sheet\r For use in the classic World of Darkness, 20th Anniversary edition.  Designed to function much like an actual paper sheet would.  With the most notable exception being that you can roll Willpower directy from the sheet.  Also, The Dice Pool section in the center at the bottom allow one to select an Attribute and/or Ability to roll; The Other Traits may also be seleceted in the Ability drop down.  All rolls from the sheet are of the from {Xd10}>Df1, where X is the number of dice and D is the difficulty.  NOTE: These rolls do not recognize botches or specialties. Further, the rolls will prompt the user to modify the number of dice rolled and set the difficulty.  The defaults for these are 0 and 6 respectively.  Also, click on the Virtues Conscience or Self-Control to change to Conviction and Instinct, repectively, click again to change back."
+	"instructions": "# Vampire: The Dark Ages Character Sheet\r For use in the classic World of Darkness, 20th Anniversary edition.  Designed to function much like an actual paper sheet would.  With the most notable exception being that you can roll Willpower directy from the sheet.  Also, The Dice Pool section in the center at the bottom allow one to select an Attribute and/or Ability to roll; The Other Traits may also be seleceted in the Ability drop down.  All rolls from the sheet are of the from {Xd10}>Df1, where X is the number of dice and D is the difficulty.  NOTE: These rolls do not recognize botches or specialties. Further, the rolls will prompt the user to modify the number of dice rolled and set the difficulty.  The defaults for these are 0 and 6 respectively.  Also, click on the Virtues Conscience or Self-Control to change to Conviction and Instinct, repectively, click again to change back.\n\n Based on Matt Zaldivar's V20 character sheet"
 }


### PR DESCRIPTION
- Added dots to Perception, Intelligence and Wits trackers, so they can go you to 8, as with the other main attributes.
- fixed sheet.json typo
