### PR TITLE
[Star Wars D6] V.1.81

### DIFF
--- a/D6StarWars/CHANGELOG.md
+++ b/D6StarWars/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 1.81 (2018-09-25):
+
+- Change roll templates of different kind of rolls to have matching colors: Blue for attributes/skills, red for weapon/armor, black for custom and initiative rolls, and keep force rolls purple
+
+- Readme link fix
+
 ### Version 1.80 (2018-09-17):
 
 - Roll Templates added (Blue, red, green, black versions of the default)

--- a/D6StarWars/D6StarWars.css
+++ b/D6StarWars/D6StarWars.css
@@ -10,7 +10,7 @@
 }
 
 .charsheet .sheet-version::after {
-    content: 'Sheet Version 1.80';
+    content: 'Sheet Version 1.81';
 }
  
 .charsheet label, h1, h2, h3{

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -93,9 +93,9 @@
 					<label>Force Points <input type="number" name="attr_forcePoints" class="smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 1 FP --->
 					<label>Dark Side Points <input type="number" name="attr_darkSidePoints" class="smallshortnumber" min="0" value="0"/></label>
 					<label>Character Points <input type="number" name="attr_characterPoints" class="smallshortnumber" min="0" value="0"/></label> <!---On char creation everyone starts with 5 CP --->
-					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"><span class="redtxt">(GM)</span>Custom Roll</button>
-					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:default} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}"><span class="redtxt">(GM)</span>Extra Dice</button>
-					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:default} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}"><span class="redtxt">(GM)</span>Char pt</button>
+					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:black} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"><span class="redtxt">(GM)</span>Custom Roll</button>
+					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:black} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}"><span class="redtxt">(GM)</span>Extra Dice</button>
+					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:black} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}"><span class="redtxt">(GM)</span>Char pt</button>
 				</div>         
 				<div class='col'>
 					<label style="text-decoration:underline;">Wound Level
@@ -111,10 +111,10 @@
 					<label>Initiative bonus
 						<input type="number" name="attr_initiative" class="smallnumber shortnumber" min="0" value="0"/>D+<input type="number" name="attr_initiativepip" class="pipnumber shortnumber" min="0" max="2" value="0"/>
 					</label>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} -@{WoundMod} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative</button>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}">Extra Dice(no wild die)</button>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}">Character points roll</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} -@{WoundMod} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}">Initiative</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}">Custom Roll(no modifiers)</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=Extra Dice}} {{Roll=[[{?{Number of  extra dice|0}d6cf0cs7}]]}}">Extra Dice(no wild die)</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=Character points roll}} {{Roll=[[?{Number of char points to spend on roll|1|2|3|4|5}d6!cf0cs6]]}}">Character points roll</button>
 				</div>
 			</div>
 		</div>
@@ -133,9 +133,9 @@
 						</select> 
 					</label>
 					<label>Initiative bonus<input type="number" name="attr_initiative" class="smallnumber shortnumber" min="0" value="0">D+<input type="number" name="attr_initiativepip" class="pipnumber shortnumber" min="0" max="2" value="0"></label>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} -@{WoundMod} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}"/>Initiative</button>
-					<button class="d6-dice" type="roll" value="&{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"/>Custom Roll(no mods)</button>
-					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:default} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"/><span class="redtxt">(GM)</span>C Roll</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=Initiative}} {{Roll=[[(@{perception} + @{initiative} -@{WoundMod} + @{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perceptionpip} + @{initiativepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6 &{tracker}]]}}"/>Initiative</button>
+					<button class="d6-dice" type="roll" value="&{template:black} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"/>Custom Roll(no mods)</button>
+					<button class="d6-dice gmroll-hide" type="roll" value="/w gm &{template:black} {{name=?{Roll Name}}} {{Roll=[[{(?{Number of dice|0} - 1)d6cf0cs7 + ?{Number of pip|0},1d6!cf1cs6}]]}}"/><span class="redtxt">(GM)</span>C Roll</button>
 				</div>
 				<div class="col">
 					<label>Physical Description & Other Info</label>
@@ -147,15 +147,15 @@
 			<table>
 				<tr>
 					<td class="tdborder"><div class="bold"><!---Perc Attribute --->
-							<button class="d6-dice" type='roll' value='&{template:default} {{name=Perception}} {{Roll=[[(@{perception} -@{WoundMod} +@{Force_Up} +?{Dice mods|0} -1)d6cf0cs7 +@{perceptionpip} +?{Other Mods(pip)|0} +1d6!cf1cs6]]}}' >Perception</button>
-							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Perception}} {{Roll=[[(@{perception} -@{WoundMod} +@{Force_Up} +?{Dice mods|0} -1)d6cf0cs7 +@{perceptionpip} +?{Other Mods(pip)|0} +1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type='roll' value='&{template:blue} {{name=Perception}} {{Roll=[[(@{perception} -@{WoundMod} +@{Force_Up} +?{Dice mods|0} -1)d6cf0cs7 +@{perceptionpip} +?{Other Mods(pip)|0} +1d6!cf1cs6]]}}' >Perception</button>
+							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:blue} {{name=Perception}} {{Roll=[[(@{perception} -@{WoundMod} +@{Force_Up} +?{Dice mods|0} -1)d6cf0cs7 +@{perceptionpip} +?{Other Mods(pip)|0} +1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_perception" class="smallnumber"  min="1" value="3"/>D+<input type="number" name="attr_perceptionpip" class="pipnumber" min="0" max="2" value="0"/>
 							</div>
 						</div>
 						<fieldset class="repeating_perckills"> <!---Perc Skills --->
-							<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type="roll" value="&{template:blue} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:blue} {{name=@{perckillname}}} {{Roll=[[(@{perckilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{perckillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							  <input class="skilltext" type="text" name="attr_perckillname"/> <!-- Misspelled attr name iis to be left as it is, otherwise it wipes char sheets from perseption skills-->
 							  <div class="right">
 								<input type="number" name="attr_perckilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_perckillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/> 
@@ -163,15 +163,15 @@
 						</fieldset>
 					</td>
 					<td class="tdborder"><div class="bold"><!---Str Attribute --->
-							<button class="d6-dice" type='roll' value='&{template:default} {{name=Strength}} {{Roll=[[(@{strength} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
-							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Strength}} {{Roll=[[(@{strength} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type='roll' value='&{template:blue} {{name=Strength}} {{Roll=[[(@{strength} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Strength</button>
+							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:blue} {{name=Strength}} {{Roll=[[(@{strength} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strengthpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_strength" class="smallnumber" min="1" value="3"/>D+<input type="number" name="attr_strengthpip" class="pipnumber" min="0" max="2" value="0"/>  
 							</div>
 						</div>
 						<fieldset class="repeating_strskills"> <!---Str Skills --->
-							<button class="d6-dice" type="roll" value="&{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide" type="roll" value="/w gm &{template:default} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type="roll" value="&{template:blue} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide" type="roll" value="/w gm &{template:blue} {{name=@{strskillname}}} {{Roll=[[(@{strskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{strskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							  <input class="skilltext" type="text" name="attr_strskillname"/> 
 							  <div class="right">
 								<input type="number" name="attr_strskilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_strskillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/> 
@@ -179,15 +179,15 @@
 						</fieldset>			
 					</td> 
 					<td class="tdborder"><div class="bold"><!---Tech Attribute --->
-							<button class="d6-dice" type='roll' value='&{template:default} {{name=Technical}} {{Roll=[[(@{technical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
-							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Technical}} {{Roll=[[(@{technical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type='roll' value='&{template:blue} {{name=Technical}} {{Roll=[[(@{technical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Technical</button>
+							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:blue} {{name=Technical}} {{Roll=[[(@{technical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{technicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_technical" class="smallnumber" min="1" value="3"/>D+<input type="number" name="attr_technicalpip" class="pipnumber" min="0" max="2" value="0"/>    
 							</div>
 						</div>
 						<fieldset class="repeating_techskills">  <!---Tech Skills --->
-							<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type="roll" value="&{template:blue} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:blue} {{name=@{techskillname}}} {{Roll=[[(@{techskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{techskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							  <input class="skilltext" type="text" name="attr_techskillname"/> 
 							  <div class="right">
 								<input type="number" name="attr_techskilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_techskillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/> 
@@ -197,15 +197,15 @@
 				</tr>
 				<tr>
 					<td class="tdborder"><div class="bold"> <!---Dex Attribute --->
-							<button class="d6-dice" type='roll'value='&{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
-							<button class="d6-dice gmroll gmroll-hide" type='roll'value='/w gm &{template:default} {{name=Dexterity}} {{Roll=[[(@{dexterity} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type='roll'value='&{template:blue} {{name=Dexterity}} {{Roll=[[(@{dexterity} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Dexterity</button>
+							<button class="d6-dice gmroll gmroll-hide" type='roll'value='/w gm &{template:blue} {{name=Dexterity}} {{Roll=[[(@{dexterity} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexteritypip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_dexterity" class="smallnumber" min="1" value="3"/>D+<input type="number" name="attr_dexteritypip" class="pipnumber" min="0" max="2" value="0"/>
 							</div>
 						</div>
 						<fieldset class="repeating_dexskills"> <!---Dex Skills --->
-							<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type="roll" value="&{template:blue} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:blue} {{name=@{dexskillname}}} {{Roll=[[(@{dexskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{dexskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							  <input class="skilltext" type="text" name="attr_dexskillname"/>
 							  <div class="right">		
 								<input type="number" name="attr_dexskilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_dexskillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/>
@@ -213,15 +213,15 @@
 						</fieldset>
 					</td>
 					<td class="tdborder"><div class="bold"> <!---Know Attribute ---> 
-							<button class="d6-dice" type='roll' value='&{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
-							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:default} {{name=Knowledge}} {{Roll=[[(@{knowledge} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
+							<button class="d6-dice" type='roll' value='&{template:blue} {{name=Knowledge}} {{Roll=[[(@{knowledge} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' >Knowledge</button>
+							<button class="d6-dice gmroll gmroll-hide" type='roll' value='/w gm &{template:blue} {{name=Knowledge}} {{Roll=[[(@{knowledge} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowledgepip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_knowledge" class="smallnumber" min="1" value="3"/>D+<input type="number" name="attr_knowledgepip" class="pipnumber" min="0" max="2" value="0"/>
 							</div>
 						</div>
 						<fieldset class="repeating_knowskills">  <!---Know Skills --->
-							<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type="roll" value="&{template:blue} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:blue} {{name=@{knowskillname}}} {{Roll=[[(@{knowskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{knowskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							<input class="skilltext" type="text" name="attr_knowskillname"/> 
 							<div class="right">
 								<input type="number" name="attr_knowskilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_knowskillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/> 
@@ -229,15 +229,15 @@
 						</fieldset>
 					</td> 
 					<td class="tdborder"><div class="bold"><!---Mech Attribute --->
-							<button class="d6-dice"  type='roll' value='&{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Mechanical</button>
-							<button class="d6-dice gmroll gmroll-hide"  type='roll' value='/w gm &{template:default} {{name=Mechanical}} {{Roll=[[(@{mechanical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' ><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type='roll' value='&{template:blue} {{name=Mechanical}} {{Roll=[[(@{mechanical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}'>Mechanical</button>
+							<button class="d6-dice gmroll gmroll-hide"  type='roll' value='/w gm &{template:blue} {{name=Mechanical}} {{Roll=[[(@{mechanical} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechanicalpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}' ><span class="redtxt">GM</span></button>
 							<div style="float:right;">
 								<input type="number" name="attr_mechanical" class="smallnumber" min="1" value="3"/>D+<input type="number" name="attr_mechanicalpip" class="pipnumber" min="0" max="2" value="0"/>
 							</div>
 						</div>
 						<fieldset class="repeating_mechskills">  <!---Mech Skills --->      
-							<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
-							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
+							<button class="d6-dice"  type="roll" value="&{template:blue} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"></button>
+							<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:blue} {{name=@{mechskillname}}} {{Roll=[[(@{mechskilldice} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs7 + @{mechskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span></button>
 							<input class="skilltext" type="text" name="attr_mechskillname"/> 
 							<div class="right">
 								<input type="number" name="attr_mechskilldice" class="smallnumber shortnumber" min="1" value="3"/>D+<input type="number" name="attr_mechskillpip" class="pipnumber shortnumber" min="0" max="2" value="0"/> 
@@ -271,10 +271,10 @@
 					<input class="smallnumber shortnumber" type="number" name="attr_ROF"/>
 					<input class="mediumnumber shortnumber" type="number" name="attr_Ammo"/>
 
-					<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs0 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Atk</button>				
-					<button class="d6-dice"  type="roll" value="&{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Dmg</button>
-					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs0 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>Atk</button>				
-					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}"><span class="redtxt">GM</span>Dmg</button>
+					<button class="d6-dice"  type="roll" value="&{template:red} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs0 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}">Atk</button>				
+					<button class="d6-dice"  type="roll" value="&{template:red} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}">Dmg</button>
+					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:red} {{name=@{weapon}}} {{Roll=[[(@{weaponskill} -@{WoundMod} +@{Force_Up} + ?{Dice mods|0} -1)d6cf0cs0 + @{weaponskillpip} + ?{Other Mods(pip)|0} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>Atk</button>				
+					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:red} {{name=@{weapon} damage}} {{Roll=[[(@{damagedice}- 1)d6cf0cs7 + @{damagepip} + (1d6!cf1cs6)]]}}"><span class="redtxt">GM</span>Dmg</button>
 				</fieldset>
 			<table>
 				<tr>
@@ -290,12 +290,12 @@
 					<input type="number" name="attr_armorPhDice" class="smallnumber shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorPhPip" class="pipnumber shortnumber" min="0" max="2" value="0"/>
 					<input type="number" name="attr_armorEnDice" class="smallnumber shortnumber" min="0" value="1"/>D+<input type="number" name="attr_armorEnPip" class="pipnumber shortnumber" min="0" max="2" value="0"/>
 					<input class="skilltext" type="text" name="attr_armor_other"/>
-					<button class="d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} +@{armorPhDice} -@{WoundMod} -1)d6cf0cs0 +@{armorPhPip} +1d6!cf1cs6]]}}">Physical</button>
-					<button class="d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} +@{armorEnDice} -@{WoundMod} -1)d6cf0cs0 +@{armorEnPip} +1d6!cf1cs6]]}}">Energy</button>
-					<button class="d6-dice"  type="roll" value="&{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} -@{WoundMod} -1)d6cf0cs7 +1d6!cf1cs6]]}}">Str only</button>	  
-					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} +@{armorPhDice} -@{WoundMod} -1)d6cf0cs0 + @{armorPhPip} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>P</button>
-					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} +@{armorEnDice} -@{WoundMod} -1)d6cf0cs0 + @{armorEnPip} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>E</button>
-					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:default} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} -@{WoundMod} -1)d6cf0cs0 + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>S</button>	  
+					<button class="d6-dice"  type="roll" value="&{template:red} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} +@{armorPhDice} -@{WoundMod} -1)d6cf0cs0 +@{armorPhPip} +1d6!cf1cs6]]}}">Physical</button>
+					<button class="d6-dice"  type="roll" value="&{template:red} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} +@{armorEnDice} -@{WoundMod} -1)d6cf0cs0 +@{armorEnPip} +1d6!cf1cs6]]}}">Energy</button>
+					<button class="d6-dice"  type="roll" value="&{template:red} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} -@{WoundMod} -1)d6cf0cs7 +1d6!cf1cs6]]}}">Str only</button>	  
+					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:red} {{name=Damage Soak(Physical)}} {{Roll=[[(@{strength} +@{armorPhDice} -@{WoundMod} -1)d6cf0cs0 + @{armorPhPip} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>P</button>
+					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:red} {{name=Damage Soak(Energy)}} {{Roll=[[(@{strength} +@{armorEnDice} -@{WoundMod} -1)d6cf0cs0 + @{armorEnPip} + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>E</button>
+					<button class="d6-dice gmroll gmroll-hide"  type="roll" value="/w gm &{template:red} {{name=Damage Soak(Strength only)}} {{Roll=[[(@{strength} -@{WoundMod} -1)d6cf0cs0 + 1d6!cf1cs6]]}}"><span class="redtxt">GM</span>S</button>	  
 				</fieldset>
 		</div>
 		<div class="section force-hide"> <!--------------------------- Force -->

--- a/D6StarWars/README.md
+++ b/D6StarWars/README.md
@@ -8,7 +8,7 @@ The text areas are expandable for additional info.
 
 ## [Wiki page for the sheet](https://wiki.roll20.net/Star_Wars_WEG_D6_character_sheet)
 
-## [Changelog](https://raw.githubusercontent.com/Roll20/roll20-character-sheets/tree/master/D6StarWars/CHANGELOG.md)
+## [Changelog](https://github.com/Roll20/roll20-character-sheets/blob/master/D6StarWars/CHANGELOG.md)
 
 Good source for all things D6 Star wars related, including fanmade conversions of campaign settings, forums and more:
 


### PR DESCRIPTION
- readme link fix
- attribute/skill rolls use blue template, weapons/armor use red, initiative/custom rolls use black
