### PR TITLE
Wrath & Glory v2.2 css Fix: wrath_and_glory.css

### DIFF
--- a/Wrath and Glory API/wrath_and_glory.css
+++ b/Wrath and Glory API/wrath_and_glory.css
@@ -1,4 +1,4 @@
-/* Version: 2.2 
+/* Version: 2.2 */
 /*  ================ Roll Templates ================  */
 .sheet-rolltemplate-roll_dicepool_nowrath table,
 .sheet-rolltemplate-roll_dicepool table,


### PR DESCRIPTION
I did not close off a comment and it broke the rendering of the sheet.  The only change is to close off the comment.

## Changes

Provide a few comments about what you have changed. 

Close off a comment in the first line.

## Additional comments

Can this be expedited as the sheet is broken in the Roll20 community.