### PR TITLE
ShadowrunAnarchy: Corrected bug in number of physical and stun boxes

### DIFF
--- a/ShadowrunAnarchy/ShadowrunAnarchy.html
+++ b/ShadowrunAnarchy/ShadowrunAnarchy.html
@@ -971,7 +971,7 @@ on("change:edge", function (){
 on("change:strength", function() {
     getAttrs(["strength"], function(v){
         var str = parseInt(v.strength) || 0;
-        var tot = Math.floor(str/2) + 8;
+        var tot = Math.ceil(str/2) + 8;
         setAttrs({
             physical_max: tot
         });
@@ -981,7 +981,7 @@ on("change:strength", function() {
 on("change:willpower", function() {
     getAttrs(["willpower"], function(v){
         var wil = parseInt(v.willpower) || 0;
-        var tot = Math.floor(wil/2) + 8;
+        var tot = Math.ceil(wil/2) + 8;
         setAttrs({
             stun_max: tot
         });


### PR DESCRIPTION
Page 64 of the Anarchy rulebook:
Divide Strength by two, round up, add eight. (Same with Willpower for Stun).

Previous was using Math.floor (round down), corrected to use Math.ceil (round up)

## Changes / Comments

Per Issue: https://github.com/Roll20/roll20-character-sheets/issues/4485

Corrected CM calculations.