### PR TITLE
ChroniquesOubliees: added the possibility to use d3 for weapon dmg.

### DIFF
--- a/ChroniquesOubliees/co.htm
+++ b/ChroniquesOubliees/co.htm
@@ -399,6 +399,7 @@
                             <td class="sheet-boxinputleft">
                                 <input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="Nombre de dés de dommage" />
                                 <select class="sheet-carac"  style="width:47px;" name="attr_armedmde" size="1" title="Dé de dommage">
+                                    <option value="3">d3</option>
                                     <option value="4" selected>d4</option>
                                     <option value="6">d6</option>
                                     <option value="8">d8</option>


### PR DESCRIPTION
*ChroniquesOubliees*

## Changes
Added the option to use a d3 in for weapon dmg (needed for fairies and pixies)

## Additional comments
Natha, the original author of the sheet asked me to maintain his sheets for Chroniques Oubliees.
