### PR TITLE
[L5R FFG] fix Endurance & Composure calculation

### DIFF
--- a/L5R Fantasy Flight Games/L5RFFGSheet.html
+++ b/L5R Fantasy Flight Games/L5RFFGSheet.html
@@ -4492,7 +4492,7 @@ Version 0.8.3 Beta
         
 		on("sheet:opened change:earth change:water", function() {
 			getAttrs(["earth", "water"], function(values) {
-				setAttrs({ foo_endurance: ((parseInt(values.earth)+parseInt(values.water))*2) });
+				setAttrs({ foo_endurance: ((parseInt(values.earth)+parseInt(values.fire))*2) });
 			});
 		});
 
@@ -4509,13 +4509,13 @@ Version 0.8.3 Beta
 		});
 	
 
-//<!-- Endurance Calculation Worker -->
+//<!-- Composure Calculation Worker -->
 
 	
         
 		on("sheet:opened change:earth change:fire", function() {
 			getAttrs(["earth", "fire"], function(values) {
-				setAttrs({ foo_composure: ((parseInt(values.earth)+parseInt(values.fire))*2) });
+				setAttrs({ foo_composure: ((parseInt(values.earth)+parseInt(values.water))*2) });
 			});
 		});
 


### PR DESCRIPTION
[Found by Grant L. (Roll20 thread)
](https://app.roll20.net/forum/post/6969899/l5r-ffg-endurance-and-composure-equations-are-swapped)
## Changes
Endurance and Composure where calculating eachothers values. 
- Now Endurance is (Earth + Fire) x2
- Now Composure is (Earth+Water)x2

## Additional comments
[source](https://imgur.com/a/2fVe5PB) p36, CRB