### PR TITLE
(DungeonWorldSpanish) cambios y arreglos html

### DIFF
--- a/DungeonWorldSpanish/DungeonWorldSpanish.html
+++ b/DungeonWorldSpanish/DungeonWorldSpanish.html
@@ -216,11 +216,15 @@
 		<span class="sheet-hide sheet-section-name sheet-right">Carga Base</span>
 	</div>
 	<div class="sheet-section-gear">
-		<fieldset class="repeating_items">
+
+            <th><span class="bottom">Objeto</th>
+            <th><span class="bottom" style="margin-left:190px;">Usos</span></th>
+            <th><span class="bottom" style="margin-left:18px;">Peso</span></th>
+
+        <fieldset class="repeating_items">
 			<input name="attr_itemname" type="text" placeholder="Nombre">
-			<input name="attr_itemtags" type="text" placeholder="Etiquetas">
-			<input name="attr_itemweight" type="number" placeholder="Peso" title="Peso">
-			<div class="sheet-clearfix"></div>
+			<input name="attr_itemuse" type="number"  title="Usos">
+			<input name="attr_itemweight" type="number" value="0" title="Peso">
 		</fieldset>
 	</div>
 </div>


### PR DESCRIPTION
1 - correjido un fallo que no se podia desplegal el textarea de los hechizos
2 - quitado las etiquetas de los objetos para que se vea mas limpio y añadido "usos" para los objetos