### PR TITLE
Update Guideline link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ PLEASE VERIFY YOUR SHEET.JSON IS VALID JSON at http://jsonlint.com before you su
 Guidelines
 ==========
 
-The former guidelines found here have been moved and expanded on in the [Roll20 Wiki: Building Character Sheets](https://wiki.roll20.net/Building_Character_Sheets).
+The former guidelines found here have been moved and expanded on in the [Roll20 Wiki: Building Character Sheets](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository).
 
 
 License


### PR DESCRIPTION
## Changes

Now it should link directly to the relevent section, instead of the wiki page in general.
