### PR TITLE
(DungeonWorldSpanish) cambios y arreglos CSS

### DIFF
--- a/DungeonWorldSpanish/DungeonWorldSpanish.css
+++ b/DungeonWorldSpanish/DungeonWorldSpanish.css
@@ -285,6 +285,12 @@ input[disabled] {-moz-appearance: textfield}
 /* ===== TWEAKS ===== */
 .sheet-section-moves textarea {
 	resize: vertical;
+	height: 120px;
+}
+
+.sheet-section-spells textarea {
+	resize: vertical;
+	height: 120px;
 }
 
 .sheet-section-moves input[name="attr_movename"],
@@ -292,12 +298,16 @@ input[disabled] {-moz-appearance: textfield}
 	width: 95%;
 }
 
-.sheet-section-gear input[name="attr_itemtags"] {
-	width: 85%;
-	float: left;
+.sheet-section-gear input[name="attr_itemname"] {
+	width: 71%;
+}
+
+.sheet-section-gear input[name="attr_itemwuse"] {
+	width: 40px;
 }
 
 .sheet-section-gear input[name="attr_itemweight"] {
-	width: 15%;
-	float: left;
+	width: 40px;
 }
+
+


### PR DESCRIPTION
1 - correjido un fallo que no se podia desplegal el textarea de los hechizos
2 - quitado las etiquetas de los objetos para que se vea mas limpio y añadido "usos" para los objetos