### PR TITLE
[Dungeon World by Roll20] - Version 2.0

### DIFF
--- a/Dungeon_World_Official/Dungeon World.css
+++ b/Dungeon_World_Official/Dungeon World.css
@@ -42,6 +42,40 @@
 	display: none;
 }
 
+.sheet-tip-confirm-flag {
+	display: none;
+}
+
+.sheet-tip-confirm-flag:checked ~ .sheet-class-tip {
+	display: none;
+}
+
+.sheet-tip-confirm-flag:not(:checked) ~ .sheet-class-tip {
+	display: block;
+	position: absolute;
+	top: 12.8em;
+	left: 10.7em;
+	background: white;
+	z-index: 99;
+	border: 2px solid black;
+	border-radius: 6px;
+	padding: 5px;
+	width: 701px;
+	height: 85px;
+}
+
+.sheet-class-tip .sheet-cancel-button {
+	float: right;
+}
+
+.sheet-class-tip button[type=action] {
+	color: black;
+}
+
+.sheet-class-tip button[type=action]:hover {
+	border-color: #6e9ec6;
+}
+
 .sheet-container.active-drop-target.dropping ~ .sheet-compendium_warning {
 	display: block;
 	position: fixed;
@@ -776,7 +810,7 @@ button span {
 	display: inline-block;
 	line-height: 14px;
 	text-align: center;
-	content: "+";
+	content: "◂";
 }
 
 .sheet-bond-expansion textarea {
@@ -788,7 +822,7 @@ button span {
 .sheet-spells .sheet-expand-spell:checked + span::before,
 .sheet-gear .sheet-expand-gear:checked + span::before,
 .sheet-gmod .sheet-expand-gmod:checked + span::before {
-	content: "-";
+	content: "▾";
 }
 
 
@@ -861,7 +895,8 @@ button span {
 }
 
 .sheet-toggler input[type=radio] + span,
-.sheet-toggler input[type=checkbox] + span {
+.sheet-toggler input[type=checkbox] + span,
+button[type=action] {
 	border: 1px solid rgb(35, 31, 32);
 	border-radius: 6px;
 	padding: 1px 6px;

--- a/Dungeon_World_Official/Dungeon World.css
+++ b/Dungeon_World_Official/Dungeon World.css
@@ -4,6 +4,7 @@
 	background-color: rgb(230, 231, 233);
 	height: auto;
 	border: 1px solid rgb(35, 31, 32);
+	min-width: 820px;
 }
 
 .charsheet .sheet-container label {
@@ -30,7 +31,30 @@
 }
 
 .sheet-compendium-drop-target.dropping {
-	background-color: yellow;
+	opacity: 0.5;
+	transition: opacity .15s ease-in-out;
+	-moz-transition: opacity .15s ease-in-out;
+	-webkit-transition: opacity .15s ease-in-out;
+	background-color: transparent;
+}
+
+.sheet-compendium_warning {
+	display: none;
+}
+
+.sheet-container.active-drop-target.dropping ~ .sheet-compendium_warning {
+	display: block;
+	position: fixed;
+	top: 50%;
+	background: white;
+	left: 50%;
+	z-index: 100;
+	border: 2px solid black;
+	width: 300px;
+	height: 85px;
+	text-align: center;
+	margin: -70px 0 0 -170px;
+	padding-top: 20px;
 }
 
 /* start npcstuff */
@@ -656,12 +680,15 @@ input[type=number]::-webkit-outer-spin-button {
 
 .sheet-dw-stat-header input {
     border-style: none;
-    border-bottom: 1px solid white;
+    border-bottom: 1px solid black;
     box-shadow: none;
+    margin-bottom: 5px;
+    width: 25px !important;
     background: none;
     color: inherit;
     text-align: right;
     align-self: flex-end;
+    padding-bottom: 0px;
 }
 
 button input[disabled=true] {
@@ -724,8 +751,8 @@ button span {
 	width: 16px;
 	height: 16px;
 	position: relative;
-	top: -5px;
-	left: 5px;
+	top: -2px;
+	left: 4px;
 	margin: -10px;
 	cursor: pointer;
 	z-index: 1;
@@ -843,6 +870,26 @@ button span {
 	text-align: center;
 	font-size: 0.8em;
 	font-weight: bold;
+}
+
+.sheet-nav-tabs {
+	margin-left: +6px;
+}
+
+.sheet-nav-tabs .sheet-toggler input[type=radio] + span {
+	border-radius: 2px;
+	font-size: 0.9em;
+	padding-top: 0.2em;
+}
+
+.sheet-nav-tabs .sheet-toggler input[type=radio]:checked + span {
+	background-color: unset;
+	background-image: linear-gradient(#ffffffb8, transparent);
+	border-bottom-color: transparent;
+}
+
+.sheet-nav-tabs .sheet-toggler input[type=radio]:focus + span {
+	border-bottom-color: transparent;
 }
 
 .sheet-toggler input[type=radio]:checked + span,
@@ -979,7 +1026,11 @@ button span {
 	flex-wrap: wrap;
 	text-align: right;
 	margin-top: 5px;
-    padding-right: 20px;
+	padding-right: 20px;
+}
+
+.sheet-move-expansion {
+	text-align: left;
 }
 
 .sheet-move-expansion input[type="text"],
@@ -1001,6 +1052,11 @@ button span {
 	font-size: 0.8em;
 	width: calc(100% - 115px);
 	height: 3em;
+}
+
+.sheet-move-expansion textarea {
+	width: calc(100% - 20px);
+	margin-top: 0px;
 }
 
 .sheet-move-expansion input[type="number"],
@@ -1136,11 +1192,18 @@ textarea.sheet-gear-details {
 }
 
 .sheet-gmod {
+	/*
 	background-color: white;
 	border: 1px solid black;
+	*/
 	padding: 2px;
-	margin-left: 0.2em;
-	width: 20em;
+	margin-left: 0.3em;
+	width: calc(100% - 1.2em);
+}
+
+.sheet-gmod .repitem {
+	width: calc(100% - 5%);
+	margin-left: 0.5em;
 }
 
 /* Roll Templates */
@@ -1220,16 +1283,16 @@ textarea.sheet-gear-details {
 /* Notes Fields */
 
 .sheet-notes{
-    border-radius: 0;
-    box-shadow: none;
-    border: 1px solid;
-    min-height: 28px;
-    padding: 5px;
-    width:49%;
-    box-sizing: border-box;
-    resize:vertical;
-    display:inline-block;
+	border-radius: 0;
+	box-shadow: none;
+	border: 1px solid;
+	min-height: 28px;
+	padding: 5px;
+	width:49%;
+	box-sizing: border-box;
+	resize:vertical;
+	display:inline-block;
 }
 .sheet-notes2{
-    margin-left:10px;
+	margin-left:10px;
 }

--- a/Dungeon_World_Official/Dungeon World.css
+++ b/Dungeon_World_Official/Dungeon World.css
@@ -78,7 +78,7 @@
 
 .sheet-container.active-drop-target.dropping ~ .sheet-compendium_warning {
 	display: block;
-	position: fixed;
+	position: absolute;
 	top: 50%;
 	background: white;
 	left: 50%;
@@ -831,7 +831,11 @@ button span {
 .sheet-spell-expansion,
 .sheet-gear-expansion,
 .sheet-gmod-expansion {
-	display: none;
+	display: block;
+	transition: max-height 0.5s ease-out;
+	opacity: 0;
+	max-height: 0;
+	overflow: hidden;
 }
 
 .sheet-expand-bond:checked ~ .sheet-bond-expansion,
@@ -840,6 +844,9 @@ button span {
 .sheet-expand-gear:checked ~ .sheet-gear-expansion ,
 .sheet-expand-gmod:checked ~ .sheet-gmod-expansion {
 	display: block;
+	opacity: 1;
+	max-height: 700px;
+	transition: max-height 0.5s ease-in;
 }
 
 .sheet-expander:focus + span::before {

--- a/Dungeon_World_Official/Dungeon World.html
+++ b/Dungeon_World_Official/Dungeon World.html
@@ -112,7 +112,7 @@
 			<input type="hidden" name="attr_comp_damagedie" accept="Base Damage">
 			<input type="hidden" name="attr_comp_classmoves" accept="data-Basic Moves">
 			<input type="hidden" name="attr_comp_load" accept="Load">
-			<input type="text" name="attr_character_class" accept="Name">
+			<input type="text" name="attr_character_class">
 		</div>
 	</div>
 </div>
@@ -725,6 +725,20 @@
 </div>
 <!-- End Container div -->
 
+<input type="checkbox" class="tip-confirm-flag" name="attr_tip_confirm_flag" value="1">
+<div class="class-tip">
+	<button type="action" class="cancel-button" name="act_cancelclass">&#128473;</button>
+	<h3><span data-i18n="getting-started">Getting Started</span></h3>
+	<p><span data-i18n="getting-started-class-tip">Welcome to the Dungeon World Character Sheet by Roll20!  To get started, drag a class from the compendium or select one from the choices below:</span></p>
+	<button type="action" name="act_bard" data-i18n="Bard">Bard</button>
+	<button type="action" name="act_cleric" data-i18n="Cleric">Cleric</button>
+	<button type="action" name="act_druid" data-i18n="Druid">Druid</button>
+	<button type="action" name="act_fighter" data-i18n="Fighter">Fighter</button>
+	<button type="action" name="act_paladin" data-i18n="Paladin">Paladin</button>
+	<button type="action" name="act_ranger" data-i18n="Ranger">Ranger</button>
+	<button type="action" name="act_thief" data-i18n="Thief">Thief</button>
+	<button type="action" name="act_wizard" data-i18n="Wizard">Wizard</button>
+</div>
 
 <div class="compendium_warning">
 	<span data-i18n="accepting-drop-u">ACCEPTING DROP FROM COMPENDIUM</span>
@@ -2275,6 +2289,57 @@ var dwMoves = {
 
 // ---- Start worker scripts ----- //
 
+
+on("sheet:opened", function() {
+	getAttrs(["character_class", "isNPC"], function(v) {
+		if (v.isNPC != "1") {
+			update = {};
+			if (v.character_class == null || v.character_class == "") {
+				update["tip_confirm_flag"] = "0";
+			} else {
+				update["tip_confirm_flag"] = "1";
+			}
+			setAttrs(update);
+		}
+	});
+});
+
+on("clicked:bard", function(eventinfo) {
+	setupClass("Bard");
+});
+
+on("clicked:cleric", function(eventinfo) {
+	setupClass("Cleric");
+});
+
+on("clicked:druid", function(eventinfo) {
+	setupClass("Druid");
+});
+
+on("clicked:fighter", function(eventinfo) {
+	setupClass("Fighter");
+});
+
+on("clicked:paladin", function(eventinfo) {
+	setupClass("Paladin");
+});
+
+on("clicked:ranger", function(eventinfo) {
+	setupClass("Ranger");
+});
+
+on("clicked:thief", function(eventinfo) {
+	setupClass("Thief");
+});
+
+on("clicked:wizard", function(eventinfo) {
+	setupClass("Wizard");
+});
+
+on("clicked:cancelclass", function(eventinfo) {
+	setAttrs({tip_confirm_flag: 1}, "silent");
+});
+
 on("change:strength change:debil_weak", function() {
 	getAttrs(["strength", "debil_weak"], function(values) {
 		setAttrs({
@@ -2330,8 +2395,16 @@ on("change:page", function() {
 });
 
 on("change:isNPC", function () {
-	getAttrs(["isNPC"], function(v) {
-		setAttrs({calc_isNPC: v.isNPC});
+	getAttrs(["isNPC", "character_class"], function(v) {
+		if (v.isNPC == "1") {
+			setAttrs({calc_isNPC: v.isNPC, tip_confirm_flag: 1});
+		} else {
+			if (v.character_class == null || v.character_class == "") {
+				setAttrs({calc_isNPC: v.isNPC, tip_confirm_flag: 0});
+			} else {
+				setAttrs({calc_isNPC: v.isNPC, tip_confirm_flag: 1});
+			}
+		}
 	});
 })
 
@@ -3055,7 +3128,7 @@ on("change:comp_NPC_moves", function() {
 // ------------------------------------------ //
 // -- Main Class Drop Compilation Function -- //
 // ------------------------------------------ //
-/*
+
 on("change:comp_name", function() {
 	getAttrs(["populate_moves", "comp_name", "comp_damagedie", "comp_classmoves", "comp_load", "strength_mod"], function(v) {
 		if (v.comp_name != "dropped") {
@@ -3063,7 +3136,9 @@ on("change:comp_name", function() {
 			// Populate all basic moves.
 			if (v.populate_moves == "all") {
 				addBasicMoves();
-				setAttrs({populate_moves: "classonly"});
+				setAttrs({
+					populate_moves: "classonly"
+				});
 			}
 
 			// Populate the Class's starting moves
@@ -3079,11 +3154,26 @@ on("change:comp_name", function() {
 					damagedie: v.comp_damagedie
 				});
 			}
+			setAttrs({character_class: v.comp_name});
 		}
 	});
-	setAttrs({comp_name: "dropped"}, "silent");
+	setAttrs({comp_name: "dropped", tip_confirm_flag: 1}, "silent");
 });
-*/
 
+// Classname is the name of the Compendium Page.
+var setupClass = function(classname) {
+	getCompendiumPage(classname, function(page) {
+		if (page["data"]) {
+			var update = {};
+			var data = page["data"];
+			update["character_class"] = classname;
+			update["comp_name"] = classname;
+			update["comp_damagedie"] = data["Base Damage"];
+			update["comp_classmoves"] = data["data-Basic Moves"];
+			update["comp_load"] = data["Load"];
+			setAttrs(update);
+		}
+	});
+};
 
 </script>

--- a/Dungeon_World_Official/Dungeon World.html
+++ b/Dungeon_World_Official/Dungeon World.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container compendium-drop-target">
 
 <input type="hidden" name="attr_sheet_version" value="110">
 <input type="hidden" name="attr_populate_moves" value="all">
@@ -29,6 +29,7 @@
 <span class="invisible" tabindex="-1" data-i18n="cantrip">Cantrip</span>
 
 
+
 <input type="checkbox" class="invisible is-npc" tabindex="-1" name="attr_calc_isNPC" value="1" />
 
 <div class="npc-toggler">
@@ -38,10 +39,10 @@
 	</label>
 </div>
 
-<div class="npc-container compendium-drop-target">
+<div class="npc-container compendium-drop-target Monsters">
 	<div class="npc-header">
 		<span class="flex-row">
-			<span><input type="text" class="npc-name" name="attr_character_name" accept="Name"></span>
+			<span><input type="text" class="npc-name" name="attr_character_name"></span>
 			<span><span data-i18n="tags:" accept="Tags">Tags: </span>
 			<input type="text" class="npc-tags" data-i18n-placeholder="tags" placeholder="Tags" name="attr_NPC_tags" accept="Tags"></span>
 		</span>
@@ -432,8 +433,7 @@
 		</div>
 		<div class="mid-content moves">
 			<fieldset class="repeating_moves">
-				<div class="move-main compendium-drop-target">
-					<input type="hidden" name="attr_comp_shortname" value="-1" accept="data-Shortname">
+				<div class="move-main">
 					<button type="roll" name="roll_move" value="&{template:move} {{charname=@{character_name}}} {{movename=@{movename_base}}} {{trigger=@{movetrigger}}} {{success=@{movesuccess}}} {{partial=@{movepartial}}} {{miss=@{movemiss}}} {{doroll=[[@{move_doroll}]]}} {{result=[[@{rolltype} + @{movestat} +@{movemod} + (@{rollforward})[forward] + @{global_ongoing}[ongoing global]]]}} {{details=@{movedetails}}}">
 					<span class="rolltext" name="attr_move_name" value="@{move_name}"></span>
 					</button>
@@ -441,8 +441,9 @@
 					<span> </span>
 					<div class="move-expansion">
 						<span class="label" data-i18n="move-name">Move Name:</span>
-						<input type="text" name="attr_movename_base" value="" accept="Name" />
+						<input type="text" name="attr_movename_base" value="" />
 						<span class="label" data-i18n="move-trigger">Trigger:</span>
+						<br>
 						<textarea type="text" name="attr_movetrigger"></textarea>
 						<br>
 						<input class="enable-roll" type="checkbox" name="attr_move_doroll" value="1" checked="checked" />
@@ -462,15 +463,18 @@
 							<input class="moveroll" type="number" name="attr_movemod" value="0" />
 						<div class="rollresults-container">
 							<span class="label" data-i18n="move-success">Success (10+):</span>
+							<br>
 							<textarea type="text" name="attr_movesuccess"></textarea>
 							<span class="label" data-i18n="move-partial">At a Cost (7-9):</span>
+							<br>
 							<textarea type="text" name="attr_movepartial"></textarea>
 							<span class="label" data-i18n="move-miss">Miss (6-):</span>
+							<br>
 							<textarea type="text" name="attr_movemiss"></textarea>
 						</div>
 						<span class="label" data-i18n="move-details">Details:</span>
 						<br />
-						<textarea class="move-details" name="attr_movedetails" accept="Details"></textarea>
+						<textarea class="move-details" name="attr_movedetails"></textarea>
 					</div>
 				</div>
 			</fieldset>
@@ -496,17 +500,17 @@
 			<span class="label" data-i18n="gear-u">GEAR</span>
 			<span class="weight-counter">
 				<span class="label" data-i18n="load-u">LOAD</span>
-				<input type="number" class="load-count" name="attr_load" value="@{calc_load}" disabled="true" /> <span class="label">/</span>
-				<input type="number" class="load-count" name="attr_load_max" value="0" />
+				<input type="number" title="Current Load" class="load-count" name="attr_load" value="@{calc_load}" disabled="true" /> <span class="label">/</span>
+				<input type="number" title="Maximum Load" class="load-count" name="attr_load_max" value="0" />
 			</span>
 		</div>
 		<div class="mid-content gear">
 			<fieldset class="repeating_gear">
-				<div class="gear-main compendium-drop-target">
+				<div class="gear-main">
 					<button type="roll" name="roll_gear" value="&{template:dwgeneral} {{charname=@{character_name}}} {{infoname=@{gearname_base}}} {{tags=@{gear_tags}}} {{details=@{geardetails}}} {{doroll=[[@{gear_doroll}]]}} {{result=[[@{damagedie} + @{gear_damage} + @{global_dmg}]]}}">
 					<span class="rolltext" name="attr_gear_name" value="@{gear_name}"></span>
 					</button>
-					<input type="hidden" name="attr_comp_gear_type" value="Item" accept="Type">
+					<input type="hidden" name="attr_comp_gear_type" value="Item">
 					<input type="hidden" name="attr_calc_gear_dmg" value="0">
 					<input type="hidden" name="attr_calc_gear_armor" value="0">
 					<input type="hidden" name="attr_calc_gear_armormod" value="0">
@@ -516,18 +520,18 @@
 					<span> </span>
 					<div class="gear-expansion">
 						<span class="label" data-i18n="gear-name">Gear Name:</span>
-						<input type="text" name="attr_gearname_base" value="" accept="Name" />
+						<input type="text" name="attr_gearname_base" value="" />
 						<span class="label" data-i18n="gear-tags">Gear Tags:</span>
-						<input type="text" name="attr_gear_tags" value="" accept="Tags" />
+						<input type="text" name="attr_gear_tags" value="" />
 						<div class="flex-row">
 							<span>
-								<span class="label" data-i18n="value:">Value:</span><input type="number" name="attr_gear_value" value="0" accept="Value" />
+								<span class="label" data-i18n="value:">Value:</span><input type="number" name="attr_gear_value" value="0" />
 							</span>
 							<span>
 								<span class="label" data-i18n="qty:">Qty:</span><input type="number" name="attr_gear_quantity" value="1" />
 							</span>
 							<span>
-								<span class="label" data-i18n="weight:">Weight:</span><input type="number" name="attr_gear_weight" accept="Weight" \>
+								<span class="label" data-i18n="weight:">Weight:</span><input type="number" name="attr_gear_weight" \>
 							</span>
 						</div>
 						<div class="toggler flex-right">
@@ -556,21 +560,21 @@
 						</div>
 						<div class="flex-row flex-right gear-weapon">
 							<span>
-								<span class="label" data-i18n="damage:">Damage:</span><input type="number" name="attr_gear_damage" value="0" accept="Damage" />
+								<span class="label" data-i18n="damage:">Damage:</span><input type="number" name="attr_gear_damage" value="0" />
 							</span>
 						</div>
 						<div class="flex-row flex-right gear-armor">
 							<span>
-								<span class="label" data-i18n="base-armor:">Base Armor:</span><input type="number" name="attr_gear_base_armor" value="0" accept="Armor" />
+								<span class="label" data-i18n="base-armor:">Base Armor:</span><input type="number" name="attr_gear_base_armor" value="0" />
 							</span>
 							<span>
-								<span class="label" data-i18n="+armor:">+ Armor:</span><input type="number" name="attr_gear_add_armor" value="0" accept="Armor Mod" />
+								<span class="label" data-i18n="+armor:">+ Armor:</span><input type="number" name="attr_gear_add_armor" value="0" />
 							</span>
 						</div>
 						<br />
 						<span class="label" data-i18n="gear-details">Details:</span>
 						<br />
-						<textarea class="gear-details" name="attr_geardetails" accept="Details"></textarea>
+						<textarea class="gear-details" name="attr_geardetails"></textarea>
 					</div>
 				</div>
 			</fieldset>
@@ -588,16 +592,16 @@
 					<button type="roll" name="roll_spell" value="&{template:spell} {{charname=@{character_name}}} {{spellname=@{spellname_base}}} {{doroll=[[@{spell_doroll}]]}} {{tags=@{spell_tags}}} {{result=[[@{spell_diecount}@{spell_die} + @{spellmod}]]}} {{level=[[@{spell_level}]]}} {{details=@{spelldetails}}}">
 					<span class="rolltext" name="attr_spell_name" value="@{spell_name}"></span>
 					</button>
-					<input type="hidden" name="attr_comp_spell_level" value="-1" accept="Level">
+					<input type="hidden" name="attr_comp_spell_level" value="-1">
 					<input type="hidden" name="attr_level0_type" value="^{rote}">
-					<input type="hidden" name="attr_comp_fullroll" value="0" accept="Roll">
+					<input type="hidden" name="attr_comp_fullroll" value="0">
 					<input class="expander expand-spell" type="checkbox" name="attr_expand_spell" value="1" title="Details" checked="checked"  />
 					<span> </span>
 					<div class="spell-expansion">
 						<span class="label" data-i18n="spell-name">Spell Name:</span>
-						<input type="text" name="attr_spellname_base" value="" accept="Name" />
+						<input type="text" name="attr_spellname_base" value="" />
 						<span class="label" data-i18n="spell-tags">Spell Tags:</span>
-						<input type="text" name="attr_spell_tags" value="" accept="Tags" />
+						<input type="text" name="attr_spell_tags" value="" />
 						<span class="label" data-i18n="spell-level">Level:</span>
 						<div class="toggler spell-level-selector">
 							<label>
@@ -642,7 +646,7 @@
 							<input class="spellroll" type="number" name="attr_spellmod" value="0" />
 						<span class="label" data-i18n="spell-details">Details:</span>
 						<br />
-						<textarea class="spell-details" name="attr_spelldetails" accept="Details"></textarea>
+						<textarea class="spell-details" name="attr_spelldetails"></textarea>
 
 
 						<input type="hidden" name="attr_calc_prepval" value="0">
@@ -709,6 +713,21 @@
 		</div>
 	</div>
 
+</div>
+</div>
+
+<!-- COMPENDIUM DROP CATCHERS -->
+<input type="hidden" name="attr_drop_category" accept="Category">
+<input type="hidden" name="attr_drop_name" accept="Name">
+<input type="hidden" name="attr_drop_data" accept="data">
+<input type="hidden" name="attr_drop_content" accept="Content">
+
+</div>
+<!-- End Container div -->
+
+
+<div class="compendium_warning">
+	<span data-i18n="accepting-drop-u">ACCEPTING DROP FROM COMPENDIUM</span>
 </div>
 
 <rolltemplate class="sheet-rolltemplate-move">
@@ -2320,7 +2339,7 @@ on("change:isNPC", function () {
 var calculateMod = function(attribute) {
 	if (attribute < 4)
 		return -3;
-	if (attribute < 6)
+	if (attribute < 6) 
 		return -2;
 	if (attribute < 9)
 		return -1;
@@ -2361,6 +2380,64 @@ var statnameToFreeform = function(statname) {
 		return "@{statmod_query}"
 	}
 	return "0[no stat]";
+}
+
+// Spell is the name of the compendium page to get.
+var addSpell = function(spell, rowid = 0) {
+	var newspellid = rowid;
+	if (!rowid) {
+		newspellid = generateRowID();
+	}
+	console.log("Adding Spell: " + spell);
+	getCompendiumPage(spell, function(page) {
+		console.log("Got compendium page for " + spell);
+		if (page["data"]) {
+			var data = page["data"];
+			console.log("dropping " + spell);
+			console.log(data);
+			var prefix = "repeating_spells_" + newspellid + "_";
+			var attrs = {};
+			attrs[prefix + "spellname_base"] = page["name"];
+			attrs[prefix + "spell_tags"] = data["Tags"] || "";
+			attrs[prefix + "comp_spell_level"] = data["Level"] || "0";
+			attrs[prefix + "comp_fullroll"] = data["Roll"] || "";
+			attrs[prefix + "spelldetails"] = data["Details"] || "";
+
+			// Don't auto-expand gear from compendium.
+			attrs[prefix + "expand_spell"] = 0;
+			setAttrs(attrs);
+		}
+	});
+}
+
+// Gear is the Name of the Compendium Page to get.
+var addGear = function(gear, rowid = 0) {
+	var newgearid = rowid;
+	if (!rowid) {
+		newgearid = generateRowID();
+	}
+	console.log("Adding Gear: " + gear);
+	getCompendiumPage(gear, function(page) {
+		console.log("Got compendium page for " + gear);
+		if (page["data"]) {
+			var data = page["data"];
+			var prefix = "repeating_gear_" + newgearid + "_";
+			var attrs = {};
+			attrs[prefix + "gearname_base"] = page["name"];
+			attrs[prefix + "gear_tags"] = data["Tags"] || "";
+			attrs[prefix + "gear_value"] = data["Value"] || "0";
+			attrs[prefix + "gear_type"] = data["Type"] || "Item";
+			attrs[prefix + "gear_weight"] = data["Weight"] || "0";
+			attrs[prefix + "gear_damage"] = data["Damage"] || "0";
+			attrs[prefix + "gear_base_armor"] = data["Armor"] || "0";
+			attrs[prefix + "gear_add_armor"] = data["Armor Mod"] || "0";
+			attrs[prefix + "geardetails"] = data["Details"] || "";
+
+			// Don't auto-expand gear from compendium.
+			attrs[prefix + "expand_gear"] = 0;
+			setAttrs(attrs);
+		}
+	});
 }
 
 // move is the shortname, no special chars, spaces, all lowercase.
@@ -2451,7 +2528,6 @@ on("change:repeating_spells", function(eventInfo) {
 			var preparedLevels = [];
 			for(var i=0; i < ids.length; i++) {
 				var attr = "repeating_spells_" + ids[i] + "_calc_prepval";
-				console.log("wtf");
 				preparedLevels.push(attr);
 			}
 
@@ -2500,7 +2576,7 @@ on("change:repeating_spells:comp_spell_level", function() {
 				repeating_spells_spell_level:v.repeating_spells_comp_spell_level,
 				repeating_spells_comp_spell_level: -1
 			});
-			if (v.repeating_spells_comp_fullroll != "" && v.repeating_spells_comp_fullroll != null) {
+			if (v.repeating_spells_comp_fullroll != "" && v.repeating_spells_comp_fullroll != null && v.repeating_spells_comp_fullroll != "") {
 				var rollPieces = [];
 				rollPieces = parseRoll(v.repeating_spells_comp_fullroll);
 				setAttrs({
@@ -2891,12 +2967,75 @@ on("change:repeating_bonds", function(eventInfo) {
 	});
 });
 
+// ---------------------- //
+// -- Compendium Drops -- //
+// ---------------------- //
+
+on("change:drop_category", function(eventinfo) {
+	if(eventinfo.newValue === "Monsters") {
+		// Handle query for changing to an NPC if not already one.
+		getAttrs(["isNPC", "drop_name"], function(v) {
+			if (v.isNPC) {
+				setAttrs({character_name: v.drop_name});
+			}
+		});
+	}
+	else {
+		handle_drop(eventinfo.newValue);
+	}
+});
+
+var handle_drop = function(category, eventinfo) {
+	console.log("Handling drop");
+	console.log(category);
+	setAttrs({drop_category: ""}, "silent", function() {
+		getAttrs(["drop_name", "drop_data", "drop_content"], function(v) {
+			pagedata = {};
+			try {
+				pagedata = JSON.parse(v.drop_data);
+			} catch(e) {
+				pagedata = v.drop_data;
+			}
+			console.log(pagedata);
+			if (category === "Moves") {
+				addMove(pagedata["data-Shortname"]);
+			} else if (category === "Equipment") {
+				addGear(v.drop_name);
+			} else if (category === "Spells") {
+				addSpell(v.drop_name);
+			} else if (category === "Classes") {
+				getAttrs(["populate_moves", "comp_name", "comp_damagedie", "comp_classmoves", "comp_load", "strength_mod"], function(v) {
+					if (v.comp_name != "dropped") {
+					
+						// Populate all basic moves.
+						if (v.populate_moves == "all") {
+							addBasicMoves();
+							setAttrs({populate_moves: "classonly"});
+						}
+
+						// Populate the Class's starting moves
+						if (v.populate_moves == "all" || v.populate_moves == "classonly") {
+							var startingMoves = []
+							startingMoves = JSON.parse(v.comp_classmoves);
+
+							for (var i = 0, len = startingMoves.length; i < len; i++) {
+								addMove(shortName(startingMoves[i]));
+							}
+
+							setAttrs({
+								damagedie: v.comp_damagedie
+							});
+						}
+					}
+				});
+				setAttrs({comp_name: "dropped"}, "silent");
+			}
+		});
+	});
+}
 // Move Drop
 on("change:repeating_moves:comp_shortname", function(eventInfo) {
-	getAttrs(["repeating_moves_comp_shortname"], function(v) {
-		addMove(v.repeating_moves_comp_shortname, eventInfo.sourceAttribute.split("_")[2]);
-		setAttrs({repeating_moves_comp_shortname: "-1"}, "silent"); // Don't repropagate.
-	});
+	
 });
 
 // NPC Drop
@@ -2916,6 +3055,7 @@ on("change:comp_NPC_moves", function() {
 // ------------------------------------------ //
 // -- Main Class Drop Compilation Function -- //
 // ------------------------------------------ //
+/*
 on("change:comp_name", function() {
 	getAttrs(["populate_moves", "comp_name", "comp_damagedie", "comp_classmoves", "comp_load", "strength_mod"], function(v) {
 		if (v.comp_name != "dropped") {
@@ -2943,7 +3083,7 @@ on("change:comp_name", function() {
 	});
 	setAttrs({comp_name: "dropped"}, "silent");
 });
-
+*/
 
 
 </script>

--- a/Dungeon_World_Official/Dungeon World.html
+++ b/Dungeon_World_Official/Dungeon World.html
@@ -106,12 +106,12 @@
 			</div>
 		</div>
 
-		<div class="class-container compendium-drop-target">
+		<div class="class-container">
 			<span class="label" data-i18n="char-class-u">CLASS</span>
-			<input type="hidden" name="attr_comp_name" accept="Name">
-			<input type="hidden" name="attr_comp_damagedie" accept="Base Damage">
-			<input type="hidden" name="attr_comp_classmoves" accept="data-Basic Moves">
-			<input type="hidden" name="attr_comp_load" accept="Load">
+			<input type="hidden" name="attr_comp_name">
+			<input type="hidden" name="attr_comp_damagedie">
+			<input type="hidden" name="attr_comp_classmoves">
+			<input type="hidden" name="attr_comp_load">
 			<input type="text" name="attr_character_class">
 		</div>
 	</div>
@@ -3077,31 +3077,13 @@ var handle_drop = function(category, eventinfo) {
 			} else if (category === "Spells") {
 				addSpell(v.drop_name);
 			} else if (category === "Classes") {
-				getAttrs(["populate_moves", "comp_name", "comp_damagedie", "comp_classmoves", "comp_load", "strength_mod"], function(v) {
-					if (v.comp_name != "dropped") {
-					
-						// Populate all basic moves.
-						if (v.populate_moves == "all") {
-							addBasicMoves();
-							setAttrs({populate_moves: "classonly"});
-						}
-
-						// Populate the Class's starting moves
-						if (v.populate_moves == "all" || v.populate_moves == "classonly") {
-							var startingMoves = []
-							startingMoves = JSON.parse(v.comp_classmoves);
-
-							for (var i = 0, len = startingMoves.length; i < len; i++) {
-								addMove(shortName(startingMoves[i]));
-							}
-
-							setAttrs({
-								damagedie: v.comp_damagedie
-							});
-						}
-					}
-				});
-				setAttrs({comp_name: "dropped"}, "silent");
+				var update = {};
+				update["comp_name"] = v.drop_name;
+				update["comp_damagedie"] = pagedata["Base Damage"];
+				update["comp_classmoves"] = pagedata["data-Basic Moves"];
+				update["comp_load"] = pagedata["Load"];
+				setAttrs(update);
+				//setAttrs({comp_name: "dropped"}, "silent");
 			}
 		});
 	});

--- a/Dungeon_World_Official/translation.json
+++ b/Dungeon_World_Official/translation.json
@@ -113,5 +113,15 @@
     "level:": "Level: ",
     "move-effect": "Effect:",
     "bond-u": "BOND",
-    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM"
+    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM",
+    "getting-started": "Getting Started",
+    "getting-started-class-tip": "Welcome to the Dungeon World Character Sheet by Roll20!  To get started, drag a class from the compendium or select one from the choices below:",
+    "Bard": "Bard",
+    "Cleric": "Cleric",
+    "Druid": "Druid",
+    "Fighter": "Fighter",
+    "Paladin": "Paladin",
+    "Ranger": "Ranger",
+    "Thief": "Thief",
+    "Wizard": "Wizard"
 }

--- a/Dungeon_World_Official/translation.json
+++ b/Dungeon_World_Official/translation.json
@@ -112,5 +112,6 @@
     "name-makes-spell": "casts a spell",
     "level:": "Level: ",
     "move-effect": "Effect:",
-    "bond-u": "BOND"
+    "bond-u": "BOND",
+    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM"
 }

--- a/Dungeon_World_Official/translations/en.json
+++ b/Dungeon_World_Official/translations/en.json
@@ -113,5 +113,15 @@
     "level:": "Level: ",
     "move-effect": "Effect:",
     "bond-u": "BOND",
-    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM"
+    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM",
+    "getting-started": "Getting Started",
+    "getting-started-class-tip": "Welcome to the Dungeon World Character Sheet by Roll20!  To get started, drag a class from the compendium or select one from the choices below:",
+    "Bard": "Bard",
+    "Cleric": "Cleric",
+    "Druid": "Druid",
+    "Fighter": "Fighter",
+    "Paladin": "Paladin",
+    "Ranger": "Ranger",
+    "Thief": "Thief",
+    "Wizard": "Wizard"
 }

--- a/Dungeon_World_Official/translations/en.json
+++ b/Dungeon_World_Official/translations/en.json
@@ -112,5 +112,6 @@
     "name-makes-spell": "casts a spell",
     "level:": "Level: ",
     "move-effect": "Effect:",
-    "bond-u": "BOND"
+    "bond-u": "BOND",
+    "accepting-drop-u": "ACCEPTING DROP FROM COMPENDIUM"
 }


### PR DESCRIPTION
## Changes

- Quickstart playbook selection - If you haven't got a class filled out, you'll be presented with the option to automate a playbook drop from compendium at the click of a button.
- Catch-all compendium drops -- the entire PC sheet is now a single drop zone, and will properly add the dropped item into the correct section on the sheet.
- Miscellaneous sheet worker changes to accommodate a plethora of changes to the Dungeon World compendium data.
- Styling updates to improve the user experience.
- Misc. bug fixes and tweaks