### PR TITLE
5eOGL: Fix bug not allowing choosing a tool as expertise.

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -11092,7 +11092,7 @@
             _.each(mancerdata, function(slide) {
                 _.each(slide.values, function(value, name) {
                     if(name.substr(-16) == "expertise_choice" && slide.values[name.replace("choice", "info")]) {
-                        if(!allProficiencies.Skill.includes(value.split(":")[1])) {
+                        if(!(allProficiencies.Skill.includes(value.split(":")[1]) || allProficiencies.Tool.includes(value.split(":")[1]))) {
                             toSet[name] = "";
                         }
                     }


### PR DESCRIPTION
*Include the name of the sheet you made changes to in the title.*

## Changes

This fixes a bug in the charactermancer that would not allow you to select a tool as an expertise choice (example: rogue thieves' tools)

## Additional comments
