### PR TITLE
[GURPS] - Mostly Cosmetic changes v1.4.3

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -650,7 +650,7 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 
 /* -- COMBAT -- */
 .sheet-active-defense { width: calc(100% - 140px - 0.8em); }
-.sheet-active-defense .sheet-col0 { width: calc(100% - 174px); }
+.sheet-active-defense .sheet-col0 { width: calc(100% - 184px); }
 .sheet-active-defense .sheet-col0 input { text-align:left; }
 .sheet-active-defense .sheet-col1 { width: 80px; }
 .sheet-active-defense .sheet-col2 { width: 40px; }
@@ -658,37 +658,41 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-active-defense .sheet-col4 { width: 22px; }
 
 .sheet-melee-attacks { width: calc(100% - 140px - 0.8em); }
-.sheet-melee-attacks .sheet-col0 { width: calc(100% - 234px); }
+.sheet-melee-attacks .sheet-col0 { width: calc(100% - 252px); }
 .sheet-melee-attacks .sheet-col0 input { text-align:left; }
 .sheet-melee-attacks .sheet-col1 { width: 40px; }
 .sheet-melee-attacks .sheet-col1 input { text-align:left; }
 .sheet-melee-attacks .sheet-col2 { width: 60px; }
 .sheet-melee-attacks .sheet-col3 { width: 60px; }
-.sheet-melee-attacks .sheet-col4 { width: 22px; }
+.sheet-melee-attacks .sheet-col4 { width: 30px; }
 .sheet-melee-attacks .sheet-col5 { width: 30px; }
+.sheet-melee-attacks .sheet-col5 input[type="text"] {background-color : #87CEFA;}
 .sheet-melee-attacks .sheet-col6 { width: 22px; }
+.sheet-melee-attacks .sheet-col6 button[type="roll"] {background-color : #87CEFA;}
 .sheet-melee-attacks .sheet-header .sheet-col5 { width: 52px; }
-.sheet-melee-attacks .sheet-header .sheet-col5 { margin-left: 22px; }
-.sheet-melee-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 256px); }
+.sheet-melee-attacks .sheet-header .sheet-col5 { margin-left: 30px; }
+.sheet-melee-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 274px); }
 
 .sheet-ranged-attacks { width: calc(100% - 140px - 0.8em); }
-.sheet-ranged-attacks .sheet-col0 { width: calc(100% - 412px); }
+.sheet-ranged-attacks .sheet-col0 { width: calc(100% - 446px); }
 .sheet-ranged-attacks .sheet-col0 input { text-align:left; }
 .sheet-ranged-attacks .sheet-col1 { width: 40px; }
 .sheet-ranged-attacks .sheet-col1 input { text-align:left; }
 .sheet-ranged-attacks .sheet-col2 { width: 30px; }
 .sheet-ranged-attacks .sheet-col3 { width: 30px; }
-.sheet-ranged-attacks .sheet-col4 { width: 43px; }
+.sheet-ranged-attacks .sheet-col4 { width: 60px; }
 .sheet-ranged-attacks .sheet-col5 { width: 39px; }
 .sheet-ranged-attacks .sheet-col6 { width: 35px; }
 .sheet-ranged-attacks .sheet-col7 { width: 60px; }
 .sheet-ranged-attacks .sheet-col8 { width: 60px; }
-.sheet-ranged-attacks .sheet-col9 { width: 22px; }
+.sheet-ranged-attacks .sheet-col9 { width: 30px; }
 .sheet-ranged-attacks .sheet-col10 { width: 30px; }
+.sheet-ranged-attacks .sheet-col10 input[type="text"] {background-color : #87CEFA;}
 .sheet-ranged-attacks .sheet-col11 { width: 22px; }
+.sheet-ranged-attacks .sheet-col11 button[type="roll"] {background-color : #87CEFA;}
 .sheet-ranged-attacks .sheet-header .sheet-col10 { width: 52px; }
-.sheet-ranged-attacks .sheet-header .sheet-col10 { margin-left: 22px; }
-.sheet-ranged-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 432px); }
+.sheet-ranged-attacks .sheet-header .sheet-col10 { margin-left: 30px; }
+.sheet-ranged-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 468px); }
 
 .sheet-damage-reduction { float: right; width: 140px; }
 .sheet-damage-reduction .sheet-col0 { width: 50px; }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -1,4 +1,4 @@
-<div class="sheet-wrapper">
+﻿<div class="sheet-wrapper">
 	<!-- HIDDEN FIELDS -->
 	<input type="hidden" name="attr_10" value="10" disabled="disabled" />
 	<input type="hidden" name="attr_VS" value="vs:" disabled="disabled" />
@@ -14,8 +14,8 @@
 
 	<!-- ===== ===== ===== ===== TABS ===== ===== ===== ===== -->
 	<input type="radio" name="attr_tab" value="1" class="sheet-tab sheet-tab1" checked="checked" /><span>General</span>
-	<input type="radio" name="attr_tab" value="2" class="sheet-tab sheet-tab2" /><span>Traits</span>
-	<input type="radio" name="attr_tab" value="3" class="sheet-tab sheet-tab3" /><span>Skills</span>
+	<input type="radio" name="attr_tab" value="2" class="sheet-tab sheet-tab2" title="Languages, Advantages, Disadvantages, and Cultural Familiarities" /><span>Traits</span>
+	<input type="radio" name="attr_tab" value="3" class="sheet-tab sheet-tab3" title="Skills and Techniques" /><span>Skils</span>
 	<input type="radio" name="attr_tab" value="4" class="sheet-tab sheet-tab4" /><span>Combat</span>
 	<input type="radio" name="attr_tab" value="5" class="sheet-tab sheet-tab5" /><span>Inventory</span>
 	<input type="radio" name="attr_tab" value="6" class="sheet-tab sheet-tab6" /><span>Grimoire</span>
@@ -1914,7 +1914,10 @@
 							</table>
 						</span>
 					</div>
-					<div class="sheet-cell sheet-col5">Skill</div>
+					<div class="sheet-cell sheet-col5">
+						<span style="background-color: #87CEFA">|  skill  |</span>
+					</div>
+
 				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_melee">
 					<input class="sheet-toggle" type="checkbox" />
@@ -2043,7 +2046,6 @@
 							See page 269.
 						</span>
 					</div>
-
 					<div class="sheet-cell sheet-col8">
 						<div class="sheet-popup">Type</div>
 						<span class="sheet-tooltip">
@@ -2072,7 +2074,10 @@
 							</table>
 						</span>
 					</div>
-					<div class="sheet-cell sheet-col10">Skill</div>
+					<div class="sheet-cell sheet-col10">
+						<span style="background-color: #87CEFA">|  skill  |</span>
+					</div>
+
 				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_ranged">
 					<input class="sheet-toggle" type="checkbox" />
@@ -2348,8 +2353,8 @@
 	<h3>Known Issues</h3>
 	<ul>
 		<li>Unable to delete a Technique - UPDATE</li>
-		<li>The issue is the 'Max' value for the Technique. If any value was placed in there, the row will not delete. So in this PULL I have blocked values from being placed there so that new Techniques can be deleted if need be. Existing Techniques that you are unable to delete � the Devs are looking into that issue and will advise me. </li>
-		<li>NOTE: Techniques, as it is now on the character sheet, does not really work well � that section will most likely be completely rewritten (I plan on doing it when I get some time and my skills at HTML improve).</li>
+		<li>The issue is the 'Max' value for the Technique. If any value was placed in there, the row will not delete. So in this PULL I have blocked values from being placed there so that new Techniques can be deleted if need be. Existing Techniques that you are unable to delete - the Devs are looking into that issue and will advise me. </li>
+		<li>NOTE: Techniques, as it is now on the character sheet, does not really work well - that section will most likely be completely rewritten (I plan on doing it when I get some time and my skills at HTML improve).</li>
 	</ul>
 
 	<h3>Revision History</h3>
@@ -2363,10 +2368,28 @@
 	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 
             Forum for now (Like Tom and I are doing) - perhaps later we can use GitHub.</p>
 
+	<h4>Version: 1.4.3</h4>
+
+	<p>Pull Request: 10/30/2018</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Fixed version 1.4.1 Pull request date – Cosmetic Only</li>
+		<li>Fixed version 1.4.2 Pull request date – Cosmetic Only </li>
+		<li>Added information pertaining to who made changes in version 1.4.2 – Cosmetic Only </li>
+		<li>Widened Shots field in Range Attacks repeating section – Cosmetic Only</li>
+		<li>Fixed widths (margins) of the Active Defenses, Melee Attacks, the Ranged Attacks sections – Cosmetic Only</li>
+		<li>Fixed widths of the Damage Macro for the Melee Attacks and the Ranged Attacks sections – Cosmetic Only </li>
+		<li>Change the background color of the Skill field and Macro field to a Light Blue for Melee Attacks and Ranged Attacks – Cosmetic Only</li>
+		<li>Added some ‘Hover’ information for the Traits and Skills Tabs  – Cosmetic Only</li>
+		<li>Restore some deleted Revision History – Cosmetic Only</li>
+	</ul>
+
 	<h4>Version: 1.4.2</h4>
 	
-	<p>Pull Request: 3/7/2018</p>
+	<p>Pull Request: 10/23/2018</p>
 	<ul>
+		<li>Changes, Fixes, and Adds made by MadCoder253
 		<li>Changed damage roll icons to red explosion to easily identify the difference from the skill roll icon</li>
 		<li>Update thrust and swing damage when striking ST is updated</li>
 		<li>Ability to enter values for Unspent points</li>
@@ -2375,10 +2398,10 @@
 	
 	<h4>Version: 1.4.1</h4>
 
-	<p>Pull Request: ##/##/2018</p>
+	<p>Pull Request: 09/11/2018</p>
 
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
 		<li>Fixed Encumbrance Table calculations to always allow for a Minimum Move of 1 and a Minimum Dodge of 1.</li>
 	</ul>
  
@@ -2387,26 +2410,25 @@
 	<p>Pull Request: 09/04/2018</p>
 
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
 		<li>Fixed bug with calculating Current Move for Heavy and Extra Heavy Encumbrances and not using a Minimum of 1. Reported by Ray G (@raymond-g)  (UserID: 1600355)</li>
 		<li>Fixed bug with calculating Total Weight from Inventory which at times created a weigh of more than 3 decimal places.</li>
-		<li >Added a �FOA� (Frequency of Appearance) field under Advantages (& Quirks) </li>
-		<li >Modified the Tool Tip for SCN under Disadvantages (& Quirks) and Racial Traits to include the wording �OR Frequency of Appearance�� Cosmetic Only</li>
+		<li >Added a "FOA" (Frequency of Appearance) field under Advantages (& Quirks) </li>
+		<li >Modified the Tool Tip for SCN under Disadvantages (& Quirks) and Racial Traits to include the wording "OR Frequency of Appearance" - Cosmetic Only</li>
 		<li>Added Max Load to the Encumbrance Table</li>
 	</ul>
  
-
 	<h4>Version: 1.3.9</h4>
 
 	<p>Pull Request: 08/21/2018</p>
 
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
-		<li>Updated the Language Box format � Cosmetic Only</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Updated the Language Box format - Cosmetic Only</li>
 		<li>Added additional options for Native Language in regards to Spoken and Written levels as a Disadvantage</li>
-		<li>Updated the Inventory Box format � Cosmetic Only</li>
-		<li>Added fields of �TL� (Tech Level) and �Ref� (Reference) to the Inventory repeating section</li>
-		<li>Fixed bug for Single Modifier Prompt and Extended Modifier Prompts if a �+� is used for a positive modifier entry</li>
+		<li>Updated the Inventory Box format - Cosmetic Only</li>
+		<li>Added fields of "TL" (Tech Level) and "Ref" (Reference) to the Inventory repeating section</li>
+		<li>Fixed bug for Single Modifier Prompt and Extended Modifier Prompts if a "+" is used for a positive modifier entry</li>
 
 	</ul>
 
@@ -2415,25 +2437,24 @@
  	<p>Pull Request: 08/08/2018</p>
             
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
 		<li>Added the Speed-Range table image to the Combat Tab - Requested by CaptainJoy (UserID: GitHub) </li>
 		<li>Set the character sheet to always open to the Updates Tab</li>
 		<li>Fixed BUG where Basic Lift calculations for ST 7 or less was incorrectly rounding for Light, Medium, and Heavy Encumbrances </li>
-		<li>Renamed Notes to Weapon Notes under Melee Attacks and Ranged Attacks � Cosmetic Only</li>
+		<li>Renamed Notes to Weapon Notes under Melee Attacks and Ranged Attacks - Cosmetic Only</li>
 		<li>Added Damage Notes with an attribute under Melee Attacks and Ranged Attacks</li>
-		<li>Changed Tool Tip for Damage, for Melee attacks and Ranged Attacks, to indicate using the Damage Notes field � Cosmetic Only</li>
-		<li>Changed Armour Divisor to Armor Divisor � Cosmetic Only</li>
-		<li> Changed the output of the Attack Macros for Melee and Ranged attacks to include the Weapons Notes attribute � Cosmetic Only</li>
-		<li>Changed the output of the Damage Macros for Melee and Ranged attacks to include the Damage Notes attribute � Cosmetic Only</li>
+		<li>Changed Tool Tip for Damage, for Melee attacks and Ranged Attacks, to indicate using the Damage Notes field - Cosmetic Only</li>
+		<li>Changed Armour Divisor to Armor Divisor - Cosmetic Only</li>
+		<li> Changed the output of the Attack Macros for Melee and Ranged attacks to include the Weapons Notes attribute - Cosmetic Only</li>
+		<li>Changed the output of the Damage Macros for Melee and Ranged attacks to include the Damage Notes attribute - Cosmetic Only</li>
 	</ul>
-
 
 	<h4>Version: 1.3.7</h4>
             
 	<p>Pull Request: 08/01/2018</p>
             
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
 		<li>Fixed alignment issue with the Notes field Under Skills not Left Justified - Cosmetic Only </li>
 		<li>Changed Hit Location box to have an additional Header identifying User Created Locations - Cosmetic Only</li>
 		<li>Changed all fields in the Hit Location box to be editable. This will enable you to change the name of any of the default Locations and the To Hit Penalty - Request from Valter (User id: 285013)</li>
@@ -2446,23 +2467,22 @@
 		<li>Fixed many miscellaneous issues to existing table fieldsets</li>
 	</ul>
 
-
 	<h4>Version: 1.3.6</h4>
             
 	<p>Pull Request: 07/25/2018</p>
             
 	<ul>
-		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610</li>
-		<li>Corrected spelling of Miscellaneous on the General page � Cosmetic only</li>
-		<li>Updated Tool Tip for Type under Melee Attacks and Ranged, removed the Multiplier information as it is irrelevant, also fixed the alignment � Cosmetic only</li>
-		<li>Added missing information from Type drop down for Ranged Attacks � missing was Affliction and Special</li>
-		<li>Changed the Label of �Quick Inventory� to �Quick Inventory & Wealth� and the Label left justified � Cosmetic only</li>
-		<li>Changed the Melee Attacks and Ranged Attacks macros to include the Notes attribute in the results in Chat � Cosmetic only </li>
-		<li>Changed all Die Macros to apply Bold to the Character Name in the results in Chat � Cosmetic only</li>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Corrected spelling of Miscellaneous on the General page - Cosmetic only</li>
+		<li>Updated Tool Tip for Type under Melee Attacks and Ranged, removed the Multiplier information as it is irrelevant, also fixed the alignment - Cosmetic only</li>
+		<li>Added missing information from Type drop down for Ranged Attacks - missing was Affliction and Special</li>
+		<li>Changed the Label of "Quick Inventory" to "Quick Inventory & Wealth" and the Label left justified - Cosmetic only</li>
+		<li>Changed the Melee Attacks and Ranged Attacks macros to include the Notes attribute in the results in Chat - Cosmetic only </li>
+		<li>Changed all Die Macros to apply Bold to the Character Name in the results in Chat - Cosmetic only</li>
 		<li>Change when adding a new Skill, Technique, or Spell, the Points defaults to 0 instead of blank</li>
-		<li>Fixed minor spelling errors � Cosmetic only</li>
-		<li>Renamed Header of CR to SCN under Disadvantages and Racial Trains to reflect correct terminology � Cosmetic only</li>        
-		<li>Fixed Tool Tip of SCN (formerly CR) under Disadvantages and Racial Trains to reflect correct terminology � changed from �Control Rating� to �Self-control Number� � Cosmetic only</li>
+		<li>Fixed minor spelling errors - Cosmetic only</li>
+		<li>Renamed Header of CR to SCN under Disadvantages and Racial Trains to reflect correct terminology - Cosmetic only</li>        
+		<li>Fixed Tool Tip of SCN (formerly CR) under Disadvantages and Racial Traits to reflect correct terminology - changed from "Control Rating" to "Self-control Number" - Cosmetic only</li>
 		<li>Added Macro for Self-control Number Roll within Disadvantages and Racial Traits</li>
  		<li>Changes and Adds requested by Mike W (@mike-w) (UserID: 1414610)</li>
   		<li>Spelling correction requested by Rabulias (@rabulias) (UserID: 4692)</li>
@@ -2482,6 +2502,31 @@
 		<li>Added a Tool Tip for Pen header in Hit Location</li>
 		<li>Requested by Mike W (@mike-w) (UserID: 1414610) see: https://app.roll20.net/forum/post/6572120/</li>
 	</ul>
+
+	<h4>Version: 1.3.4</h4>
+            
+	<p>Pull Request: 3/7/2018</p>
+	<ul>
+		<li>Changes made by MadCoder https://github.com/MadCoder253/roll20-character-sheets/issues</li>
+                <li>Add Revision History Tab</li>
+                <li>Changed roll buttons to use dicefontd6 (requested by Mike W 
+                (@mike-w) (UserID: 1414610) see: https://app.roll20.net/forum/post/5845539/</li>
+                <li>Fix lift & encumbrance rounding error for low ST. Round to whole number. 
+                (requested by Lucy (@lucy) (UserID: 359497) see: https://app.roll20.net/forum/permalink/5142954/</li>
+	</ul>
+            
+	<h4>Version 1.3.3</h4>
+            
+	<p>Pull Request: 3/1/2018</p>
+            
+	<ul>
+		<li>Changes made by MadCoder https://github.com/MadCoder253/roll20-character-sheets/issues</li>
+                <li>Restyled tabs to work with Firefox and MS Edge</li>
+                <li>Traits tab -> disadvantages section: slight changes to column spacing</li>
+                <li>Combat tab -> Ranged attacks section: slight changes to column spacing and abbreviate titles</li>
+                <li>Skills Tab -> Techniques section: slight changes to column spacing</li>
+                <li>Added URL to GURPS roll20 wiki</li>
+            </ul>
 
         </div>
 		
@@ -2571,7 +2616,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = '1.4.2';
+	var version = '1.4.3';
 
 	var modCascade = true;
 	var modCascadeAll = true;


### PR DESCRIPTION
•	Fixed version 1.4.1 Pull request date – Cosmetic Only.
•	Fixed version 1.4.2 Pull request date – Cosmetic Only.
•	Added information pertaining to who made changes in version 1.4.2 – Cosmetic Only.
•	Widened Shots field in the Range Attacks section – Cosmetic Only.
•	Fixed widths (margins) of the Active Defenses, Melee Attacks, and the Ranged Attacks sections – Cosmetic Only.
•	Fixed widths of the Damage Macro for the Melee Attacks and the Ranged Attacks sections – Cosmetic Only.
•	Change the background color of the Skill field and Macro field to a Light Blue for Melee Attacks and Ranged Attacks – Cosmetic Only.
•	 Added some ‘Hover’ information for the Trait and Skills Tabs – Cosmetic Only.
•	Restore some deleted Revision History – Cosmetic Only.

*Include the name of the sheet you made changes to in the title.*

## Changes

Provide a few comments about what you have changed. 

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.

## Additional comments
