### PR TITLE
Escape reserved HTML tags using backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Due to copyright restrctions, please don't attempt to include functionality for 
 
 
 **Don't Use Reserved HTML**
-Your HTML file must **not** have a <head> or <body> tag, or your character sheet may not load in the virtual tabletop.
+Your HTML file must **not** have a `<head>` or `<body>` tag, or your character sheet may not load in the virtual tabletop.
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Due to copyright restrctions, please don't attempt to include functionality for 
 
 
 **Don't Use Reserved HTML**
+
 Your HTML file must **not** have a `<head>` or `<body>` tag, or your character sheet may not load in the virtual tabletop.
 
 License


### PR DESCRIPTION
This prevents an issue where the `<head>` and `<body>` tags were not displaying on GitHub, causing the readme to read:

> Your HTML file must **not** have a or tag, or your character sheet may not load in the virtual tabletop.

This PR also adds a newline after the "**Don't Use Reserved HTML**" line, so that the pseudo-heading and the comment do not run together.