### PR TITLE
W&G ver 2.2

### DIFF
--- a/Wrath and Glory API/wrath_and_glory_api.html
+++ b/Wrath and Glory API/wrath_and_glory_api.html
@@ -1,5 +1,7 @@
 <!-- WRATH & GLORY Multi-tab character sheet integrated with the Wrath & Glory API Die Roller  -->
-<!-- Version: 2.1 -->
+<!-- Version: 2.2 -->
+<input  type="hidden" value="0" name="attr_sheetversion"/>
+<input  type="hidden" value="2.2" name="attr_release"/>
 <!-- Begin Character sheets with Background -->
 <div class="wrapper">
 
@@ -64,7 +66,7 @@
 									<textarea placeholder="Enter Tier Ascension notes here." class="sheet-tooltip sheet-width-W75" name="attr_TierAscensionNotes-tooltip" title="Tier Ascension Notes"></textarea>
 								</td>
 								<td class="sheet-width-W45 sheet-left"><span class="sheet-background sheet-right">Custom:</span>
-									<input class="sheet-2digitspin-button" type="number" name="attr_customtier" title="Custom Tier Value; use only if Tier is greater than 5."/>
+									<input class="sheet-2digitspin-button" type="number" name="attr_customtier" value="0" title="Custom Tier Value; use only if Tier is greater than 5."/>
 								</td>
 							</tr>
 						</table>
@@ -123,10 +125,16 @@
 					<tr>
 						<td class="sheet-width-W5 sheet-left"><span class="sheet-background">Keywords:</span></td>
 						<td class="sheet-width-W95"><input class="sheet-width-W100" type="text" name="attr_keywords" title="Character keywords." style="width:98%;margin-left:4px;"/></td>
-					</tr>				
+					</tr>
+				</table>
+				<table>
+					<tr>
+						<td class="sheet-width-W6"></td>
+						<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_keywordPsyker" value="1" title="Check if the character is a psyker; this applies 1/2 WillPower to the base DR of force weapons."/></td>
+						<td class="sheet-width-W90 sheet-left"><span class="sheet-background">Psyker</span></td>
+					</tr>					
 				</table>		
 			</div>
-			<br>
 			<!-- Attributes and Mental/Social Traits -->
 			<div class="sheet-2colrow" width="100%"> 	
 				<!-- COLUMN 1 - Attributes -->
@@ -403,58 +411,6 @@
 						</table>
 				</div>
 			</div>
-
-			<!--- SAVED FOR FUTURE USE WHEN FULL RULES ARE RELEASED To be used to modify calculated values identified from core rules -->
-			<!---<div class="sheet-header" title="Use this section to apply permanent modifiers to calculated values.">Fixed Modifiers</div>
-				<div class="sheet-subsection">	
-					<table> 
-							<tr> 
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Might:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_MiScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Prowess:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_PrScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Quickness:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_QuScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Vigor:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_ViScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Charisma:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_ChScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Insight:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_InScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Logic:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_LoScoreMod" value="0" /></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Resolve:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input class="sheet-spin-button" type="number" name="attr_ReScoreMod" value="0" /></td>
-							</tr>
-							<tr> 
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Avoidance:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0" name="attr_AvoidanceMod" title="The total of all modifications to Avoidance."/></span></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Fortitude:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_FortitudeMod" title="The total of all modifications to Fortitude."/></span></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Discipline:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_DisciplineMod" title="The total of all modifications to Discipline."/></span></td>			
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Stamina:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_StaminaMod" title="The total of all modifications to Stamina."/></span></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Wounds:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_WoundsMod" title="The total of all modifications to Wounds."/></span></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Burnout:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_BOMod" title="The total of all modifications to Burnout Threshold."/></span></td>		
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Horror:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_HorrorMod" title="The total of all modifications to Horror Points."/></span></td>
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >Pace:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_PaceMod" title="The total of all modifications to Pace."/></span></td>
-							</tr>
-							<tr>										
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >AR Bal:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_BallisticARMod" title="The total of all modifications to Ballistic Armor Rating."/></span></td>												
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >AR Mel:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_MeleeARMod" title="The total of all modifications to Melee Armor Rating."/></span></td>												
-								<td class="sheet-width-W6 sheet-right"><span class="sheet-large-textblock sheet-spin-button" >AR Eng:</span></td>
-								<td class="sheet-width-W6 sheet-center"><input  class="sheet-width-W95 sheet-large-textblock sheet-spin-button" type="number" value="0"  name="attr_EnergyARMod" title="The total of all modifications to Energy Armor Rating."/></span></td>
-							</tr>
-					</table>
-				</div>	-->
-
 		</div>
 	
 		<!-- Tab 2: SKILLS -------------------------------------------------------------------------------------->
@@ -473,7 +429,7 @@
 					<th class="sheet-width-W10"><H3>Assist</H3></th>
 				</tr>
 				<tr>
-					<td><H5>Athletics</H5></td>									
+					<td><H5 title="Physical prowess used for climbing, swimming, and acrobatics.">Athletics</H5></td>									
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_AthBaseRat" value="0" title="Base Athletics score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_AthLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -518,7 +474,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Awareness</H5></td>								
+					<td><H5 title="Notice details or perceive hidden or obscured objects - including clues.">Awareness</H5></td>								
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_AwareBaseRat" value="0" title="Base Awareness score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_AwareLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -563,7 +519,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Ballistic Skill</H5></td>							
+					<td><H5 title="Competency with firearms used to make attacks with ranged weapons, maintain/repair ranged weapons, and working knowledge of firearms.">Ballistic Skill</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_BallBaseRat" value="0" title="Base Ballistic score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_BallLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -608,7 +564,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Cunning</H5></td>							
+					<td><H5 title="Locate and interact with parties to obtain goods, services and information outside of traditional/official channels. Also used to question a witness or person of interest.">Cunning</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_CunnBaseRat" value="0" title="Base Cunning score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_CunnLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -653,7 +609,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Deception</H5></td>							
+					<td><H5 title="Tell a credible lie; resisted by Deception.">Deception</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_DecepBaseRat" value="0" title="Base Deception score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_DecepLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -698,7 +654,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Insight</H5></td>							
+					<td><H5 title="Determine motives, goals, read social clues, and see through lies.  Resists Deception.">Insight</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_insightBaseRat" value="0" title="Base Insight score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_insightLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -743,7 +699,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Intimidation</H5></td>							
+					<td><H5 title="Frighten a foe into making a mistake in combat or exert force of will to cow an opponent into taking an action.  Resisted by Intimidation or Resolve.">Intimidation</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_IntimBaseRat" value="0" title="Base Intimidation score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_IntimLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -788,7 +744,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Investigation</H5></td>							
+					<td><H5 title="Research and assemble clues into a coherent picture by revealing motives and inconsistencies.">Investigation</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_InvestBaseRat" value="0" title="Base Investigation score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_InvestLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -833,7 +789,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Leadership</H5></td>							
+					<td><H5 title="Execute a strategy without error, inspire to exceed abilities through encouragement or intimidation. Used to remove combat effects.">Leadership</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_LeadBaseRat" value="0" title="Base Leadership score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_LeadLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -878,7 +834,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Medicae</H5></td>							
+					<td><H5 title="Diagnose and heal wounds, cure diseases, counter toxins, and other problems of the physical body.">Medicae</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_MediBaseRat" value="0" title="Base Medicae score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_MediLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -923,7 +879,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Persuasion</H5></td>							
+					<td><H5 title="Use logic, emotional requests, and seduction to persuade an opponent into taking an action.  Resisted by itself or Resolve.">Persuasion</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_PersBaseRat" value="0" title="Base Persuasion score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_PersLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -944,12 +900,12 @@
 					<td class="sheet-center">
 						<button class="sheet-diebutton-api" type="roll" 
 								title="Click to make a Persuasion skill test." 
-								value="!wag {{[[[[@{PersTotal} + @{PersBonusRoll} - 1]]d6]]}} {{[[1d6]]}} --Name|@{character_name} --Skill|Persuasion Assist --Modifier|@{PersRollMod}"
+								value="!wag {{[[[[@{PersTotal} + @{PersBonusRoll} - 1]]d6]]}} {{[[1d6]]}} --Name|@{character_name} --Skill|Persuasion --Modifier|@{PersRollMod}"
 								name="roll_PersuasionAssist" style="font-size: 175%;">
 						</button>
 						<button class="sheet-diebutton-simple" type="roll"
 								title="Click to make a Persuasion skill test." 
-								value="&{template:roll_dicepool} {{name=@{character_name} makes a Persuasion Skill Assist roll}} {{dice=[[@{PersTotal} + @{PersBonusRoll}]]}} {{roll=[[[[@{PersTotal} + @{PersBonusRoll} - {1}]]d6>4]]}} {{wrath=[[1d6]]}}"
+								value="&{template:roll_dicepool} {{name=@{character_name} makes a Persuasion Skill roll}} {{dice=[[@{PersTotal} + @{PersBonusRoll}]]}} {{roll=[[[[@{PersTotal} + @{PersBonusRoll} - {1}]]d6>4]]}} {{wrath=[[1d6]]}}"
 								name="roll_dice4PersuasionAssist" style="font-size: 175%;">
 						</button>	
 					</td>	
@@ -968,7 +924,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Pilot</H5></td>							
+					<td><H5 title="Driving a land, sea, air or void vehicle. Opposed by itself in a chase.">Pilot</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_PilotBaseRat" value="0" title="Base Pilot score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_PilotLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1013,7 +969,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Psychic Mastery</H5></td>							
+					<td><H5 title="Activate psychic powers; requires Psyker keyword.">Psychic Mastery</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_PsychicBaseRat" value="0" title="Base Psychic Mastery score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_PsychicLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1058,7 +1014,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Scholar</H5></td>							
+					<td><H5 title="Measure of understanding of the greater world; includes forbidden lore and public information.">Scholar</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_SchoBaseRat" value="0" title="Base Scholar score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_SchoLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1103,7 +1059,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Stealth</H5></td>							
+					<td><H5 title="Remain unnoticed through concealment and bypass security measures.">Stealth</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_StealthBaseRat" value="0" title="Base Stealth score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_StealthLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1148,7 +1104,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Survival</H5></td>							
+					<td><H5 title="find basic provisions, secure shelter, navigate surface, and tracking.">Survival</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_SurvBaseRat" value="0" title="Base Survival score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_SurvLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1193,7 +1149,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Tech</H5></td>							
+					<td><H5 title="Utilize, maintain, and repair technology.">Tech</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_TechBaseRat" value="0" title="Base Tech score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_TechLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1238,7 +1194,7 @@
 					</td>	
 				</tr>
 				<tr>
-					<td><H5>Weapon Skill</H5></td>							
+					<td><H5  title="Competency in armed and unarmed melee, conduct maintenance of melee weapons, and familiarity with rare or unknown weapons.">Weapon Skill</H5></td>							
 					<td class="sheet-center"><input class="sheet-spin-button" type="number" name="attr_WpnSkillBaseRat" value="0" title="Base Weapon Skill score."/></td> 
 					<td class="sheet-center">
 						<select class="sheet-width-W95 sheet-dropdown" name="attr_WpnSkillLinkedAttr" value="0"  title="Select the attribute associated with the skill.">
@@ -1364,19 +1320,28 @@
 					<div class="sheet-header">Health</div>
 					<table>
 						<tr>					
-							<td class="sheet-width-W50"><span class="sheet-background">Shock/Current: </span></td>
-							<td class="sheet-width-W50 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_shock" title="Shock Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_shockCurrent" title="Current Shock."/></td>												
+							<td class="sheet-width-W20"><span class="sheet-background">Shock: </span></td>
+							<td class="sheet-width-W40 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_shock_max" readonly title="Shock Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_shock" title="Current Shock."/></td>												
+							<td class="sheet-width-W40"><span class="sheet-background">Mod: </span><input type="number" value="0" name="attr_shockmod" title="Permanent modifier to Shock from race, abilities, talents, or other."/></td>
 						</tr>
 						<tr>				
-							<td class="sheet-width-W50"><span class="sheet-background">Wounds/Current: </span></td>
-							<td class="sheet-width-W50 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_wounds" title="Wound Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_woundsCurrent" title="Current Wounds."/></td>					
+							<td class="sheet-width-W20"><span class="sheet-background">Wounds: </span></td>
+							<td class="sheet-width-W40 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_wounds_max" readonly title="Wound Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_wounds" title="Current Wounds."/></td>					
+							<td class="sheet-width-W40"><span class="sheet-background">Mod: </span><input type="number" value="0" name="attr_woundsmod" title="Permanent modifier to Wounds from race, abilities, talents, or other."/></td>
 						</tr>
-						<tr>	
-							<td class="sheet-width-W50"><span class="sheet-background">Heavily Wounded at:</span></td>
-							<td class="sheet-width-W50 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_heavywound" title="The point the character is considered heavily wounded."/></span></td>								
-						</tr>
+					</table>
+					<table>
 						<tr>
-							<td class="sheet-width-W50"><span class="sheet-background">Soak Value:</span><span class="sheet-circle"><input type="number" value="0" name="attr_Soak" title="Soak."/></span></td>	
+							<td class="sheet-width-W20"><span class="sheet-background">Wnd Lvl:</span></td>	
+							<td class="sheet-width-W10 sheet-left"><span class="sheet-circle"><input type="number" readonly value="0" name="attr_lightwound" title="The point the character is considered lightly wounded."/></span></td>					
+							<td class="sheet-width-W30 sheet-left"><span class="sheet-background">&nbsp;: Lgt(+1DN)</span></td>
+							<td class="sheet-width-W10 sheet-left"><span class="sheet-circle"><input type="number" readonly value="0" name="attr_heavywound" title="The point the character is considered heavily wounded."/></span></td>
+							<td class="sheet-width-W30 sheet-left"><span class="sheet-background">&nbsp;: Hvy(+2DN)</span></td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td class="sheet-width-W30"><span class="sheet-background">Soak Value:</span><span class="sheet-circle"><input type="number" value="0" name="attr_Soak" title="Soak."/></span></td>	
 						</tr>
 					</table>
 				</div>
@@ -1441,7 +1406,12 @@
 							<td class="sheet-width-W20 sheet-left"><input class="sheet-smallspin-button" type="number" value="1" name="attr_gloryUsed" title="Number of Glory spent to roll additional bonus dice."/></td>
 							<td class="sheet-width-W25"><span>Roll Glory </span></td>
 							<td class="sheet-width-W15">
-								<button class="sheet-diebutton-all  sheet-right" type="roll" 
+								<button class="sheet-diebutton-api sheet-diebutton-attack" type="roll" 
+										title="Click to roll Glory dice." 
+										value="!wag {{[[[[@{gloryUsed}]]d6]]}} --Name|@{character_name} --Glory|@{gloryUsed}d6"
+										name="roll_GloryDice" style="font-size: 175%;">
+								</button>
+								<button class="sheet-diebutton-simple  sheet-right" type="roll" 
 										title="Click to roll one or more Dice for Glory." 
 										value="&{template:glory_roll} {{name=@{character_name} Rolls Glory}} {{number=@{gloryUsed}}} {{roll=[[[[@{gloryUsed}]]d6>4]]}}"
 										name="roll_dice4glory" style="font-size: 175%;">
@@ -1456,15 +1426,15 @@
 				<table>
 					<tr>
 						<th class="sheet-width-W15"><H3 class="sheet-header-override" title="name of the weapon.">Weapon</H3></th>
-						<th class="sheet-width-W3"><H3 class="sheet-header-override"title="Weapon traits and additional details.">Notes</H3></th>
-						<th class="sheet-width-W4"><H3 title="Is the weapon a melee weapon?  check so adjusted str is applied.">Mel?</H3></th>
-						<th class="sheet-width-W5"><H3 title="Base Weapon DR">W DR</H3></th>
-						<th class="sheet-width-W4"><H3 title="Adjusted Strength Modifier applied to a melee weapons DR.">+Str</H3></th>
+						<th class="sheet-width-W3"><H3 title="Weapon traits and additional details.">NB</H3></th>
+						<th class="sheet-width-W3"><H3 title="Is the weapon a melee weapon?  check so adjusted str is applied.">Mel?</H3></th>
+						<th class="sheet-width-W3"><H3 title="Is the weapon a force weapon?  check so DR is adjusted based on being a psyker or not.">Frc?</H3></th>
+						<th class="sheet-width-W5"><H3 title="Base Weapon DR">Base DR</H3></th>
 						<th class="sheet-width-W4"><H3 title="Base Weapon DR + Adjusted STR">DR</H3></th>
 						<th class="sheet-width-W5"><H3 title="Number of Extra Dice applied to Damage.">+ED</H3></th>
 						<th class="sheet-width-W5"><H3 title="Armor Piercing Value of the weapon.">AP</H3></th>
-						<th class="sheet-width-W5"><H3 title="The weapons salvo value.">Salvo</H3></th>
-						<th class="sheet-width-W4"><H3 title="Is the weapon out of ammo?">Empty?</H3></th>
+						<th class="sheet-width-W4"><H3 title="The weapons salvo value.">Salvo</H3></th>
+						<th class="sheet-width-W4"><H3 title="EMPTY. Is the weapon out of ammo?">EMTY?</H3></th>
 						<th class="sheet-width-W5"><H3 title="Range of the weapon; enter M for melee.">Rng</H3></th>
 						<th class="sheet-width-W8"><H3 class="sheet-header-override" title="The Skill and Attribute applied to the weapon attack roll; based on the skill on the skills tab.">Skill/Attr</H3></th>
 						<th class="sheet-width-W4"><H3 title="Combined rating of the Skill and Attribute applied to the weapon attack roll; based on the skill on the skills tab.">Rating</H3></th>
@@ -1485,15 +1455,15 @@
 								<input type="checkbox" class="sheet-hover-hidden"/><span></span>
 								<textarea placeholder="Enter additional weapon details -- such as traits with description." class="sheet-tooltip sheet-width-W75" name="attr_wpnDetailTrait-tooltip"></textarea>
 							</td>
-							<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_meleeWpn" value="1" title="Check if the weapon is melee and strength is applied to the DR should be applied."/></td>
+							<td class="sheet-width-W3 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_meleeWpn" value="1" title="Check if the weapon is melee and strength is applied to the DR should be applied."/></td>
+							<td class="sheet-width-W3 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_forceWpn" value="1" title="Check if the weapon is a force weapon; if a psyker add 1/2 Willpower to DR (pg 275), otherwise -2 to DR (pg 292)."/></td>
 							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnBaseDR"  value="0" title="Base Damage Rating of the weapon."/></td>
-							<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_DRStrMod" readonly value="0" title="Strength modifier applied to melee weapons."/></span></td>						
-							<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnDR" disabled="true" value="((@{wpnBaseDR} + @{DRStrMod}))" title="Weapon Base DR + Adjusted Strength."/></span></td>						
+							<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnDR" readonly value="0" title="Weapon Base DR + Adjusted Strength + 1/2 Willpower if psyker and a force weapon or -2 if not a psyker and a force weapon."/></span></td>						
 							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnED"  value="1" title="Weapon Extra Damage Dice to be rolled."/></td>
 							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAP"  value="0" title="Weapon Armor Penetration."/></td>
-							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnSalvo"  value="0" title="Weapon Salvo value."/></td>
+							<td class="sheet-width-W4 sheet-center"><input class="sheet-tiny-textblock sheet-center" type="text" name="attr_wpnSalvo"  value="0" title="Weapon Salvo value."/></td>
 							<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_wpnEmpty" value="1" title="Check if the weapon ammo is out."/></td>
-							<td class="sheet-width-W5 sheet-center"><input class="sheet-verysmall-textblock" type="text" name="attr_wpnRange"  value="0" title="The range of the attack; enter M for melee."/></span></td>					
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-verysmall-textblock sheet-center" type="text" name="attr_wpnRange"  value="0" title="The range of the attack; enter M for melee."/></span></td>					
 							<td class="sheet-width-W8 sheet-center">
 								<select class="sheet-width-W95 smaller-text sheet-meddropdown sheet-left" name="attr_wpnAttackSkill" value="0"  title="Select the skill used to make the attack.">
 									<option value="(0)" selected="true" >None</option>
@@ -1697,14 +1667,23 @@
 			<table>
 				<tr>				
 					<th class="sheet-width-W20"><h3 class="sheet-header-override" title="Name of the Gear or Asset">Gear/Asset</h3></th>
-					<th class="sheet-width-W80"><h3 class="sheet-header-override" title="Brief description of the gear or asset">Brief Description</h3></th>
+					<th class="sheet-width-W5"><h3 class="sheet-header-override" title="Gear Detail">Notes</h3></th>
+					<th class="sheet-width-W70"><h3 class="sheet-header-override" title="Brief description of the gear or asset">Brief Description</h3></th>
+					<th class="sheet-width-W5"><h3 class="sheet-header-override" title="Brief description of the gear or asset">Quantity</h3></th>
 				</tr>
 			</table>
 			<fieldset class="repeating_gear">
 				<table>
 					<tr>
-						<td class="sheet-width-W20"><input class="sheet-width-W95"  type="text" name="attr_gear" placeholder="Gear or Asset Name" /></td>
-						<td class="sheet-width-W80"><input class="sheet-width-W100" type="text" name="attr_gearDescription"/></td>				
+						<td class="sheet-width-W25">
+							<input class="sheet-width-W90 smaller-text sheet-hover" placeholder="Gear" type="text" name="attr_gear" title="name of the weapon."/>		
+							<span class="sheet-tooltip" name="attr_gearDetail-tooltip" ></span>
+							<input type="checkbox" class="sheet-hover-hidden"/><span></span>
+							<textarea placeholder="Enter additional gear details." class="sheet-tooltip sheet-width-W75" name="attr_gearDetail-tooltip"></textarea>
+						</td>
+						<td class="sheet-width-W70"><input class="sheet-width-W100" type="text" name="attr_gearDescription"/></td>
+						<td class="sheet-width-W5"><span class="sheet-circle"><input type="text" class="sheet-width-W100" type="text" name="attr_gearQuantity"/></span></td>				
+
 					</tr>	
 				</table>	
 			</fieldset>
@@ -1873,7 +1852,7 @@
 				<fieldset class="repeating_advancements"> 
 					<table>
 					<tr>		
-						<td class="sheet-width-w95"><input class="sheet-width-W100" type="text" name="attr_AdvancementR" title="List the advancement purchased" placeholder="Advancements Purcheased" /></td>
+						<td class="sheet-width-w95"><input class="sheet-width-W100" type="text" name="attr_AdvancementR" title="List the advancement purchased" placeholder="Advancements Purchased" /></td>
 						<td class="sheet-small-textblock sheet-center"><span class="sheet-circle"><input type="number" name="attr_XPSpent" value="0" title="cost in Build Points (BP) to purchase the advancement" /></span></td>						
 					</tr>
 					</table>
@@ -1913,30 +1892,42 @@
 				<!-- General NPC Details -->
 				<table>
 					<tr>					
-						<td class="sheet-width-W25"><span>Tag:</span><input class="sheet-verylarge-textblock" type="text" name="attr_archetype"/></td>
-						<td class="sheet-width-W25 sheet-center"><span class="sheet-background">Type:</span>
-									<select class="sheet-xtralargedropdown" name="attr_typeOfThreat" value="0"  title="Select the type of threat.">
-										<option value="0" selected="true" ></option>
-										<option value="1">Adversary</option>
-										<option value="2">Elite</option>
-										<option value="3">Mob</option>
-										<option value="4">Monstrous Creature</option>
-										<option value="5">Troop</option>
-									</select>
+						<td class="sheet-width-W24"><span>Tag:</span><input class="sheet-verylarge-textblock" type="text" name="attr_archetype"/></td>
+						<td class="sheet-width-W21"><span class="sheet-background">Type:</span>
+							<select class="sheet-xtralargedropdown" name="attr_typeOfThreat" value="0"  title="Select the type of threat.">
+								<option value="0" selected="true" ></option>
+								<option value="1">Adversary</option>
+								<option value="2">Elite</option>
+								<option value="3">Mob</option>
+								<option value="4">Monstrous Creature</option>
+								<option value="5">Troop</option>
+							</select>
 						</td>
-						<td class="sheet-width-W18 sheet-center"><span class="sheet-background"># Troops/Mob:</span><input class="sheet-2digitspin-button"  type="number"  value="0" name="attr_mobSize" title="Number of Troops in the Mob."/></td>
-						<td class="sheet-width-W18"><span class="sheet-background">Size:</span>
-									<select class="sheet-verylargedropdown" name="attr_npcSize" value="0"  title="Size of the NPC.">
-										<option value="0" selected="true" ></option>
-										<option value="1">Tiny</option>
-										<option value="2">Small</option>
-										<option value="3">Average</option>
-										<option value="4">Large</option>
-										<option value="5">Huge</option>
-										<option value="6">Gargantuan</option>
-									</select>
+							<td class="sheet-width-W16 sheet-left"><span class="sheet-background">Size:</span>
+							<select class="sheet-verylargedropdown" name="attr_npcSize" value="0"  title="Size of the NPC.">
+								<option value="0" selected="true" ></option>
+								<option value="1">Tiny</option>
+								<option value="2">Small</option>
+								<option value="3">Average</option>
+								<option value="4">Large</option>
+								<option value="5">Huge</option>
+								<option value="6">Gargantuan</option>
+							</select>
 						</td>
-						<td class="sheet-width-W9"><span>Ruin:</span><input class="sheet-2digitspin-button" type="number" name="attr_wrath" title="Adversary ruin pool."/></td>
+						<td class="sheet-width-W9 sheet-left"><span class="sheet-background"># Mob:</span><input class="sheet-2digitspin-button"  type="number"  value="0" name="attr_mobSize" title="Number of Troops in the Mob."/></td>
+						<td class="sheet-width-W12"><span class="sheet-background">Tier:</span>
+							<select class="sheet-meddropdown sheet-hover" name="attr_tier" value="1"  title="Character Tier.">
+								<option value="1" selected="true">I</option>
+								<option value="2">II</option>
+								<option value="3">III</option>
+								<option value="4">IV</option>
+								<option value="5">V</option>
+								<option value="6">Custom</option>
+							</select>
+						</td>
+						<td class="sheet-width-W10 sheet-left"><span class="sheet-background sheet-right">Custom:</span>
+							<input class="sheet-2digitspin-button" type="number" name="attr_customtier" value="0" title="Custom Tier Value; use only if Tier is greater than 5."/>
+						</td>
 					</tr>
 				</table>
 				<div>
@@ -1944,11 +1935,17 @@
 						<tr>
 							<td class="sheet-width-W5 sheet-left"><span class="sheet-background">Keywords:</span></td>
 							<td class="sheet-width-W95"><input class="sheet-width-W100" type="text" name="attr_keywords" title="Character keywords." style="width:98%;margin-left:4px;"/></td>
-						</tr>				
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td class="sheet-width-W6"></td>
+							<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_keywordPsyker" value="1" title="Check if the character is a psyker; this applies 1/2 WillPower to the base DR of force weapons."/></td>
+							<td class="sheet-width-W90 sheet-left"><span class="sheet-background">Psyker</span></td>
+						</tr>					
 					</table>		
 				</div>
-				<br>
-				
+
 				<!-- Attributes and Traits -->
 				<div class="sheet-2colrow" width="100%"> 	
 					<!-- COLUMN 1 - Attributes -->
@@ -2158,9 +2155,10 @@
 						<div class="sheet-header">Traits</div>
 						<!-- Defense & Resilience -->
 						<table>	
-								<td class="sheet-width-W30 sheet-left"><span class="sheet-background sheet-right">Reloads:</span><input type="number" value="0" name="attr_reloads" title="Rounds of ammo available."/></td>
-								<td class="sheet-width-W30 sheet-left"><span class="sheet-background">Speed:</span><span class="sheet-circle"><input type="number" value="0" name="attr_speed" title="Speed."/></td>
-								<td class="sheet-width-W40 sheet-left"><span class="sheet-background">Soak </span><span class="sheet-circle"><input type="number" value="0" name="attr_Soak" title="Soak."/></span></td>									
+								<td class="sheet-width-W25 sheet-left"><span class="sheet-background sheet-right">Reloads:</span><input type="number" value="0" name="attr_reloads" title="Rounds of ammo available."/></td>
+								<td class="sheet-width-W25 sheet-left"><span class="sheet-background">Speed:</span><span class="sheet-circle"><input type="number" value="0" name="attr_speed" title="Speed."/></td>
+								<td class="sheet-width-W25 sheet-left"><span class="sheet-background">Soak </span><span class="sheet-circle"><input type="number" value="0" name="attr_Soak" title="Soak."/></span></td>									
+								<td class="sheet-width-W25 sheet-left"><span class="sheet-background">Ruin:</span><input class="sheet-2digitspin-button" type="number" name="attr_wrath" title="Adversary ruin pool."/></td>
 							</tr>
 						</table>
 						<div class="sheet-minorheader">Defensive</div>
@@ -2171,18 +2169,26 @@
 							</tr>	
 						</table>
 						<div class="sheet-minorheader">Health</div>
-						<table>
-							<tr>					
-								<td class="sheet-width-W15"><span class="sheet-background">Shock/Current: </span></td>
-								<td class="sheet-width-W85 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_shock" title="Shock Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_shockCurrent" title="Current Shock."/></td>												
-							</tr>	
-						</table>
-						<table>
-							<tr>				
-								<td class="sheet-width-W15"><span class="sheet-background">Wnds/Current: </span></td>
-								<td class="sheet-width-W30 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_wounds" title="Wound Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_woundsCurrent" title="Current Wounds."/></td>					
-								<td class="sheet-width-W55 sheet-left"><span class="sheet-background">Heavily Wounded at:</span><span class="sheet-circle"><input type="number" value="0" name="attr_heavywound" title="The point the character is considered heavily wounded."/></span></td>								
-							</tr>
+					<table>
+						<tr>					
+							<td class="sheet-width-W20"><span class="sheet-background">Shock: </span></td>
+							<td class="sheet-width-W40 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_shock_max" readonly title="Shock Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_shock" title="Current Shock."/></td>												
+							<td class="sheet-width-W40"><span class="sheet-background">Mod: </span><input type="number" value="0" name="attr_shockmod" title="Permanent modifier to Shock from race, abilities, talents, or other."/></td>
+						</tr>
+						<tr>				
+							<td class="sheet-width-W20"><span class="sheet-background">Wounds: </span></td>
+							<td class="sheet-width-W40 sheet-left"><span class="sheet-circle"><input type="number" value="0" name="attr_wounds_max" readonly title="Wound Rating."/></span><span> / </span><input class="sheet-spin-button" type="number" value="0" name="attr_wounds" title="Current Wounds."/></td>					
+							<td class="sheet-width-W40"><span class="sheet-background">Mod: </span><input type="number" value="0" name="attr_woundsmod" title="Permanent modifier to Wounds from race, abilities, talents, or other."/></td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td class="sheet-width-W20"><span class="sheet-background">Wnd Lvl:</span></td>	
+							<td class="sheet-width-W10 sheet-left"><span class="sheet-circle"><input type="number" readonly value="0" name="attr_lightwound" title="The point the character is considered lightly wounded."/></span></td>					
+							<td class="sheet-width-W30 sheet-left"><span class="sheet-background">&nbsp;: Lgt(+1DN)</span></td>
+							<td class="sheet-width-W10 sheet-left"><span class="sheet-circle"><input type="number" readonly value="0" name="attr_heavywound" title="The point the character is considered heavily wounded."/></span></td>
+							<td class="sheet-width-W30 sheet-left"><span class="sheet-background">&nbsp;: Hvy(+2DN)</span></td>	</tr>
+					</table>
 						</table>
 						<div class="sheet-minorheader">Combat Rolls</div>
 						<table>
@@ -2384,15 +2390,15 @@
 				<table>
 					<tr>
 						<th class="sheet-width-W15"><H3 class="sheet-header-override" title="name of the weapon.">Weapon</H3></th>
-						<th class="sheet-width-W3"><H3 class="sheet-header-override"title="Weapon traits and additional details.">Notes</H3></th>
-						<th class="sheet-width-W4"><H3 title="Is the weapon a melee weapon?  check so adjusted str is applied.">Mel?</H3></th>
-						<th class="sheet-width-W5"><H3 title="Base Weapon DR">W DR</H3></th>
-						<th class="sheet-width-W4"><H3 title="Adjusted Strength Modifier applied to a melee weapons DR.">+Str</H3></th>
+						<th class="sheet-width-W3"><H3 title="Weapon traits and additional details.">NB</H3></th>
+						<th class="sheet-width-W3"><H3 title="Is the weapon a melee weapon?  check so adjusted str is applied.">Mel?</H3></th>
+						<th class="sheet-width-W3"><H3 title="Is the weapon a force weapon?  check so DR is adjusted based on being a psyker or not.">Frc?</H3></th>
+						<th class="sheet-width-W5"><H3 title="Base Weapon DR">Base DR</H3></th>
 						<th class="sheet-width-W4"><H3 title="Base Weapon DR + Adjusted STR">DR</H3></th>
 						<th class="sheet-width-W5"><H3 title="Number of Extra Dice applied to Damage.">+ED</H3></th>
 						<th class="sheet-width-W5"><H3 title="Armor Piercing Value of the weapon.">AP</H3></th>
-						<th class="sheet-width-W5"><H3 title="The weapons salvo value.">Salvo</H3></th>
-						<th class="sheet-width-W4"><H3 title="Is the weapon out of ammo?">Empty?</H3></th>
+						<th class="sheet-width-W4"><H3 title="The weapons salvo value.">Salvo</H3></th>
+						<th class="sheet-width-W4"><H3 title="EMPTY. Is the weapon out of ammo?">EMTY?</H3></th>
 						<th class="sheet-width-W5"><H3 title="Range of the weapon; enter M for melee.">Rng</H3></th>
 						<th class="sheet-width-W8"><H3 class="sheet-header-override" title="The Skill and Attribute applied to the weapon attack roll; based on the skill on the skills tab.">Skill/Attr</H3></th>
 						<th class="sheet-width-W4"><H3 title="Combined rating of the Skill and Attribute applied to the weapon attack roll; based on the skill on the skills tab.">Rating</H3></th>
@@ -2405,62 +2411,62 @@
 					</tr>	
 				</table>
 				<fieldset class="repeating_weapon">
-						<table>
-							<tr>
-								<td class="sheet-width-W18">
-									<input class="sheet-width-W85 smaller-text sheet-hover" placeholder="Weapon Name" type="text" name="attr_Weapon" title="name of the weapon."/>		
-									<span class="sheet-tooltip" name="attr_wpnDetailTrait-tooltip" ></span>
-									<input type="checkbox" class="sheet-hover-hidden"/><span></span>
-									<textarea placeholder="Enter additional weapon details -- such as traits with description." class="sheet-tooltip sheet-width-W75" name="attr_wpnDetailTrait-tooltip"></textarea>
-								</td>
-								<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_meleeWpn" value="1" title="Check if the weapon is melee and strength is applied to the DR should be applied."/></td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnBaseDR"  value="0" title="Base Damage Rating of the weapon."/></td>
-								<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_DRStrMod" readonly value="0" title="Strength modifier applied to melee weapons."/></span></td>						
-								<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnDR" disabled="true" value="((@{wpnBaseDR} + @{DRStrMod}))" title="Weapon Base DR + Adjusted Strength."/></span></td>						
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnED"  value="1" title="Weapon Extra Damage Dice to be rolled."/></td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAP"  value="0" title="Weapon Armor Penetration."/></td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnSalvo"  value="0" title="Weapon Salvo value."/></td>
-								<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_wpnEmpty" value="1" title="Check if the weapon ammo is out."/></td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-verysmall-textblock" type="text" name="attr_wpnRange"  value="0" title="The range of the attack; enter M for melee."/></span></td>					
-								<td class="sheet-width-W8 sheet-center">
-									<select class="sheet-width-W95 smaller-text sheet-meddropdown sheet-left" name="attr_wpnAttackSkill" value="0"  title="Select the skill used to make the attack.">
-										<option value="(0)" selected="true" >None</option>
-										<option value="(@{BallTotal})">BS/AG</option>
-										<option value="(@{WpnSkillTotal})">WS/IN</option>
-									</select>
-								</td>	
-								<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnAttkSkill" disabled="true" value="((@{wpnAttackSkill}))" title="Attribute + Skill modifier.  Does not include BD or Mod from the attribute or skill table."/></span></td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAttBD"  value="0" title="Bonus Dice for Attack Roll."/></td>	
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAttMod"  value="0" title="Modifier to each die rolled on the attack."/></td>	
-								<td class="sheet-width-W4 sheet-center">
-									<button class="sheet-diebutton-attack sheet-diebutton-api" type="roll" 
-										title="Click to make an Attack test with '+@{Weapon}+'." 
-										value="!wag {{[[[[@{wpnAttkSkill} + @{wpnAttBD} - 1]]d6]]}} {{[[1d6]]}} --Name|@{character_name} --Attack|@{Weapon} --Bonus Dice|@{wpnAttBD} --Modifier|@{wpnAttMod}"
-										name="roll_NPCWeaponAttackTest" style="font-size: 175%;">
-									</button>
-									<button class="sheet-diebutton-attack sheet-diebutton-simple" type="roll"
-											title="Click to make an Attack test with '+@{Weapon}+'." 
-											value="&{template:roll_dicepool} {{name=@{character_name} makes an Attack test with '+@{Weapon}+'.}} {{dice=[[@{wpnAttkSkill} + @{wpnAttBD}]]}} {{roll=[[[[@{wpnAttkSkill} + @{wpnAttBD} - {1}]]d6>4]]}} {{wrath=[[1d6]]}}"
-											name="roll_NPCdice4NPCWeaponAttackTest" style="font-size: 175%;">
-									</button>	
-								</td>
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnDmgBD"  value="0" title="Bonus Dice for Damage Roll."/></td>	
-								<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnDmgMod"  value="0" title="Modifier to each die rolled for Damage."/></td>		
-								<td class="sheet-width-W4 sheet-center">
-									<button class="sheet-diebutton-damage sheet-diebutton-api" type="roll" 
-										title="Click to roll damage for '+@{Weapon}+'." 
-										value="!wag {{[[[[@{wpnED} + @{wpnDmgBD}]]d6]]}} {{[[@{wpnDmgMod}]]}} --Name|@{character_name} --Damage|@{Weapon} --DR/AP|@{wpnDR}/@{wpnAP} --Modifier|@{wpnDmgMod}"
-										name="roll_NPCWpnDamage" style="font-size: 175%;">
-									</button>
-									<button class="sheet-diebutton-damage sheet-diebutton-simple" type="roll"
-											title="Click to roll damage for '+@{Weapon}+'." 
-											value="&{template:roll_dicepool_nowrath} {{name=@{character_name} rolls damage for '+@{Weapon}+'.}} {{dice=[[@{wpnED} + @{wpnDmgBD}]]}} {{roll=[[[[@{wpnED} + @{wpnDmgBD}]]d6>4]]}}"
-											name="roll_NPCdice4NPCWpnDamage" style="font-size: 175%;">
-									</button>	
-								</td>											
-							</tr>
-						</table>
-					</fieldset>
+					<table>
+						<tr>
+							<td class="sheet-width-W18">
+								<input class="sheet-width-W85 smaller-text sheet-hover" placeholder="Weapon Name" type="text" name="attr_Weapon" title="name of the weapon."/>		
+								<span class="sheet-tooltip" name="attr_wpnDetailTrait-tooltip" ></span>
+								<input type="checkbox" class="sheet-hover-hidden"/><span></span>
+								<textarea placeholder="Enter additional weapon details -- such as traits with description." class="sheet-tooltip sheet-width-W75" name="attr_wpnDetailTrait-tooltip"></textarea>
+							</td>
+							<td class="sheet-width-W3 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_meleeWpn" value="1" title="Check if the weapon is melee and strength is applied to the DR should be applied."/></td>
+							<td class="sheet-width-W3 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_forceWpn" value="1" title="Check if the weapon is a force weapon; if a psyker add 1/2 Willpower to DR (pg 275), otherwise -2 to DR (pg 292)."/></td>
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnBaseDR"  value="0" title="Base Damage Rating of the weapon."/></td>
+							<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnDR" readonly value="0" title="Weapon Base DR + Adjusted Strength + 1/2 Willpower if psyker and a force weapon or -2 if not a psyker and a force weapon."/></span></td>						
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnED"  value="1" title="Weapon Extra Damage Dice to be rolled."/></td>
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAP"  value="0" title="Weapon Armor Penetration."/></td>
+							<td class="sheet-width-W4 sheet-center"><input class="sheet-tiny-textblock sheet-center" type="text" name="attr_wpnSalvo"  value="0" title="Weapon Salvo value."/></td>
+							<td class="sheet-width-W4 sheet-center"><input class="sheet-objective-checkbox sheet-center" type="checkbox" name="attr_wpnEmpty" value="1" title="Check if the weapon ammo is out."/></td>
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-verysmall-textblock sheet-center" type="text" name="attr_wpnRange"  value="0" title="The range of the attack; enter M for melee."/></span></td>					
+							<td class="sheet-width-W8 sheet-center">
+								<select class="sheet-width-W95 smaller-text sheet-meddropdown sheet-left" name="attr_wpnAttackSkill" value="0"  title="Select the skill used to make the attack.">
+									<option value="(0)" selected="true" >None</option>
+									<option value="(@{BallTotal})">BS/AG</option>
+									<option value="(@{WpnSkillTotal})">WS/IN</option>
+								</select>
+							</td>	
+							<td class="sheet-width-W4 sheet-center"><span class="sheet-circle"><input type="number" name="attr_wpnAttkSkill" disabled="true" value="((@{wpnAttackSkill}))" title="Attribute + Skill modifier.  Does not include BD or Mod from the attribute or skill table."/></span></td>
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAttBD"  value="0" title="Bonus Dice for Attack Roll."/></td>	
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnAttMod"  value="0" title="Modifier to each die rolled on the attack."/></td>	
+							<td class="sheet-width-W4 sheet-center">
+								<button class="sheet-diebutton-api sheet-diebutton-attack" type="roll" 
+										title="Click to make an Attack roll." 
+										value="!wag {{[[[[@{wpnAttkSkill} + @{wpnAttBD} - 1]]d6]]}} {{[[1d6]]}} --Name|@{character_name} --Attack with|@{Weapon} --Bonus Dice|@{wpnAttBD} --Modifier|@{wpnAttMod}"
+										name="roll_repeatingWeaponattack" style="font-size: 175%;">
+								</button>
+								<button class="sheet-diebutton-simple sheet-diebutton-attack" type="roll"
+										title="Click to make an Attack roll." 
+										value="&{template:roll_dicepool} {{name=@{character_name} makes an Attack test.}} {{dice=[[@{wpnAttkSkill} + @{wpnAttBD}]]}} {{roll=[[[[@{wpnAttkSkill} + @{wpnAttBD} - {1}]]d6>4]]}} {{wrath=[[1d6]]}}"
+										name="roll_dice4repeatingWeaponattack" style="font-size: 175%;">
+								</button>	
+							</td>
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnDmgBD"  value="0" title="Bonus Dice for Damage Roll."/></td>	
+							<td class="sheet-width-W5 sheet-center"><input class="sheet-smallspin-button" type="number" name="attr_wpnDmgMod"  value="0" title="Modifier to each die rolled for Damage."/></td>		
+							<td class="sheet-width-W4 sheet-center">
+								<button class="sheet-diebutton-api sheet-diebutton-damage" type="roll" 
+										title="Click to make a Damage roll with '+@{Weapon}+'." 
+										value="!wag {{[[[[@{wpnED} + @{wpnDmgBD}]]d6]]}} --Name|@{character_name} --Damage with|@{Weapon} --DR/AP|@{wpnDR}/@{wpnAP} --Modifier|@{wpnDmgMod}"
+										name="roll_wpnDamage" style="font-size: 175%;">
+								</button>
+								<button class="sheet-diebutton-simple sheet-diebutton-damage" type="roll"
+										title="Click to make a Damage roll with '+@{Weapon}+'." 
+										value="&{template:roll_dicepool_nowrath} {{name=@{character_name} does damage with '+@{Weapon}+'.}} {{dice=[[@{wpnED} + @{wpnDmgBD}]]}} {{roll=[[[[@{wpnED} + @{wpnDmgBD}]]d6>4]]}}"
+										name="roll_dice4wpnDamage" style="font-size: 175%;">
+								</button>	
+							</td>											
+						</tr>
+					</table>
+				</fieldset>
 			
 				<!-- Abilities -->			
 				<div class="sheet-header">Abilities</div>
@@ -3049,11 +3055,12 @@
 	<!-- ************************************** Hidden Fields for Sheet Workers ************************************** -->
 	<div>
 		<!-- For debugging sheet workers 
-		field names<input readonly name="attr_testA"/>
-		checked B4<input readonly name="attr_testB"/>
-		checked after<input readonly name="attr_testC"/>
-		New Str Adj<input readonly name="attr_testD"/> -->
-	
+		Value A<input readonly name="attr_testA"/>
+		Value B<input readonly name="attr_testB"/>
+		Value C<input readonly name="attr_testC"/>
+		Value D<input readonly name="attr_testD"/>
+		Value E<input readonly name="attr_testE"/>
+		Value F<input readonly name="attr_testF"/>  -->
 	</div>
 	
 	
@@ -3121,22 +3128,130 @@
 		
 		//******************************** Open Sheet ************************************************ 
 		//******************************************************************************************** 
-	
+		
 		// EXECUTE: When the sheet is opened, update score fields for anyone using an older sheet.
 		on('sheet:opened',function(){
-			// Update corruption labels
-			getAttrs(["corrbase"], function(values) {
-				var corruption = (values.corrbase)*1;
-				corruption = Math.max(0,corruption); 								// corruption does not go below 0; throws an error on the lookup if below 0
-				corruption = Math.min(30,corruption);								// corruption does not go above 30; throws an error on the lookup if above 30
-				var label = lookup_corruption_lvl(corruption);
-				var dn = lookup_corruption_dn(corruption);
-				
-				setAttrs({CorrLevel:label});
-				setAttrs({CorrResistDN:dn});
+			getAttrs(["sheetversion"], function(values) {
+				var version = (values.sheetversion)*1;
+				// section 2.2 and lower update
+				if(version < 2.2) {
+					
+					// Update corruption labels
+					getAttrs(["corrbase"], function(values) {
+						var corruption = (values.corrbase)*1;
+						corruption = Math.max(0,corruption); 								// corruption does not go below 0; throws an error on the lookup if below 0
+						corruption = Math.min(30,corruption);								// corruption does not go above 30; throws an error on the lookup if above 30
+						var label = lookup_corruption_lvl(corruption);
+						var dn = lookup_corruption_dn(corruption);
+						setAttrs({CorrLevel:label});
+						setAttrs({CorrResistDN:dn});
+					});
+					
+					// handle changes to wound and shock changes to enable token max + set Heavy and Light wound levels
+					getAttrs(["shockcurrent","woundscurrent","tier","tghbase","tghmod","woundsmod","customtier","willbase","willmod","shockmod"], function(values) { 
+						var sc = (values.shockcurrent*1);
+						var wc = (values.woundscurrent*1);
+						
+						// set current wounds and shock = to old values
+						setAttrs({wounds:wc});
+						setAttrs({shock:sc});
+						
+						
+						// calculate wound max and shock max
+						var t = (values.tier)*1;
+						var tgh = ((values.tghbase)*1)+((values.tghmod)*1);
+						var wm = (values.woundsmod)*1;
+						var will = ((values.willbase)*1)+((values.willmod)*1);
+						var sm = (values.shockmod)*1;
+						var ct = (values.customtier)*1;
+						var totalw = tgh + t + wm;
+						var totals = will + t + sm;
+						
+						if(t === 6) {
+							totalw = tgh + ct + wm;
+							totals = will + ct + sm;
+						}
+						if(t < 6) {
+							setAttrs({customtier:0});
+						}
+						
+						// set new max values
+						setAttrs({shock_max:totals});
+						setAttrs({wounds_max:totalw});
+						// set old values to new totals
+						setAttrs({shockcurrent:totals});
+						setAttrs({woundscurrent:totalw});
+						
+						var maxwnd = totalw*1;
+						var wndl = 0;
+						var wndh = 0;
+						
+						// calculate and set lighly wounded and heavily wounded
+						if(maxwnd > 1) {
+							wndl = Math.ceil(.5*maxwnd);
+							wndh = wndl + 1;
+						}
+						
+						setAttrs({lightwound: wndl});
+						setAttrs({heavywound: wndh});
+						
+					});
+					
+					// update weapon DR
+					getAttrs(["strbase","strmod","willbase","willmod","keywordpsyker"], function(values) {
+						var ispsyker = (values.keywordpsyker)*1;
+						var str = (values.strbase)*1 + (values.strmod)*1;
+						var will = (values.willbase)*1 + (values.willmod)*1;
+						
+						var newdr = 0;
+						var ismelee = 0;	
+						var isforce = 0;	
+						
+						// get all repeating rows and retrieve melee, force, and dr for all weapons
+						getSectionIDs("repeating_weapon", function(IDArray) {
+							var fieldNames = [];
+							_.each(IDArray, function(currentID, i) {
+								fieldNames.push("repeating_weapon_" + currentID + "_meleewpn");
+								fieldNames.push("repeating_weapon_" + currentID + "_forcewpn");
+								fieldNames.push("repeating_weapon_" + currentID + "_wpnbasedr");
+								fieldNames.push("repeating_weapon_" + currentID + "_wpndr");
+							});
+							
+							// for each check if it is checked, if checked then set drstrmod
+							getAttrs(fieldNames, function(values) {
+								_.each(IDArray, function(currentID) {
+									newdr = parseInt((values["repeating_weapon_" + currentID + "_wpnbasedr"]));
+									ismelee = parseInt((values["repeating_weapon_" + currentID + "_meleewpn"]));	
+									isforce = parseInt((values["repeating_weapon_" + currentID + "_forcewpn"]));
+									
+									if(ismelee === 1) {
+										newdr = newdr + str;
+									}
+									
+									if(isforce === 1) {
+										if(ispsyker === 1) {
+											newdr = newdr + Math.ceil(.5*will);
+										}
+										else {	
+											newdr = Math.max(0, newdr - 2);
+										}
+									}
+									
+									setAttrs({["repeating_weapon_" + currentID + "_wpndr"]: newdr});
+								});
+							});
+						});	
+					});	
+					// end of update weapon DR
+					
+				} // END OF section 2.2 and lower update
+			});
+			// Update Version = to current release
+			getAttrs(["release","sheetversion"], function(values) {
+				var release = (values.release)*1;
+				setAttrs({sheetversion: release});
 			});
 		});
-		
 		//******************************** Update Corruption Labels ********************************** 
 		//******************************************************************************************** 
 		on("change:corrbase", function() {
@@ -3151,53 +3266,150 @@
 				setAttrs({CorrResistDN:dn});
 			});
 		});
-
-		//******************************** Update WPN +STR if weapon is melee ************************ 
+		
+		//******************************** Update Custom when Tier <> 6 ****************************** 
 		//******************************************************************************************** 
-		on("change:repeating_weapon:meleewpn", function() {
-			getAttrs(["repeating_weapon_meleewpn","strbase","strmod"], function(values) {
-				var checked = parseInt(values.repeating_weapon_meleewpn);
-				var sb = (values.strbase)*1;
-				var sm = (values.strmod)*1;
-			
-				if(checked === 1) {
-					setAttrs({repeating_weapon_drstrmod: (sb+sm)});
-				}
-				else {	
-					setAttrs({repeating_weapon_drstrmod: 0});
+		on("change:tier", function() {
+			getAttrs(["tier"], function(values) {
+				var tier = (values.tier)*1;
+				
+				if(tier < 6) {
+					setAttrs({customtier:0});
 				}
 			});
 		});
-		
-		//Update All Melee WPNS if StrAdj changes  
-		on("change:strbase change:strmod", function() {
-			getAttrs(["strbase","strmod"], function(values) {
-				var sb = (values.strbase)*1;
-				var sm = (values.strmod)*1;
-				var newstradj = 0;
-				var checked = 0;	
+		//******************************** AutoCalc Wounds and Shock ********************************* 
+		//******************************************************************************************** 
+		on("change:tier change:tghbase change:tghmod change:woundsmod change:customtier", function() {
+			getAttrs(["tier","tghbase","tghmod","woundsmod","customtier"], function(values) {
+				var t = (values.tier)*1;
+				var tgh = ((values.tghbase)*1)+((values.tghmod)*1);
+				var wm = (values.woundsmod)*1;
+				var ct = (values.customtier)*1;
+				var total = tgh + t + wm;
+				if(t === 6) {
+					total = tgh + ct + wm;
+				}
 				
-				// get all repeating rows and retrieve checked
+				setAttrs({wounds_max:total});
+				setAttrs({wounds:total});
+			});
+		});
+		
+		on("change:tier change:willbase change:willmod change:shockmod change:customtier", function() {
+			getAttrs(["tier","willbase","willmod","shockmod","customtier"], function(values) {
+				var t = (values.tier)*1;
+				var will = ((values.willbase)*1)+((values.willmod)*1);
+				var sm = (values.shockmod)*1;
+				var ct = (values.customtier)*1;
+				var total = will + t + sm;
+				
+				if(t === 6) {
+					total = will + ct + sm;
+				}
+				
+				setAttrs({shock_max:total});
+				setAttrs({shock:total});
+			});
+		});
+		//******************************** Auto Calculate Weapon DR ********************************** 
+		//******************************************************************************************** 
+		// initiate on a change to: psyker keyword, willpower (base or mod), strength (base or mod), is a force weapon, is a melee weapon, weapon base DR
+		on("change:repeating_weapon:wpnbasedr change:repeating_weapon:meleewpn change:repeating_weapon:forcewpn", function() {
+			getAttrs(["repeating_weapon_meleewpn","repeating_weapon_forcewpn","repeating_weapon_wpnbasedr","strbase","strmod","willbase","willmod","keywordpsyker"], function(values) {
+				var ismelee = parseInt(values.repeating_weapon_meleewpn);
+				var isforce = parseInt(values.repeating_weapon_forcewpn);
+				var ispsyker = (values.keywordpsyker)*1;
+				
+				var newdr = (values.repeating_weapon_wpnbasedr)*1;
+				var str = (values.strbase)*1 + (values.strmod)*1;
+				var will = (values.willbase)*1 + (values.willmod)*1;
+			
+				if(ismelee === 1) {
+					newdr = newdr + str;
+				}
+				
+				if(isforce === 1) {
+					if(ispsyker === 1) {
+						newdr = newdr + Math.ceil(.5*will);
+					}
+					else {	
+						newdr = Math.max(0, newdr - 2);
+					}
+				}
+				
+				setAttrs({repeating_weapon_wpndr: newdr});
+			});
+		});
+
+		//Update All Melee WPNS if Str, Willpower or Keyword Psyker changes  
+		on("change:keywordpsyker change:willbase change:willmod change:strbase change:strmod", function() {
+			getAttrs(["strbase","strmod","willbase","willmod","keywordpsyker"], function(values) {
+				var ispsyker = (values.keywordpsyker)*1;
+				var str = (values.strbase)*1 + (values.strmod)*1;
+				var will = (values.willbase)*1 + (values.willmod)*1;
+				
+				var newdr = 0;
+				var ismelee = 0;	
+				var isforce = 0;	
+				
+				// get all repeating rows and retrieve melee, force, and dr for all weapons
 				getSectionIDs("repeating_weapon", function(IDArray) {
 					var fieldNames = [];
 					_.each(IDArray, function(currentID, i) {
 						fieldNames.push("repeating_weapon_" + currentID + "_meleewpn");
+						fieldNames.push("repeating_weapon_" + currentID + "_forcewpn");
+						fieldNames.push("repeating_weapon_" + currentID + "_wpnbasedr");
+						fieldNames.push("repeating_weapon_" + currentID + "_wpndr");
 					});
 					
 					// for each check if it is checked, if checked then set drstrmod
 					getAttrs(fieldNames, function(values) {
 						_.each(IDArray, function(currentID) {
-							newstradj = 0; //need to ensure the next iteration is 0
-							checked = (values["repeating_weapon_" + currentID + "_meleewpn"]);	
-							checked = parseInt(checked);	
-							if(checked === 1) {newstradj = sb + sm;};
-							setAttrs({["repeating_weapon_" + currentID + "_drstrmod"]: newstradj});
+							newdr = parseInt((values["repeating_weapon_" + currentID + "_wpnbasedr"]));
+							ismelee = parseInt((values["repeating_weapon_" + currentID + "_meleewpn"]));	
+							isforce = parseInt((values["repeating_weapon_" + currentID + "_forcewpn"]));
+							
+							if(ismelee === 1) {
+								newdr = newdr + str;
+							}
+							
+							if(isforce === 1) {
+								if(ispsyker === 1) {
+									newdr = newdr + Math.ceil(.5*will);
+								}
+								else {	
+									newdr = Math.max(0, newdr - 2);
+								}
+							}
+							
+							setAttrs({["repeating_weapon_" + currentID + "_wpndr"]: newdr});
 						});
 					});
 				});	
 			});	
 		});
-		
+		//******************************** Generate Wound Levels ************************************* 
+		//******************************************************************************************** 
+		on("change:wounds_max change:woundsmod", function() {
+			getAttrs(["wounds_max"], function(values) {
+				var wnd = (values.wounds_max)*1;
+				var wndl = 0;
+				var wndh = 0;
+				
+				if(wnd < 2) {
+					wndl=0;
+					wndh=0;
+				}
+				else {
+					wndl = Math.ceil(.5*wnd);
+					wndh = wndl + 1;
+				}
+				
+				setAttrs({lightwound: wndl});
+				setAttrs({heavywound: wndh});
+			});
+		});
 		//******************************** SUM XP EARNED & SPENT ************************************* 
 		//********************************************************************************************
 		
@@ -3359,5 +3571,5 @@
 				case "default": return "--";
 			};	
 		};			
-	
+		
 	</script>


### PR DESCRIPTION
1. Fixed minor types [Thanks to Dean for the catch]
2. Fixed label on Persuasion roll - when rolled it said Persuasion Assist when it should have been persuasion.
3. Roll Glory now uses API or inline dice rolling.
4. Added hover text to skills for quick reference on use.
5. Removed woundscurrent and shockcurrent and added wounds_max and shock_max so token bars operate properly [Thanks to Dean for the suggestion]
6. Created script to update wounds and shock based on existing scores in woundscurrent and shockcurrent
7. Added a gear tooltip to the gear and assets for PC's [Thanks to Dean for the suggestion]
8. added a quantity field to gear [Thanks to Dean for the suggestion]
9. Auto calculate wounds_max and shock_max; wounds = modified toughness + tier + mod; shock = modified willpower + tier + mod.  Both shock and wounds will also calculate off of custom tier.
10. Added a Mod field to shock and wounds to update values from abilities, powers, etc.
11. Added check on tier; when not set to custom the value is changed to 0.
12. Added Lightly wounded value.
13. Auto Generate light and heavy wounded values.
14. Salvo needs to be a text field to allow for --; -- has specific rules implementations.  Field originally allowed only numeric characters.
15. If a psyker (added as a checkbox under keywords) and a weapon is a force weapon add 1/2 Base Willpower to DR.  If the character is not a psyker and the weapon is a force weapon -2 to DR. [Thanks to Morback for the suggestion]
16. For PC & NPC sheets: Onload of a character sheet with current version, automatically update all weapon DR's, corruption levels, wound, shock, light wounded, heavy wounded.