### PR TITLE
[GURPS] Cosmetic changes and a few bug fixes in gurps.html and gurps.css

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -206,7 +206,7 @@ input {
 }
 
 .charsheet .sheet-row input.sheet-editable {
-    background-color: #ffe6e6;
+    background-color: #E0E0E0;
 }
 
 .repitem:nth-child(odd) .sheet-row-stats,
@@ -545,7 +545,7 @@ input.sheet-tab0 + span {
     border-radius:5px;
     background: #fffAF0;
     line-height: 1.5em;
-    font-size: 10px;
+    font-size: 11px;
 }
 
 .sheet-tooltip table {
@@ -608,17 +608,17 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-ranged-attacks .sheet-tooltip { margin-left: -100px; }
 .sheet-ranged-attacks .sheet-col1 .sheet-tooltip { margin-left: -40px; }
 .sheet-encumberance .sheet-tooltip { margin-left: -40px; }
-
+.sheet-points .sheet-tooltip { margin-left: -300px; }
 
 
 /* -- GENERAL -- */
 .sheet-attribute { width: 180px; }
-.sheet-attribute .sheet-header .sheet-col0 { width: 80px; }
+.sheet-attribute .sheet-header .sheet-col0 { width: 85px; }
 .sheet-attribute .sheet-header .sheet-col1 { width: 30px; }
-.sheet-attribute .sheet-header .sheet-col2 { width: 52px; }
+.sheet-attribute .sheet-header .sheet-col2 { width: 35px; }
 .sheet-attribute .sheet-row .sheet-col0 { width: 50px; }
 .sheet-attribute .sheet-row .sheet-col1 { width: 35px; }
-.sheet-attribute .sheet-row .sheet-col2 { width: 35px; }
+.sheet-attribute .sheet-row .sheet-col2 { width: 30px; }
 .sheet-attribute .sheet-row .sheet-col3 { width: 35px; }
 .sheet-attribute .sheet-row .sheet-col4 { width: 22px; }
 .sheet-attribute .sheet-row-thrust-damage .sheet-col1 { width: 90px; }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -493,7 +493,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_thrust" value="1d6-2" />
+						<input type="text" name="attr_thrust" value="1d6-2" class="editable" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 					    <input type="hidden" name="attr_thrust_damage_dice_icon" class="thrust-damage-dice-icon" value="explode" />
@@ -546,7 +546,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_swing" value="1d6" />
+						<input type="text" name="attr_swing" value="1d6" class="editable" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<input type="hidden" name="attr_swing_damage_dice_icon" class="swing-damage-dice-icon" value="explode" />
@@ -672,7 +672,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_hit_points" value="10"/>
+						<input type="number" name="attr_hit_points" value="10" class="editable" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-fatigue-points">
@@ -941,13 +941,32 @@
 			<div class="sheet-table">
 			    <input type="hidden" name="attr_toggle_unspent_points" class="sheet-toggle-unspoint-points" value="0" />
 				<div class="sheet-header">
-					<div class="sheet-cell sheet-col0">
-						Point Sum
-					</div>
+					<div class="sheet-popup">Point Sum</div>
+					<span class="sheet-tooltip">
+						<strong>Total</strong>: Manual input: Represents to total value of the<br/>
+						PC in Character Points (spent and unspent combined).
+						<br />
+						<strong>Spent</strong>: Automatic total of Spent points: Attributes +<br/>
+						Traits + Skills + Other.
+						<br/>
+						<strong>Unspent</strong>: Has the option of being Manual or<br/>
+						Automatic, depending on an option selected on the
+						<br/>
+						Settings page entitled ‘Enter Unspent Points’.
+						<br/>
+						Manual Mode (Blue color): You manually enter your
+						<br/>
+						Unspent points.
+						<br/>
+						Automatic mode (Black color): It calculates the
+						<br/>
+						point total difference between Total and Spent.
+					</span>
 				</div> <!-- .sheet-header -->
+
 				<div class="sheet-row sheet-row-other">
 					<div class="sheet-cell sheet-col0 sheet-label">
-						Starting
+						Total
 					</div>
 					<div class="sheet-cell sheet-col1">
 						<input type="text" name="attr_total_points" value="150" class="editable" />
@@ -987,10 +1006,10 @@
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-other">
 					<div class="sheet-cell sheet-col0 sheet-label">
-						Total
+						Spent
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_point_summary" disabled="disabled" value="@{att_points} + @{trait_points} + @{skills_points} + @{misc_points}" />
+						<input type="text" name="attr_point_summary" disabled="disabled" value="@{att_points} + @{trait_points} + @{skill_points} + @{misc_points}" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-total sheet-hr">
@@ -998,7 +1017,7 @@
 						Unspent
 					</div>
 					<div class="sheet-cell sheet-col1">
-					    <input type="text" name="attr_point_diff" value="@{total_points} - (@{att_points} + @{trait_points} + @{skills_points} + @{misc_points})" disabled="disabled" />
+					    <input type="text" name="attr_point_diff" value="@{total_points} - (@{att_points} + @{trait_points} + @{skill_points} + @{misc_points})" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-unspent sheet-hr">
@@ -2476,6 +2495,8 @@
 	<div class="sheet-tab7">
 
 	<div>
+	<h3>Latest Changes: Updated 11/27/2018</h3>
+		
 	<h3>Known Issues</h3>
 	<ul>
 		<li>Unable to delete a Technique - UPDATE</li>
@@ -2498,7 +2519,24 @@
 	<p>In your post, please specify if it is an Issue or Suggestion with as much detail information as possible. Screen shots help a lot! I am just learning to work with HTML and CSS so I may not be able to do everything requested. I make no promises on how fast I may be able to implement a Fix or a Suggestion - so please be patient. -Thanks, Mike W.</p>
 
 	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 forum for now - perhaps later we can use GitHub.</p>
-		
+
+	<h4>Version: 1.4.7</h4>
+	
+	<p>Pull Request: 11/27/2018</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Added 'Latest Update' with date to the top of the Updates page - Cosmetic Only</li>
+		<li>Changed the Input color from pink to a light gray: Because of so many complaints about the pink - Cosmetic Only</li>
+		<li>Fixed the Current HP, Thrust, and Swing fields on the General page to display the Input Color – Cosmetic Only</li>
+		<li>Fixed bug for the Total Points and the calculated Unspent Points were not totaling correctly on the General page – The actual fix was spotted and provided by Filipe (UserID: 1089514)</li>
+		<li>Fix alignment of columns for Attributes on the General page - Cosmetic Only</li>
+		<li>Fix base tooltip font size from 10 to 11 to make it more readable - Cosmetic Only</li>
+		<li>Added tooltips for POINT SUM on the General page  for Total, Spent, and Unspent - Cosmetic Only</li>
+		<li>Under POINT SUM in the General page, changed ‘Starting’ to ‘Total’ and changed ‘Total’ to ‘Spent‘ - Requested first by Valter (UserID:285013), then by many others  – Cosmetic Only</li>
+			
+	</ul>
+	
 	<h4>Version: 1.4.6</h4>
 
 	<p>Pull Request: 11/20/2018</p>
@@ -2511,8 +2549,6 @@
 		<li>Fixed tooltip format specifically the width and placement  – Cosmetic Only</li>					
 		<li>Fixed tooltip for Attribute Mod, Shots, and RoF to fit the format – Cosmetic Only</li>
 		<li>Fixed the tooltip for Combat Reflexes, changed +3 fear to +2 Fright – Cosmetic Only </li>
-		<li></li>
-		<li></li>
 	</ul>
 
 		<h4>Version: 1.4.5</h4>
@@ -2813,7 +2849,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = "1.4.6";
+	var version = "1.4.7";
 
 	var modCascade = true;
 	var modCascadeAll = true;


### PR DESCRIPTION
•	Added Latest Update with date to the top of the Updates page - Cosmetic Only
•	Changed the Input color from pink to a light gray (Because of so many complaints about the pink)- Cosmetic Only
•	Fixed the Current HP, Thrust, and Swing fields on the General page to display the Input Color – Cosmetic Only
•	Fixed bug for the Total Points and the calculated Unspent Points were not totaling correctly on the General page – The actual fix was spotted and provided by Filipe (UserID: 1089514)
•	Fix alignment of columns for Attributes on the General page - Cosmetic Only
•	Fix base tooltip font size from 10 to 11 to make it more readable - Cosmetic Only
•	Added tooltips for POINT SUM on the General page  for Total, Spent, and Unspent - Cosmetic Only
•	Under POINT SUM in the General page, changed ‘Starting’ to ‘Total’ and changed ‘Total’ to ‘Spent‘ - Requested first by Valter (UserID:285013), then by many others  – Cosmetic Only

*Include the name of the sheet you made changes to in the title.*

## Changes

*Provide a few comments about what you have changed.*


## Additional comments


*Anything else we should know?.*



## Roll20 Requests

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.