### PR TITLE
(Urban Shadows) Fix the Hunter's Custom Weapon fields

### DIFF
--- a/Urban_Shadows/sheet.html
+++ b/Urban_Shadows/sheet.html
@@ -1141,7 +1141,7 @@
 					<label class="sheet-custom">Custom Weapons:</label>
 					<fieldset class="repeating_custweap">
 						Name/Description:<input type="text" name="attr_custname"/><br>
-						Tags:<br><input type="text" name="attr_custname"/>
+						Tags:<br><input type="text" name="attr_custtags"/>
 					</fieldset>
 				</div>
 


### PR DESCRIPTION
## Changes

I fixed the Custom Weapons fields, which had the same names, and as a result duplicated content. Now, the two fields are distinct, as they should be.