### PR TITLE
[Urban Shadows] Adding Session Intro button

### DIFF
--- a/Urban_Shadows/sheet.html
+++ b/Urban_Shadows/sheet.html
@@ -653,6 +653,8 @@
 			          <option value="@{power}">Power</option>
 			          <option value="@{wild}">Wild</option>
 			      </select>
+			     <label class="sheet-buttonLbl">Session Intro:</label>
+  			     <button type='roll' value='&{template:us} {{name=@{character_name}}} {{roll_name=Session Intro}} {{roll_mod=[[@{factionroll}]]}} {{result=[[2d6 + @{factionroll}]]}}' name='roll_sessionintro'></button>
 			     <label class="sheet-buttonLbl">Hit the Streets:</label>
   			     <button type='roll' value='&{template:us} {{name=@{character_name}}} {{roll_name=Hit the Streets}} {{roll_mod=[[@{factionroll}]]}} {{result=[[2d6 + @{factionroll}]]}}' name='roll_hitstreets'></button>
 				  <label class="sheet-buttonLbl">Put a Face to a Name:</label>


### PR DESCRIPTION
## Changes

Added a button for Session Intro, another move that uses the faction ratings.

## Additional comments

Very small change, adding this because my group has been rolling manually or selecting other faction moves, so this is a little more convenient.